### PR TITLE
Include map name in scene description message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           packages:
             - cppcheck
       script:
-        - cppcheck . -iBuild -i.pb.cc --error-exitcode=1 --enable=warning --quiet
+        - cppcheck . -iBuild -i.pb.cc --error-exitcode=1 --enable=warning --inline-suppr --quiet
 
     - env: TEST="MkDocs"
       install:

--- a/PythonClient/carla/carla_server_pb2.py
+++ b/PythonClient/carla/carla_server_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='carla_server.proto',
   package='carla_server',
   syntax='proto3',
-  serialized_pb=_b('\n\x12\x63\x61rla_server.proto\x12\x0c\x63\x61rla_server\"+\n\x08Vector3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"6\n\nRotation3D\x12\r\n\x05pitch\x18\x01 \x01(\x02\x12\x0b\n\x03yaw\x18\x02 \x01(\x02\x12\x0c\n\x04roll\x18\x03 \x01(\x02\"\x92\x01\n\tTransform\x12(\n\x08location\x18\x01 \x01(\x0b\x32\x16.carla_server.Vector3D\x12/\n\x0borientation\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3DB\x02\x18\x01\x12*\n\x08rotation\x18\x03 \x01(\x0b\x32\x18.carla_server.Rotation3D\"a\n\x0b\x42oundingBox\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12&\n\x06\x65xtent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\"\x80\x01\n\x06Sensor\x12\n\n\x02id\x18\x01 \x01(\x07\x12\'\n\x04type\x18\x02 \x01(\x0e\x32\x19.carla_server.Sensor.Type\x12\x0c\n\x04name\x18\x03 \x01(\t\"3\n\x04Type\x12\x0b\n\x07UNKNOWN\x10\x00\x12\n\n\x06\x43\x41MERA\x10\x01\x12\x12\n\x0eLIDAR_RAY_CAST\x10\x02\"}\n\x07Vehicle\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x04 \x01(\x0b\x32\x19.carla_server.BoundingBox\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x80\x01\n\nPedestrian\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x04 \x01(\x0b\x32\x19.carla_server.BoundingBox\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x94\x01\n\x0cTrafficLight\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x05state\x18\x02 \x01(\x0e\x32 .carla_server.TrafficLight.State\"\'\n\x05State\x12\t\n\x05GREEN\x10\x00\x12\n\n\x06YELLOW\x10\x01\x12\x07\n\x03RED\x10\x02\"Q\n\x0eSpeedLimitSign\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12\x13\n\x0bspeed_limit\x18\x02 \x01(\x02\"\xe5\x01\n\x05\x41gent\x12\n\n\x02id\x18\x01 \x01(\x07\x12(\n\x07vehicle\x18\x02 \x01(\x0b\x32\x15.carla_server.VehicleH\x00\x12.\n\npedestrian\x18\x03 \x01(\x0b\x32\x18.carla_server.PedestrianH\x00\x12\x33\n\rtraffic_light\x18\x04 \x01(\x0b\x32\x1a.carla_server.TrafficLightH\x00\x12\x38\n\x10speed_limit_sign\x18\x05 \x01(\x0b\x32\x1c.carla_server.SpeedLimitSignH\x00\x42\x07\n\x05\x61gent\"%\n\x11RequestNewEpisode\x12\x10\n\x08ini_file\x18\x01 \x01(\t\"n\n\x10SceneDescription\x12\x33\n\x12player_start_spots\x18\x01 \x03(\x0b\x32\x17.carla_server.Transform\x12%\n\x07sensors\x18\x02 \x03(\x0b\x32\x14.carla_server.Sensor\"/\n\x0c\x45pisodeStart\x12\x1f\n\x17player_start_spot_index\x18\x01 \x01(\r\"\x1d\n\x0c\x45pisodeReady\x12\r\n\x05ready\x18\x01 \x01(\x08\"^\n\x07\x43ontrol\x12\r\n\x05steer\x18\x01 \x01(\x02\x12\x10\n\x08throttle\x18\x02 \x01(\x02\x12\r\n\x05\x62rake\x18\x03 \x01(\x02\x12\x12\n\nhand_brake\x18\x04 \x01(\x08\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\"\xd1\x04\n\x0cMeasurements\x12\x14\n\x0c\x66rame_number\x18\x05 \x01(\x04\x12\x1a\n\x12platform_timestamp\x18\x01 \x01(\r\x12\x16\n\x0egame_timestamp\x18\x02 \x01(\r\x12J\n\x13player_measurements\x18\x03 \x01(\x0b\x32-.carla_server.Measurements.PlayerMeasurements\x12.\n\x11non_player_agents\x18\x04 \x03(\x0b\x32\x13.carla_server.Agent\x1a\xfa\x02\n\x12PlayerMeasurements\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x0c \x01(\x0b\x32\x19.carla_server.BoundingBox\x12,\n\x0c\x61\x63\x63\x65leration\x18\x03 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x04 \x01(\x02\x12\x1a\n\x12\x63ollision_vehicles\x18\x05 \x01(\x02\x12\x1d\n\x15\x63ollision_pedestrians\x18\x06 \x01(\x02\x12\x17\n\x0f\x63ollision_other\x18\x07 \x01(\x02\x12\x1e\n\x16intersection_otherlane\x18\x08 \x01(\x02\x12\x1c\n\x14intersection_offroad\x18\t \x01(\x02\x12\x30\n\x11\x61utopilot_control\x18\n \x01(\x0b\x32\x15.carla_server.ControlB\x03\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x12\x63\x61rla_server.proto\x12\x0c\x63\x61rla_server\"+\n\x08Vector3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"6\n\nRotation3D\x12\r\n\x05pitch\x18\x01 \x01(\x02\x12\x0b\n\x03yaw\x18\x02 \x01(\x02\x12\x0c\n\x04roll\x18\x03 \x01(\x02\"\x92\x01\n\tTransform\x12(\n\x08location\x18\x01 \x01(\x0b\x32\x16.carla_server.Vector3D\x12/\n\x0borientation\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3DB\x02\x18\x01\x12*\n\x08rotation\x18\x03 \x01(\x0b\x32\x18.carla_server.Rotation3D\"a\n\x0b\x42oundingBox\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12&\n\x06\x65xtent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\"\x80\x01\n\x06Sensor\x12\n\n\x02id\x18\x01 \x01(\x07\x12\'\n\x04type\x18\x02 \x01(\x0e\x32\x19.carla_server.Sensor.Type\x12\x0c\n\x04name\x18\x03 \x01(\t\"3\n\x04Type\x12\x0b\n\x07UNKNOWN\x10\x00\x12\n\n\x06\x43\x41MERA\x10\x01\x12\x12\n\x0eLIDAR_RAY_CAST\x10\x02\"}\n\x07Vehicle\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x04 \x01(\x0b\x32\x19.carla_server.BoundingBox\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x80\x01\n\nPedestrian\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x04 \x01(\x0b\x32\x19.carla_server.BoundingBox\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x94\x01\n\x0cTrafficLight\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x05state\x18\x02 \x01(\x0e\x32 .carla_server.TrafficLight.State\"\'\n\x05State\x12\t\n\x05GREEN\x10\x00\x12\n\n\x06YELLOW\x10\x01\x12\x07\n\x03RED\x10\x02\"Q\n\x0eSpeedLimitSign\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12\x13\n\x0bspeed_limit\x18\x02 \x01(\x02\"\xe5\x01\n\x05\x41gent\x12\n\n\x02id\x18\x01 \x01(\x07\x12(\n\x07vehicle\x18\x02 \x01(\x0b\x32\x15.carla_server.VehicleH\x00\x12.\n\npedestrian\x18\x03 \x01(\x0b\x32\x18.carla_server.PedestrianH\x00\x12\x33\n\rtraffic_light\x18\x04 \x01(\x0b\x32\x1a.carla_server.TrafficLightH\x00\x12\x38\n\x10speed_limit_sign\x18\x05 \x01(\x0b\x32\x1c.carla_server.SpeedLimitSignH\x00\x42\x07\n\x05\x61gent\"%\n\x11RequestNewEpisode\x12\x10\n\x08ini_file\x18\x01 \x01(\t\"\x80\x01\n\x10SceneDescription\x12\x10\n\x08map_name\x18\x03 \x01(\t\x12\x33\n\x12player_start_spots\x18\x01 \x03(\x0b\x32\x17.carla_server.Transform\x12%\n\x07sensors\x18\x02 \x03(\x0b\x32\x14.carla_server.Sensor\"/\n\x0c\x45pisodeStart\x12\x1f\n\x17player_start_spot_index\x18\x01 \x01(\r\"\x1d\n\x0c\x45pisodeReady\x12\r\n\x05ready\x18\x01 \x01(\x08\"^\n\x07\x43ontrol\x12\r\n\x05steer\x18\x01 \x01(\x02\x12\x10\n\x08throttle\x18\x02 \x01(\x02\x12\r\n\x05\x62rake\x18\x03 \x01(\x02\x12\x12\n\nhand_brake\x18\x04 \x01(\x08\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\"\xd1\x04\n\x0cMeasurements\x12\x14\n\x0c\x66rame_number\x18\x05 \x01(\x04\x12\x1a\n\x12platform_timestamp\x18\x01 \x01(\r\x12\x16\n\x0egame_timestamp\x18\x02 \x01(\r\x12J\n\x13player_measurements\x18\x03 \x01(\x0b\x32-.carla_server.Measurements.PlayerMeasurements\x12.\n\x11non_player_agents\x18\x04 \x03(\x0b\x32\x13.carla_server.Agent\x1a\xfa\x02\n\x12PlayerMeasurements\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x0c\x62ounding_box\x18\x0c \x01(\x0b\x32\x19.carla_server.BoundingBox\x12,\n\x0c\x61\x63\x63\x65leration\x18\x03 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x04 \x01(\x02\x12\x1a\n\x12\x63ollision_vehicles\x18\x05 \x01(\x02\x12\x1d\n\x15\x63ollision_pedestrians\x18\x06 \x01(\x02\x12\x17\n\x0f\x63ollision_other\x18\x07 \x01(\x02\x12\x1e\n\x16intersection_otherlane\x18\x08 \x01(\x02\x12\x1c\n\x14intersection_offroad\x18\t \x01(\x02\x12\x30\n\x11\x61utopilot_control\x18\n \x01(\x0b\x32\x15.carla_server.ControlB\x03\xf8\x01\x01\x62\x06proto3')
 )
 
 
@@ -564,14 +564,21 @@ _SCENEDESCRIPTION = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='player_start_spots', full_name='carla_server.SceneDescription.player_start_spots', index=0,
+      name='map_name', full_name='carla_server.SceneDescription.map_name', index=0,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='player_start_spots', full_name='carla_server.SceneDescription.player_start_spots', index=1,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sensors', full_name='carla_server.SceneDescription.sensors', index=1,
+      name='sensors', full_name='carla_server.SceneDescription.sensors', index=2,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -589,8 +596,8 @@ _SCENEDESCRIPTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1279,
-  serialized_end=1389,
+  serialized_start=1280,
+  serialized_end=1408,
 )
 
 
@@ -620,8 +627,8 @@ _EPISODESTART = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1391,
-  serialized_end=1438,
+  serialized_start=1410,
+  serialized_end=1457,
 )
 
 
@@ -651,8 +658,8 @@ _EPISODEREADY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1440,
-  serialized_end=1469,
+  serialized_start=1459,
+  serialized_end=1488,
 )
 
 
@@ -710,8 +717,8 @@ _CONTROL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1471,
-  serialized_end=1565,
+  serialized_start=1490,
+  serialized_end=1584,
 )
 
 
@@ -804,8 +811,8 @@ _MEASUREMENTS_PLAYERMEASUREMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1783,
-  serialized_end=2161,
+  serialized_start=1802,
+  serialized_end=2180,
 )
 
 _MEASUREMENTS = _descriptor.Descriptor(
@@ -862,8 +869,8 @@ _MEASUREMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1568,
-  serialized_end=2161,
+  serialized_start=1587,
+  serialized_end=2180,
 )
 
 _TRANSFORM.fields_by_name['location'].message_type = _VECTOR3D

--- a/PythonClient/client_example.py
+++ b/PythonClient/client_example.py
@@ -103,7 +103,7 @@ def run_carla_client(args):
             # Notify the server that we want to start the episode at the
             # player_start index. This function blocks until the server is ready
             # to start the episode.
-            print('Starting new episode...')
+            print('Starting new episode at %r...' % scene.map_name)
             client.start_episode(player_start)
 
             # Iterate every frame in the episode.

--- a/PythonClient/view_start_positions.py
+++ b/PythonClient/view_start_positions.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 
 import argparse
 import logging
+import sys
 import time
 
 import matplotlib.image as mpimg
@@ -36,16 +37,13 @@ def view_start_positions(args):
         scene = client.load_settings(CarlaSettings())
         print("Received the start positions")
 
-        # We get the number of player starts, in order to detect the city.
-        number_of_player_starts = len(scene.player_start_spots)
-        if number_of_player_starts > 100:  # WARNING: unsafe way to check for city, see issue #313
-            image = mpimg.imread("carla/planner/Town01.png")
-            carla_map = CarlaMap('Town01', 0.1653, 50)
-
-        else:
-
-            image = mpimg.imread("carla/planner/Town02.png")
-            carla_map = CarlaMap('Town02', 0.1653, 50)
+        try:
+            image = mpimg.imread('carla/planner/%s.png' % scene.map_name)
+            carla_map = CarlaMap(scene.map_name, 0.1653, 50)
+        except IOError as exception:
+            logging.error(exception)
+            logging.error('Cannot find map "%s"', scene.map_name)
+            sys.exit(1)
 
         fig, ax = plt.subplots(1)
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -68,10 +68,12 @@ void ACarlaGameModeBase::InitGame(
       constexpr auto PIEPrefix = TEXT("UEDPIE_0_");
       CorrectedMapName.RemoveFromStart(PIEPrefix);
       UE_LOG(LogCarla, Log, TEXT("Corrected map name from %s to %s"), *MapName, *CorrectedMapName);
-      CarlaSettings.LoadWeatherDescriptions(CorrectedMapName);
+      CarlaSettings.MapName = CorrectedMapName;
+      CarlaSettings.LoadWeatherDescriptions();
     }
 #else
-    CarlaSettings.LoadWeatherDescriptions(MapName);
+    CarlaSettings.MapName = MapName;
+    CarlaSettings.LoadWeatherDescriptions();
 #endif // WITH_EDITOR
     GameController->Initialize(CarlaSettings);
     CarlaSettings.ValidateWeatherId();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Lidar.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Lidar.h
@@ -37,7 +37,7 @@ private:
   bool ShootLaser(uint32 Channel, float HorizontalAngle, FVector &Point) const;
 
   UPROPERTY(Category = "Lidar", VisibleAnywhere)
-  const ULidarDescription *Description;
+  const ULidarDescription *Description = nullptr;
 
   TArray<float> LaserAngles;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaEncoder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaEncoder.cpp
@@ -24,18 +24,6 @@ static constexpr float TO_METERS = 1e-2;
 // -- Static local methods -----------------------------------------------------
 // =============================================================================
 
-static auto MakeCharBuffer(const FString &String)
-{
-  const char *Ptr = TCHAR_TO_UTF8(*String);
-  auto Buffer = MakeUnique<char[]>(std::strlen(Ptr) + 1u); // + null terminator.
-  #if defined(_WIN32)
-  strcpy_s(Buffer.Get(),String.Len()+1, Ptr);
-  #else
-  std::strcpy(Buffer.Get(), Ptr);
-  #endif
-  return TUniquePtr<const char[]>(Buffer.Release());
-}
-
 static void Encode(const FVector &Vector, carla_vector3d &Data)
 {
   Data = {Vector.X, Vector.Y, Vector.Z};
@@ -67,7 +55,7 @@ static TUniquePtr<const char[]> Encode(
       else return CARLA_SERVER_SENSOR_UNKNOWN;
 #undef CARLA_CHECK_TYPE
   }(SensorDescription.Type);
-  auto Memory = MakeCharBuffer(SensorDescription.Name);
+  auto Memory = FCarlaEncoder::Encode(SensorDescription.Name);
   Data.name = Memory.Get();
   return Memory;
 }
@@ -75,6 +63,18 @@ static TUniquePtr<const char[]> Encode(
 // =============================================================================
 // -- FCarlaEncoder static methods ---------------------------------------------
 // =============================================================================
+
+TUniquePtr<const char[]> FCarlaEncoder::Encode(const FString &String)
+{
+  const char *Ptr = TCHAR_TO_UTF8(*String);
+  auto Buffer = MakeUnique<char[]>(std::strlen(Ptr) + 1u); // + null terminator.
+#if defined(_WIN32)
+  strcpy_s(Buffer.Get(),String.Len()+1, Ptr);
+#else
+  std::strcpy(Buffer.Get(), Ptr);
+#endif
+  return TUniquePtr<const char[]>(Buffer.Release());
+}
 
 void FCarlaEncoder::Encode(
     const TArray<APlayerStart *> &AvailableStartSpots,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaEncoder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaEncoder.h
@@ -18,6 +18,8 @@ class FCarlaEncoder : private IAgentComponentVisitor
 {
 public:
 
+  static TUniquePtr<const char[]> Encode(const FString &String);
+
   static void Encode(
     const TArray<APlayerStart *> &AvailableStartSpots,
     TArray<carla_transform> &Data);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -71,11 +71,15 @@ FCarlaServer::ErrorCode FCarlaServer::ReadNewEpisode(FString &IniFile, const boo
 }
 
 FCarlaServer::ErrorCode FCarlaServer::SendSceneDescription(
+    const FString &MapName,
     const TArray<APlayerStart *> &AvailableStartSpots,
     const TArray<USensorDescription *> &SensorDescriptions,
     const bool bBlocking)
 {
   carla_scene_description scene;
+  // Encode map name.
+  const auto MapNameBuffer = FCarlaEncoder::Encode(MapName);
+  scene.map_name = MapNameBuffer.Get();
   // Encode start spots.
   TArray<carla_transform> Transforms;
   FCarlaEncoder::Encode(AvailableStartSpots, Transforms);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
@@ -37,6 +37,7 @@ public:
   ErrorCode ReadNewEpisode(FString &IniFile, bool bBlocking);
 
   ErrorCode SendSceneDescription(
+      const FString &MapName,
       const TArray<APlayerStart *> &AvailableStartSpots,
       const TArray<USensorDescription *> &SensorDescriptions,
       bool bBlocking);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerGameController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerGameController.cpp
@@ -54,7 +54,8 @@ APlayerStart *FServerGameController::ChoosePlayerStart(
   if (Server.IsValid()) {
     TArray<USensorDescription *> Sensors;
     CarlaSettings->SensorDescriptions.GenerateValueArray(Sensors);
-    if (Errc::Success != Server->SendSceneDescription(AvailableStartSpots, Sensors, BLOCKING)) {
+    const auto &MapName = CarlaSettings->MapName;
+    if (Errc::Success != Server->SendSceneDescription(MapName, AvailableStartSpots, Sensors, BLOCKING)) {
       UE_LOG(LogCarlaServer, Warning, TEXT("Failed to send scene description, server needs restart"));
       Server = nullptr;
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -218,7 +218,7 @@ void UCarlaSettings::LoadSettingsFromString(const FString &INIFileContents)
   CurrentFileName = TEXT("<string-provided-by-client>");
 }
 
-void UCarlaSettings::LoadWeatherDescriptions(const FString &MapName)
+void UCarlaSettings::LoadWeatherDescriptions()
 {
   WeatherDescriptions.Empty();
   ADynamicWeather::LoadWeatherDescriptionsFromFile(MapName, WeatherDescriptions);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
@@ -9,7 +9,6 @@
 #include "WeatherDescription.h"
 #include "CarlaSettings.generated.h"
 
-
 UENUM(BlueprintType)
 enum class EQualitySettingsLevel : uint8
 {
@@ -17,8 +16,7 @@ enum class EQualitySettingsLevel : uint8
   Low     UMETA(DisplayName = "Low"),
   Medium  UMETA(DisplayName = "Medium"),
   High    UMETA(DisplayName = "High"),
-  Epic    UMETA(DisplayName = "Epic") 
-	
+  Epic    UMETA(DisplayName = "Epic")
 };
 
 UCLASS(BlueprintType)
@@ -27,12 +25,13 @@ class CARLA_API UQualitySettings : public UObject
 	GENERATED_BODY()
 
 public:
+
  using uint_type = typename std::underlying_type<EQualitySettingsLevel>::type;
  UFUNCTION(BlueprintCallable)
  static EQualitySettingsLevel FromString(const FString &SQualitySettingsLevel);
  UFUNCTION(BlueprintCallable)
  static FString ToString(EQualitySettingsLevel QualitySettingsLevel);
- 
+
  static constexpr uint_type ToUInt(EQualitySettingsLevel quality_settings_level)
  {
    return static_cast<uint_type>(quality_settings_level);
@@ -52,11 +51,11 @@ class CARLA_API UCarlaSettings : public UObject
   GENERATED_BODY()
 
 public:
-  
-  /** 
-   * Sets the new quality settings level and make changes in the game related to it. 
+
+  /**
+   * Sets the new quality settings level and make changes in the game related to it.
    * @note This will not apply the quality settings. Use ApplyQualitySettings functions instead
-   * @param newQualityLevel Store the new quality 
+   * @param newQualityLevel Store the new quality
    */
   UFUNCTION(BlueprintCallable, Category="CARLA Settings")
   void SetQualitySettingsLevel(EQualitySettingsLevel newQualityLevel);
@@ -64,7 +63,7 @@ public:
   /** @return current quality settings level (could not be applied yet) */
   UFUNCTION(BlueprintCallable, Category="CARLA Settings")
   EQualitySettingsLevel GetQualitySettingsLevel() const { return QualitySettingsLevel; }
-  
+
   /** Load the settings based on the command-line arguments and the INI file if provided. */
   void LoadSettings();
 
@@ -72,7 +71,7 @@ public:
   void LoadSettingsFromString(const FString &INIFileContents);
 
   /** Load weather description from config files. (There may be overrides for each map). */
-  void LoadWeatherDescriptions(const FString &MapName);
+  void LoadWeatherDescriptions();
 
   /** Check if requested weather id is present in WeatherDescriptions. */
   void ValidateWeatherId();
@@ -97,6 +96,7 @@ public:
 
   UFUNCTION(BlueprintCallable)
   const FWeatherDescription &GetWeatherDescriptionByIndex(int32 Index);
+
   ///----------- constants ------------------
 public:
   /**
@@ -104,11 +104,12 @@ public:
    */
   static const FName CARLA_ROAD_TAG;
   /**
-   * CARLA_SKY name to tag the sky sphere (BPS) actors in the scenes 
+   * CARLA_SKY name to tag the sky sphere (BPS) actors in the scenes
    */
   static const FName CARLA_SKY_TAG;
 
 private:
+
   /***/
   void LoadSettingsFromFile(const FString &FilePath, bool bLogOnFailure);
 
@@ -155,6 +156,10 @@ public:
   /// @{
 public:
 
+  /** Display name of the current map. */
+  UPROPERTY(Category = "Level Settings", VisibleAnywhere)
+  FString MapName;
+
   /** Path to the pawn class of the player. */
   UPROPERTY(Category = "Level Settings", VisibleAnywhere)
   FString PlayerVehicle;
@@ -183,7 +188,6 @@ public:
   UPROPERTY(Category = "Level Settings", VisibleAnywhere)
   int32 SeedVehicles = 123456789;
 
-  
   /// @}
 
   // ===========================================================================
@@ -191,14 +195,16 @@ public:
   // ===========================================================================
   /// @{
 private:
+
   /** Quality Settings level. */
   UPROPERTY(Category = "Quality Settings", VisibleAnywhere, meta =(AllowPrivateAccess="true"))
   EQualitySettingsLevel QualitySettingsLevel = EQualitySettingsLevel::Epic;
- 
- public:
+
+public:
+
   /** @TODO : Move Low quality vars to a generic map of structs with the quality level as key*/
 
-  /** Low quality Road Materials. 
+  /** Low quality Road Materials.
    * Uses slots name to set material for each part of the road for low quality
    */
   UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config, DisplayName="Road Materials List for Low Quality")
@@ -206,7 +212,7 @@ private:
 
   //distances
   /**
-   * Distance at which the light function should be completely faded to DisabledBrightness.  
+   * Distance at which the light function should be completely faded to DisabledBrightness.
    * This is useful for hiding aliasing from light functions applied in the distance.
    */
   UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config)
@@ -215,22 +221,22 @@ private:
   /**
    * Default low distance for all primitive components
    */
-  UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config, meta = (ClampMin = "5000.0", ClampMax = "20000.0", UIMin = "5000.0", UIMax = "20000.0")) 
+  UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config, meta = (ClampMin = "5000.0", ClampMax = "20000.0", UIMin = "5000.0", UIMax = "20000.0"))
   float LowStaticMeshMaxDrawDistance = 10000.0f;
 
   /**
    * Default low distance for roads meshes
    */
-  UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config, meta = (ClampMin = "5000.0", ClampMax = "20000.0", UIMin = "5000.0", UIMax = "20000.0")) 
+  UPROPERTY(Category = "Quality Settings/Low", BlueprintReadOnly, EditAnywhere, config, meta = (ClampMin = "5000.0", ClampMax = "20000.0", UIMin = "5000.0", UIMax = "20000.0"))
   float LowRoadPieceMeshMaxDrawDistance = 15000.0f;
 
 
-  /** EPIC quality Road Materials. 
+  /** EPIC quality Road Materials.
    * Uses slots name to set material for each part of the road for Epic quality
    */
   UPROPERTY(Category = "Quality Settings/Epic", BlueprintReadOnly, EditAnywhere, config, DisplayName="Road Materials List for EPIC Quality")
   TArray<FStaticMaterial> EpicRoadMaterials;
-  
+
   /// @}
 
   // ===========================================================================

--- a/Util/CarlaServer/include/carla/carla_server.h
+++ b/Util/CarlaServer/include/carla/carla_server.h
@@ -121,6 +121,8 @@ extern "C" {
   /* ======================================================================== */
 
   struct carla_scene_description {
+    /** Display name of the current map. */
+    const char *map_name;
     /** Collection of the initial player start locations. */
     const struct carla_transform *player_start_spots;
     uint32_t number_of_player_start_spots;

--- a/Util/CarlaServer/source/carla/server/CarlaEncoder.cpp
+++ b/Util/CarlaServer/source/carla/server/CarlaEncoder.cpp
@@ -132,6 +132,7 @@ namespace server {
   std::string CarlaEncoder::Encode(const carla_scene_description &values) {
     auto *message = _protobuf.CreateMessage<cs::SceneDescription>();
     DEBUG_ASSERT(message != nullptr);
+    message->set_map_name(std::string(values.map_name));
     for (auto &spot : start_spots(values)) {
       Set(message->add_player_start_spots(), spot);
     }

--- a/Util/CarlaServer/source/test/Test_CarlaServer.cpp
+++ b/Util/CarlaServer/source/test/Test_CarlaServer.cpp
@@ -84,6 +84,8 @@ TEST(CarlaServerAPI, SimBlocking) {
     {
       test_log("sending scene description...");
       const carla_scene_description values{
+          // cppcheck-suppress constStatement
+          "TestTown01",
           start_locations,
           SIZE_OF_ARRAY(start_locations),
           sensor_definitions,

--- a/Util/Proto/carla_server.proto
+++ b/Util/Proto/carla_server.proto
@@ -103,6 +103,7 @@ message RequestNewEpisode {
 }
 
 message SceneDescription {
+  string map_name = 3;
   repeated Transform player_start_spots = 1;
   repeated Sensor sensors = 2;
 }


### PR DESCRIPTION
#### Description

Adds an extra string to the scene description message with the current map name. I also updated `view_start_positions.py` and `manual_control.py` to use it.

Fixes #313.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/358)
<!-- Reviewable:end -->
