### PR TITLE
Add movable static meshes to the actor registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Latest Changes
 
   * Fixed `manual_control.py` and `no_rendering_mode.py` to prevent crashes when used in "no rendering mode"
+  * Added movable props present in the map (e.g. chairs and tables) as actors so they can be controlled from Python
   * Refactored `no_rendering_mode.py` to improve performance and interface
 
 ## CARLA 0.9.3

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -12,6 +12,7 @@
 #include "Carla/Vehicle/VehicleSpawnPoint.h"
 
 #include "EngineUtils.h"
+#include "Engine/StaticMeshActor.h"
 #include "GameFramework/SpectatorPawn.h"
 
 static FString UCarlaEpisode_GetTrafficSignId(ETrafficSignState State)
@@ -107,5 +108,20 @@ void UCarlaEpisode::InitializeAtBeginPlay()
     Description.Id = UCarlaEpisode_GetTrafficSignId(Actor->GetTrafficSignState());
     Description.Class = Actor->GetClass();
     ActorDispatcher->RegisterActor(*Actor, Description);
+  }
+
+  for (TActorIterator<AStaticMeshActor> It(World); It; ++It)
+  {
+    auto Actor = *It;
+    check(Actor != nullptr);
+    auto MeshComponent = Actor->GetStaticMeshComponent();
+    check(MeshComponent != nullptr);
+    if (MeshComponent->Mobility == EComponentMobility::Movable)
+    {
+      FActorDescription Description;
+      Description.Id = TEXT("static.prop");
+      Description.Class = Actor->GetClass();
+      ActorDispatcher->RegisterActor(*Actor, Description);
+    }
   }
 }


### PR DESCRIPTION
#### Description

Make possible to control movable objects already present in the map, e.g. chairs and tables in Town01

![moving_props](https://user-images.githubusercontent.com/4332953/52855788-c11c0980-3122-11e9-9499-1e08d8ab1461.gif)


```python
props = [(x, x.get_transform()) for x in world.get_actors().filter("static.prop*")]
for actor, _ in props:
    actor.add_impulse(carla.Vector3D(z=1.5))
    actor.set_angular_velocity(carla.Vector3D(z=14000))
time.sleep(0.3)
for actor, _ in props:
    actor.set_simulate_physics(False)
time.sleep(3)
for actor, transform in props:
    actor.set_transform(transform)
```

What I did is parsing the scene at begin play and adding every static mesh that is movable to the actor registry so they're visible in the API as actors.

#### Possible Drawbacks

If art team forgets to set an unwanted object as "static" in UE4Editor, this object will show up in the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1256)
<!-- Reviewable:end -->
