### PR TITLE
Opendrive elevation

### DIFF
--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -124,20 +124,29 @@ namespace opendrive {
     // Transforma data for the MapBuilder
     for (road_data_t::iterator it = roadData.begin(); it != roadData.end(); ++it) {
       carla::road::element::RoadSegmentDefinition roadSegment(it->first);
-      carla::road::element::RoadInfoLane *roadInfoLanes =
+      carla::road::element::RoadInfoLane *RoadInfoLanes =
           roadSegment.MakeInfo<carla::road::element::RoadInfoLane>();
 
-      carla::road::element::RoadGeneralInfo *roadGeneralInfo =
+      carla::road::element::RoadGeneralInfo *RoadGeneralInfo =
           roadSegment.MakeInfo<carla::road::element::RoadGeneralInfo>();
-      roadGeneralInfo->SetJunctionId(it->second->attributes.junction);
+      RoadGeneralInfo->SetJunctionId(it->second->attributes.junction);
 
       for (size_t i = 0; i < it->second->lanes.lane_offset.size(); ++i) {
         double s = it->second->lanes.lane_offset[i].s;
         double a = it->second->lanes.lane_offset[i].a;
-        roadGeneralInfo->SetLanesOffset(s, a);
+        RoadGeneralInfo->SetLanesOffset(s, a);
       }
 
-      /////////////////////////////////////////////////////////////////////////
+      for(auto &&elevation : it->second->road_profiles.elevation_profile) {
+        roadSegment.MakeInfo<carla::road::element::RoadElevationInfo>(
+          elevation.start_position,
+          elevation.start_position,
+          elevation.elevation,
+          elevation.slope,
+          elevation.vertical_curvature,
+          elevation.curvature_change
+        );
+      }
 
       std::map<int, int> leftLanesGoToSuccessor, leftLanesGoToPredecessor;
       std::map<int, int> rightLanesGoToSuccessor, rightLanesGoToPredecessor;
@@ -204,12 +213,12 @@ namespace opendrive {
           &it->second->lanes.lane_sections.front().right;
 
       for (size_t i = 0; i < lanesLeft->size(); ++i) {
-        roadInfoLanes->addLaneInfo(lanesLeft->at(i).attributes.id,
+        RoadInfoLanes->addLaneInfo(lanesLeft->at(i).attributes.id,
             lanesLeft->at(i).lane_width[0].width,
             lanesLeft->at(i).attributes.type);
       }
       for (size_t i = 0; i < lanesRight->size(); ++i) {
-        roadInfoLanes->addLaneInfo(lanesRight->at(i).attributes.id,
+        RoadInfoLanes->addLaneInfo(lanesRight->at(i).attributes.id,
             lanesRight->at(i).lane_width[0].width,
             lanesRight->at(i).attributes.type);
       }

--- a/LibCarla/source/carla/road/element/Geometry.h
+++ b/LibCarla/source/carla/road/element/Geometry.h
@@ -36,7 +36,8 @@ namespace element {
         tangent(t) {}
 
     geom::Location location = {0, 0, 0};
-    double tangent = 0; // [radians]
+    double tangent = 0.0; // [radians]
+    double pitch = 0.0;   // [radians]
     bool valid = true;
 
     static DirectedPoint Invalid() {

--- a/LibCarla/source/carla/road/element/RoadInfo.h
+++ b/LibCarla/source/carla/road/element/RoadInfo.h
@@ -70,6 +70,70 @@ namespace element {
     }
   };
 
+  class RoadElevationInfo : public RoadInfo {
+  public:
+
+    void AcceptVisitor(RoadInfoVisitor &v) final {
+      v.Visit(*this);
+    }
+
+    RoadElevationInfo(double d,
+        double start_position,
+        double elevation,
+        double slope,
+        double vertical_curvature,
+        double curvature_change)
+      : RoadInfo(d),
+        _start_position(start_position),
+        _elevation(elevation),
+        _slope(slope),
+        _vertical_curvature(vertical_curvature),
+        _curvature_change(curvature_change) {}
+
+    double Evaluate(const double dist, double *out_tan) const {
+      const double t = dist - _start_position;
+      const double pos = _elevation +
+          _slope * t +
+          _vertical_curvature * t * t +
+          _curvature_change * t * t * t;
+
+      if (out_tan) {
+        *out_tan = _slope + t *
+            (2 * _vertical_curvature + t * 3 * _curvature_change);
+      }
+
+      return pos;
+    }
+
+    double GetStartPosition() const {
+      return _start_position;
+    }
+
+    double GetElevation() const {
+      return _elevation;
+    }
+
+    double GetSlope() const {
+      return _slope;
+    }
+
+    double GetVerticalCurvature() const {
+      return _vertical_curvature;
+    }
+
+    double GetCurvatureChange() const {
+      return _curvature_change;
+    }
+
+  private:
+
+    double _start_position;      // (S) start position(s - offset)[meters]
+    double _elevation;           // (A) elevation [meters]
+    double _slope;               // (B)
+    double _vertical_curvature;  // (C)
+    double _curvature_change;    // (D)
+  };
+
   class RoadInfoVelocity : public RoadInfo {
   public:
 

--- a/LibCarla/source/carla/road/element/RoadInfoVisitor.h
+++ b/LibCarla/source/carla/road/element/RoadInfoVisitor.h
@@ -16,6 +16,7 @@ namespace element {
   class RoadInfoLane;
   class RoadGeneralInfo;
   class RoadInfoVelocity;
+  class RoadElevationInfo;
 
   class RoadInfoVisitor {
   public:
@@ -23,6 +24,7 @@ namespace element {
     virtual void Visit(RoadInfoLane &) {}
     virtual void Visit(RoadGeneralInfo &) {}
     virtual void Visit(RoadInfoVelocity &) {}
+    virtual void Visit(RoadElevationInfo &) {}
   };
 
   template <typename T, typename IT>

--- a/LibCarla/source/carla/road/element/RoadSegment.h
+++ b/LibCarla/source/carla/road/element/RoadSegment.h
@@ -247,7 +247,7 @@ namespace element {
     DirectedPoint DirectedPointWithElevation(double dist, DirectedPoint dp) const {
         const RoadElevationInfo *elev_info = GetInfo<RoadElevationInfo>(dist);
         if (elev_info) {
-          dp.location.z = elev_info->Evaluate(dist, nullptr);
+          dp.location.z = elev_info->Evaluate(dist, &dp.pitch);
         }
         return dp;
     }

--- a/LibCarla/source/carla/road/element/Waypoint.cpp
+++ b/LibCarla/source/carla/road/element/Waypoint.cpp
@@ -93,9 +93,10 @@ namespace element {
     road::element::DirectedPoint dp =
         _map->GetData().GetRoad(_road_id)->GetDirectedPointIn(_dist);
 
-    geom::Rotation rot(0.0, geom::Math::to_degrees(dp.tangent), 0.0);
+    geom::Rotation rot(geom::Math::to_degrees(dp.pitch), geom::Math::to_degrees(dp.tangent), 0.0);
     if (_lane_id > 0) {
       rot.yaw += 180.0;
+      rot.pitch = 360 - rot.pitch;
     }
 
     const auto *road_segment = _map->GetData().GetRoad(_road_id);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
@@ -64,7 +64,7 @@ AOpenDriveActor::AOpenDriveActor(const FObjectInitializer& ObjectInitializer) :
     SpriteComponent->SpriteInfo.DisplayName = ConstructorStatics.Name;   // Assign sprite display name
     SpriteComponent->SetupAttachment(RootComponent); // Attach sprite to scene component
     SpriteComponent->Mobility = EComponentMobility::Static;
-    SpriteComponent->SetEditorScale(1.5f);
+    SpriteComponent->SetEditorScale(0.8f);
   }
 #endif // WITH_EDITORONLY_DATA
 }
@@ -241,6 +241,8 @@ void AOpenDriveActor::RemoveRoutes()
 TArray<AOpenDriveActor::DirectedPoint> AOpenDriveActor::GenerateLaneZeroPoints(
     const RoadSegment *road)
 {
+  using RoadElevationInfo = carla::road::element::RoadElevationInfo;
+
   size_t LanesOffsetIndex = 0;
   TArray<DirectedPoint> LaneZeroPoints;
 
@@ -260,6 +262,12 @@ TArray<AOpenDriveActor::DirectedPoint> AOpenDriveActor::GenerateLaneZeroPoints(
     // NOTE(Andrei): Get waypoin at the offset, and invert the y axis
     DirectedPoint Waypoint = road->GetDirectedPointIn(WaypointsOffset);
     Waypoint.location.z = 1;
+
+    const RoadElevationInfo *ElevInfo = road->GetInfo<RoadElevationInfo>(WaypointsOffset);
+
+    if(ElevInfo) {
+      Waypoint.location.z += (float)ElevInfo->Evaluate(WaypointsOffset, nullptr);
+    }
 
     // NOTE(Andrei): Applyed the laneOffset of the lane section
     Waypoint.ApplyLateralOffset(LanesOffset[LanesOffsetIndex].second);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
@@ -261,13 +261,9 @@ TArray<AOpenDriveActor::DirectedPoint> AOpenDriveActor::GenerateLaneZeroPoints(
 
     // NOTE(Andrei): Get waypoin at the offset, and invert the y axis
     DirectedPoint Waypoint = road->GetDirectedPointIn(WaypointsOffset);
-    Waypoint.location.z = 1;
 
-    const RoadElevationInfo *ElevInfo = road->GetInfo<RoadElevationInfo>(WaypointsOffset);
-
-    if(ElevInfo) {
-      Waypoint.location.z += (float)ElevInfo->Evaluate(WaypointsOffset, nullptr);
-    }
+    // Elevate the generated road 1m because the triggers and visualization
+    Waypoint.location.z += 1;
 
     // NOTE(Andrei): Applyed the laneOffset of the lane section
     Waypoint.ApplyLateralOffset(LanesOffset[LanesOffsetIndex].second);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
@@ -64,7 +64,7 @@ AOpenDriveActor::AOpenDriveActor(const FObjectInitializer& ObjectInitializer) :
     SpriteComponent->SpriteInfo.DisplayName = ConstructorStatics.Name;   // Assign sprite display name
     SpriteComponent->SetupAttachment(RootComponent); // Attach sprite to scene component
     SpriteComponent->Mobility = EComponentMobility::Static;
-    SpriteComponent->SetEditorScale(0.8f);
+    SpriteComponent->SetEditorScale(1.0f);
   }
 #endif // WITH_EDITORONLY_DATA
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.h
@@ -59,7 +59,7 @@ private:
 
   /// If true, spawners will be placed when generating the routes
   UPROPERTY(Category = "Spawners", EditAnywhere)
-  bool bAddSpawners = true;
+  bool bAddSpawners = false;
 
   /// Determine the height where the spawners will be placed, relative to each RoutePlanner
   UPROPERTY(Category = "Spawners", EditAnywhere)


### PR DESCRIPTION
#### Description
Improved the integration with OpenDrive:
- **Python API**: Now you can get the height and rotation of the waypoints.
- **OpenDriveActor**: Now spawns trigger boxes with the correct map elevation.
- **OpenDriveActor**: Disabled `AddSpawners` by default.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** 4.19

#### Possible Drawbacks
Nothing found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1031)
<!-- Reviewable:end -->
