### PR TITLE
Add option to skip content download

### DIFF
--- a/Docs/faq.md
+++ b/Docs/faq.md
@@ -27,6 +27,19 @@ building CARLA from source.
 
 Once you open the project in the Unreal Editor, you can hit Play to test CARLA.
 
+#### Can I skip the download step in Setup.sh?
+
+It is possible to skip the download step by passing the `-s` argument to the
+setup script
+
+    $ ./Setup.sh -s
+
+Bear in mind that if you do so, you are supposed to manually download and
+extract the content package yourself, check out the last output of the Setup.sh
+for instructions or run
+
+    $ ./Update.sh -s
+
 #### How can I create a binary version of CARLA?
 
 To compile a binary (packaged) version of CARLA, open the CarlaUE4 project with

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -26,3 +26,16 @@ rebuild of all the project files with
     $ cd Unreal/CarlaUE4/
     $ make CarlaUE4Editor ARGS=-clean
     $ make CarlaUE4Editor
+
+#### Setup.sh fails to download content
+
+It is possible to skip the download step by passing the `-s` argument to the
+setup script
+
+    $ ./Setup.sh -s
+
+Bear in mind that if you do so, you are supposed to manually download and
+extract the content package yourself, check out the last output of the Setup.sh
+for instructions or run
+
+    $ ./Update.sh -s

--- a/Setup.sh
+++ b/Setup.sh
@@ -1,16 +1,24 @@
 #! /bin/bash
 
 ################################################################################
-# CARLA Util Setup
+# CARLA Setup.sh
 #
-# This downloads and compiles libc++. So we can build and compile our
-# dependencies with libc++ for linking against Unreal.
+# This script sets up the environment and dependencies for compiling CARLA on
+# Linux.
+#
+#   1) Download CARLA Content if necessary.
+#   2) Download and compile libc++.
+#   3) Download other third-party libraries and compile them with libc++.
 #
 # Thanks to the people at https://github.com/Microsoft/AirSim for providing the
 # important parts of this script.
 ################################################################################
 
 set -e
+
+# ==============================================================================
+# -- Set up environment --------------------------------------------------------
+# ==============================================================================
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
@@ -21,9 +29,6 @@ command -v clang++-3.9 >/dev/null 2>&1 || {
   echo >&2 "make sure you build Unreal Engine with clang 3.9 too.";
   exit 1;
 }
-
-# Update content.
-./Update.sh
 
 mkdir -p Util/Build
 pushd Util/Build >/dev/null
@@ -160,6 +165,13 @@ if [[ ! -f $CARLA_SETTINGS_FILE ]]; then
 fi
 
 ./Util/Protoc.sh
+
+# ==============================================================================
+# -- Update CARLA Content ------------------------------------------------------
+# ==============================================================================
+
+echo
+./Update.sh $@
 
 # ==============================================================================
 # -- ...and we are done --------------------------------------------------------

--- a/Update.sh
+++ b/Update.sh
@@ -6,6 +6,38 @@
 
 set -e
 
+# ==============================================================================
+# -- Parse arguments -----------------------------------------------------------
+# ==============================================================================
+
+USAGE_STRING="Usage: $0 [-h|--help] [-s|--skip-download]"
+
+SKIP_DOWNLOAD=false
+
+OPTS=`getopt -o hs --long help,skip-download -n 'parse-options' -- "$@"`
+
+if [ $? != 0 ] ; then echo "$USAGE_STRING" ; exit 2 ; fi
+
+eval set -- "$OPTS"
+
+while true; do
+  case "$1" in
+    -s | --skip-download )
+      SKIP_DOWNLOAD=true;
+      shift ;;
+    -h | --help )
+      echo "$USAGE_STRING"
+      exit 1
+      ;;
+    * )
+      break ;;
+  esac
+done
+
+# ==============================================================================
+# -- Set up environment --------------------------------------------------------
+# ==============================================================================
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
 
@@ -29,6 +61,19 @@ function download_content {
   echo "$CONTENT_GDRIVE_ID" > "$VERSION_FILE"
   echo "Content updated successfully."
 }
+
+# ==============================================================================
+# -- Download Content if necessary ---------------------------------------------
+# ==============================================================================
+
+if $SKIP_DOWNLOAD ; then
+  echo "Skipping 'Content' update. Please manually download the package from"
+  echo
+  echo "  https://drive.google.com/open?id=$CONTENT_GDRIVE_ID"
+  echo
+  echo "and extract it under Unreal/CarlaUE4/Content."
+  exit 0
+fi
 
 if [[ -d "$CONTENT_FOLDER/.git" ]]; then
   echo "Using git version of 'Content', skipping update."


### PR DESCRIPTION
Added the `-s` and `--skip-download` options to "Update.sh" and "Setup.sh". This way people having troubles downloading the 10GB of content can manually download this file, possibly from somewhere else, and run setup.