### PR TITLE
Fix TCP accept error: Too many open files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - get_angular_velocity: for getting the angular velocity
     - add_impulse: for applying an impulse (in world axis)
   * Added support for gnss_sensor
+  * Fix TCP accept error, too many open files while creating and destroying a lot of sensors
   * OpenDriveActor has been rewritten using the Waypoint API, this has fixed some bugs
 
 ## CARLA 0.9.2

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
@@ -72,6 +72,7 @@ namespace detail {
   void Dispatcher::DeregisterSession(std::shared_ptr<Session> session) {
     DEBUG_ASSERT(session != nullptr);
     std::lock_guard<std::mutex> lock(_mutex);
+    ClearExpiredStreams();
     auto search = _stream_map.find(session->get_stream_id());
     if (search != _stream_map.end()) {
       auto stream_state = search->second.lock();
@@ -80,6 +81,14 @@ namespace detail {
       }
     }
   }
+
+  void Dispatcher::ClearExpiredStreams() {
+    for (auto it = _stream_map.begin(); it != _stream_map.end(); ) {
+      if (it->second.expired()) {
+        it = _stream_map.erase(it);
+      } else {
+        ++it;
+      }
     }
   }
 

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.h
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.h
@@ -51,7 +51,7 @@ namespace detail {
     /// them alive the whole run.
     std::unordered_map<
         stream_id_type,
-        std::shared_ptr<StreamStateBase>> _stream_map;
+        std::weak_ptr<StreamStateBase>> _stream_map;
   };
 
 } // namespace detail

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.h
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.h
@@ -41,6 +41,8 @@ namespace detail {
 
   private:
 
+    void ClearExpiredStreams();
+
     // We use a mutex here, but we assume that sessions and streams won't be
     // created too often.
     std::mutex _mutex;

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -44,8 +44,8 @@ namespace tcp {
       auto handle_query = [this, self, callback=std::move(on_opened)](
           const boost::system::error_code &ec,
           size_t DEBUG_ONLY(bytes_received)) {
-        DEBUG_ASSERT_EQ(bytes_received, sizeof(_stream_id));
         if (!ec) {
+          DEBUG_ASSERT_EQ(bytes_received, sizeof(_stream_id));
           log_debug("session", _session_id, "for stream", _stream_id, " started");
           _socket.get_io_service().post([=]() { callback(self); });
         } else {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/CollisionSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/CollisionSensor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "Carla/Actor/ActorDefinition.h"
 #include "Carla/Sensor/Sensor.h"
 
 #include "CollisionSensor.generated.h"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include "Carla/Sensor/PixelReader.h"
 #include "Carla/Sensor/SceneCaptureSensor.h"
+
+#include "Carla/Actor/ActorDefinition.h"
+#include "Carla/Sensor/PixelReader.h"
 
 #include "SceneCaptureCamera.generated.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SemanticSegmentationCamera.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SemanticSegmentationCamera.h
@@ -8,6 +8,8 @@
 
 #include "Carla/Sensor/ShaderBasedSensor.h"
 
+#include "Carla/Actor/ActorDefinition.h"
+
 #include "SemanticSegmentationCamera.generated.h"
 
 /// Sensor that produces "semantic segmentation" images.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "Carla.h"
+#include "Carla/Sensor/Sensor.h"
+
+#include "Carla/Actor/ActorDescription.h"
+#include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
+
+void ASensor::Set(const FActorDescription &Description)
+{
+  // set the tick interval of the sensor
+  if (Description.Variations.Contains("sensor_tick"))
+  {
+    SetActorTickInterval(
+        UActorBlueprintFunctionLibrary::ActorAttributeToFloat(Description.Variations["sensor_tick"],
+        0.0f));
+  }
+}
+
+void ASensor::EndPlay(EEndPlayReason::Type EndPlayReason)
+{
+  Super::EndPlay(EndPlayReason);
+  Stream = FDataStream();
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include "GameFramework/Actor.h"
-
-#include "Carla/Actor/ActorDescription.h"
-#include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
 #include "Carla/Sensor/DataStream.h"
 
+#include "GameFramework/Actor.h"
+
 #include "Sensor.generated.h"
+
+struct FActorDescription;
 
 /// Base class for sensors.
 UCLASS(Abstract, hidecategories = (Collision, Attachment, Actor))
@@ -22,16 +22,7 @@ class CARLA_API ASensor : public AActor
 
 public:
 
-  virtual void Set(const FActorDescription &Description)
-  {
-    // set the tick interval of the sensor
-    if (Description.Variations.Contains("sensor_tick"))
-    {
-      SetActorTickInterval(
-          UActorBlueprintFunctionLibrary::ActorAttributeToFloat(Description.Variations["sensor_tick"],
-          0.0f));
-    }
-  }
+  virtual void Set(const FActorDescription &Description);
 
   /// Replace the FDataStream associated with this sensor.
   ///
@@ -42,6 +33,8 @@ public:
   }
 
 protected:
+
+  void EndPlay(EEndPlayReason::Type EndPlayReason) override;
 
   /// Return the FDataStream associated with this sensor.
   FDataStream &GetDataStream()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/TheNewCarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/TheNewCarlaServer.cpp
@@ -161,6 +161,10 @@ private:
     return it->second;
   }
 
+  void ClearSensorStream(FActorView ActorView) {
+    _StreamMap.erase(ActorView.GetActorId());
+  }
+
   std::unordered_map<FActorView::IdType, carla::streaming::Stream> _StreamMap;
 };
 
@@ -272,6 +276,7 @@ void FTheNewCarlaServer::FPimpl::BindActions()
       UE_LOG(LogCarlaServer, Warning, TEXT("unable to destroy actor: not found"));
       return false;
     }
+    ClearSensorStream(ActorView);
     return Episode->DestroyActor(ActorView.GetActor());
   });
 


### PR DESCRIPTION
#### Description

Fixes #1119.

We were keeping unnecessary references to expired server sessions, thus keeping these sessions alive and their sockets open. I made sure streams and sessions are discarded when the sensor is destroyed. Note also that we need to explicitly remove the stream on end play since the sensor actor is not actually destructed until UE4 garbage collector kicks in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1150)
<!-- Reviewable:end -->
