### PR TITLE
Remove install folder path check

### DIFF
--- a/Util/BuildTools/BuildLibCarla.bat
+++ b/Util/BuildTools/BuildLibCarla.bat
@@ -86,21 +86,21 @@ cd "%LIBCARLA_VSPROJECT_PATH%"
 
 rem Build libcarla server
 rem
-if %BUILD_SERVER% == true if not exist "%LIBCARLA_SERVER_INSTALL_PATH%" (
+if %BUILD_SERVER% == true (
     cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Server -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP" -DCMAKE_INSTALL_PREFIX=%LIBCARLA_SERVER_INSTALL_PATH% %ROOT_PATH%
     if %errorlevel% neq 0 goto error_cmake
 
-    cmake --build . --config Release --target install
+    cmake --build . --config Release --target install | findstr /V "Up-to-date:"
     if %errorlevel% neq 0 goto error_install
 )
 
 rem Build libcarla client
 rem
-if %BUILD_CLIENT% == true if not exist "%LIBCARLA_CLIENT_INSTALL_PATH%" (
+if %BUILD_CLIENT% == true (
     cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Client -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP" -DCMAKE_INSTALL_PREFIX=%LIBCARLA_CLIENT_INSTALL_PATH% %ROOT_PATH%
     if %errorlevel% neq 0 goto error_cmake
 
-    cmake --build . --config Release --target install
+    cmake --build . --config Release --target install  | findstr /V "Up-to-date:"
     if %errorlevel% neq 0 goto error_install
 )
 

--- a/Util/BuildTools/BuildPythonAPI.bat
+++ b/Util/BuildTools/BuildPythonAPI.bat
@@ -83,7 +83,7 @@ if %REMOVE_INTERMEDIATE% == true (
 )
 
 cd "%PYTHON_LIB_PATH%"
-if exist "%PYTHON_LIB_PATH%dist" goto already_installed
+rem if exist "%PYTHON_LIB_PATH%dist" goto already_installed
 
 rem ============================================================================
 rem -- Check for py ------------------------------------------------------------


### PR DESCRIPTION
For "CarlaLIB" and "PythonAPI" don't check if the a build already exists, as the build check is done by the compiler and installation check is done by CMake.

#### Where has this been tested?

  * **Platform(s):** Windows 10 x64 1803
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/762)
<!-- Reviewable:end -->
