### PR TITLE
Road lane next prev

### DIFF
--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -128,6 +128,12 @@ namespace opendrive {
           }
         } else {
           roadSegment.AddSuccessorID(it->second->road_link.successor->id, is_start);
+          for(size_t i = 0; i < lanesLeft.size(); ++i) {
+            if(lanesLeft[i].link != nullptr) {
+              roadSegment.AddNextLaneInfo(lanesLeft[i].attributes.id, lanesLeft[i].link->successor_id, it->second->road_link.successor->id);
+              roadSegment.AddPrevLaneInfo(lanesLeft[i].attributes.id, lanesLeft[i].link->predecessor_id, it->second->road_link.predecessor->id);
+            }
+          }
         }
       }
 
@@ -142,6 +148,12 @@ namespace opendrive {
           }
         } else {
           roadSegment.AddPredecessorID(it->second->road_link.predecessor->id, is_start);
+          for(size_t i = 0; i < lanesRight.size(); ++i) {
+            if(lanesRight[i].link != nullptr) {
+              roadSegment.AddNextLaneInfo(lanesRight[i].attributes.id, lanesRight[i].link->successor_id, it->second->road_link.successor->id);
+              roadSegment.AddPrevLaneInfo(lanesRight[i].attributes.id, lanesRight[i].link->predecessor_id, it->second->road_link.predecessor->id);
+            }
+          }
         }
       }
 

--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -1,6 +1,5 @@
 #include "OpenDrive.h"
 
-
 #include "../road/MapBuilder.h"
 
 namespace carla {
@@ -125,6 +124,10 @@ namespace opendrive {
             junctionsData[it->second->road_link.successor->id][it->first];
           for (size_t i = 0; i < options.size(); ++i) {
             roadSegment.AddSuccessorID(options[i].connection_road, options[i].contact_point == "start");
+
+            for(size_t j = 0; j < options[i].from_lane.size(); ++j) {
+              roadSegment.AddNextLaneInfo(options[i].from_lane[j], options[i].to_lane[j], options[i].connection_road);
+            }
           }
         } else {
           roadSegment.AddSuccessorID(it->second->road_link.successor->id, is_start);
@@ -145,6 +148,10 @@ namespace opendrive {
             junctionsData[it->second->road_link.predecessor->id][it->first];
           for (size_t i = 0; i < options.size(); ++i) {
             roadSegment.AddPredecessorID(options[i].connection_road, options[i].contact_point == "start");
+
+            for(size_t j = 0; j < options[i].from_lane.size(); ++j) {
+              roadSegment.AddNextLaneInfo(options[i].from_lane[j], options[i].to_lane[j], options[i].connection_road);
+            }
           }
         } else {
           roadSegment.AddPredecessorID(it->second->road_link.predecessor->id, is_start);

--- a/LibCarla/source/carla/road/MapBuilder.h
+++ b/LibCarla/source/carla/road/MapBuilder.h
@@ -19,8 +19,7 @@ namespace road {
 
     bool AddRoadSegmentDefinition(element::RoadSegmentDefinition &seg);
 
-    void SetJunctionInformation(const std::vector<carla::road::lane_junction_t> &junctionInfo)
-    {
+    void SetJunctionInformation(const std::vector<carla::road::lane_junction_t> &junctionInfo) {
       _map_data.SetJunctionInformation(junctionInfo);
     }
 

--- a/LibCarla/source/carla/road/element/RoadSegment.h
+++ b/LibCarla/source/carla/road/element/RoadSegment.h
@@ -31,7 +31,9 @@ namespace element {
       : _id(def.GetId()),
         _successors_is_start(std::move(def._successor_is_start)),
         _predecessors_is_start(std::move(def._predecessors_is_start)),
-        _geom(std::move(def._geom)) {
+        _geom(std::move(def._geom)),
+        _next_lane(std::move(def._next_lane)),
+        _prev_lane(std::move(def._prev_lane)) {
       for (auto &&a : def._info) {
         _info.insert(std::move(a));
       }
@@ -110,6 +112,36 @@ namespace element {
 
     const std::vector<RoadSegment *> GetPredecessors() const {
       return _predecessors;
+    }
+
+    // Given the current lane it gives an std::pair of the lane id the and road id
+    // where you can go.
+    //
+    // INPUT:
+    //    int current_lane_id           for which lane do you want the next
+    //
+    // OUTPUT:
+    //    std::pair<int, int>           return a pair with lane id (first int) and the road id (second int),
+    //                                  if no lane has been found the given pair it will be (0, 0) as lane id
+    //                                  zero used for the reference line
+    std::pair<int, int> GetNextLane(int current_lane_id) const {
+      std::map<int, std::pair<int, int>>::const_iterator it = _next_lane.find(current_lane_id);
+      return it == _next_lane.end() ? std::pair<int, int>(0, 0) : it->second;
+    }
+
+    // Given the current lane it gives an std::pair with the lane id the and road id
+    // where you can go.
+    //
+    // INPUT:
+    //    int current_lane_id           for which lane do you want the next
+    //
+    // OUTPUT:
+    //    std::pair<int, int>           return a pair with lane id (first int) and the road id (second int),
+    //                                  if no lane has been found the given pair it will be (0, 0) as lane id
+    //                                  zero used for the reference line
+    std::pair<int, int> GetPrevLane(int current_lane_id) const {
+      std::map<int, std::pair<int, int>>::const_iterator it = _prev_lane.find(current_lane_id);
+      return it == _next_lane.end() ? std::pair<int, int>(0, 0) : it->second;
     }
 
     // Search for the last geometry with less start_offset before 'dist'
@@ -207,6 +239,8 @@ namespace element {
     std::vector<std::unique_ptr<Geometry>> _geom;
     std::multiset<std::shared_ptr<RoadInfo>, LessComp> _info;
     double _length = -1.0;
+    std::map<int, std::pair<int, int>> _next_lane;
+    std::map<int, std::pair<int, int>> _prev_lane;
   };
 
 } // namespace element

--- a/LibCarla/source/carla/road/element/RoadSegment.h
+++ b/LibCarla/source/carla/road/element/RoadSegment.h
@@ -115,33 +115,33 @@ namespace element {
     }
 
     // Given the current lane it gives an std::pair of the lane id the and road id
-    // where you can go.
+    // where you can go.  First integer of the pair is the lane id and the second the road id.
     //
     // INPUT:
-    //    int current_lane_id           for which lane do you want the next
+    //    int current_lane_id               for which lane do you want the next
     //
     // OUTPUT:
-    //    std::pair<int, int>           return a pair with lane id (first int) and the road id (second int),
-    //                                  if no lane has been found the given pair it will be (0, 0) as lane id
-    //                                  zero used for the reference line
-    std::pair<int, int> GetNextLane(int current_lane_id) const {
-      std::map<int, std::pair<int, int>>::const_iterator it = _next_lane.find(current_lane_id);
-      return it == _next_lane.end() ? std::pair<int, int>(0, 0) : it->second;
+    //    std::vector<std::pair<int, int>>  return a pair with lane id (first int) and the road id (second int),
+    //                                      if no lane has been found the given pair it will be (0, 0) as lane id
+    //                                      zero used for the reference line
+    std::vector<std::pair<int, int>> GetNextLane(int current_lane_id) const {
+      std::map<int, std::vector<std::pair<int, int>>>::const_iterator it = _next_lane.find(current_lane_id);
+      return it == _next_lane.end() ? std::vector<std::pair<int, int>>() : it->second;
     }
 
-    // Given the current lane it gives an std::pair with the lane id the and road id
-    // where you can go.
+    // Given the current lane it gives an std::pair vector with the lane id the and road id
+    // where you can go. First integer of the pair is the lane id and the second the road id.
     //
     // INPUT:
-    //    int current_lane_id           for which lane do you want the next
+    //    int current_lane_id               for which lane do you want the next
     //
     // OUTPUT:
-    //    std::pair<int, int>           return a pair with lane id (first int) and the road id (second int),
-    //                                  if no lane has been found the given pair it will be (0, 0) as lane id
-    //                                  zero used for the reference line
-    std::pair<int, int> GetPrevLane(int current_lane_id) const {
-      std::map<int, std::pair<int, int>>::const_iterator it = _prev_lane.find(current_lane_id);
-      return it == _next_lane.end() ? std::pair<int, int>(0, 0) : it->second;
+    //    std::vector<std::pair<int, int>>  return a pair with lane id (first int) and the road id (second int),
+    //                                      if no lane has been found the given pair it will be (0, 0) as lane id
+    //                                      zero used for the reference line
+    std::vector<std::pair<int, int>> GetPrevLane(int current_lane_id) const {
+      std::map<int, std::vector<std::pair<int, int>>>::const_iterator it = _prev_lane.find(current_lane_id);
+      return it == _next_lane.end() ? std::vector<std::pair<int, int>>() : it->second;
     }
 
     // Search for the last geometry with less start_offset before 'dist'
@@ -239,8 +239,12 @@ namespace element {
     std::vector<std::unique_ptr<Geometry>> _geom;
     std::multiset<std::shared_ptr<RoadInfo>, LessComp> _info;
     double _length = -1.0;
-    std::map<int, std::pair<int, int>> _next_lane;
-    std::map<int, std::pair<int, int>> _prev_lane;
+
+    // first  int     current lane
+    // second int     to which lane
+    // third  int     to which road
+    std::map<int, std::vector<std::pair<int, int>>> _next_lane;
+    std::map<int, std::vector<std::pair<int, int>>> _prev_lane;
   };
 
 } // namespace element

--- a/LibCarla/source/carla/road/element/Types.h
+++ b/LibCarla/source/carla/road/element/Types.h
@@ -28,7 +28,9 @@ namespace element {
         _successor_is_start(std::move(rsd._successor_is_start)),
         _predecessors_is_start(std::move(rsd._predecessors_is_start)),
         _geom(std::move(rsd._geom)),
-        _info(std::move(rsd._info)) {}
+        _info(std::move(rsd._info)),
+        _next_lane(std::move(rsd._next_lane)),
+        _prev_lane(std::move(rsd._prev_lane)) {}
 
     RoadSegmentDefinition(id_type id) {
       assert(id >= 0);
@@ -47,6 +49,14 @@ namespace element {
     void AddPredecessorID(const id_type &id, bool is_start = true) {
       _predecessor_id.emplace_back(id);
       _predecessors_is_start.emplace_back(is_start);
+    }
+
+    void AddNextLaneInfo(int current_lane_id, int next_lane_id, int next_road_id) {
+      _next_lane[current_lane_id] = std::pair<int, int>(next_lane_id, next_road_id);
+    }
+
+    void AddPrevLaneInfo(int current_lane_id, int next_lane_id, int next_road_id) {
+      _prev_lane[current_lane_id] = std::pair<int, int>(next_lane_id, next_road_id);
     }
 
     // usage MakeGeometry<GeometryArc>(len, st_pos_offs, head, st_pos, curv)
@@ -85,6 +95,8 @@ namespace element {
     std::vector<bool> _predecessors_is_start;
     std::vector<std::unique_ptr<Geometry>> _geom;
     std::vector<std::shared_ptr<RoadInfo>> _info;
+    std::map<int, std::pair<int, int>> _next_lane;
+    std::map<int, std::pair<int, int>> _prev_lane;
   };
 
 } // namespace element

--- a/LibCarla/source/carla/road/element/Types.h
+++ b/LibCarla/source/carla/road/element/Types.h
@@ -52,11 +52,11 @@ namespace element {
     }
 
     void AddNextLaneInfo(int current_lane_id, int next_lane_id, int next_road_id) {
-      _next_lane[current_lane_id] = std::pair<int, int>(next_lane_id, next_road_id);
+      _next_lane[current_lane_id].emplace_back(std::pair<int, int>(next_lane_id, next_road_id));
     }
 
     void AddPrevLaneInfo(int current_lane_id, int next_lane_id, int next_road_id) {
-      _prev_lane[current_lane_id] = std::pair<int, int>(next_lane_id, next_road_id);
+      _prev_lane[current_lane_id].emplace_back(std::pair<int, int>(next_lane_id, next_road_id));
     }
 
     // usage MakeGeometry<GeometryArc>(len, st_pos_offs, head, st_pos, curv)
@@ -95,8 +95,12 @@ namespace element {
     std::vector<bool> _predecessors_is_start;
     std::vector<std::unique_ptr<Geometry>> _geom;
     std::vector<std::shared_ptr<RoadInfo>> _info;
-    std::map<int, std::pair<int, int>> _next_lane;
-    std::map<int, std::pair<int, int>> _prev_lane;
+
+    // first  int     current lane
+    // second int     to which lane
+    // third  int     to which road
+    std::map<int, std::vector<std::pair<int, int>>> _next_lane;
+    std::map<int, std::vector<std::pair<int, int>>> _prev_lane;
   };
 
 } // namespace element

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
@@ -124,6 +124,7 @@ ARoutePlanner *AOpenDriveActor::GenerateRoutePlanner(const TArray<FVector> &wayp
     ARoutePlanner *routePlanner = GetWorld()->SpawnActor<ARoutePlanner>();
     routePlanner->SetActorLocation(waypoints[0]);
 
+    routePlanner->SetBoxExtent(FVector(70.0f, 70.0f, 50.0f));
     routePlanner->AddRoute(1.0f, waypoints);
     routePlanner->Init();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.cpp
@@ -193,7 +193,7 @@ void ARoutePlanner::DrawRoutes()
   {
     FVector boxCenter = Routes[i]->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World);
     boxCenter.Z += i * 101.0f;
-    DrawDebugBox(GetWorld(), boxCenter, FVector(100.0f, 100.0f, 50.0f), SplineColor, true);
+    DrawDebugBox(GetWorld(), boxCenter, TriggerVolume->GetUnscaledBoxExtent() - FVector(10.0f, 10.0f, 10.0f), SplineColor, true);
 
     for (int j = 0, lenNumPoints = Routes[i]->GetNumberOfSplinePoints() - 1; j < lenNumPoints; ++j)
     {


### PR DESCRIPTION
#### Description
Currently given a lane from a road segment there is no way to know which is the next or previous lane. The missing information has been added as is needed for the PythonAPI.

Each road section has a function called `GetNextLane` and `GetPrevLane` that accepts as input the current lane and return a vector of pairs where the first element of the pair is the next lane id and the second one the next road id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/938)
<!-- Reviewable:end -->
