### PR TITLE
Fix race condition

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerGameController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerGameController.cpp
@@ -121,17 +121,18 @@ void FServerGameController::Tick(float DeltaSeconds)
 
   // Send measurements.
   {
-	if(CarlaSettings->bSynchronousMode)
-	{
-	  FlushRenderingCommands();
-	}
+    if (CarlaSettings->bSynchronousMode)
+    {
+      FlushRenderingCommands();
+    }
 
     if (Errc::Error == Server->SendMeasurements(
             DataRouter.GetPlayerState(),
             DataRouter.GetAgents(),
-            CarlaSettings->bSendNonPlayerAgentsInfo)) 
-	{
-      Server = nullptr;
+            CarlaSettings->bSendNonPlayerAgentsInfo))
+    {
+      // The error here must be ignored, otherwise we can create a race
+      // condition between the different ports.
       return;
     }
   }
@@ -140,12 +141,10 @@ void FServerGameController::Tick(float DeltaSeconds)
   {
     const bool bShouldBlock = CarlaSettings->bSynchronousMode;
     FVehicleControl Control;
-    if (Errc::Error == Server->ReadControl(Control, bShouldBlock)) {
-      Server = nullptr;
-      return;
-    } else {
+    if (Errc::Error != Server->ReadControl(Control, bShouldBlock))
+    {
       DataRouter.ApplyVehicleControl(Control);
-    }
+    } // Here we ignore the error too.
   }
 }
 


### PR DESCRIPTION
#### Description

Fix the race condition between the client and server that causes the server
to reset the connection.

Now disconnect errors in ports 2001 and 2002 are ignored.

Fixes #297.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
