### PR TITLE
Change cmake version from 3.9 to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.1)
 project(CARLA)
 
 include("Build/CMakeLists.txt.in")

--- a/Docs/how_to_build_on_linux.md
+++ b/Docs/how_to_build_on_linux.md
@@ -12,10 +12,6 @@ sudo apt-get install build-essential clang-5.0 lld-5.0 g++-7 ninja-build python 
 pip install --user setuptools nose2
 ```
 
-Note that some dependencies require **CMake 3.9** or later installed in your
-machine, you can retrieve the latest version from the
-[CMake download page][cmakelink].
-
 To avoid compatibility issues between Unreal Engine and the CARLA dependencies,
 the best configuration is to compile everything with the same compiler version
 and C++ runtime library. We use clang 5.0 and LLVM's libc++. We recommend to

--- a/LibCarla/cmake/CMakeLists.txt
+++ b/LibCarla/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.1)
 project(libcarla)
 
 message(STATUS "Building ${PROJECT_NAME} version ${CARLA_VERSION}")

--- a/LibCarla/cmake/client/CMakeLists.txt
+++ b/LibCarla/cmake/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.1)
 project(libcarla-client)
 
 # Install rpclib.

--- a/LibCarla/cmake/server/CMakeLists.txt
+++ b/LibCarla/cmake/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.1)
 project(libcarla-server)
 
 # Install libc++ shared libraries.

--- a/LibCarla/cmake/test/CMakeLists.txt
+++ b/LibCarla/cmake/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.5.1)
 project(libcarla-unit-tests)
 
 file(GLOB_RECURSE libcarla_test_sources

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -149,6 +149,10 @@ else
 
   log "Building rpclib with libc++."
 
+  # rpclib does not use any cmake 3.9 feature. 
+  # As cmake 3.9 is not standard in Ubuntu 16.04, change cmake version to 3.5
+  sed -i s/"3.9.0"/"3.5.0"/g ${RPCLIB_BASENAME}-source/CMakeLists.txt
+
   mkdir -p ${RPCLIB_BASENAME}-libcxx-build
 
   pushd ${RPCLIB_BASENAME}-libcxx-build >/dev/null


### PR DESCRIPTION
No feature of cmake newer than 3.5 is used. Therefore, we can use
cmake 3.5, which is also standard in Ubuntu 16.04, whereas cmake 3.9
is non-standard.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check`

Where has this been tested?
  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** Python 2.7
  * **Unreal Engine version(s):** Unreal 4.19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/980)
<!-- Reviewable:end -->
