### PR TITLE
Disable texture streaming

### DIFF
--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -28,6 +28,7 @@ r.DefaultFeature.AmbientOcclusionStaticFraction=False
 r.DefaultFeature.AutoExposure=False
 r.CustomDepth=3
 r.Streaming.PoolSize=2000
+r.TextureStreaming=False
 
 [/Script/AIModule.AISense_Sight]
 bAutoRegisterAllPawnsAsSources=False


### PR DESCRIPTION
#### Description

Fixes the issue of textures loading only in low quality in the camera sensors (images retrieved in the Python API).

#### Drawbacks

May reduce performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/913)
<!-- Reviewable:end -->
