### PR TITLE
Fixes #1217 to prevent crashes when run in no-rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Latest Changes
+
+  * Fixed `manual_control.py` and `no_rendering_mode` to prevent crashes when used in "no rendering mode"
 ## CARLA 0.9.3
 
   * Upgraded to Unreal Engine 4.21

--- a/PythonAPI/manual_control.py
+++ b/PythonAPI/manual_control.py
@@ -356,8 +356,8 @@ class HUD(object):
         collision = [x / max_col for x in collision]
         vehicles = world.world.get_actors().filter('vehicle.*')
         self._info_text = [
-            'Server:  % 16s FPS' % round(self.server_fps),
-            'Client:  % 16s FPS' % round(clock.get_fps()),
+            'Server:  % 16.0f FPS' % self.server_fps,
+            'Client:  % 16.0f FPS' % clock.get_fps(),
             '',
             'Vehicle: % 20s' % get_actor_display_name(world.player, truncate=20),
             'Map:     % 20s' % world.world.map_name,

--- a/PythonAPI/no_rendering_mode.py
+++ b/PythonAPI/no_rendering_mode.py
@@ -821,8 +821,8 @@ class ModuleWorld(object):
 
         self.server_fps = self.server_clock.get_fps()
         module_info_text = [
-            'Server:  % 16s FPS' % round(self.server_fps),
-            'Client:  % 16s FPS' % round(clock.get_fps()),
+            'Server:  % 16.0f FPS' % self.server_fps,
+            'Client:  % 16.0f FPS' % clock.get_fps(),
             'Map Name:          %10s' % self.world.map_name,
         ]
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x ] All tests passing with `make check`
  - [x ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

- Fixes the bug in `manual_control.py` and `no_rendering_mode.py` to avoid crashes due to:
```bash
OverflowError: cannot convert float infinity to integer
Segmentation fault (core dumped)
```
(See #1217  for more information)

Fixes #1217

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** 3.6, 3.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1218)
<!-- Reviewable:end -->
