### PR TITLE
 adding a docker tutorial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
         - pip3 install --user setuptools nose2
         - make setup
       script:
+        - make setup >/dev/null
+        - make LibCarla >/dev/null
+        - make PythonAPI >/dev/null
         - make check ARGS="--all --gtest_args=--gtest_filter=-*_mt"
 
     - env: TEST="Pylint 2"

--- a/Docs/carla_docker.md
+++ b/Docs/carla_docker.md
@@ -1,3 +1,4 @@
+
 <h1>Running CARLA in a Docker </h1>
 
 
@@ -9,6 +10,7 @@ This tutorial is designed for:
 
 This tutorial was tested in Ubuntu 16.04 and using NVIDIA 396.37 drivers.
 This method requires a version of NVIDIA drivers >=390.
+
 
 ## Docker Installation
 
@@ -58,5 +60,4 @@ select the port that is going to be used:
 
 At the list of parameters do not forget to add "-world-port=<port_number>" so that CARLA runs on server mode
 listening to the "<port_number>"
-
 

--- a/Docs/carla_docker.md
+++ b/Docs/carla_docker.md
@@ -20,9 +20,7 @@ This method requires a version of NVIDIA drivers >=390.
 ### Docker CE
 
 For our tests we used the Docker CE version.
-To install Docker CE we recommend using this tutorial:
-[https://docs.docker.com/install/linux/docker-ce/ubuntu/#extra-steps-for-aufs](
-https://docs.docker.com/install/linux/docker-ce/ubuntu/#extra-steps-for-aufs)
+To install Docker CE we recommend using [this tutorial](https://docs.docker.com/install/linux/docker-ce/ubuntu/#extra-steps-for-aufs)
 
 ### NVIDIA-Docker2
 

--- a/Docs/carla_docker.md
+++ b/Docs/carla_docker.md
@@ -1,0 +1,62 @@
+<h1>Running CARLA under Docker</h1>
+
+
+
+This tutorial is designed for:
+
+  * People that want to run CARLA without needing to install all dependencies.
+  * Recommended way of running CARLA on servers.
+
+This tutorial was tested in Ubuntu 16.04 and using NVIDIA 396.37 drivers.
+
+
+## Docker Installation
+
+!!! note
+    Docker requires sudo to run. Follow this guide to add users to the docker sudo
+    group https://docs.docker.com/install/linux/linux-postinstall/
+
+### Docker CE
+
+For our tests we used the Docker CE version.
+To install Docker CE we recommend using this tutorial:
+[https://docs.docker.com/install/linux/docker-ce/ubuntu/#extra-steps-for-aufs](
+https://docs.docker.com/install/linux/docker-ce/ubuntu/#extra-steps-for-aufs)
+
+### NVIDIA-Docker2
+
+To install nvidia-docker-2 we recommend using the "Quick Start"
+section from the [nvidia-dockers github](https://github.com/NVIDIA/nvidia-docker).
+
+
+
+
+## Getting it Running
+
+
+Pull the CARLA image.
+
+    docker pull carlasim/carla:0.8.4
+
+
+Running CARLA under docker:
+
+    docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=0 carlasim/carla:0.8.4
+
+The "-p 2000-2002:2000-2002" argument is to redirect host ports for the docker container.
+Use "NVIDIA_VISIBLE_DEVICES=<gpu_number>" to select the GPU.
+
+You can also pass parameters to the CARLA executable. With this you can chose the town and
+select the port that is going to be used:
+
+    docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=0 carlasim/carla:0.8.4 /bin/bash CarlaUE4.sh  < Your list of parameters >
+
+At the list of parameters do not forget to add "-world-port=<port_number>" so that CARLA runs on server mode
+listening to the "<port_number>"
+
+
+
+Obs: you can also pull different versions of CARLA. To pull, for instance, version 0.8.2
+
+
+    docker pull carlasim/carla:0.8.2

--- a/Docs/carla_docker.md
+++ b/Docs/carla_docker.md
@@ -1,14 +1,14 @@
-<h1>Running CARLA under Docker</h1>
+<h1>Running CARLA in a Docker </h1>
 
 
 
 This tutorial is designed for:
 
   * People that want to run CARLA without needing to install all dependencies.
-  * Recommended way of running CARLA on servers.
+  * Recommended solution to run multiple CARLA servers and perform GPU mapping
 
 This tutorial was tested in Ubuntu 16.04 and using NVIDIA 396.37 drivers.
-
+This method requires a version of NVIDIA drivers >=390.
 
 ## Docker Installation
 
@@ -36,7 +36,12 @@ section from the [nvidia-dockers github](https://github.com/NVIDIA/nvidia-docker
 
 Pull the CARLA image.
 
-    docker pull carlasim/carla:0.8.4
+    docker pull carlasim/carla:version
+
+For selecting a version, for instance, version 0.8.2 (stable), do:
+
+    docker pull carlasim/carla:0.8.2
+
 
 
 Running CARLA under docker:
@@ -55,8 +60,3 @@ At the list of parameters do not forget to add "-world-port=<port_number>" so th
 listening to the "<port_number>"
 
 
-
-Obs: you can also pull different versions of CARLA. To pull, for instance, version 0.8.2
-
-
-    docker pull carlasim/carla:0.8.2

--- a/Docs/carla_docker.md
+++ b/Docs/carla_docker.md
@@ -1,4 +1,3 @@
-
 <h1>Running CARLA in a Docker </h1>
 
 
@@ -60,4 +59,5 @@ select the port that is going to be used:
 
 At the list of parameters do not forget to add "-world-port=<port_number>" so that CARLA runs on server mode
 listening to the "<port_number>"
+
 

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -33,7 +33,7 @@
   * [Python API](python_api.md)
   <!-- * [Simulator keyboard input](simulator_keyboard_input.md) -->
   * [Running without display and selecting GPUs](carla_headless.md)
-  * [Running CARLA under Docker](carla_docker.md)
+  * [Running CARLA in a Docker](carla_docker.md)
   * [How to link Epic's Automotive Materials](epic_automotive_materials.md)
 
 <h3>Contributing</h3>

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -33,6 +33,7 @@
   * [Python API](python_api.md)
   <!-- * [Simulator keyboard input](simulator_keyboard_input.md) -->
   * [Running without display and selecting GPUs](carla_headless.md)
+  * [Running CARLA under Docker](carla_docker.md)
   * [How to link Epic's Automotive Materials](epic_automotive_materials.md)
 
 <h3>Contributing</h3>

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -33,7 +33,9 @@
   * [Python API](python_api.md)
   <!-- * [Simulator keyboard input](simulator_keyboard_input.md) -->
   * [Running without display and selecting GPUs](carla_headless.md)
-  * [Running CARLA in a Docker](carla_docker.md)
+
+  * [Running in a Docker](carla_docker.md)
+
   * [How to link Epic's Automotive Materials](epic_automotive_materials.md)
 
 <h3>Contributing</h3>

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -33,7 +33,6 @@
   * [Python API](python_api.md)
   <!-- * [Simulator keyboard input](simulator_keyboard_input.md) -->
   * [Running without display and selecting GPUs](carla_headless.md)
-
   * [Running in a Docker](carla_docker.md)
 
   * [How to link Epic's Automotive Materials](epic_automotive_materials.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ pages:
   - 'Python API': 'python_api.md'
   # - 'Simulator keyboard input': 'simulator_keyboard_input.md'
   - 'Running without display and selecting GPUs': 'carla_headless.md'
+  - 'Running CARLA under Docker': 'carla_docker.md'
   - "How to link Epic's Automotive Materials": 'epic_automotive_materials.md'
 - Contributing:
   - 'Contribution guidelines': 'CONTRIBUTING.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ pages:
   - 'Python API': 'python_api.md'
   # - 'Simulator keyboard input': 'simulator_keyboard_input.md'
   - 'Running without display and selecting GPUs': 'carla_headless.md'
-  - 'Running CARLA under Docker': 'carla_docker.md'
+  - 'Running CARLA in a Docker': 'carla_docker.md'
   - "How to link Epic's Automotive Materials": 'epic_automotive_materials.md'
 - Contributing:
   - 'Contribution guidelines': 'CONTRIBUTING.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,6 @@ pages:
   - 'Python API': 'python_api.md'
   # - 'Simulator keyboard input': 'simulator_keyboard_input.md'
   - 'Running without display and selecting GPUs': 'carla_headless.md'
-
   - 'Running in a Docker': 'carla_docker.md'
 
   - "How to link Epic's Automotive Materials": 'epic_automotive_materials.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,9 @@ pages:
   - 'Python API': 'python_api.md'
   # - 'Simulator keyboard input': 'simulator_keyboard_input.md'
   - 'Running without display and selecting GPUs': 'carla_headless.md'
-  - 'Running CARLA in a Docker': 'carla_docker.md'
+
+  - 'Running in a Docker': 'carla_docker.md'
+
   - "How to link Epic's Automotive Materials": 'epic_automotive_materials.md'
 - Contributing:
   - 'Contribution guidelines': 'CONTRIBUTING.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ pages:
   # - 'Simulator keyboard input': 'simulator_keyboard_input.md'
   - 'Running without display and selecting GPUs': 'carla_headless.md'
   - 'Running in a Docker': 'carla_docker.md'
-
   - "How to link Epic's Automotive Materials": 'epic_automotive_materials.md'
 - Contributing:
   - 'Contribution guidelines': 'CONTRIBUTING.md'


### PR DESCRIPTION
#### Description
Adding a tutorial for the CARLA docker.

#### Where has this been tested?
CARLA 0.8.4

#### Possible Drawbacks

Docker's pull using 

     docker pull carlasim/latest

Was not working for me. We should probably add docker pull carlasim/stable
and docker pull carlasim/latest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/616)
<!-- Reviewable:end -->
