### PR TITLE
Changes in CarlaSettingsDelegate so it wont apply max distance culling to foliage in Low mode

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -37,7 +37,9 @@ public class Carla : ModuleRules
         "Engine",
         "PhysXVehicles",
         "Slate",
-        "SlateCore"
+        "SlateCore",
+        "Landscape",
+        "Foliage"
         // ... add private dependencies that you statically link with here ...
       }
       );

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -35,9 +35,9 @@ void UCarlaSettingsDelegate::RegisterSpawnHandler(UWorld *InWorld)
 void UCarlaSettingsDelegate::OnActorSpawned(AActor* InActor)
 {
   check(CarlaSettings!=nullptr);
-  if (InActor != nullptr && IsValid(InActor) && !InActor->IsPendingKill() && 
-      InActor->IsA<AInstancedFoliageActor>() || //foliage culling is controlled per instance
-      InActor->IsA<ALandscape>() || //dont touch landscapes nor roads
+  if (InActor != nullptr && IsValid(InActor) && !InActor->IsPendingKill() &&
+      !InActor->IsA<AInstancedFoliageActor>() && //foliage culling is controlled per instance
+      !InActor->IsA<ALandscape>() && //dont touch landscapes nor roads
 	  !InActor->ActorHasTag(UCarlaSettings::CARLA_ROAD_TAG) && 
 	  !InActor->ActorHasTag(UCarlaSettings::CARLA_SKY_TAG)
   ){

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -9,8 +9,9 @@
 #include "Engine/DirectionalLight.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/PostProcessVolume.h"
-#include "UObjectIterator.h"
 #include "Async.h"
+#include "Landscape.h"
+#include "InstancedFoliageActor.h"
 
 ///quality settings configuration between runs
 EQualitySettingsLevel UCarlaSettingsDelegate::AppliedLowPostResetQualitySettingsLevel = EQualitySettingsLevel::Epic;
@@ -35,9 +36,11 @@ void UCarlaSettingsDelegate::OnActorSpawned(AActor* InActor)
 {
   check(CarlaSettings!=nullptr);
   if (InActor != nullptr && IsValid(InActor) && !InActor->IsPendingKill() && 
+      InActor->IsA<AInstancedFoliageActor>() || //foliage culling is controlled per instance
+      InActor->IsA<ALandscape>() || //dont touch landscapes nor roads
 	  !InActor->ActorHasTag(UCarlaSettings::CARLA_ROAD_TAG) && 
 	  !InActor->ActorHasTag(UCarlaSettings::CARLA_SKY_TAG)
-  ){   
+  ){
 	 TArray<UActorComponent*> components = InActor->GetComponentsByClass(UPrimitiveComponent::StaticClass());
 	 switch(CarlaSettings->GetQualitySettingsLevel())
 	 {
@@ -63,7 +66,7 @@ void UCarlaSettingsDelegate::ApplyQualitySettingsLevelPostRestart()
 	CheckCarlaSettings(nullptr);
 	UWorld *InWorld = CarlaSettings->GetWorld();
   
-  EQualitySettingsLevel QualitySettingsLevel = CarlaSettings->GetQualitySettingsLevel();
+    const EQualitySettingsLevel QualitySettingsLevel = CarlaSettings->GetQualitySettingsLevel();
 	if(AppliedLowPostResetQualitySettingsLevel==QualitySettingsLevel) return;
 	
 	switch(QualitySettingsLevel)
@@ -190,8 +193,9 @@ void UCarlaSettingsDelegate::SetAllRoads(UWorld* world, const float max_draw_dis
     
     for(int32 i=0; i<actors.Num(); i++)
     {
-    if(!IsValid(actors[i]) || actors[i]->IsPendingKillPending()) continue;
-      TArray<UActorComponent*> components = actors[i]->GetComponentsByClass(UStaticMeshComponent::StaticClass());
+      AActor* actor = actors[i];
+      if(!IsValid(actor) || actor->IsPendingKillPending()) continue;
+      TArray<UActorComponent*> components = actor->GetComponentsByClass(UStaticMeshComponent::StaticClass());
       for(int32 j=0; j<components.Num(); j++)
       {
         UStaticMeshComponent* staticmeshcomponent = Cast<UStaticMeshComponent>(components[j]);
@@ -257,13 +261,16 @@ void UCarlaSettingsDelegate::SetAllActorsDrawDistance(UWorld* world, const float
     UGameplayStatics::GetAllActorsOfClass(world, AActor::StaticClass(),actors);
     for(int32 i=0; i<actors.Num(); i++)
     {
-    if(!IsValid(actors[i]) || actors[i]->IsPendingKillPending() || 
-      actors[i]->ActorHasTag(UCarlaSettings::CARLA_ROAD_TAG) ||
-      actors[i]->ActorHasTag(UCarlaSettings::CARLA_SKY_TAG)
+      AActor* actor = actors[i];
+      if(!IsValid(actor) || actor->IsPendingKillPending() || 
+        actor->IsA<AInstancedFoliageActor>() || //foliage culling is controlled per instance
+        actor->IsA<ALandscape>() || //dont touch landscapes nor roads
+        actor->ActorHasTag(UCarlaSettings::CARLA_ROAD_TAG) ||
+        actor->ActorHasTag(UCarlaSettings::CARLA_SKY_TAG)
       ){
         continue;
       }
-      SetActorComponentsDrawDistance(actors[i], max_draw_distance);
+      SetActorComponentsDrawDistance(actor, max_draw_distance);
     }
   });
 }
@@ -275,8 +282,9 @@ void UCarlaSettingsDelegate::SetPostProcessEffectsEnabled(UWorld* world, const b
   UGameplayStatics::GetAllActorsOfClass(world, APostProcessVolume::StaticClass(), actors);
   for(int32 i=0; i<actors.Num(); i++)
   {
-	  if(!IsValid(actors[i]) || actors[i]->IsPendingKillPending()) continue;
-      APostProcessVolume* postprocessvolume = Cast<APostProcessVolume>(actors[i]);
+      AActor* actor = actors[i];
+	  if(!IsValid(actor) || actor->IsPendingKillPending()) continue;
+      APostProcessVolume* postprocessvolume = Cast<APostProcessVolume>(actor);
 	  if(postprocessvolume)
 	  {
   		postprocessvolume->bEnabled = enabled;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -194,7 +194,7 @@ void UCarlaSettingsDelegate::SetAllRoads(UWorld* world, const float max_draw_dis
     for(int32 i=0; i<actors.Num(); i++)
     {
       AActor* actor = actors[i];
-      if(!IsValid(actor) || actor->IsPendingKillPending()) continue;
+      if(!IsValid(actor) || actor->IsPendingKill()) continue;
       TArray<UActorComponent*> components = actor->GetComponentsByClass(UStaticMeshComponent::StaticClass());
       for(int32 j=0; j<components.Num(); j++)
       {
@@ -262,7 +262,7 @@ void UCarlaSettingsDelegate::SetAllActorsDrawDistance(UWorld* world, const float
     for(int32 i=0; i<actors.Num(); i++)
     {
       AActor* actor = actors[i];
-      if(!IsValid(actor) || actor->IsPendingKillPending() || 
+      if(!IsValid(actor) || actor->IsPendingKill() || 
         actor->IsA<AInstancedFoliageActor>() || //foliage culling is controlled per instance
         actor->IsA<ALandscape>() || //dont touch landscapes nor roads
         actor->ActorHasTag(UCarlaSettings::CARLA_ROAD_TAG) ||
@@ -283,7 +283,7 @@ void UCarlaSettingsDelegate::SetPostProcessEffectsEnabled(UWorld* world, const b
   for(int32 i=0; i<actors.Num(); i++)
   {
       AActor* actor = actors[i];
-	  if(!IsValid(actor) || actor->IsPendingKillPending()) continue;
+	  if(!IsValid(actor) || actor->IsPendingKill()) continue;
       APostProcessVolume* postprocessvolume = Cast<APostProcessVolume>(actor);
 	  if(postprocessvolume)
 	  {
@@ -342,7 +342,7 @@ void UCarlaSettingsDelegate::SetAllLights(UWorld* world, const float max_distanc
     UGameplayStatics::GetAllActorsOfClass(world, ALight::StaticClass(), actors);
     for(int32 i=0;i<actors.Num();i++)
     {
-    if(!IsValid(actors[i]) || actors[i]->IsPendingKillPending()) continue;
+    if(!IsValid(actors[i]) || actors[i]->IsPendingKill()) continue;
       //tweak directional lights
       ADirectionalLight* directionallight = Cast<ADirectionalLight>(actors[i]);
       if(directionallight)


### PR DESCRIPTION
Fix #396 
Now we don't get all the actors primitive components for landscapes actors or instancedfoliage actors to apply the max culling distance to them when the settings quality changes.

### Where has this been tested?

  * **Platform(s): Windows 10 x64
  * **Unreal Engine version(s):** 4.18.3

### Possible Drawbacks
Foliage models should now define a max distance for culling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/397)
<!-- Reviewable:end -->
