### PR TITLE
Change HUD: replace "FPS" by "Simulation Step"

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
@@ -69,11 +69,12 @@ static FText GetHUDText(const ACarlaPlayerState &Vehicle)
   HighPrecision.MinimumFractionalDigits = 2u;
   HighPrecision.MaximumFractionalDigits = 2u;
 
+  constexpr float TO_MILLISECONDS = 1e3;
   constexpr float TO_METERS = 1e-2;
   constexpr float TO_KMPH = 0.036f;
 
   FFormatNamedArguments Args;
-  Args.Add("FPS", RoundedFloatAsText(Vehicle.GetFramesPerSecond()));
+  Args.Add("SimStep", RoundedFloatAsText(Vehicle.GetSimulationStepInSeconds() * TO_MILLISECONDS));
   Args.Add("Location", GetVectorAsText(Vehicle.GetLocation() * TO_METERS));
   Args.Add("Acceleration", GetVectorAsText(Vehicle.GetAcceleration() * TO_METERS, HighPrecision));
   Args.Add("Orientation", GetVectorAsText(Vehicle.GetOrientation(), HighPrecision));
@@ -88,7 +89,7 @@ static FText GetHUDText(const ACarlaPlayerState &Vehicle)
   Args.Add("IntersectionOffRoad", RoundedFloatAsText(100.0f * Vehicle.GetOffRoadIntersectionFactor()));
   return FText::Format(
       LOCTEXT("HUDTextFormat",
-          "FPS: {FPS}\n"
+          "Simulation Step: {SimStep} ms\n"
           "\n"
           "Speed:         {Speed} km/h\n"
           "Gear:          {Gear}\n"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.cpp
@@ -28,7 +28,7 @@ void ACarlaPlayerState::CopyProperties(APlayerState *PlayerState)
     if (Other != nullptr)
     {
       FrameNumber = Other->FrameNumber;
-      FramesPerSecond = Other->FramesPerSecond;
+      SimulationStepInSeconds = Other->SimulationStepInSeconds;
       PlatformTimeStamp = Other->PlatformTimeStamp;
       GameTimeStamp = Other->GameTimeStamp;
       Transform = Other->Transform;
@@ -78,7 +78,7 @@ static int32 RoundToMilliseconds(float Seconds)
 void ACarlaPlayerState::UpdateTimeStamp(float DeltaSeconds)
 {
   FrameNumber = GFrameCounter;
-  FramesPerSecond = 1.0f / DeltaSeconds;
+  SimulationStepInSeconds = DeltaSeconds;
   PlatformTimeStamp = RoundToMilliseconds(FPlatformTime::Seconds());
   GameTimeStamp += RoundToMilliseconds(DeltaSeconds);
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.h
@@ -46,9 +46,9 @@ public:
   }
 
   UFUNCTION(BlueprintCallable)
-  float GetFramesPerSecond() const
+  float GetSimulationStepInSeconds() const
   {
-    return FramesPerSecond;
+    return SimulationStepInSeconds;
   }
 
   UFUNCTION(BlueprintCallable)
@@ -229,7 +229,7 @@ private:
   uint64 FrameNumber;
 
   UPROPERTY(VisibleAnywhere)
-  float FramesPerSecond;
+  float SimulationStepInSeconds;
 
   UPROPERTY(VisibleAnywhere)
   int32 PlatformTimeStamp;


### PR DESCRIPTION
The fixed time-step mode keeps generating a lot of confusion. I think partly because of using the term FPS for both modes while they're not exactly the same (frames-per-simulation-second vs frames-per-real-second). While we cannot change the command line args because they're handled by UE4, at least we can change the HUD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/478)
<!-- Reviewable:end -->
