### PR TITLE
Allow iterating attributes of an Actor's Blueprint

### DIFF
--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -38,12 +38,15 @@
 - `contains_attribute(key)`
 - `get_attribute(key)`
 - `set_attribute(key, value)`
+- `__len__`
+- `__iter__`
 
 ## `carla.ActorAttribute`
 
-- `is_modifiable`
+- `id`
 - `type`
 - `recommended_values`
+- `is_modifiable`
 - `as_bool()`
 - `as_int()`
 - `as_float()`

--- a/LibCarla/source/carla/client/ActorAttribute.h
+++ b/LibCarla/source/carla/client/ActorAttribute.h
@@ -53,14 +53,8 @@ namespace client {
       Validate();
     }
 
-    /// Set the value of this attribute.
-    ///
-    /// @throw InvalidAttributeValue if attribute is not modifiable.
-    /// @throw InvalidAttributeValue if format does not match this type.
-    void Set(std::string value);
-
-    bool IsModifiable() const {
-      return _attribute.is_modifiable;
+    const std::string &GetId() const {
+      return _attribute.id;
     }
 
     rpc::ActorAttributeType GetType() const {
@@ -70,6 +64,16 @@ namespace client {
     const std::vector<std::string> &GetRecommendedValues() const {
       return _attribute.recommended_values;
     }
+
+    bool IsModifiable() const {
+      return _attribute.is_modifiable;
+    }
+
+    /// Set the value of this attribute.
+    ///
+    /// @throw InvalidAttributeValue if attribute is not modifiable.
+    /// @throw InvalidAttributeValue if format does not match this type.
+    void Set(std::string value);
 
     /// Cast the value to the given type.
     ///

--- a/LibCarla/source/carla/client/ActorBlueprint.h
+++ b/LibCarla/source/carla/client/ActorBlueprint.h
@@ -89,6 +89,10 @@ namespace client {
       _attributes.at(id).Set(std::move(value));
     }
 
+    size_t size() const {
+      return _attributes.size();
+    }
+
     auto begin() const {
       return iterator::make_map_values_iterator(_attributes.begin());
     }

--- a/PythonAPI/source/libcarla/Blueprint.cpp
+++ b/PythonAPI/source/libcarla/Blueprint.cpp
@@ -14,10 +14,13 @@
 
 template <typename Iterable>
 static std::ostream &PrintList(std::ostream &out, const Iterable &list) {
-  auto it = list.begin();
-  out << '[' << *it;
-  for (++it; it != list.end(); ++it) {
-    out << ", " << *it;
+  out << '[';
+  if (!list.empty()) {
+    auto it = list.begin();
+    out << *it;
+    for (++it; it != list.end(); ++it) {
+      out << ", " << *it;
+    }
   }
   out << ']';
   return out;


### PR DESCRIPTION
#### Description

Added a way of iterating all the attributes of an actor blueprint, the following code now works

```py
for blueprint in blueprint_library:
    print(blueprint)
    for attribute in blueprint:
        print('  - %s' % attribute)
```

Also does minor improvements to the Python prints of blueprint related objects.

Fixes #702.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** Python 2.7
  * **Unreal Engine version(s):** 4.19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/736)
<!-- Reviewable:end -->
