### PR TITLE
Add get_forward_vector to rotation and transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Added point transformation functionality for LibCarla and PythonAPI
   * Added "sensor_tick" attribute to sensors (cameras and lidars) to specify the capture rate in seconds
+  * Added "get_forward_vector()" to rotation and transform, retrieves the unit vector on the rotation's X-axis
   * Added support for Deepin in PythonAPI's setup.py
 
 ## CARLA 0.9.2

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -243,6 +243,7 @@ Static presets
 - `pitch`
 - `yaw`
 - `roll`
+- `get_forward_vector()`
 - `__eq__(other)`
 - `__ne__(other)`
 
@@ -250,10 +251,10 @@ Static presets
 
 - `location`
 - `rotation`
+- `transform(geom_object)`
+- `get_forward_vector()`
 - `__eq__(other)`
 - `__ne__(other)`
-- `transform_point`
-- `transform_point_list`
 
 ## `carla.BoundingBox`
 

--- a/LibCarla/source/carla/geom/Location.h
+++ b/LibCarla/source/carla/geom/Location.h
@@ -19,17 +19,25 @@ namespace geom {
   class Location : public Vector3D {
   public:
 
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
     Location() = default;
 
     using Vector3D::Vector3D;
 
-    using Vector3D::x;
-    using Vector3D::y;
-    using Vector3D::z;
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
 
-    using Vector3D::msgpack_pack;
-    using Vector3D::msgpack_unpack;
-    using Vector3D::msgpack_object;
+    double Distance(const Location &loc) const {
+      return Math::Distance(*this, loc);
+    }
+
+    // =========================================================================
+    // -- Arithmetic operators -------------------------------------------------
+    // =========================================================================
 
     Location &operator+=(const Location &rhs) {
       static_cast<Vector3D &>(*this) += rhs;
@@ -67,6 +75,10 @@ namespace geom {
       return rhs;
     }
 
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
+
     bool operator==(const Location &rhs) const {
       return static_cast<const Vector3D &>(*this) == rhs;
     }
@@ -75,9 +87,9 @@ namespace geom {
       return !(*this == rhs);
     }
 
-    double Distance(const Location &loc) const {
-      return Math::Distance(*this, loc);
-    }
+    // =========================================================================
+    // -- Conversions to UE4 types ---------------------------------------------
+    // =========================================================================
 
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 

--- a/LibCarla/source/carla/geom/Math.cpp
+++ b/LibCarla/source/carla/geom/Math.cpp
@@ -9,121 +9,123 @@
 namespace carla {
 namespace geom {
 
-    /// Returns a pair containing:
-    /// - @b first:  distance from v to p' where p' = p projected on segment (w - v)
-    /// - @b second: Euclidean distance from p to p'
-    ///   @param p point to calculate distance
-    ///   @param v first point of the segment
-    ///   @param w second point of the segment
-    std::pair<double, double> Math::DistSegmentPoint(
-        const Vector3D &p,
-        const Vector3D &v,
-        const Vector3D &w) {
-      const double l2 = DistanceSquared2D(v, w);
-      const double l = std::sqrt(l2);
-      if (l2 == 0.0) {
-        return std::make_pair(0.0, Distance2D(v, p));
-      }
-      const double dot_p_w = Dot2D(p - v, w - v);
-      const double t = clamp01(dot_p_w / l2);
-      const Vector3D projection = v + t * (w - v);
-      return std::make_pair(t * l, Distance2D(projection, p));
+  /// Returns a pair containing:
+  /// - @b first:  distance from v to p' where p' = p projected on segment (w -
+  /// v)
+  /// - @b second: Euclidean distance from p to p'
+  ///   @param p point to calculate distance
+  ///   @param v first point of the segment
+  ///   @param w second point of the segment
+  std::pair<double, double> Math::DistSegmentPoint(
+      const Vector3D &p,
+      const Vector3D &v,
+      const Vector3D &w) {
+    const double l2 = DistanceSquared2D(v, w);
+    const double l = std::sqrt(l2);
+    if (l2 == 0.0) {
+      return std::make_pair(0.0, Distance2D(v, p));
     }
+    const double dot_p_w = Dot2D(p - v, w - v);
+    const double t = clamp01(dot_p_w / l2);
+    const Vector3D projection = v + t * (w - v);
+    return std::make_pair(t * l, Distance2D(projection, p));
+  }
 
-    Vector3D Math::RotatePointOnOrigin2D(Vector3D p, double angle) {
-      double s = std::sin(angle);
-      double c = std::cos(angle);
-      return Vector3D(p.x * c - p.y * s, p.x * s + p.y * c, 0.0);
-    }
+  Vector3D Math::RotatePointOnOrigin2D(Vector3D p, double angle) {
+    double s = std::sin(angle);
+    double c = std::cos(angle);
+    return Vector3D(p.x * c - p.y * s, p.x * s + p.y * c, 0.0);
+  }
 
-    /// Returns a pair containing:
-    /// - @b first:  distance across the arc from start_pos to p' where p' = p projected on Arc
-    /// - @b second: Euclidean distance from p to p'
-    std::pair<double, double> Math::DistArcPoint(
-        Vector3D p,
-        Vector3D start_pos,
-        double length,
-        double heading, // [radians]
-        double curvature) {
+  /// Returns a pair containing:
+  /// - @b first:  distance across the arc from start_pos to p' where p' = p
+  /// projected on Arc
+  /// - @b second: Euclidean distance from p to p'
+  std::pair<double, double> Math::DistArcPoint(
+      Vector3D p,
+      Vector3D start_pos,
+      double length,
+      double heading,   // [radians]
+      double curvature) {
 
-      /// @todo: Because Unreal's coordinates, hacky way to correct
-      /// the -y, this must be changed in the future
+    /// @todo: Because Unreal's coordinates, hacky way to correct
+    /// the -y, this must be changed in the future
+    p.y = -p.y;
+    start_pos.y = -start_pos.y;
+    heading = -heading;
+
+    // since this algorithm is working for positive curvatures,
+    // and we are only calculating distances, we can invert the y
+    // axis (along with the curvature and the heading), so if the
+    // curvature is negative, so the algorithm will work as expected
+    if (curvature < 0.0) {
       p.y = -p.y;
       start_pos.y = -start_pos.y;
       heading = -heading;
-
-      // since this algorithm is working for positive curvatures,
-      // and we are only calculating distances, we can invert the y
-      // axis (along with the curvature and the heading), so if the
-      // curvature is negative, so the algorithm will work as expected
-      if (curvature < 0.0) {
-        p.y = -p.y;
-        start_pos.y = -start_pos.y;
-        heading = -heading;
-        curvature = -curvature;
-      }
-
-      // transport point relative to the arc starting poistion and rotation
-      const Vector3D rotated_p(RotatePointOnOrigin2D(p - start_pos, -heading));
-
-      const double radius = 1.0 / curvature;
-      const Vector3D circ_center(0, radius, 0);
-
-      // check if the point is in the center of the circle, so we know p
-      // is in the same distance of every possible point in the arc
-      if (rotated_p == circ_center) {
-        return std::make_pair(0.0, radius);
-      }
-
-      // find intersection position using the unit vector from the center
-      // of the circle to the point and multiplying by the radius
-      const Vector3D intersection = ((rotated_p - circ_center).MakeUnitVector() * radius) + circ_center;
-
-      // use the arc length to calculate the angle in the last point of it
-      // circumference of a circle = 2 * PI * r
-      // last_point_angle = (length / circumference) * 2 * PI
-      // so last_point_angle = length / radius
-      const double last_point_angle = length / radius;
-
-      // move the point relative to the center of the circle and find
-      // the angle between the point and the center of coords in rad
-      double angle = std::atan2(intersection.y - radius, intersection.x) + pi_half();
-
-      if(angle < 0.0) {
-        angle += pi_double();
-      }
-
-      // see if the angle is between 0 and last_point_angle
-      DEBUG_ASSERT(angle >= 0.0);
-      if (angle <= last_point_angle) {
-        return std::make_pair(
-            angle * radius,
-            Distance2D(intersection, rotated_p));
-      }
-
-      // find the nearest point, start or end to intersection
-      const double start_dist = Distance2D(Vector3D(), rotated_p);
-
-      const Vector3D end_pos(
-          radius * std::cos(last_point_angle - pi_half()),
-          radius * std::sin(last_point_angle - pi_half()) + circ_center.y,
-          0.0);
-      const double end_dist = Distance2D(end_pos, rotated_p);
-      return (start_dist < end_dist) ?
-          std::make_pair(0.0, start_dist) :
-          std::make_pair(length, end_dist);
+      curvature = -curvature;
     }
 
-    bool Math::PointInRectangle(
-        const Vector3D &pos,
-        const Vector3D &extent,
-        double angle, // [radians]
-        const Vector3D &p) {
-      // Move p relative to pos's position and angle
-      Vector3D transf_p = RotatePointOnOrigin2D(p - pos, -angle);
-      return transf_p.x <=  extent.x && transf_p.y <=  extent.y &&
-             transf_p.x >= -extent.x && transf_p.y >= -extent.y;
+    // transport point relative to the arc starting poistion and rotation
+    const Vector3D rotated_p(RotatePointOnOrigin2D(p - start_pos, -heading));
+
+    const double radius = 1.0 / curvature;
+    const Vector3D circ_center(0, radius, 0);
+
+    // check if the point is in the center of the circle, so we know p
+    // is in the same distance of every possible point in the arc
+    if (rotated_p == circ_center) {
+      return std::make_pair(0.0, radius);
     }
+
+    // find intersection position using the unit vector from the center
+    // of the circle to the point and multiplying by the radius
+    const Vector3D intersection = ((rotated_p - circ_center).MakeUnitVector() * radius) + circ_center;
+
+    // use the arc length to calculate the angle in the last point of it
+    // circumference of a circle = 2 * PI * r
+    // last_point_angle = (length / circumference) * 2 * PI
+    // so last_point_angle = length / radius
+    const double last_point_angle = length / radius;
+
+    // move the point relative to the center of the circle and find
+    // the angle between the point and the center of coords in rad
+    double angle = std::atan2(intersection.y - radius, intersection.x) + pi_half();
+
+    if (angle < 0.0) {
+      angle += pi_double();
+    }
+
+    // see if the angle is between 0 and last_point_angle
+    DEBUG_ASSERT(angle >= 0.0);
+    if (angle <= last_point_angle) {
+      return std::make_pair(
+          angle * radius,
+          Distance2D(intersection, rotated_p));
+    }
+
+    // find the nearest point, start or end to intersection
+    const double start_dist = Distance2D(Vector3D(), rotated_p);
+
+    const Vector3D end_pos(
+        radius * std::cos(last_point_angle - pi_half()),
+        radius *std::sin(last_point_angle - pi_half()) + circ_center.y,
+        0.0);
+    const double end_dist = Distance2D(end_pos, rotated_p);
+    return (start_dist < end_dist) ?
+           std::make_pair(0.0, start_dist) :
+           std::make_pair(length, end_dist);
+  }
+
+  bool Math::PointInRectangle(
+      const Vector3D &pos,
+      const Vector3D &extent,
+      double angle,   // [radians]
+      const Vector3D &p) {
+    // Move p relative to pos's position and angle
+    Vector3D transf_p = RotatePointOnOrigin2D(p - pos, -angle);
+    return transf_p.x <=  extent.x && transf_p.y <=  extent.y &&
+           transf_p.x >= -extent.x && transf_p.y >= -extent.y;
+  }
 
 } // namespace geom
 } // namespace carla

--- a/LibCarla/source/carla/geom/Math.cpp
+++ b/LibCarla/source/carla/geom/Math.cpp
@@ -6,6 +6,8 @@
 
 #include "carla/geom/Math.h"
 
+#include "carla/geom/Rotation.h"
+
 namespace carla {
 namespace geom {
 
@@ -125,6 +127,14 @@ namespace geom {
     Vector3D transf_p = RotatePointOnOrigin2D(p - pos, -angle);
     return transf_p.x <=  extent.x && transf_p.y <=  extent.y &&
            transf_p.x >= -extent.x && transf_p.y >= -extent.y;
+  }
+
+  Vector3D Math::GetForwardVector(const Rotation &rotation) {
+    const float cp = std::cos(to_radians(rotation.pitch));
+    const float sp = std::sin(to_radians(rotation.pitch));
+    const float cy = std::cos(to_radians(rotation.yaw));
+    const float sy = std::sin(to_radians(rotation.yaw));
+    return {cy * cp, sy * cp, sp};
   }
 
 } // namespace geom

--- a/LibCarla/source/carla/geom/Math.h
+++ b/LibCarla/source/carla/geom/Math.h
@@ -15,6 +15,8 @@
 namespace carla {
 namespace geom {
 
+  class Rotation;
+
   class Math {
   public:
 
@@ -99,6 +101,9 @@ namespace geom {
         const Vector3D &,
         double, // [radians]
         const Vector3D &);
+
+    /// Compute the unit vector pointing towards the X-axis of @a rotation.
+    static Vector3D GetForwardVector(const Rotation &rotation);
   };
 
 } // namespace geom

--- a/LibCarla/source/carla/geom/Math.h
+++ b/LibCarla/source/carla/geom/Math.h
@@ -17,6 +17,7 @@ namespace geom {
 
   class Math {
   public:
+
     static constexpr auto pi() {
       return 3.14159265358979323846264338327950288;
     }

--- a/LibCarla/source/carla/geom/Rotation.h
+++ b/LibCarla/source/carla/geom/Rotation.h
@@ -18,6 +18,22 @@ namespace geom {
   class Rotation {
   public:
 
+    // =========================================================================
+    // -- Public data members --------------------------------------------------
+    // =========================================================================
+
+    float pitch = 0.0f;
+
+    float yaw = 0.0f;
+
+    float roll = 0.0f;
+
+    MSGPACK_DEFINE_ARRAY(pitch, yaw, roll);
+
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
     Rotation() = default;
 
     Rotation(float p, float y, float r)
@@ -25,9 +41,9 @@ namespace geom {
         yaw(y),
         roll(r) {}
 
-    float pitch = 0.0f;
-    float yaw = 0.0f;
-    float roll = 0.0f;
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
 
     bool operator==(const Rotation &rhs) const  {
       return (pitch == rhs.pitch) && (yaw == rhs.yaw) && (roll == rhs.roll);
@@ -36,6 +52,10 @@ namespace geom {
     bool operator!=(const Rotation &rhs) const  {
       return !(*this == rhs);
     }
+
+    // =========================================================================
+    // -- Conversions to UE4 types ---------------------------------------------
+    // =========================================================================
 
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 
@@ -47,8 +67,6 @@ namespace geom {
     }
 
 #endif // LIBCARLA_INCLUDED_FROM_UE4
-
-    MSGPACK_DEFINE_ARRAY(pitch, yaw, roll);
   };
 
 } // namespace geom

--- a/LibCarla/source/carla/geom/Rotation.h
+++ b/LibCarla/source/carla/geom/Rotation.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "carla/MsgPack.h"
+#include "carla/geom/Math.h"
+#include "carla/geom/Vector3D.h"
 
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 #  include "Math/Rotator.h"
@@ -40,6 +42,14 @@ namespace geom {
       : pitch(p),
         yaw(y),
         roll(r) {}
+
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
+
+    Vector3D GetForwardVector() const {
+      return Math::GetForwardVector(*this);
+    }
 
     // =========================================================================
     // -- Comparison operators -------------------------------------------------

--- a/LibCarla/source/carla/geom/Transform.h
+++ b/LibCarla/source/carla/geom/Transform.h
@@ -45,6 +45,10 @@ namespace geom {
     // -- Other methods --------------------------------------------------------
     // =========================================================================
 
+    Vector3D GetForwardVector() const {
+      return rotation.GetForwardVector();
+    }
+
     void TransformPoint(Vector3D &in_point) const {
       // Rotate
       double cy = cos(Math::to_radians(rotation.yaw));

--- a/LibCarla/source/carla/geom/Transform.h
+++ b/LibCarla/source/carla/geom/Transform.h
@@ -21,25 +21,31 @@ namespace geom {
   class Transform {
   public:
 
+    // =========================================================================
+    // -- Public data members --------------------------------------------------
+    // =========================================================================
+
+    Location location;
+
+    Rotation rotation;
+
+    MSGPACK_DEFINE_ARRAY(location, rotation);
+
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
     Transform() = default;
 
     Transform(const Location &in_location, const Rotation &in_rotation)
       : location(in_location),
         rotation(in_rotation) {}
 
-    Location location;
-    Rotation rotation;
-
-    bool operator==(const Transform &rhs) const {
-      return (location == rhs.location) && (rotation == rhs.rotation);
-    }
-
-    bool operator!=(const Transform &rhs) const {
-      return !(*this == rhs);
-    }
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
 
     void TransformPoint(Vector3D &in_point) const {
-
       // Rotate
       double cy = cos(Math::to_radians(rotation.yaw));
       double sy = sin(Math::to_radians(rotation.yaw));
@@ -66,6 +72,22 @@ namespace geom {
       in_point = out_point;
     }
 
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
+
+    bool operator==(const Transform &rhs) const {
+      return (location == rhs.location) && (rotation == rhs.rotation);
+    }
+
+    bool operator!=(const Transform &rhs) const {
+      return !(*this == rhs);
+    }
+
+    // =========================================================================
+    // -- Conversions to UE4 types ---------------------------------------------
+    // =========================================================================
+
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 
     Transform(const FTransform &transform)
@@ -77,8 +99,6 @@ namespace geom {
     }
 
 #endif // LIBCARLA_INCLUDED_FROM_UE4
-
-    MSGPACK_DEFINE_ARRAY(location, rotation);
   };
 
 } // namespace geom

--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -17,9 +17,19 @@ namespace geom {
   class Vector3D {
   public:
 
+    // =========================================================================
+    // -- Public data members --------------------------------------------------
+    // =========================================================================
+
     float x = 0.0f;
+
     float y = 0.0f;
+
     float z = 0.0f;
+
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
 
     Vector3D() = default;
 
@@ -27,6 +37,29 @@ namespace geom {
       : x(ix),
         y(iy),
         z(iz) {}
+
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
+
+    double SquaredLength() const {
+      return x * x + y * y + z * z;
+    }
+
+    double Length() const {
+       return std::sqrt(SquaredLength());
+    }
+
+    Vector3D MakeUnitVector() const {
+      const double len = Length();
+      DEBUG_ASSERT(len > std::numeric_limits<double>::epsilon());
+      double k = 1.0 / len;
+      return Vector3D(x * k, y * k, z * k);
+    }
+
+    // =========================================================================
+    // -- Arithmetic operators -------------------------------------------------
+    // =========================================================================
 
     Vector3D &operator+=(const Vector3D &rhs) {
       x += rhs.x;
@@ -86,27 +119,16 @@ namespace geom {
       return rhs;
     }
 
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
+
     bool operator==(const Vector3D &rhs) const {
       return (x == rhs.x) && (y == rhs.y) && (z == rhs.z);
     }
 
     bool operator!=(const Vector3D &rhs) const {
       return !(*this == rhs);
-    }
-
-    double SquaredLength() const {
-      return x * x + y * y + z * z;
-    }
-
-    double Length() const {
-       return std::sqrt(SquaredLength());
-    }
-
-    Vector3D MakeUnitVector() const {
-      const double len = Length();
-      DEBUG_ASSERT(len > std::numeric_limits<double>::epsilon());
-      double k = 1.0 / len;
-      return Vector3D(x * k, y * k, z * k);
     }
 
     // =========================================================================

--- a/LibCarla/source/test/test_geom.cpp
+++ b/LibCarla/source/test/test_geom.cpp
@@ -11,6 +11,17 @@
 #include <carla/geom/Transform.h>
 #include <limits>
 
+namespace carla {
+namespace geom {
+
+  std::ostream &operator<<(std::ostream &out, const Vector3D &vector3D) {
+    out << "{x=" << vector3D.x << ", y=" << vector3D.y << ", z=" << vector3D.z << '}';
+    return out;
+  }
+
+} // namespace geom
+} // namespace carla
+
 using namespace carla::geom;
 
 TEST(geom, single_point_no_transform) {
@@ -76,7 +87,6 @@ TEST(geom, single_point_translation_and_rotation) {
   ASSERT_NEAR(point.z, result_point.z, error);
 }
 
-
 TEST(geom, distance) {
   constexpr double error = .01;
   ASSERT_NEAR(Math::Distance({0, 0, 0}, {0, 0, 0}), 0.0, error);
@@ -136,6 +146,27 @@ TEST(geom, nearest_point_segment) {
     }
     ASSERT_EQ(id, results[i]) << "Fails point number: " << i;
   }
+}
+
+TEST(geom, forward_vector) {
+  auto compare = [](Rotation rotation, Vector3D expected) {
+    constexpr float eps = 2.0f * std::numeric_limits<float>::epsilon();
+    auto result = rotation.GetForwardVector();
+    EXPECT_TRUE(
+            (std::abs(expected.x - result.x) < eps) &&
+            (std::abs(expected.y - result.y) < eps) &&
+            (std::abs(expected.z - result.z) < eps))
+        << "result   = " << result << '\n'
+        << "expected = " << expected;
+  };
+  //        pitch     yaw    roll       x     y     z
+  compare({  0.0f,   0.0f,   0.0f}, {1.0f, 0.0f, 0.0f});
+  compare({  0.0f,   0.0f, 123.0f}, {1.0f, 0.0f, 0.0f});
+  compare({360.0f, 360.0f,   0.0f}, {1.0f, 0.0f, 0.0f});
+  compare({  0.0f,  90.0f,   0.0f}, {0.0f, 1.0f, 0.0f});
+  compare({  0.0f, -90.0f,   0.0f}, {0.0f,-1.0f, 0.0f});
+  compare({ 90.0f,   0.0f,   0.0f}, {0.0f, 0.0f, 1.0f});
+  compare({180.0f, -90.0f,   0.0f}, {0.0f, 1.0f, 0.0f});
 }
 
 TEST(geom, point_in_rectangle) {

--- a/PythonAPI/source/libcarla/Geom.cpp
+++ b/PythonAPI/source/libcarla/Geom.cpp
@@ -100,24 +100,25 @@ class_<cg::Location, bases<cg::Vector3D>>("Location")
     .def_readwrite("pitch", &cg::Rotation::pitch)
     .def_readwrite("yaw", &cg::Rotation::yaw)
     .def_readwrite("roll", &cg::Rotation::roll)
+    .def("get_forward_vector", &cg::Rotation::GetForwardVector)
     .def("__eq__", &cg::Rotation::operator==)
     .def("__ne__", &cg::Rotation::operator!=)
     .def(self_ns::str(self_ns::self))
   ;
 
   class_<cg::Transform>("Transform")
-
     .def(init<cg::Location, cg::Rotation>(
         (arg("location")=cg::Location(), arg("rotation")=cg::Rotation())))
     .def_readwrite("location", &cg::Transform::location)
     .def_readwrite("rotation", &cg::Transform::rotation)
-    .def("__eq__", &cg::Transform::operator==)
-    .def("__ne__", &cg::Transform::operator!=)
     .def("transform", &TransformList)
     .def("transform", +[](const cg::Transform &self, cg::Vector3D &location) {
       self.TransformPoint(location);
       return location;
     }, arg("in_point"))
+    .def("get_forward_vector", &cg::Transform::GetForwardVector)
+    .def("__eq__", &cg::Transform::operator==)
+    .def("__ne__", &cg::Transform::operator!=)
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/PythonAPI/source/libcarla/libcarla.cpp
+++ b/PythonAPI/source/libcarla/libcarla.cpp
@@ -119,12 +119,12 @@ static auto MakeCallback(boost::python::object callback) {
   };
 }
 
+#include "Geom.cpp"
 #include "Actor.cpp"
 #include "Blueprint.cpp"
 #include "Client.cpp"
 #include "Control.cpp"
 #include "Exception.cpp"
-#include "Geom.cpp"
 #include "Map.cpp"
 #include "Sensor.cpp"
 #include "SensorData.cpp"


### PR DESCRIPTION
#### Description

Required by #748.

Added a convenient method to compute the forward vector of a rotation (unit vector pointing towards the X-axis of the rotation). The method is also exposed to Python API.

Since I was there I also uncrustified and organised the geom classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1145)
<!-- Reviewable:end -->
