### PR TITLE
Fixed .gitignore not ignoring the Content

### DIFF
--- a/Unreal/CarlaUE4/.gitignore
+++ b/Unreal/CarlaUE4/.gitignore
@@ -13,7 +13,7 @@ Plugins/Carla/DerivedDataCache
 Plugins/Carla/Intermediate
 Plugins/Carla/Saved
 
-./Content*
+/Content
 Config/CarlaSettings.ini
 Config/DefaultEditor.ini
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing
    - [ ] `make check`
    - [ ] `pylint --disable=R,C --rcfile=PythonClient/.pylintrc PythonClient/carla PythonClient/*.py`
    - [ ] `cppcheck . -iBuild -i.pb.cc --enable=warning`

-->

#### Description

Now `\Unreal\CarlaUE4\Content\` folder is ignored again, but git will track `\Unreal\CarlaUE4\Plugins\Carla\Content\`.

Fixes #804

#### Where has this been tested?

  * **Platform(s):** Win10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/827)
<!-- Reviewable:end -->
