### PR TITLE
Upgrade rpclib to fix crash when client exits too fast

### DIFF
--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -125,7 +125,7 @@ unset BOOST_BASENAME
 # -- Get rpclib and compile it with libc++ and libstdc++ -----------------------
 # ==============================================================================
 
-RPCLIB_BASENAME=rpclib-2.2.1
+RPCLIB_BASENAME=rpclib-d1146b7
 
 RPCLIB_LIBCXX_INCLUDE=${PWD}/${RPCLIB_BASENAME}-libcxx-install/include
 RPCLIB_LIBCXX_LIBPATH=${PWD}/${RPCLIB_BASENAME}-libcxx-install/lib
@@ -142,7 +142,10 @@ else
 
   log "Retrieving rpclib."
 
-  git clone --depth=1 -b v2.2.1 https://github.com/rpclib/rpclib.git ${RPCLIB_BASENAME}-source
+  git clone https://github.com/rpclib/rpclib.git ${RPCLIB_BASENAME}-source
+  pushd ${RPCLIB_BASENAME}-source >/dev/null
+  git reset --hard d1146b7
+  popd >/dev/null
 
   log "Building rpclib with libc++."
 

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -33,7 +33,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-set RPC_VERSION=v2.2.1
+set RPC_VERSION=d1146b7
 set RPC_SRC=rpclib-src
 set RPC_SRC_DIR=%BUILD_DIR%%RPC_SRC%\
 set RPC_INSTALL=rpclib-install
@@ -47,8 +47,11 @@ if exist "%RPC_INSTALL_DIR%" (
 if not exist "%RPC_SRC_DIR%" (
     echo %FILE_N% Cloning rpclib - version "%RPC_VERSION%"...
 
-    call git clone --depth=1 -b %RPC_VERSION% https://github.com/rpclib/rpclib.git %RPC_SRC_DIR%
+    call git clone https://github.com/rpclib/rpclib.git %RPC_SRC_DIR%
     if %errorlevel% neq 0 goto error_git
+    pushd %RPC_SRC_DIR%
+    call git reset --hard d1146b7
+    popd
 ) else (
     echo %FILE_N% Not cloning rpclib because already exists a folder called "%RPC_SRC%".
 )

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -40,6 +40,8 @@ set RPC_INSTALL=rpclib-install
 set RPC_INSTALL_DIR=%BUILD_DIR%%RPC_INSTALL%\
 set RPC_BUILD_DIR=%RPC_SRC_DIR%build
 
+set PUSHD_RPC=%RPC_SRC_DIR:\=/%
+
 if exist "%RPC_INSTALL_DIR%" (
     goto already_build
 )
@@ -49,7 +51,7 @@ if not exist "%RPC_SRC_DIR%" (
 
     call git clone https://github.com/rpclib/rpclib.git %RPC_SRC_DIR%
     if %errorlevel% neq 0 goto error_git
-    pushd %RPC_SRC_DIR%
+    pushd %PUSHD_RPC%
     call git reset --hard d1146b7
     popd
 ) else (


### PR DESCRIPTION
We observed a crash when the client disconnects during an rpc call. It seems to be fixed by https://github.com/rpclib/rpclib/pull/167.

I have upgraded rpclib to the commit that fixes this.

@iFuSiiOnzZ Please check the Windows script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/928)
<!-- Reviewable:end -->
