### PR TITLE
Drop off png support (for now)

### DIFF
--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -293,12 +293,12 @@ endif ()
 
 EOL
 
-if [ "${TRAVIS}" == "true" ] ; then
-  log "Travis CI build detected: disabling PNG support."
-  echo "add_definitions(-DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=false)" >> ${CMAKE_CONFIG_FILE}.gen
-else
-  echo "add_definitions(-DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=true)" >> ${CMAKE_CONFIG_FILE}.gen
-fi
+log "Disabling PNG support."
+# This usage (or at least the usage of libpng16) causes a bunch of removes of libraries and
+# programs that others will use with carla (for example ros or libpcl). Likely needs investigation
+# to determine why we need 1.6 vs 1.2 and perhaps just sticking with 1.2 until some future
+# date.
+echo "add_definitions(-DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=false)" >> ${CMAKE_CONFIG_FILE}.gen
 
 # -- Move files ----------------------------------------------------------------
 


### PR DESCRIPTION
This has various issues that it is causing with other libraries
folks are using with carla; so until it gets a little more attention
we should just avoid png support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/924)
<!-- Reviewable:end -->
