### PR TITLE
Fix dictionary order issue on driving benchmark

### DIFF
--- a/PythonClient/carla/driving_benchmark/metrics.py
+++ b/PythonClient/carla/driving_benchmark/metrics.py
@@ -42,6 +42,8 @@ class Metrics(object):
         """
 
         # Read previous for position zero
+        print (measurements_matrix)
+        print (header)
         prev_start = measurements_matrix[0, header.index('start_point')]
         prev_end = measurements_matrix[0, header.index('end_point')]
         prev_exp_id = measurements_matrix[0, header.index('exp_id')]
@@ -242,6 +244,7 @@ class Metrics(object):
         measurements_matrix = np.loadtxt(os.path.join(path, 'measurements.csv'), delimiter=",",
                                          skiprows=1)
 
+        print (" FULL MAT ", measurements_matrix)
         metrics_dictionary = {'episodes_completion': {w: [0] * len(tasks) for w in all_weathers},
                               'intersection_offroad': {w: [[] for i in range(len(tasks))] for w in
                                                        all_weathers},
@@ -271,12 +274,14 @@ class Metrics(object):
                     np.logical_and(result_matrix[:, header.index(
                         'exp_id')] == tasks[t], result_matrix[:, header.index('weather')] == w)]
 
+
                 experiment_metrics_matrix = measurements_matrix[
                     np.logical_and(measurements_matrix[:, header_metrics.index(
                         'exp_id')] == float(tasks[t]),
                                    measurements_matrix[:, header_metrics.index('weather')] == float(
                                        w))]
-
+                print ("task ", float(tasks[t]), " weather",float(w))
+                print(" EXPERIMENT ", experiment_metrics_matrix)
                 metrics_dictionary['episodes_fully_completed'][w][t] = \
                     experiment_results_matrix[:, header.index('result')].tolist()
 

--- a/PythonClient/carla/driving_benchmark/metrics.py
+++ b/PythonClient/carla/driving_benchmark/metrics.py
@@ -42,8 +42,6 @@ class Metrics(object):
         """
 
         # Read previous for position zero
-        print (measurements_matrix)
-        print (header)
         prev_start = measurements_matrix[0, header.index('start_point')]
         prev_end = measurements_matrix[0, header.index('end_point')]
         prev_exp_id = measurements_matrix[0, header.index('exp_id')]
@@ -244,7 +242,6 @@ class Metrics(object):
         measurements_matrix = np.loadtxt(os.path.join(path, 'measurements.csv'), delimiter=",",
                                          skiprows=1)
 
-        print (" FULL MAT ", measurements_matrix)
         metrics_dictionary = {'episodes_completion': {w: [0] * len(tasks) for w in all_weathers},
                               'intersection_offroad': {w: [[] for i in range(len(tasks))] for w in
                                                        all_weathers},
@@ -274,14 +271,12 @@ class Metrics(object):
                     np.logical_and(result_matrix[:, header.index(
                         'exp_id')] == tasks[t], result_matrix[:, header.index('weather')] == w)]
 
-
                 experiment_metrics_matrix = measurements_matrix[
                     np.logical_and(measurements_matrix[:, header_metrics.index(
                         'exp_id')] == float(tasks[t]),
                                    measurements_matrix[:, header_metrics.index('weather')] == float(
                                        w))]
-                print ("task ", float(tasks[t]), " weather",float(w))
-                print(" EXPERIMENT ", experiment_metrics_matrix)
+
                 metrics_dictionary['episodes_fully_completed'][w][t] = \
                     experiment_results_matrix[:, header.index('result')].tolist()
 

--- a/PythonClient/carla/driving_benchmark/recording.py
+++ b/PythonClient/carla/driving_benchmark/recording.py
@@ -49,8 +49,11 @@ class Recording(object):
                                   )
 
         # Check for continuation of experiment, also returns the last line, used for test purposes
-        # If you don't want to continue it will create a new path name with a number
-        self._path, _ = self._continue_experiment(continue_experiment)
+        # If you don't want to continue it will create a new path name with a number.
+        # Also returns the fieldnames for both measurements and summary, so you can keep the
+        # previous order
+        self._path, _, self._summary_fieldnames, self._measurements_fieldnames\
+            = self._continue_experiment(continue_experiment)
 
         self._create_log_files()
 
@@ -106,6 +109,7 @@ class Recording(object):
 
         with open(os.path.join(self._path, 'summary.csv'), 'a+') as ofd:
             w = csv.DictWriter(ofd, self._dict_summary.keys())
+            w.fieldnames = self._summary_fieldnames
 
             w.writerow(self._dict_summary)
 
@@ -115,8 +119,8 @@ class Recording(object):
         controls and status of the entire benchmark.
         """
         with open(os.path.join(self._path, 'measurements.csv'), 'a+') as rfd:
-            rw = csv.DictWriter(rfd, self._dict_measurements.keys())
-
+            mw = csv.DictWriter(rfd, self._dict_measurements.keys())
+            mw.fieldnames = self._measurements_fieldnames
             for i in range(len(reward_vec)):
                 self._dict_measurements['exp_id'] = experiment.task
                 self._dict_measurements['rep'] = rep
@@ -144,7 +148,7 @@ class Recording(object):
                 self._dict_measurements['brake'] = control_vec[
                     i].brake
 
-                rw.writerow(self._dict_measurements)
+                mw.writerow(self._dict_measurements)
 
     def _create_log_files(self):
         """
@@ -155,12 +159,16 @@ class Recording(object):
             os.mkdir(self._path)
 
             with open(os.path.join(self._path, 'summary.csv'), 'w') as ofd:
-                w = csv.DictWriter(ofd, self._dict_summary.keys())
-                w.writeheader()
+                sw = csv.DictWriter(ofd, self._dict_summary.keys())
+                sw.writeheader()
+                if self._summary_fieldnames is None:
+                    self._summary_fieldnames = sw.fieldnames
 
             with open(os.path.join(self._path, 'measurements.csv'), 'w') as rfd:
-                rw = csv.DictWriter(rfd, self._dict_measurements.keys())
-                rw.writeheader()
+                mw = csv.DictWriter(rfd, self._dict_measurements.keys())
+                mw.writeheader()
+                if self._measurements_fieldnames is None:
+                    self._measurements_fieldnames = mw.fieldnames
 
     def _continue_experiment(self, continue_experiment):
         """
@@ -185,6 +193,8 @@ class Recording(object):
 
         # start the new path as the same one as before
         new_path = self._path
+        summary_fieldnames = None
+        measurements_fieldnames = None
 
         # if the experiment exist
         if self._experiment_exist():
@@ -192,6 +202,13 @@ class Recording(object):
             # If you want to continue just get the last position
             if continue_experiment:
                 line_on_file = self._get_last_position()
+                # Get the previously used fileorder
+                with open(os.path.join(self._path, 'summary.csv'), 'r') as ofd:
+                    summary_reader = csv.DictReader(ofd)
+                    summary_fieldnames = summary_reader.fieldnames
+                with open(os.path.join(self._path, 'measurements.csv'), 'r') as ofd:
+                    measurements_reader = csv.DictReader(ofd)
+                    measurements_fieldnames = measurements_reader.fieldnames
 
             else:
                 # Get a new non_conflicting path name
@@ -200,7 +217,7 @@ class Recording(object):
 
         else:
             line_on_file = 1
-        return new_path, line_on_file
+        return new_path, line_on_file, summary_fieldnames, measurements_fieldnames
 
     def save_images(self, sensor_data, episode_name, frame):
         """

--- a/PythonClient/carla/driving_benchmark/recording.py
+++ b/PythonClient/carla/driving_benchmark/recording.py
@@ -4,12 +4,19 @@ import os
 
 
 class Recording(object):
+    """
+    Class to record all the logs for the benchmark. It records individual episodes measurements
+    and also summary for each episodes.
+    """
 
-    def __init__(self
-                 , name_to_save
-                 , continue_experiment
-                 , save_images
-                 ):
+    def __init__(self, name_to_save, continue_experiment, save_images):
+        """
+        Recorder constructors
+        Args:
+            name_to_save: Name of the log
+            continue_experiment: If you want to continue a previous experiment with the same names
+            save_images: If you want to save images to the disk.
+        """
 
         self._dict_summary = {'exp_id': -1,
                               'rep': -1,
@@ -44,15 +51,13 @@ class Recording(object):
             os.mkdir('_benchmarks_results')
 
         # Generate the full path for the log files
-        self._path = os.path.join('_benchmarks_results'
-                                  , name_to_save
-                                  )
+        self._path = os.path.join('_benchmarks_results', name_to_save)
 
         # Check for continuation of experiment, also returns the last line, used for test purposes
         # If you don't want to continue it will create a new path name with a number.
         # Also returns the fieldnames for both measurements and summary, so you can keep the
         # previous order
-        self._path, _, self._summary_fieldnames, self._measurements_fieldnames\
+        self._path, _, self._summary_fieldnames, self._measurements_fieldnames \
             = self._continue_experiment(continue_experiment)
 
         self._create_log_files()
@@ -72,20 +77,31 @@ class Recording(object):
         return self._path
 
     def log_poses(self, start_index, end_index, weather_id):
+        """
+            Log tested poses by the benchmark
+        """
         with open(self._internal_log_name, 'a+') as log:
             log.write(' Start Poses  (%d  %d ) on weather %d \n ' %
                       (start_index, end_index, weather_id))
 
     def log_poses_finish(self):
+        """
+            Log when a set of poses (task) is finished by the benchmark
+        """
         with open(self._internal_log_name, 'a+') as log:
             log.write('Finished Task')
 
     def log_start(self, id_experiment):
-
+        """
+            Log when a set of poses (task) is started by the benchmark
+        """
         with open(self._internal_log_name, 'a+') as log:
             log.write('Start Task %d \n' % id_experiment)
 
     def log_end(self):
+        """
+            Log when the benchmark is finished
+        """
         with open(self._internal_log_name, 'a+') as log:
             log.write('====== Finished Entire Benchmark ======')
 
@@ -110,7 +126,6 @@ class Recording(object):
         with open(os.path.join(self._path, 'summary.csv'), 'a+') as ofd:
             w = csv.DictWriter(ofd, self._dict_summary.keys())
             w.fieldnames = self._summary_fieldnames
-
             w.writerow(self._dict_summary)
 
     def write_measurements_results(self, experiment, rep, pose, reward_vec, control_vec):

--- a/PythonClient/carla/driving_benchmark/recording.py
+++ b/PythonClient/carla/driving_benchmark/recording.py
@@ -109,7 +109,7 @@ class Recording(object):
                               path_distance, remaining_distance,
                               final_time, time_out, result):
         """
-        Method to record the summary of an episode(pose) execution
+            Method to record the summary of an episode(pose) execution
         """
 
         self._dict_summary['exp_id'] = experiment.task
@@ -253,11 +253,11 @@ class Recording(object):
         line_on_file = self._get_last_position() - 1
         if line_on_file == 0:
             return 0, 0
-        else:
-            return line_on_file % number_poses_task, line_on_file // number_poses_task
+
+        return line_on_file % number_poses_task, line_on_file // number_poses_task
 
     def _experiment_exist(self):
-
+        """ Check if the experiment exists"""
         return os.path.exists(self._path)
 
     def _get_last_position(self):

--- a/PythonClient/test/unit_tests/test_recording.py
+++ b/PythonClient/test/unit_tests/test_recording.py
@@ -54,8 +54,54 @@ class testRecording(unittest.TestCase):
             self.assertEqual(len(written_row), len(recording._dict_summary))
 
 
+    def test_write_summary_results_good_order(self):
 
-    def teste_write_measurements_results(self):
+        import os
+        from carla.driving_benchmark.experiment import Experiment
+
+        recording = Recording(name_to_save='Test_good_order'
+                              , continue_experiment=False, save_images=True
+                              )
+
+
+        for i in range(0, 10):
+            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
+                                             path_distance=200, remaining_distance=0,
+                                             final_time=0.2, time_out=49, result=1)
+
+        recording = Recording(name_to_save='Test_good_order'
+                          , continue_experiment=True, save_images=True
+                          )
+
+
+        for i in range(0, 10):
+            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
+                                             path_distance=200, remaining_distance=0,
+                                             final_time=0.2, time_out=49, result=1)
+
+
+        recording = Recording(name_to_save='Test_good_order'
+                          , continue_experiment=True, save_images=True
+                          )
+
+
+        for i in range(0, 10):
+            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
+                                             path_distance=200, remaining_distance=0,
+                                             final_time=0.2, time_out=49, result=1)
+
+        recording = Recording(name_to_save='Test_good_order'
+                          , continue_experiment=True, save_images=True
+                          )
+
+
+        for i in range(0, 10):
+            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
+                                             path_distance=200, remaining_distance=0,
+                                             final_time=0.2, time_out=49, result=1)
+
+
+    def test_write_measurements_results(self):
 
         import os
         from carla.driving_benchmark.experiment import Experiment

--- a/PythonClient/test/unit_tests/test_recording.py
+++ b/PythonClient/test/unit_tests/test_recording.py
@@ -13,8 +13,7 @@ class testRecording(unittest.TestCase):
         """
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         _ = open(os.path.join(recording._path, 'summary.csv'), 'r')
         _ = open(os.path.join(recording._path, 'measurements.csv'), 'r')
@@ -28,8 +27,7 @@ class testRecording(unittest.TestCase):
         from carla.driving_benchmark.experiment import Experiment
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                         path_distance=200, remaining_distance=0,
@@ -62,8 +60,7 @@ class testRecording(unittest.TestCase):
                                             final_time=0.2, time_out=49, result=1)
 
         recording = Recording(name_to_save='Test_good_order',
-                              continue_experiment=True, save_images=True
-                              )
+                              continue_experiment=True, save_images=True)
 
         for i in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
@@ -71,8 +68,7 @@ class testRecording(unittest.TestCase):
                                             final_time=0.2, time_out=49, result=1)
 
         recording = Recording(name_to_save='Test_good_order',
-                              continue_experiment=True, save_images=True
-                              )
+                              continue_experiment=True, save_images=True)
 
         for i in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
@@ -80,8 +76,7 @@ class testRecording(unittest.TestCase):
                                             final_time=0.2, time_out=49, result=1)
 
         recording = Recording(name_to_save='Test_good_order',
-                              continue_experiment=True, save_images=True
-                              )
+                              continue_experiment=True, save_images=True)
 
         for i in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
@@ -96,8 +91,7 @@ class testRecording(unittest.TestCase):
         from carla.carla_server_pb2 import Control
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         reward_vec = [Measurements().player_measurements for x in range(20)]
         control_vec = [Control() for x in range(25)]
@@ -122,8 +116,7 @@ class testRecording(unittest.TestCase):
     def test_continue_experiment(self):
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         # A just started case should return the continue experiment case
         self.assertEqual(recording._continue_experiment(True)[1], 1)
@@ -147,8 +140,7 @@ class testRecording(unittest.TestCase):
     def test_get_pose_and_experiment(self):
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         from carla.driving_benchmark.experiment import Experiment
 
@@ -193,8 +185,7 @@ class testRecording(unittest.TestCase):
         from carla.driving_benchmark.experiment import Experiment
 
         recording = Recording(name_to_save='Test1',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
         pose, experiment = recording.get_pose_and_experiment(1)
 

--- a/PythonClient/test/unit_tests/test_recording.py
+++ b/PythonClient/test/unit_tests/test_recording.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from carla.driving_benchmark.recording import Recording
 
@@ -5,11 +6,8 @@ from carla.driving_benchmark.recording import Recording
 class testRecording(unittest.TestCase):
 
     def test_init(self):
-        import os
-
         """
             The recording should have a reasonable full name
-
         """
 
         recording = Recording(name_to_save='Test1',
@@ -22,8 +20,9 @@ class testRecording(unittest.TestCase):
         self.assertEqual(len(os.listdir(recording._path)), 3)
 
     def test_write_summary_results(self):
-
-        import os
+        """
+            Test writting summary results.
+        """
         from carla.driving_benchmark.experiment import Experiment
 
         recording = Recording(name_to_save='Test1',
@@ -47,14 +46,16 @@ class testRecording(unittest.TestCase):
             self.assertEqual(len(written_row), len(recording._dict_summary))
 
     def test_write_summary_results_good_order(self):
+        """
+            Test if the summary results are writen in the same order on a new process
+        """
 
         from carla.driving_benchmark.experiment import Experiment
 
         recording = Recording(name_to_save='Test_good_order',
-                              continue_experiment=False, save_images=True
-                              )
+                              continue_experiment=False, save_images=True)
 
-        for i in range(0, 10):
+        for _ in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
@@ -62,7 +63,7 @@ class testRecording(unittest.TestCase):
         recording = Recording(name_to_save='Test_good_order',
                               continue_experiment=True, save_images=True)
 
-        for i in range(0, 10):
+        for _ in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
@@ -70,7 +71,7 @@ class testRecording(unittest.TestCase):
         recording = Recording(name_to_save='Test_good_order',
                               continue_experiment=True, save_images=True)
 
-        for i in range(0, 10):
+        for _ in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
@@ -78,12 +79,17 @@ class testRecording(unittest.TestCase):
         recording = Recording(name_to_save='Test_good_order',
                               continue_experiment=True, save_images=True)
 
-        for i in range(0, 10):
+        for _ in range(0, 10):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
+
+        # Check if the the test_good_order summaries have all the same files.
 
     def test_write_measurements_results(self):
+        """
+            Test writing a few measurements into the log
+        """
 
         import os
         from carla.driving_benchmark.experiment import Experiment
@@ -93,8 +99,8 @@ class testRecording(unittest.TestCase):
         recording = Recording(name_to_save='Test1',
                               continue_experiment=False, save_images=True)
 
-        reward_vec = [Measurements().player_measurements for x in range(20)]
-        control_vec = [Control() for x in range(25)]
+        reward_vec = [Measurements().player_measurements for _ in range(20)]
+        control_vec = [Control() for _ in range(25)]
 
         recording.write_measurements_results(experiment=Experiment(),
                                              rep=1, pose=[24, 32], reward_vec=reward_vec,
@@ -114,7 +120,9 @@ class testRecording(unittest.TestCase):
             self.assertEqual(len(written_row), len(recording._dict_measurements))
 
     def test_continue_experiment(self):
-
+        """
+            Test if you are able to continue an experiment after restarting the process
+        """
         recording = Recording(name_to_save='Test1',
                               continue_experiment=False, save_images=True)
 
@@ -138,6 +146,9 @@ class testRecording(unittest.TestCase):
         self.assertEqual(recording._continue_experiment(False)[1], 1)
 
     def test_get_pose_and_experiment(self):
+        """
+            Test getting the pose and the experiment from a previous executed benchmark
+        """
 
         recording = Recording(name_to_save='Test1',
                               continue_experiment=False, save_images=True)
@@ -162,7 +173,7 @@ class testRecording(unittest.TestCase):
         self.assertEqual(pose, 2)
         self.assertEqual(experiment, 0)
 
-        for i in range(23):
+        for _ in range(23):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
@@ -171,7 +182,7 @@ class testRecording(unittest.TestCase):
         self.assertEqual(pose, 0)
         self.assertEqual(experiment, 1)
 
-        for i in range(23):
+        for _ in range(23):
             recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
                                             path_distance=200, remaining_distance=0,
                                             final_time=0.2, time_out=49, result=1)
@@ -181,7 +192,9 @@ class testRecording(unittest.TestCase):
         self.assertEqual(experiment, 1)
 
     def test_get_pose_and_experiment_corner(self):
-
+        """
+            Test getting the pose from multiple cases.
+        """
         from carla.driving_benchmark.experiment import Experiment
 
         recording = Recording(name_to_save='Test1',

--- a/PythonClient/test/unit_tests/test_recording.py
+++ b/PythonClient/test/unit_tests/test_recording.py
@@ -1,9 +1,8 @@
-
 import unittest
 from carla.driving_benchmark.recording import Recording
 
-class testRecording(unittest.TestCase):
 
+class testRecording(unittest.TestCase):
 
     def test_init(self):
         import os
@@ -13,93 +12,81 @@ class testRecording(unittest.TestCase):
 
         """
 
-
-        recording = Recording(name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
 
-
-        _ = open(os.path.join(recording._path,'summary.csv'), 'r')
+        _ = open(os.path.join(recording._path, 'summary.csv'), 'r')
         _ = open(os.path.join(recording._path, 'measurements.csv'), 'r')
 
         # There should be three files in any newly created case
         self.assertEqual(len(os.listdir(recording._path)), 3)
-
 
     def test_write_summary_results(self):
 
         import os
         from carla.driving_benchmark.experiment import Experiment
 
-        recording = Recording(name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
 
-        recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
+        recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
 
         with open(os.path.join(recording._path, 'summary.csv'), 'r') as f:
-
             header = f.readline().split(',')
-            #Assert if header is header
+            # Assert if header is header
             self.assertIn('exp_id', header)
 
             self.assertEqual(len(header), len(recording._dict_summary))
-            #Assert if there is something writen in the row
+            # Assert if there is something writen in the row
 
             written_row = f.readline().split(',')
 
-            #Assert if the number of collums is correct
+            # Assert if the number of collums is correct
             self.assertEqual(len(written_row), len(recording._dict_summary))
-
 
     def test_write_summary_results_good_order(self):
 
-        import os
         from carla.driving_benchmark.experiment import Experiment
 
-        recording = Recording(name_to_save='Test_good_order'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test_good_order',
+                              continue_experiment=False, save_images=True
                               )
 
+        for i in range(0, 10):
+            recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                            path_distance=200, remaining_distance=0,
+                                            final_time=0.2, time_out=49, result=1)
+
+        recording = Recording(name_to_save='Test_good_order',
+                              continue_experiment=True, save_images=True
+                              )
 
         for i in range(0, 10):
-            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                             path_distance=200, remaining_distance=0,
-                                             final_time=0.2, time_out=49, result=1)
+            recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                            path_distance=200, remaining_distance=0,
+                                            final_time=0.2, time_out=49, result=1)
 
-        recording = Recording(name_to_save='Test_good_order'
-                          , continue_experiment=True, save_images=True
-                          )
-
-
-        for i in range(0, 10):
-            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                             path_distance=200, remaining_distance=0,
-                                             final_time=0.2, time_out=49, result=1)
-
-
-        recording = Recording(name_to_save='Test_good_order'
-                          , continue_experiment=True, save_images=True
-                          )
-
+        recording = Recording(name_to_save='Test_good_order',
+                              continue_experiment=True, save_images=True
+                              )
 
         for i in range(0, 10):
-            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                             path_distance=200, remaining_distance=0,
-                                             final_time=0.2, time_out=49, result=1)
+            recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                            path_distance=200, remaining_distance=0,
+                                            final_time=0.2, time_out=49, result=1)
 
-        recording = Recording(name_to_save='Test_good_order'
-                          , continue_experiment=True, save_images=True
-                          )
-
+        recording = Recording(name_to_save='Test_good_order',
+                              continue_experiment=True, save_images=True
+                              )
 
         for i in range(0, 10):
-            recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                             path_distance=200, remaining_distance=0,
-                                             final_time=0.2, time_out=49, result=1)
-
+            recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                            path_distance=200, remaining_distance=0,
+                                            final_time=0.2, time_out=49, result=1)
 
     def test_write_measurements_results(self):
 
@@ -108,11 +95,9 @@ class testRecording(unittest.TestCase):
         from carla.carla_server_pb2 import Measurements
         from carla.carla_server_pb2 import Control
 
-
-        recording = Recording(name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
-
 
         reward_vec = [Measurements().player_measurements for x in range(20)]
         control_vec = [Control() for x in range(25)]
@@ -122,24 +107,22 @@ class testRecording(unittest.TestCase):
                                              control_vec=control_vec)
 
         with open(os.path.join(recording._path, 'measurements.csv'), 'r') as f:
-
             header = f.readline().split(',')
-            #Assert if header is header
+            # Assert if header is header
             self.assertIn('exp_id', header)
 
             self.assertEqual(len(header), len(recording._dict_measurements))
-            #Assert if there is something writen in the row
+            # Assert if there is something writen in the row
 
             written_row = f.readline().split(',')
 
-            #Assert if the number of collums is correct
+            # Assert if the number of collums is correct
             self.assertEqual(len(written_row), len(recording._dict_measurements))
-
 
     def test_continue_experiment(self):
 
-        recording = Recording( name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
 
         # A just started case should return the continue experiment case
@@ -150,30 +133,24 @@ class testRecording(unittest.TestCase):
         from carla.driving_benchmark.experiment import Experiment
 
         recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
         recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
 
         # After writing two experiments it should return 2, so you could start writing os pos 3
         self.assertEqual(recording._continue_experiment(True)[1], 3)
         # If you dont want to continue, should return also one
         self.assertEqual(recording._continue_experiment(False)[1], 1)
 
-
     def test_get_pose_and_experiment(self):
 
-
-
-        recording = Recording( name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
 
-
-
         from carla.driving_benchmark.experiment import Experiment
-
 
         pose, experiment = recording.get_pose_and_experiment(25)
 
@@ -182,13 +159,12 @@ class testRecording(unittest.TestCase):
         self.assertEqual(pose, 0)
         self.assertEqual(experiment, 0)
 
-
-        recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
-        recording.write_summary_results( experiment=Experiment(), pose=[24,32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
+        recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
+        recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
 
         pose, experiment = recording.get_pose_and_experiment(25)
         self.assertEqual(pose, 2)
@@ -214,11 +190,10 @@ class testRecording(unittest.TestCase):
 
     def test_get_pose_and_experiment_corner(self):
 
-
         from carla.driving_benchmark.experiment import Experiment
 
-        recording = Recording( name_to_save='Test1'
-                              , continue_experiment=False, save_images=True
+        recording = Recording(name_to_save='Test1',
+                              continue_experiment=False, save_images=True
                               )
 
         pose, experiment = recording.get_pose_and_experiment(1)
@@ -232,43 +207,38 @@ class testRecording(unittest.TestCase):
         self.assertEqual(pose, 0)
         self.assertEqual(experiment, 0)
 
-
-        recording.write_summary_results( experiment=Experiment(), pose=[24, 32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
-
+        recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
 
         pose, experiment = recording.get_pose_and_experiment(1)
 
-        print (pose, experiment)
+        print(pose, experiment)
         self.assertEqual(pose, 0)
         self.assertEqual(experiment, 1)
 
-
         pose, experiment = recording.get_pose_and_experiment(2)
 
-        print (pose, experiment)
+        print(pose, experiment)
         # An starting experiment should return one
         self.assertEqual(pose, 1)
         self.assertEqual(experiment, 0)
 
         pose, experiment = recording.get_pose_and_experiment(3)
 
-        print (pose, experiment)
+        print(pose, experiment)
         # An starting experiment should return one
         self.assertEqual(pose, 1)
         self.assertEqual(experiment, 0)
 
-        recording.write_summary_results( experiment=Experiment(), pose=[24, 32], rep=1,
-                                         path_distance=200, remaining_distance=0,
-                                         final_time=0.2, time_out=49, result=1)
-
+        recording.write_summary_results(experiment=Experiment(), pose=[24, 32], rep=1,
+                                        path_distance=200, remaining_distance=0,
+                                        final_time=0.2, time_out=49, result=1)
 
         pose, experiment = recording.get_pose_and_experiment(2)
 
         self.assertEqual(pose, 0)
         self.assertEqual(experiment, 1)
-
 
         pose, experiment = recording.get_pose_and_experiment(3)
 
@@ -278,4 +248,3 @@ class testRecording(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    


### PR DESCRIPTION
#### Description
On Driving Benchmark:

Fixing a newly found bug that made the writing on the csv
to go on different order when RESTARTING the benchmark process
or when using in a subprocess.


#### Where has this been tested?

  * **Platform(s):**  16.04 ubuntu linux
  * **Python version(s):**  python3.6, python 2.7

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/514)
<!-- Reviewable:end -->
