### PR TITLE
Fix road map generator generates duplicated meshes

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
@@ -16,10 +16,31 @@
 #include "Paths.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #ifdef CARLA_ROAD_GENERATOR_EXTRA_LOG
 #include <sstream>
 #endif // CARLA_ROAD_GENERATOR_EXTRA_LOG
+
+// =============================================================================
+// -- Private types ------------------------------------------------------------
+// =============================================================================
+
+class FHalfEdgeCounter {
+public:
+
+  using HalfEdge = MapGen::DoublyConnectedEdgeList::HalfEdge;
+
+  bool IsVisited(const HalfEdge &InHalfEdge)
+  {
+    return Set.insert(&InHalfEdge).second &&
+           Set.insert(&MapGen::DoublyConnectedEdgeList::GetPair(InHalfEdge)).second;
+  }
+
+private:
+
+  std::unordered_set<const HalfEdge *> Set;
+};
 
 // =============================================================================
 // -- Constructor and destructor -----------------------------------------------
@@ -135,35 +156,39 @@ void ACityMapGenerator::GenerateRoads()
 
   const uint32 margin = CityMapMeshTag::GetRoadIntersectionSize() / 2u;
 
+  FHalfEdgeCounter HalfEdgeCounter;
+
   // For each edge add road segment.
   for (auto &edge : graph.GetHalfEdges()) {
-    auto source = Graph::GetSource(edge).GetPosition();
-    auto target = Graph::GetTarget(edge).GetPosition();
+    if (HalfEdgeCounter.IsVisited(edge)) {
+      auto source = Graph::GetSource(edge).GetPosition();
+      auto target = Graph::GetTarget(edge).GetPosition();
 
-    if (source.x == target.x) {
-      // vertical
-      auto y = 1u + margin + std::min(source.y, target.y);
-      auto end = std::max(source.y, target.y) - margin;
-      for (; y < end; ++y) {
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneLeft,          source.x, y, HALF_PI);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneRight,         source.x, y, HALF_PI);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkLeft,      source.x, y, HALF_PI);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkRight,     source.x, y, HALF_PI);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneMarkingBroken, source.x, y, HALF_PI);
+      if (source.x == target.x) {
+        // vertical
+        auto y = 1u + margin + std::min(source.y, target.y);
+        auto end = std::max(source.y, target.y) - margin;
+        for (; y < end; ++y) {
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneLeft,          source.x, y, HALF_PI);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneRight,         source.x, y, HALF_PI);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkLeft,      source.x, y, HALF_PI);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkRight,     source.x, y, HALF_PI);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneMarkingBroken, source.x, y, HALF_PI);
+        }
+      } else if (source.y == target.y) {
+        // horizontal
+        auto x = 1u + margin + std::min(source.x, target.x);
+        auto end = std::max(source.x, target.x) - margin;
+        for (; x < end; ++x) {
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneLeft,          x, source.y);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneRight,         x, source.y);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkLeft,      x, source.y);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkRight,     x, source.y);
+          AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneMarkingBroken, x, source.y);
+        }
+      } else {
+        UE_LOG(LogCarla, Warning, TEXT("Diagonal edge ignored"));
       }
-    } else if (source.y == target.y) {
-      // horizontal
-      auto x = 1u + margin + std::min(source.x, target.x);
-      auto end = std::max(source.x, target.x) - margin;
-      for (; x < end; ++x) {
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneLeft,          x, source.y);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneRight,         x, source.y);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkLeft,      x, source.y);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_SidewalkRight,     x, source.y);
-        AddInstance(ECityMapMeshTag::RoadTwoLanes_LaneMarkingBroken, x, source.y);
-      }
-    } else {
-      UE_LOG(LogCarla, Warning, TEXT("Diagonal edge ignored"));
     }
   }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
@@ -31,7 +31,7 @@ public:
 
   using HalfEdge = MapGen::DoublyConnectedEdgeList::HalfEdge;
 
-  bool IsVisited(const HalfEdge &InHalfEdge)
+  bool Insert(const HalfEdge &InHalfEdge)
   {
     return Set.insert(&InHalfEdge).second &&
            Set.insert(&MapGen::DoublyConnectedEdgeList::GetPair(InHalfEdge)).second;
@@ -160,7 +160,7 @@ void ACityMapGenerator::GenerateRoads()
 
   // For each edge add road segment.
   for (auto &edge : graph.GetHalfEdges()) {
-    if (HalfEdgeCounter.IsVisited(edge)) {
+    if (HalfEdgeCounter.Insert(edge)) {
       auto source = Graph::GetSource(edge).GetPosition();
       auto target = Graph::GetTarget(edge).GetPosition();
 


### PR DESCRIPTION
#### Description

While iterating the graph I was adding road both for a half-edge and its pair. Now I keep a count of the edges (and its pairs) that have being visited and skip the visited ones.

Fix #221.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Unreal Engine version(s):** 4.17.2
