### PR TITLE
Improve time-out error messages and fix 1151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   * Fixed `manual_control.py` and `no_rendering_mode.py` to prevent crashes when used in "no rendering mode"
   * Added movable props present in the map (e.g. chairs and tables) as actors so they can be controlled from Python
   * Refactored `no_rendering_mode.py` to improve performance and interface
+  * Improved time-out related error messages
+  * Fixed issue of retrieving an empty list when calling `world.get_actors()` right after creating the world
 
 ## CARLA 0.9.3
 

--- a/LibCarla/source/carla/client/TimeoutException.cpp
+++ b/LibCarla/source/carla/client/TimeoutException.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/client/TimeoutException.h"
+
+namespace carla {
+namespace client {
+
+  using namespace std::string_literals;
+
+  TimeoutException::TimeoutException(
+      const std::string &endpoint,
+      time_duration timeout)
+    : std::runtime_error(
+        "time-out of "s + std::to_string(timeout.milliseconds()) +
+        "ms while waiting for the simulator, "
+        "make sure the simulator is ready and connected to " + endpoint) {}
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/TimeoutException.h
+++ b/LibCarla/source/carla/client/TimeoutException.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/Time.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace carla {
+namespace client {
+
+  class TimeoutException : public std::runtime_error {
+  public:
+
+    explicit TimeoutException(
+        const std::string &endpoint,
+        time_duration timeout);
+  };
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -59,6 +59,10 @@ namespace detail {
 
     void SetTimeout(time_duration timeout);
 
+    time_duration GetTimeout() const;
+
+    const std::string &GetEndpoint() const;
+
     std::string GetClientVersion();
 
     std::string GetServerVersion();

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -53,7 +53,7 @@ namespace detail {
 
     std::vector<rpc::Actor> GetActors();
 
-    Timestamp WaitForState(time_duration timeout) {
+    boost::optional<Timestamp> WaitForState(time_duration timeout) {
       return _timestamp.WaitFor(timeout);
     }
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -63,6 +63,7 @@ namespace detail {
       ValidateVersions(_client);
       _episode = std::make_shared<Episode>(_client);
       _episode->Listen();
+      WaitForTick(_client.GetTimeout());
     }
     return EpisodeProxy{shared_from_this()};
   }

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -107,10 +107,7 @@ namespace detail {
     // =========================================================================
     /// @{
 
-    Timestamp WaitForTick(time_duration timeout) {
-      DEBUG_ASSERT(_episode != nullptr);
-      return _episode->WaitForState(timeout);
-    }
+    Timestamp WaitForTick(time_duration timeout);
 
     void RegisterOnTickEvent(std::function<void(Timestamp)> callback) {
       DEBUG_ASSERT(_episode != nullptr);

--- a/LibCarla/source/test/client/test_recurrent_shared_future.cpp
+++ b/LibCarla/source/test/client/test_recurrent_shared_future.cpp
@@ -22,8 +22,9 @@ TEST(recurrent_shared_future, use_case) {
 
   threads.CreateThreads(number_of_threads, [&]() {
     while (!done) {
-      int result = future.WaitFor(1s);
-      ASSERT_EQ(result, 42);
+      auto result = future.WaitFor(1s);
+      ASSERT_TRUE(result.has_value());
+      ASSERT_EQ(*result, 42);
       ++count;
     }
   });
@@ -42,7 +43,8 @@ TEST(recurrent_shared_future, use_case) {
 TEST(recurrent_shared_future, timeout) {
   using namespace carla;
   RecurrentSharedFuture<int> future;
-  ASSERT_THROW(future.WaitFor(1ns), std::runtime_error);
+  auto result = future.WaitFor(1ns);
+  ASSERT_FALSE(result.has_value());
 }
 
 TEST(recurrent_shared_future, exception) {


### PR DESCRIPTION
#### Description

- Improved time-out error messages, now instead of an rpc error you get the following message
```
RuntimeError: time-out of 2000ms while waiting for the simulator, make sure
the simulator is ready and connected to 127.0.0.1:2000
```
- Print same error message if we meet the time-out in `world.wait_for_tick` (RecurrentSharedFuture), previously the message was very cryptic.
- Wait for tick after subscribing to the world observer to have the world ready after `client.get_world()`, solves issues of having an empty list when calling `world.get_actors()` right after creating the world.

Fixes #1151.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1257)
<!-- Reviewable:end -->
