### PR TITLE
Add quality level switch to python client examples

### DIFF
--- a/PythonClient/client_example.py
+++ b/PythonClient/client_example.py
@@ -49,7 +49,8 @@ def run_carla_client(args):
                     SendNonPlayerAgentsInfo=True,
                     NumberOfVehicles=20,
                     NumberOfPedestrians=40,
-                    WeatherId=random.choice([1, 3, 7, 8, 14]))
+                    WeatherId=random.choice([1, 3, 7, 8, 14]),
+                    QualityLevel=args.quality_level)
                 settings.randomize_seeds()
 
                 # Now we want to add a couple of cameras to the player vehicle.
@@ -201,6 +202,12 @@ def main():
         '-l', '--lidar',
         action='store_true',
         help='enable Lidar')
+    argparser.add_argument(
+        '-q', '--quality-level',
+        choices=['Low', 'Epic'],
+        type=lambda s: s.title(),
+        default='Epic',
+        help='graphics quality level, a lower level makes the simulation run considerably faster.')
     argparser.add_argument(
         '-i', '--images-to-disk',
         action='store_true',

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -199,6 +199,15 @@ void ACarlaGameModeBase::BeginPlay()
   GameController->BeginPlay();
 }
 
+void ACarlaGameModeBase::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	Super::EndPlay(EndPlayReason);
+	if(CarlaSettingsDelegate!=nullptr && EndPlayReason==EEndPlayReason::EndPlayInEditor)
+	{
+	  CarlaSettingsDelegate->Reset();
+	}
+}
+
 void ACarlaGameModeBase::Tick(float DeltaSeconds)
 {
   Super::Tick(DeltaSeconds);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -38,6 +38,8 @@ public:
 
   virtual void BeginPlay() override;
 
+  virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
   virtual void Tick(float DeltaSeconds) override;
 
   FDataRouter &GetDataRouter()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -11,9 +11,18 @@
 #include "Engine/PostProcessVolume.h"
 #include "UObjectIterator.h"
 
+///quality settings configuration between runs
+EQualitySettingsLevel UCarlaSettingsDelegate::AppliedLowPostResetQualitySettingsLevel = EQualitySettingsLevel::Epic;
+
 UCarlaSettingsDelegate::UCarlaSettingsDelegate() :
   ActorSpawnedDelegate(FOnActorSpawned::FDelegate::CreateUObject(this, &UCarlaSettingsDelegate::OnActorSpawned))
 {
+}
+
+void UCarlaSettingsDelegate::Reset()
+{
+	LaunchEpicQualityCommands(GetLocalWorld());
+	AppliedLowPostResetQualitySettingsLevel = EQualitySettingsLevel::Epic;
 }
 
 void UCarlaSettingsDelegate::RegisterSpawnHandler(UWorld *InWorld)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.h
@@ -21,6 +21,9 @@ public:
   /** Constructor */
   UCarlaSettingsDelegate();
 
+  /** Reset settings to default */
+  void Reset();
+
   /** Create the event trigger handler for all new spawned actors to be processed with a custom function here */
   void RegisterSpawnHandler(UWorld *World);
 
@@ -65,7 +68,7 @@ private:
 private:
 
   /** currently applied settings level after level is restarted */
-  EQualitySettingsLevel AppliedLowPostResetQualitySettingsLevel = EQualitySettingsLevel::Epic;
+  static EQualitySettingsLevel AppliedLowPostResetQualitySettingsLevel;
 
   /** */
   UCarlaSettings* CarlaSettings = nullptr;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/VehicleSpawnerBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/VehicleSpawnerBase.cpp
@@ -90,7 +90,7 @@ void AVehicleSpawnerBase::SetNumberOfVehicles(const int32 Count)
 void AVehicleSpawnerBase::TryToSpawnRandomVehicle()
 {
   auto SpawnPoint = GetRandomSpawnPoint();
-  if ((SpawnPoint != nullptr)) {
+  if (SpawnPoint != nullptr) {
       SpawnVehicleAtSpawnPoint(*SpawnPoint);
   } else {
     UE_LOG(LogCarla, Error, TEXT("Unable to find spawn point"));


### PR DESCRIPTION
#### Description

Added a switch to set the quality level of the simulation in both `client_example.py` and `manual_control.py`.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7, 3.5