### PR TITLE
Fix crash in Lidar

### DIFF
--- a/PythonClient/carla/sensor.py
+++ b/PythonClient/carla/sensor.py
@@ -121,7 +121,7 @@ class Lidar(Sensor):
     def __init__(self, name, **kwargs):
         super(Lidar, self).__init__(name, sensor_type="LIDAR_RAY_CAST")
         self.Channels = 32
-        self.Range = 5000.0
+        self.Range = 50.0
         self.PointsPerSecond = 56000
         self.RotationFrequency = 10.0
         self.UpperFovLimit = 10.0

--- a/PythonClient/client_example.py
+++ b/PythonClient/client_example.py
@@ -76,7 +76,7 @@ def run_carla_client(args):
                     lidar.set_rotation(0, 0, 0)
                     lidar.set(
                         Channels=32,
-                        Range=5000,
+                        Range=50,
                         PointsPerSecond=100000,
                         RotationFrequency=10,
                         UpperFovLimit=10,

--- a/PythonClient/manual_control.py
+++ b/PythonClient/manual_control.py
@@ -321,7 +321,7 @@ class CarlaGame(object):
 
         if self._lidar_measurement is not None:
             lidar_data = np.array(self._lidar_measurement.data[:, :2])
-            lidar_data /= 50.0
+            lidar_data *= 2.0
             lidar_data += 100.0
             lidar_data = np.fabs(lidar_data)
             lidar_data = lidar_data.astype(np.int32)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Lidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Lidar.cpp
@@ -60,7 +60,17 @@ void ALidar::ReadPoints(const float DeltaTime)
   const uint32 PointsToScanWithOneLaser =
     FMath::RoundHalfFromZero(
         Description->PointsPerSecond * DeltaTime / float(ChannelCount));
-  check(PointsToScanWithOneLaser > 0);
+
+  if (PointsToScanWithOneLaser <= 0)
+  {
+    UE_LOG(
+        LogCarla,
+        Warning,
+        TEXT("%s: no points requested this frame, try increasing the number of points per second."),
+        *GetName());
+    return;
+  }
+
   check(ChannelCount == LaserAngles.Num());
   check(Description != nullptr);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarMeasurement.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarMeasurement.h
@@ -75,9 +75,10 @@ public:
   {
     check(Header[1] > Channel);
     Header[2u + Channel] += 1u;
-    Points.Emplace(Point.X);
-    Points.Emplace(Point.Y);
-    Points.Emplace(Point.Z);
+    constexpr float TO_METERS = 1e-2f;
+    Points.Emplace(TO_METERS * Point.X);
+    Points.Emplace(TO_METERS * Point.Y);
+    Points.Emplace(TO_METERS * Point.Z);
   }
 
   FSensorDataView GetView() const


### PR DESCRIPTION
#### Description

  * Fixes #290 Crash when requesting too few Lidar points.
  * Fixes Lidar points were sent in centimeters.
  * Fixes some Lidar examples had incorrect units.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.6, 3.5