### PR TITLE
Remove crash reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added support for Deepin in PythonAPI's setup.py
   * Added support for spawning and controlling walkers (pedestrians)
   * Renamed vehicle.get_vehicle_control() to vehicle.get_control() to be consistent with walkers
+  * Remove crash reporter from packaged build
   * Added a few methods to manage an actor:
     - set_velocity: for setting the linear velocity
     - set_angular_velocity: for setting the angular velocity

--- a/Unreal/CarlaUE4/Config/DefaultGame.ini
+++ b/Unreal/CarlaUE4/Config/DefaultGame.ini
@@ -39,7 +39,7 @@ IncludeAppLocalPrerequisites=False
 bShareMaterialShaderCode=False
 bSharedMaterialNativeLibraries=False
 ApplocalPrerequisitesDirectory=(Path="")
-IncludeCrashReporter=True
+IncludeCrashReporter=False
 InternationalizationPreset=English
 -CulturesToStage=en
 +CulturesToStage=en

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -70,7 +70,7 @@ if $DO_PACKAGE ; then
       -nocompileeditor -nop4 -cook -stage -archive -package \
       -clientconfig=Development -ue4exe=UE4Editor \
       -pak -prereqs -nodebuginfo \
-      -targetplatform=Linux -build -CrashReporter -utf8output \
+      -targetplatform=Linux -build -utf8output \
       -archivedirectory="${BUILD_FOLDER}"
 
   popd >/dev/null


### PR DESCRIPTION
#### Description

Remove UE4 crash reporter from the packaged version.

By default UE4 includes a crash reporter in packaged builds, however since we don't use it, it's only causing noise in the output and stalling the simulator after a crash.

Related to #1111.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1176)
<!-- Reviewable:end -->
