### PR TITLE
Fix bounding box was scaled twice when computing map intersection

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaVehicleController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaVehicleController.cpp
@@ -119,7 +119,7 @@ void ACarlaVehicleController::IntersectPlayerWithRoadMap()
   check(BoundingBox != nullptr);
   auto Result = RoadMap->Intersect(
       BoundingBox->GetComponentTransform(),
-      Vehicle->GetVehicleBoundingBoxExtent(), // Get scaled bounding box extent.
+      BoundingBox->GetUnscaledBoxExtent(),
       ChecksPerCentimeter);
 
   CarlaPlayerState->OffRoadIntersectionFactor = Result.OffRoad;


### PR DESCRIPTION
Bounding box was scaled twice when computing map intersection (bounding box transform already contains an scale).

Fixes #371.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/372)
<!-- Reviewable:end -->
