### PR TITLE
Change autopilot to turn at intersections based on front wheels position

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
@@ -203,7 +203,13 @@ void AWheeledVehicleAIController::TickAutopilotController()
 
 float AWheeledVehicleAIController::GoToNextTargetLocation(FVector &Direction)
 {
-  const auto &CurrentLocation = Vehicle->GetActorLocation();
+  // Get middle point between the two front wheels.
+  const auto CurrentLocation = [&](){
+    const auto &Wheels = Vehicle->GetVehicleMovementComponent()->Wheels;
+    check((Wheels.Num() > 1) && (Wheels[0u] != nullptr) && (Wheels[1u] != nullptr));
+    return (Wheels[0u]->Location + Wheels[1u]->Location) / 2.0f;
+  }();
+
   const auto Target = [&](){
     const auto &Result = TargetLocations.front();
     return FVector{Result.X, Result.Y, CurrentLocation.Z};


### PR DESCRIPTION
This modifies the autopilot to look at the front wheels position while following way-points. This makes the turns at intersections more coherent among vehicles independently of their length.

**Important: This requires the latest changes in the map, as the intersections have been slightly adapted to the new behavior. This changes will be made public with the 0.8.4 release.**
- - -
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/507)
<!-- Reviewable:end -->
