### PR TITLE
Remove news section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ If you want to benchmark your model in the same conditions as in our CoRL’17
 paper, check out
 [Benchmarking](http://carla.readthedocs.io/en/latest/benchmark_start/).
 
-News
-----
-
-- 23.04.2018 CARLA 0.8.2 released: [post](http://carla.org/2018/04/23/release-0.8.2/), [change log](https://github.com/carla-simulator/carla/blob/master/CHANGELOG.md#carla-082), [release](https://github.com/carla-simulator/carla/releases/tag/0.8.2).
-- 05.04.2018 CARLA 0.8.1 released: [post](http://carla.org/2018/04/05/release-0.8.1/), [change log](https://github.com/carla-simulator/carla/blob/master/CHANGELOG.md#carla-081), [release](https://github.com/carla-simulator/carla/releases/tag/0.8.1).
-- 27.03.2018 CARLA 0.8.0 released: [post](http://carla.org/2018/03/27/release-0.8.0/), [change log](https://github.com/carla-simulator/carla/blob/master/CHANGELOG.md#carla-080), [release](https://github.com/carla-simulator/carla/releases/tag/0.8.0).
-- 25.01.2018 CARLA 0.7.1 released: [change log](https://github.com/carla-simulator/carla/blob/master/CHANGELOG.md#carla-071), [release](https://github.com/carla-simulator/carla/releases/tag/0.7.1).
-
 Roadmap
 -------
 


### PR DESCRIPTION
I'm removing the news section from the README because we are no longer keeping it up-to-date. I believe that with the rest of channels that we have now for news, this one is no longer necessary, and it's just a source of misinformation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/512)
<!-- Reviewable:end -->
