### PR TITLE
Get config loading working again (for abs paths)

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -127,8 +127,8 @@ static bool GetSettingsFilePathFromCommandLine(FString &Value)
     if (FPaths::IsRelative(Value))
     {
       Value = FPaths::ConvertRelativePathToFull(FPaths::LaunchDir(), Value);
-      return true;
     }
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
The main reason this wasn't working was because it
was only returning true for the relative path; when
it should return true in both cases.

Fixes #215

