### PR TITLE
 Adding unit/acceptance test for map changing

### DIFF
--- a/PythonClient/carla/settings.py
+++ b/PythonClient/carla/settings.py
@@ -39,6 +39,7 @@ class CarlaSettings(object):
         # [CARLA/QualitySettings]
         self.QualityLevel = 'Epic'
         # [CARLA/LevelSettings]
+        self.MapName = 'Town02'
         self.PlayerVehicle = None
         self.NumberOfVehicles = 20
         self.NumberOfPedestrians = 30
@@ -97,6 +98,7 @@ class CarlaSettings(object):
         add_section(S_QUALITY, self, [
             'QualityLevel'])
         add_section(S_LEVEL, self, [
+            'MapName',
             'NumberOfVehicles',
             'NumberOfPedestrians',
             'WeatherId',

--- a/PythonClient/test/acceptance_tests/test_map_changing.py
+++ b/PythonClient/test/acceptance_tests/test_map_changing.py
@@ -1,0 +1,92 @@
+"""
+For now we use the unit tests for this part
+Basically the difference between this folder and the other, the unit tests folder
+is that the acceptance tests is carla based
+
+TODO: Change the name
+
+"""
+
+import unittest
+import random
+import time
+
+from carla.client import make_carla_client
+from carla.sensor import Camera, Lidar
+from carla.settings import CarlaSettings
+
+from carla.util import print_over_same_line
+
+from carla.tcp import TCPConnectionError
+
+from carla.driving_benchmark.experiment_suites.basic_experiment_suite import BasicExperimentSuite
+
+from carla.driving_benchmark.experiment_suites.corl_2017 import CoRL2017
+
+
+def print_measurements(measurements):
+    number_of_agents = len(measurements.non_player_agents)
+    player_measurements = measurements.player_measurements
+    message = 'Vehicle at ({pos_x:.1f}, {pos_y:.1f}), '
+    message += '{speed:.0f} km/h, '
+    message += 'Collision: {{vehicles={col_cars:.0f}, pedestrians={col_ped:.0f}, other={col_other:.0f}}}, '
+    message += '{other_lane:.0f}% other lane, {offroad:.0f}% off-road, '
+    message += '({agents_num:d} non-player agents in the scene)'
+    message = message.format(
+        pos_x=player_measurements.transform.location.x,
+        pos_y=player_measurements.transform.location.y,
+        speed=player_measurements.forward_speed * 3.6, # m/s -> km/h
+        col_cars=player_measurements.collision_vehicles,
+        col_ped=player_measurements.collision_pedestrians,
+        col_other=player_measurements.collision_other,
+        other_lane=100 * player_measurements.intersection_otherlane,
+        offroad=100 * player_measurements.intersection_offroad,
+        agents_num=number_of_agents)
+    print_over_same_line(message)
+
+
+
+class testMapChanging(unittest.TestCase):
+
+
+
+
+    def test_properties(self):
+        # Here we will run 3 episodes with 300 frames each.
+
+
+        with make_carla_client('127.0.0.1', 2000) as client:
+            print('CarlaClient connected')
+
+            # Run Eight episodes
+            for episode in range(0, 8):
+                # Start a new episode.
+
+
+                # We take different map on each episode
+                if episode % 2 == 0:
+                    map_name = "Town01"
+                else:
+                    map_name = "Town02"
+
+                settings = CarlaSettings()
+                settings.set(
+                    SynchronousMode=True,
+                    SendNonPlayerAgentsInfo=True,
+                    MapName=map_name,
+                    NumberOfVehicles=20,
+                    NumberOfPedestrians=40,
+                    WeatherId=random.choice([1, 3, 7, 8, 14]),
+                    QualityLevel='Epic')
+                settings.randomize_seeds()
+
+
+                scene = client.load_settings(settings)
+
+
+
+                print('Starting new episode at %r...' % scene.map_name)
+                client.start_episode(0)
+                time.sleep(1)
+                # Check if the map loaded in the settings is the map received as loaded.
+                self.assertEqual(scene.map_name, map_name)


### PR DESCRIPTION
Hello @juaxix,
Thanks for the very useful feature of map changing on client side !
First of all, I added on carla/settings.py the possibility of changing the map name
on the carla settings code. Quite trivial.

Now about the tests.
At first it seemed to be working correctly. I was able to start CARLA on Town01 and execute
tests on Town02. However I decided to make a test to stress this map change since it is a very
important functionality.
For that, I created the acceptance_test called " test_map_changing.py"
Basically, what it does is changing maps from Town01 to Town02 and then Town02 to Town01 ...
repeating this process 8 times. At each time it asserts if the map name received is the same
as the map loaded by the client. 
What happens is the following:

It starts on town 01 , receives town01  --- Correct
It starts on town 02 , receives town02  --- Correct
Then something weird happens:
It starts on town 01 , receives town02 and the connection crashes!

Please accept the pull request and try to reproduce the problem by running the test_map_changing.py
script with nosetests3. 

Thanks again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/472)
<!-- Reviewable:end -->
