### PR TITLE
Change timeout to use seconds in Python and add timeout to manual control

### DIFF
--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -8,7 +8,7 @@
 ## `carla.Client`
 
 - `Client(host, port, worker_threads=0)`
-- `set_timeout(seconds)`
+- `set_timeout(float_seconds)`
 - `get_client_version()`
 - `get_server_version()`
 - `ping()`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -8,7 +8,7 @@
 ## `carla.Client`
 
 - `Client(host, port, worker_threads=0)`
-- `set_timeout(milliseconds)`
+- `set_timeout(seconds)`
 - `get_client_version()`
 - `get_server_version()`
 - `ping()`

--- a/LibCarla/source/carla/Time.h
+++ b/LibCarla/source/carla/Time.h
@@ -49,6 +49,10 @@ namespace carla {
       return to_posix_time();
     }
 
+    constexpr size_t milliseconds() const noexcept {
+      return _milliseconds;
+    }
+
   private:
 
     size_t _milliseconds;

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "carla/NonCopyable.h"
+#include "carla/Time.h"
 #include "carla/Version.h"
 #include "carla/client/Control.h"
 #include "carla/client/Memory.h"
@@ -40,8 +41,8 @@ namespace client {
         uint16_t port,
         size_t worker_threads = 0u);
 
-    void SetTimeout(int64_t milliseconds) {
-      _client.set_timeout(milliseconds);
+    void SetTimeout(time_duration timeout) {
+      _client.set_timeout(timeout.milliseconds());
     }
 
     template <typename T, typename ... Args>

--- a/PythonAPI/example.py
+++ b/PythonAPI/example.py
@@ -41,7 +41,7 @@ def save_to_disk(image):
 
 def main(add_a_camera, enable_autopilot):
     client = carla.Client('localhost', 2000)
-    client.set_timeout(2000)
+    client.set_timeout(2.0)
 
     print('client version: %s' % client.get_client_version())
     print('server version: %s' % client.get_server_version())

--- a/PythonAPI/manual_control.py
+++ b/PythonAPI/manual_control.py
@@ -71,6 +71,7 @@ CAMERA_POSITION = carla.Transform(carla.Location(x=0.5, z=1.40))
 class CarlaGame(object):
     def __init__(self, args):
         self._client = carla.Client(args.host, args.port)
+        self._client.set_timeout(2.0)
         self._display = None
         self._surface = None
         self._camera = None

--- a/PythonAPI/source/libcarla/Client.cpp
+++ b/PythonAPI/source/libcarla/Client.cpp
@@ -9,13 +9,18 @@
 
 #include <boost/python.hpp>
 
+static void SetTimeout(carla::client::Client &client, double seconds) {
+  size_t ms = static_cast<size_t>(1e3 * seconds);
+  client.SetTimeout(carla::time_duration::milliseconds(ms));
+}
+
 void export_client() {
   using namespace boost::python;
   namespace cc = carla::client;
 
   class_<cc::Client, boost::noncopyable, boost::shared_ptr<cc::Client>>("Client",
       init<std::string, uint16_t, size_t>((arg("host"), arg("port"), arg("worker_threads")=0u)))
-    .def("set_timeout", &cc::Client::SetTimeout, (arg("milliseconds")))
+    .def("set_timeout", &::SetTimeout, (arg("seconds")))
     .def("get_client_version", &cc::Client::GetClientVersion)
     .def("get_server_version", &cc::Client::GetServerVersion)
     .def("ping", &cc::Client::Ping)


### PR DESCRIPTION
#### Description

- Change Python client timeout to float seconds for convenience.
- Add timeout to manual_control.py.

Related #809, by adding a timeout to the manual control script we avoid blocking the GIL forever.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** Python 2.7
  * **Unreal Engine version(s):** 4.19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/819)
<!-- Reviewable:end -->
