### PR TITLE
Add Dockerfile for running Carla releases

### DIFF
--- a/Package.sh
+++ b/Package.sh
@@ -118,6 +118,7 @@ if $DO_COPY_FILES ; then
   cp -v ./CHANGELOG.md ${DESTINATION}/CHANGELOG
   cp -v ./Docs/release_readme.md ${DESTINATION}/README
   cp -v ./Docs/Example.CarlaSettings.ini ${DESTINATION}/Example.CarlaSettings.ini
+  cp -v ./Util/Docker/Release.Dockerfile ${DESTINATION}/Dockerfile
 
   rsync -vhr --delete --delete-excluded \
       --exclude "*.egg-info" \

--- a/Util/Docker/Release.Dockerfile
+++ b/Util/Docker/Release.Dockerfile
@@ -1,0 +1,27 @@
+# Make sure drivers are >= 390
+# sudo docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=ID carla:latest ./CarlaUE4.sh
+# /Game/Maps/Town01 -benchmark -carla-server -fps=10 -world-port=2000 -windowed -ResX=100 -ResY=100 -carla-no-hud
+
+FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04
+
+
+RUN apt-get update; apt-get install -y libsdl2-2.0
+
+RUN useradd -m carla
+USER carla
+ENV HOME /home/carla
+COPY . /home/carla
+
+USER root
+RUN chown -R carla:carla /home/carla
+
+RUN apt-get -y install sudo
+RUN echo "carla:carla" | chpasswd && adduser carla sudo
+
+USER carla
+WORKDIR /home/carla
+
+
+ENV SDL_VIDEODRIVER=offscreen
+
+CMD /bin/bash CarlaUE4.sh -carla-server


### PR DESCRIPTION
Adding the Dockerfile provided by @germanros1987 to the repo.

I changed _Package.sh_ to include the Dockerfile automatically on each new release.

Download and extract the [release package](http://158.109.9.218:8080/blue/organizations/jenkins/carla/detail/PR-481/1/artifacts), and on that folder
```
$ docker build -t carla -f Dockerfile .
$ docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=0 carla:latest ./CarlaUE4.sh  /Game/Maps/Town01 -benchmark -carla-server -fps=10 -world-port=2000 -windowed -ResX=100 -ResY=100 -carla-no-hud
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/481)
<!-- Reviewable:end -->
