### PR TITLE
Simplify Dockerfile and halve image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Latest Changes
-
+  * Simplify Dockerfile and halve Carla Docker image size
   * Synchronous mode, controlled with `client.tick()`
   * Allow changing map from client-side, added `client.load_map(name)`, `client.reload_map()`, and `client.get_available_maps()`
   * Control over multiple vehicles in batch mode

--- a/Util/Docker/Release.Dockerfile
+++ b/Util/Docker/Release.Dockerfile
@@ -1,26 +1,19 @@
 # Make sure drivers are >= 390
-# sudo docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=ID carla:latest ./CarlaUE4.sh
-# /Game/Maps/Town01 -benchmark -carla-server -fps=10 -world-port=2000 -windowed -ResX=100 -ResY=100 -carla-no-hud
+# docker run -p 2000-2002:2000-2002 --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=ID carla:latest ./CarlaUE4.sh
+# /Game/Carla/Maps/Town01 -benchmark -carla-server -fps=10 -world-port=2000 -windowed -ResX=100 -ResY=100 -carla-no-hud
 
 FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04
 
-
-RUN apt-get update; apt-get install -y libsdl2-2.0
+RUN packages='libsdl2-2.0' \
+	&& apt-get update && apt-get install -y $packages --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m carla
-USER carla
-ENV HOME /home/carla
-COPY . /home/carla
 
-USER root
-RUN chown -R carla:carla /home/carla
-
-RUN apt-get -y install sudo
-RUN echo "carla:carla" | chpasswd && adduser carla sudo
+COPY --chown=carla:carla . /home/carla
 
 USER carla
 WORKDIR /home/carla
-
 
 ENV SDL_VIDEODRIVER=offscreen
 


### PR DESCRIPTION
#### Description

- Fixed error in run arguments documentation
- Modified package installation to recommended, non-polluting variant
- Unified COPY and chown steps which halves the image size
- Removed installing sudo

#### Where has this been tested?

  * **Platform(s): Ubuntu 16.04, Docker
  * **Python version(s): - 
  * **Unreal Engine version(s): - 

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1318)
<!-- Reviewable:end -->
