### PR TITLE
Fix win32 compilation

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorAttribute.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorAttribute.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/ActorAttributeType.h>
+#include <compiler/enable-ue4-macros.h>
 
 #include "ActorAttribute.generated.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.h
@@ -6,7 +6,8 @@
 
 
 #include "Util/NonCopyable.h"
-#include "EngineMinimal.h"
+#include "Logging/LogMacros.h"
+#include "Modules/ModuleInterface.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogCarla, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogCarlaServer, Log, All);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.h
@@ -4,9 +4,9 @@
 // plugin.
 #pragma once
 
-#include "ModuleManager.h"
 
 #include "Util/NonCopyable.h"
+#include "EngineMinimal.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogCarla, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogCarlaServer, Log, All);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.cpp
@@ -7,8 +7,6 @@
 #include "Carla.h"
 #include "Carla/Util/OpenDrive.h"
 
-#include "Engine.h"
-
 FString FOpenDrive::Load(FString MapName)
 {
 #if WITH_EDITOR


### PR DESCRIPTION
#### Description

Depending on the included headers sometimes the compilation was failing giving errors as ` {instrinsic funtion} is not a member of {class name}` or some Unreal functions as `GetObject` was replaced by the `GetObjectW` macro of Windows. So to fix the problem some of the general Unreal includes and some other unused includes have been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/988)
<!-- Reviewable:end -->
