### PR TITLE
Speed up setup script

### DIFF
--- a/Docs/how_to_build_on_linux.md
+++ b/Docs/how_to_build_on_linux.md
@@ -47,7 +47,8 @@ Note that the `master` branch contains the latest fixes and features, for the
 latest stable code may be best to switch to the latest release tag.
 
 Run the setup script to download the content and build all dependencies. It
-takes a while
+takes a while (you can speed up the process by parallelizing the script with the
+`--jobs=8` flag)
 
     $ ./Setup.sh
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
         stage('Setup') {
             steps {
-                sh './Setup.sh'
+                sh './Setup.sh --jobs=12'
             }
         }
 


### PR DESCRIPTION
A couple of measures to speed up the _Setup.sh_ script.

  * Added an option to run the `make` commands with multiple async jobs.
  * Boost only compiles the used libraries, `system`.

It runs now in about 5min30s in our build machine (before it was 12min) :+1:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/408)
<!-- Reviewable:end -->
