### PR TITLE
Waypoint API extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   * Fixed static objects present in the map were marked as "movable"
   * Fixed BP_MultipleFloor, tweaked offset in BaseFloor to adjust meshes between them
   * New traffic signs assets: one-way, no-turn, more speed limits, do not enter, arrow floors, Michigan left, and lane end
+  * Extended the Waypoint API with `lane_change`, `lane_type`, `right_lane()` and `left_lane()`
   * Expose traffic sign's trigger volumes on Python API
   * Updated the Python API to enable the user to acquire a traffic light's pole index and all traffic lights in it's group
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
   * Fixed static objects present in the map were marked as "movable"
   * Fixed BP_MultipleFloor, tweaked offset in BaseFloor to adjust meshes between them
   * New traffic signs assets: one-way, no-turn, more speed limits, do not enter, arrow floors, Michigan left, and lane end
-  * Extended the Waypoint API with `lane_change`, `lane_type`, `right_lane()` and `left_lane()`
+  * Extended the Waypoint API with `lane_change`, `lane_type`, `get_right_lane()` and `get_left_lane()`
   * Expose traffic sign's trigger volumes on Python API
   * Updated the Python API to enable the user to acquire a traffic light's pole index and all traffic lights in it's group
 

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -263,6 +263,7 @@
 - `road_id`
 - `lane_id`
 - `lane_change`
+- `lane_type`
 - `next(distance)`
 - `right_lane()`
 - `left_lane()`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -268,6 +268,12 @@
 - `right_lane()`
 - `left_lane()`
 
+## `carla.LaneChange`
+- `None`
+- `Right`
+- `Left`
+- `Both`
+
 ## `carla.WeatherParameters`
 
 - `cloudyness`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -262,7 +262,10 @@
 - `lane_width`
 - `road_id`
 - `lane_id`
+- `lane_change`
 - `next(distance)`
+- `right_lane()`
+- `left_lane()`
 
 ## `carla.WeatherParameters`
 

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -265,8 +265,8 @@
 - `lane_change`
 - `lane_type`
 - `next(distance)`
-- `right_lane()`
-- `left_lane()`
+- `get_right_lane()`
+- `get_left_lane()`
 
 ## `carla.LaneChange`
 - `None`

--- a/LibCarla/source/carla/client/Waypoint.cpp
+++ b/LibCarla/source/carla/client/Waypoint.cpp
@@ -9,13 +9,16 @@
 #include "carla/client/Map.h"
 #include "carla/road/WaypointGenerator.h"
 
+#include <boost/optional.hpp>
+
 namespace carla {
 namespace client {
 
   Waypoint::Waypoint(SharedPtr<const Map> parent, road::element::Waypoint waypoint)
     : _parent(std::move(parent)),
       _waypoint(std::move(waypoint)),
-      _transform(_waypoint.ComputeTransform()) {}
+      _transform(_waypoint.ComputeTransform()),
+      _mark_record(_waypoint.GetMarkRecord()) {}
 
   Waypoint::~Waypoint() = default;
 
@@ -27,6 +30,66 @@ namespace client {
       result.emplace_back(SharedPtr<Waypoint>(new Waypoint(_parent, std::move(waypoint))));
     }
     return result;
+  }
+
+  SharedPtr<Waypoint> Waypoint::Right() const {
+    auto right_lane_waypoint =
+        road::WaypointGenerator::GetRight(_waypoint);
+    if (right_lane_waypoint.has_value()) {
+      return SharedPtr<Waypoint>(new Waypoint(_parent, std::move(*right_lane_waypoint)));
+    }
+    return nullptr;
+  }
+
+  SharedPtr<Waypoint> Waypoint::Left() const {
+    auto left_lane_waypoint =
+        road::WaypointGenerator::GetLeft(_waypoint);
+    if (left_lane_waypoint.has_value()) {
+      return SharedPtr<Waypoint>(new Waypoint(_parent, std::move(*left_lane_waypoint)));
+    }
+    return nullptr;
+  }
+
+  template <typename EnumT>
+  static EnumT operator&(EnumT lhs, EnumT rhs) {
+    return static_cast<EnumT>(
+        static_cast<typename std::underlying_type<EnumT>::type>(lhs) &
+        static_cast<typename std::underlying_type<EnumT>::type>(rhs));
+  }
+
+  template <typename EnumT>
+  static EnumT operator|(EnumT lhs, EnumT rhs) {
+    return static_cast<EnumT>(
+        static_cast<typename std::underlying_type<EnumT>::type>(lhs) |
+        static_cast<typename std::underlying_type<EnumT>::type>(rhs));
+  }
+
+  Waypoint::LaneChange Waypoint::GetLaneChange() const {
+    const auto lane_change_right = _mark_record.first.GetLaneChange();
+    const auto lane_change_left = _mark_record.second.GetLaneChange();
+
+    auto c_right = static_cast<Waypoint::LaneChange>(lane_change_right);
+    auto c_left = static_cast<Waypoint::LaneChange>(lane_change_left);
+
+    if (_mark_record.first.GetLaneId() > 0) {
+      // road goes backward
+      if (c_right == Waypoint::LaneChange::Right) {
+        c_right = Waypoint::LaneChange::Left;
+      } else if (c_right == Waypoint::LaneChange::Left) {
+        c_right = Waypoint::LaneChange::Right;
+      }
+    }
+
+    if (_mark_record.second.GetLaneId() > 0) {
+      // road goes backward
+      if (c_left == Waypoint::LaneChange::Right) {
+        c_left = Waypoint::LaneChange::Left;
+      } else if (c_left == Waypoint::LaneChange::Left) {
+        c_left = Waypoint::LaneChange::Right;
+      }
+    }
+
+    return (c_right & Waypoint::LaneChange::Right) | (c_left & Waypoint::LaneChange::Left);
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/Waypoint.cpp
+++ b/LibCarla/source/carla/client/Waypoint.cpp
@@ -72,7 +72,7 @@ namespace client {
     auto c_left = static_cast<Waypoint::LaneChange>(lane_change_left);
 
     if (_mark_record.first.GetLaneId() > 0) {
-      // road goes backward
+      // if road goes backward
       if (c_right == Waypoint::LaneChange::Right) {
         c_right = Waypoint::LaneChange::Left;
       } else if (c_right == Waypoint::LaneChange::Left) {
@@ -81,7 +81,7 @@ namespace client {
     }
 
     if (_mark_record.second.GetLaneId() > 0) {
-      // road goes backward
+      // if road goes backward
       if (c_left == Waypoint::LaneChange::Right) {
         c_left = Waypoint::LaneChange::Left;
       } else if (c_left == Waypoint::LaneChange::Left) {

--- a/LibCarla/source/carla/client/Waypoint.h
+++ b/LibCarla/source/carla/client/Waypoint.h
@@ -51,6 +51,10 @@ namespace client {
       return _waypoint.GetLaneId();
     }
 
+    std::string GetType() const {
+      return _waypoint.GetType();
+    }
+
     std::vector<SharedPtr<Waypoint>> Next(double distance) const;
 
     SharedPtr<Waypoint> Right() const;

--- a/LibCarla/source/carla/client/Waypoint.h
+++ b/LibCarla/source/carla/client/Waypoint.h
@@ -9,6 +9,7 @@
 #include "carla/Memory.h"
 #include "carla/NonCopyable.h"
 #include "carla/road/element/Waypoint.h"
+#include "carla/road/element/RoadInfoMarkRecord.h"
 
 namespace carla {
 namespace client {
@@ -19,6 +20,14 @@ namespace client {
     : public EnableSharedFromThis<Waypoint>,
       private NonCopyable {
   public:
+
+    /// Can be used as flags
+    enum class LaneChange : uint8_t {
+      None  = 0x00, //00
+      Right = 0x01, //01
+      Left  = 0x02, //10
+      Both  = 0x03  //11
+    };
 
     ~Waypoint();
 
@@ -44,6 +53,12 @@ namespace client {
 
     std::vector<SharedPtr<Waypoint>> Next(double distance) const;
 
+    SharedPtr<Waypoint> Right() const;
+
+    SharedPtr<Waypoint> Left() const;
+
+    Waypoint::LaneChange GetLaneChange() const;
+
   private:
 
     friend class Map;
@@ -55,6 +70,11 @@ namespace client {
     road::element::Waypoint _waypoint;
 
     geom::Transform _transform;
+
+    // Mark record right and left respectively
+    std::pair<
+        road::element::RoadInfoMarkRecord,
+        road::element::RoadInfoMarkRecord> _mark_record;
   };
 
 } // namespace client

--- a/LibCarla/source/carla/geom/CubicPolynomial.h
+++ b/LibCarla/source/carla/geom/CubicPolynomial.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/Debug.h"
+
+#include <array>
+
+namespace carla {
+namespace geom {
+
+  /// Describes a Cubic Polynomial so:
+  /// f(x) = a + bx + cx^2 + dx^3
+  class CubicPolynomial {
+  public:
+
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
+    CubicPolynomial() = default;
+
+    CubicPolynomial(const CubicPolynomial &) = default;
+
+    CubicPolynomial(
+        const double &a,
+        const double &b,
+        const double &c,
+        const double &d)
+      : _v{{a, b, c, d}} {}
+
+    // =========================================================================
+    // -- Getters --------------------------------------------------------------
+    // =========================================================================
+
+    double GetA() const {
+      return _v[0];
+    }
+
+    double GetB() const {
+      return _v[1];
+    }
+
+    double GetC() const {
+      return _v[2];
+    }
+
+    double GetD() const {
+      return _v[3];
+    }
+
+    // =========================================================================
+    // -- Evaluate methods -----------------------------------------------------
+    // =========================================================================
+
+    /// Evaluates f(x) = a + bx + cx^2 + dx^3
+    double Evaluate(const double &x) const {
+      // return _v[0] + _v[1] * (x) + _v[2] * (x * x) + _v[3] * (x * x * x);
+      return _v[0] + x * (_v[1] + x * (_v[2] + x * _v[3]));
+    }
+
+    /// Evaluates the tangent using df/dx = b + 2cx + 3dx^2
+    double Tangent(const double &x) const {
+      return _v[1] + x * (2 * _v[2] + x * 3 * _v[3]);
+    }
+
+    // =========================================================================
+    // -- Arithmetic operators -------------------------------------------------
+    // =========================================================================
+
+    CubicPolynomial &operator+=(const CubicPolynomial &rhs) {
+      for (auto i = 0u; i < _v.size(); ++i) {
+        _v[i] += rhs._v[i];
+      }
+      return *this;
+    }
+
+    friend CubicPolynomial operator+(CubicPolynomial lhs, const CubicPolynomial &rhs) {
+      lhs += rhs;
+      return lhs;
+    }
+
+    CubicPolynomial &operator*=(const double &rhs) {
+      for (auto i = 0u; i < _v.size(); ++i) {
+        _v[i] *= rhs;
+      }
+      return *this;
+    }
+
+    friend CubicPolynomial operator*(CubicPolynomial lhs, const double &rhs) {
+      lhs *= rhs;
+      return lhs;
+    }
+
+    friend CubicPolynomial operator*(const double &lhs, CubicPolynomial rhs) {
+      rhs *= lhs;
+      return rhs;
+    }
+
+  private:
+
+    // =========================================================================
+    // -- Private data members -------------------------------------------------
+    // =========================================================================
+
+    // a - elevation
+    // b - slope
+    // c - vertical curvature
+    // d - curvature change
+    std::array<double, 4> _v = {0.0, 0.0, 0.0, 0.0};
+
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/CubicPolynomial.h
+++ b/LibCarla/source/carla/geom/CubicPolynomial.h
@@ -31,7 +31,18 @@ namespace geom {
         const double &b,
         const double &c,
         const double &d)
-      : _v{{a, b, c, d}} {}
+      : _v{ {a, b, c, d} } {}
+
+    CubicPolynomial(
+        const double &a,
+        const double &b,
+        const double &c,
+        const double &d,
+        const double &s) // lateral offset
+      : _v{ {a - b * s + c * s * s - d * s * s * s,
+             b - 2 * c * s + 3 * d * s * s,
+             c - 3 * d * s,
+             d} } {}
 
     // =========================================================================
     // -- Getters --------------------------------------------------------------

--- a/LibCarla/source/carla/geom/Transform.h
+++ b/LibCarla/source/carla/geom/Transform.h
@@ -37,6 +37,10 @@ namespace geom {
 
     Transform() = default;
 
+    Transform(const Location &in_location)
+      : location(in_location),
+        rotation() {}
+
     Transform(const Location &in_location, const Rotation &in_rotation)
       : location(in_location),
         rotation(in_rotation) {}

--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -364,7 +364,8 @@ namespace opendrive {
         }
 
         current_lane_id = 0;
-        for (auto &&lane_section_center : lane_section.center) { // @todo: .[0]!!
+        // @todo: there must be only one center lane, so maybe use [0]
+        for (auto &&lane_section_center : lane_section.center) {
           for (auto &&road_marker : lane_section_center.road_marker) {
               road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
                 start_position + road_marker.soffset,

--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -6,18 +6,16 @@
 
 #include "OpenDrive.h"
 
-#include "../road/MapBuilder.h"
+#include "carla/road/MapBuilder.h"
+#include "carla/road/element/RoadInfoMarkRecord.h"
 #include "carla/Debug.h"
 
 namespace carla {
 namespace opendrive {
 
-#define UNUSED(x) (void) x
-
   static void fnc_generate_roads_data(
       opendrive::types::OpenDriveData &openDriveRoad,
-      std::map<int,
-      opendrive::types::RoadInformation *> &out_roads) {
+      std::map<int, opendrive::types::RoadInformation *> &out_roads) {
     for (size_t i = 0; i < openDriveRoad.roads.size(); ++i) {
       out_roads[openDriveRoad.roads[i].attributes.id] = &openDriveRoad.roads[i];
     }
@@ -25,15 +23,14 @@ namespace opendrive {
 
   static void fnc_generate_junctions_data(
       opendrive::types::OpenDriveData &openDriveRoad,
-      std::map<int,
-      std::map<int, std::vector<carla::road::lane_junction_t>>> &out_data) {
+      std::map<int, std::map<int, std::vector<carla::road::lane_junction_t>>> &out_data) {
     for (size_t i = 0; i < openDriveRoad.junctions.size(); ++i) {
       for (size_t j = 0; j < openDriveRoad.junctions[i].connections.size(); ++j) {
         carla::road::lane_junction_t junctionData;
-        int junctionID = openDriveRoad.junctions[i].attributes.id;
+        const int junctionID = openDriveRoad.junctions[i].attributes.id;
 
-        int incommingRoad = openDriveRoad.junctions[i].connections[j].attributes.incoming_road;
-        int connectingRoad = openDriveRoad.junctions[i].connections[j].attributes.connecting_road;
+        const int incommingRoad = openDriveRoad.junctions[i].connections[j].attributes.incoming_road;
+        const int connectingRoad = openDriveRoad.junctions[i].connections[j].attributes.connecting_road;
 
         junctionData.incomming_road = incommingRoad;
         junctionData.connection_road = connectingRoad;
@@ -49,29 +46,29 @@ namespace opendrive {
     }
   }
 
-  static void test_fnc_generate_junctions_data(
-      opendrive::types::OpenDriveData &openDriveRoad,
-      std::vector<carla::road::lane_junction_t> &out_data) {
-    for (size_t i = 0; i < openDriveRoad.junctions.size(); ++i) {
-      for (size_t j = 0; j < openDriveRoad.junctions[i].connections.size(); ++j) {
-        carla::road::lane_junction_t junctionData;
-        junctionData.junction_id = openDriveRoad.junctions[i].attributes.id;
+  // static void test_fnc_generate_junctions_data(
+  //     opendrive::types::OpenDriveData &openDriveRoad,
+  //     std::vector<carla::road::lane_junction_t> &out_data) {
+  //   for (size_t i = 0; i < openDriveRoad.junctions.size(); ++i) {
+  //     for (size_t j = 0; j < openDriveRoad.junctions[i].connections.size(); ++j) {
+  //       carla::road::lane_junction_t junctionData;
+  //       junctionData.junction_id = openDriveRoad.junctions[i].attributes.id;
 
-        int incommingRoad = openDriveRoad.junctions[i].connections[j].attributes.incoming_road;
-        int connectingRoad = openDriveRoad.junctions[i].connections[j].attributes.connecting_road;
+  //       const int incommingRoad = openDriveRoad.junctions[i].connections[j].attributes.incoming_road;
+  //       const int connectingRoad = openDriveRoad.junctions[i].connections[j].attributes.connecting_road;
 
-        junctionData.incomming_road = incommingRoad;
-        junctionData.connection_road = connectingRoad;
+  //       junctionData.incomming_road = incommingRoad;
+  //       junctionData.connection_road = connectingRoad;
 
-        for (size_t k = 0; k < openDriveRoad.junctions[i].connections[j].links.size(); ++k) {
-          junctionData.from_lane.emplace_back(openDriveRoad.junctions[i].connections[j].links[k].from);
-          junctionData.to_lane.emplace_back(openDriveRoad.junctions[i].connections[j].links[k].to);
-        }
+  //       for (size_t k = 0; k < openDriveRoad.junctions[i].connections[j].links.size(); ++k) {
+  //         junctionData.from_lane.emplace_back(openDriveRoad.junctions[i].connections[j].links[k].from);
+  //         junctionData.to_lane.emplace_back(openDriveRoad.junctions[i].connections[j].links[k].to);
+  //       }
 
-        out_data.emplace_back(junctionData);
-      }
-    }
-  }
+  //       out_data.emplace_back(junctionData);
+  //     }
+  //   }
+  // }
 
   // HACK(Andrei):
   static int fnc_get_first_driving_line(opendrive::types::RoadInformation *roadInfo, int id = 0) {
@@ -117,9 +114,9 @@ namespace opendrive {
     using junction_data_t = std::map<int, std::map<int, std::vector<carla::road::lane_junction_t>>>;
     using road_data_t = std::map<int, carla::opendrive::types::RoadInformation *>;
 
-    std::vector<carla::road::lane_junction_t> junctionInfo;
-    test_fnc_generate_junctions_data(open_drive_road, junctionInfo);
-    mapBuilder.SetJunctionInformation(junctionInfo);
+    // std::vector<carla::road::lane_junction_t> junctionInfo;
+    // test_fnc_generate_junctions_data(open_drive_road, junctionInfo);
+    // mapBuilder.SetJunctionInformation(junctionInfo);
 
     junction_data_t junctionsData;
     road_data_t roadData;
@@ -129,12 +126,12 @@ namespace opendrive {
 
     // Transforma data for the MapBuilder
     for (road_data_t::iterator it = roadData.begin(); it != roadData.end(); ++it) {
-      carla::road::element::RoadSegmentDefinition roadSegment(it->first);
+      carla::road::element::RoadSegmentDefinition road_segment(it->first);
       carla::road::element::RoadInfoLane *RoadInfoLanes =
-          roadSegment.MakeInfo<carla::road::element::RoadInfoLane>();
+          road_segment.MakeInfo<carla::road::element::RoadInfoLane>();
 
       carla::road::element::RoadGeneralInfo *RoadGeneralInfo =
-          roadSegment.MakeInfo<carla::road::element::RoadGeneralInfo>();
+          road_segment.MakeInfo<carla::road::element::RoadGeneralInfo>();
       RoadGeneralInfo->SetJunctionId(it->second->attributes.junction);
 
       for (size_t i = 0; i < it->second->lanes.lane_offset.size(); ++i) {
@@ -144,7 +141,7 @@ namespace opendrive {
       }
 
       for (auto &&elevation : it->second->road_profiles.elevation_profile) {
-        roadSegment.MakeInfo<carla::road::element::RoadElevationInfo>(
+        road_segment.MakeInfo<carla::road::element::RoadElevationInfo>(
             elevation.start_position,
             elevation.start_position,
             elevation.elevation,
@@ -153,33 +150,45 @@ namespace opendrive {
             elevation.curvature_change);
       }
 
-      std::map<int, int> leftLanesGoToSuccessor, leftLanesGoToPredecessor;
-      std::map<int, int> rightLanesGoToSuccessor, rightLanesGoToPredecessor;
+      std::unordered_map<int, int> left_lanes_go_to_successor, left_lanes_go_to_predecessor;
+      // std::unordered_map<int, int> center_lanes_go_to_successor, center_lanes_go_to_predecessor;
+      std::unordered_map<int, int> right_lanes_go_to_successor, right_lanes_go_to_predecessor;
 
-      for (auto &&leftlanes : it->second->lanes.lane_sections[0].left) {
-        if (leftlanes.link != nullptr) {
-          if (leftlanes.attributes.type != "driving") {
+      for (auto &&left_lanes : it->second->lanes.lane_sections[0].left) {
+        if (left_lanes.link != nullptr) {
+          if (left_lanes.attributes.type != "driving") {
             continue;
           }
-          if (leftlanes.link->successor_id != 0) {
-            leftLanesGoToSuccessor[leftlanes.attributes.id] = leftlanes.link->successor_id;
+          if (left_lanes.link->successor_id != 0) {
+            left_lanes_go_to_successor[left_lanes.attributes.id] = left_lanes.link->successor_id;
           }
-          if (leftlanes.link->predecessor_id != 0) {
-            leftLanesGoToPredecessor[leftlanes.attributes.id] = leftlanes.link->predecessor_id;
+          if (left_lanes.link->predecessor_id != 0) {
+            left_lanes_go_to_predecessor[left_lanes.attributes.id] = left_lanes.link->predecessor_id;
           }
         }
       }
 
-      for (auto &&rightlanes : it->second->lanes.lane_sections[0].right) {
-        if (rightlanes.link != nullptr) {
-          if (rightlanes.attributes.type != "driving") {
+      // for (auto &&center_lanes : it->second->lanes.lane_sections[0].center) {
+      //   if (center_lanes.link != nullptr) {
+      //     if (center_lanes.link->successor_id != 0) {
+      //       center_lanes_go_to_successor[center_lanes.attributes.id] = center_lanes.link->successor_id;
+      //     }
+      //     if (center_lanes.link->predecessor_id != 0) {
+      //       center_lanes_go_to_predecessor[center_lanes.attributes.id] = center_lanes.link->predecessor_id;
+      //     }
+      //   }
+      // }
+
+      for (auto &&right_lanes : it->second->lanes.lane_sections[0].right) {
+        if (right_lanes.link != nullptr) {
+          if (right_lanes.attributes.type != "driving") {
             continue;
           }
-          if (rightlanes.link->successor_id != 0) {
-            rightLanesGoToSuccessor[rightlanes.attributes.id] = rightlanes.link->successor_id;
+          if (right_lanes.link->successor_id != 0) {
+            right_lanes_go_to_successor[right_lanes.attributes.id] = right_lanes.link->successor_id;
           }
-          if (rightlanes.link->predecessor_id != 0) {
-            rightLanesGoToPredecessor[rightlanes.attributes.id] = rightlanes.link->predecessor_id;
+          if (right_lanes.link->predecessor_id != 0) {
+            right_lanes_go_to_predecessor[right_lanes.attributes.id] = right_lanes.link->predecessor_id;
           }
         }
       }
@@ -189,7 +198,7 @@ namespace opendrive {
             itLaneSec != it->second->lanes.lane_sections.end();
             ++itLaneSec) {
           for (auto &&itLanes : itLaneSec->left) {
-            for (auto &&itTest : leftLanesGoToSuccessor) {
+            for (auto &&itTest : left_lanes_go_to_successor) {
               if (itTest.second == itLanes.attributes.id && itLanes.link) {
                 itTest.second = itLanes.link->successor_id;
               }
@@ -197,11 +206,23 @@ namespace opendrive {
           }
         }
 
+        // for (auto itLaneSec = it->second->lanes.lane_sections.begin() + 1;
+        //     itLaneSec != it->second->lanes.lane_sections.end();
+        //     ++itLaneSec) {
+        //   for (auto &&itLanes : itLaneSec->center) {
+        //     for (auto &&itTest : center_lanes_go_to_successor) {
+        //       if (itTest.second == itLanes.attributes.id && itLanes.link) {
+        //         itTest.second = itLanes.link->successor_id;
+        //       }
+        //     }
+        //   }
+        // }
+
         for (auto itLaneSec = it->second->lanes.lane_sections.begin() + 1;
             itLaneSec != it->second->lanes.lane_sections.end();
             ++itLaneSec) {
           for (auto &&itLanes : itLaneSec->right) {
-            for (auto &&itTest : rightLanesGoToSuccessor) {
+            for (auto &&itTest : right_lanes_go_to_successor) {
               if (itTest.second == itLanes.attributes.id && itLanes.link) {
                 itTest.second = itLanes.link->successor_id;
               }
@@ -233,7 +254,7 @@ namespace opendrive {
           std::vector<carla::road::lane_junction_t> &options =
               junctionsData[it->second->road_link.successor->id][it->first];
           for (size_t i = 0; i < options.size(); ++i) {
-            roadSegment.AddSuccessorID(options[i].connection_road, options[i].contact_point == "start");
+            road_segment.AddSuccessorID(options[i].connection_road, options[i].contact_point == "start");
 
             for (size_t j = 0; j < options[i].from_lane.size(); ++j) {
               bool is_end = options[i].contact_point == "end";
@@ -243,19 +264,23 @@ namespace opendrive {
                 to_lane = fnc_get_first_driving_line(roadData[options[i].connection_road], to_lane);
               }
 
-              roadSegment.AddNextLaneInfo(options[i].from_lane[j], to_lane, options[i].connection_road);
+              road_segment.AddNextLaneInfo(options[i].from_lane[j], to_lane, options[i].connection_road);
             }
           }
         } else {
           bool is_start = it->second->road_link.successor->contact_point == "start";
-          roadSegment.AddSuccessorID(it->second->road_link.successor->id, is_start);
+          road_segment.AddSuccessorID(it->second->road_link.successor->id, is_start);
 
-          for (auto &&lanes : rightLanesGoToSuccessor) {
-            roadSegment.AddNextLaneInfo(lanes.first, lanes.second, it->second->road_link.successor->id);
+          for (auto &&lanes : right_lanes_go_to_successor) {
+            road_segment.AddNextLaneInfo(lanes.first, lanes.second, it->second->road_link.successor->id);
           }
 
-          for (auto &&lanes : leftLanesGoToSuccessor) {
-            roadSegment.AddNextLaneInfo(lanes.first, lanes.second, it->second->road_link.successor->id);
+          // for (auto &&lanes : center_lanes_go_to_successor) {
+          //   road_segment.AddNextLaneInfo(lanes.first, lanes.second, it->second->road_link.successor->id);
+          // }
+
+          for (auto &&lanes : left_lanes_go_to_successor) {
+            road_segment.AddNextLaneInfo(lanes.first, lanes.second, it->second->road_link.successor->id);
           }
         }
       }
@@ -265,7 +290,7 @@ namespace opendrive {
           std::vector<carla::road::lane_junction_t> &options =
               junctionsData[it->second->road_link.predecessor->id][it->first];
           for (size_t i = 0; i < options.size(); ++i) {
-            roadSegment.AddPredecessorID(options[i].connection_road, options[i].contact_point == "start");
+            road_segment.AddPredecessorID(options[i].connection_road, options[i].contact_point == "start");
 
             for (size_t j = 0; j < options[i].from_lane.size(); ++j) {
               bool is_end = options[i].contact_point == "end";
@@ -275,23 +300,110 @@ namespace opendrive {
                 to_lane = fnc_get_first_driving_line(roadData[options[i].connection_road], to_lane);
               }
 
-              roadSegment.AddPrevLaneInfo(options[i].from_lane[j], to_lane, options[i].connection_road);
+              road_segment.AddPrevLaneInfo(options[i].from_lane[j], to_lane, options[i].connection_road);
             }
           }
         } else {
           bool is_start = it->second->road_link.predecessor->contact_point == "start";
-          roadSegment.AddPredecessorID(it->second->road_link.predecessor->id, is_start);
+          road_segment.AddPredecessorID(it->second->road_link.predecessor->id, is_start);
 
-          for (auto &&lanes : rightLanesGoToPredecessor) {
-            roadSegment.AddPrevLaneInfo(lanes.first, lanes.second, it->second->road_link.predecessor->id);
+          for (auto &&lanes : right_lanes_go_to_predecessor) {
+            road_segment.AddPrevLaneInfo(lanes.first, lanes.second, it->second->road_link.predecessor->id);
           }
 
-          for (auto &&lanes : leftLanesGoToPredecessor) {
-            roadSegment.AddPrevLaneInfo(lanes.first, lanes.second, it->second->road_link.predecessor->id);
+          for (auto &&lanes : left_lanes_go_to_predecessor) {
+            road_segment.AddPrevLaneInfo(lanes.first, lanes.second, it->second->road_link.predecessor->id);
           }
         }
       }
 
+      // Add lane change information
+      for (auto &&lane_section : it->second->lanes.lane_sections) {
+
+        // Lambda to convert from string to enum LaneChange
+        auto string_2_lane_change_enum = [](auto lane_change)->
+            carla::road::element::RoadInfoMarkRecord::LaneChange {
+          if (lane_change == "increase") {
+            return carla::road::element::RoadInfoMarkRecord::LaneChange::Increase;
+          }
+          else if (lane_change == "decrease") {
+            return carla::road::element::RoadInfoMarkRecord::LaneChange::Decrease;
+          }
+          else if (lane_change == "both") {
+            return carla::road::element::RoadInfoMarkRecord::LaneChange::Both;
+          }
+          else {
+            return carla::road::element::RoadInfoMarkRecord::LaneChange::None;
+          }
+        };
+
+        double start_position = lane_section.start_position;
+
+        // Create a new RoadInfoMarkRecord for each lane section. Each RoadInfoMarkRecord
+        // will contain the actual distance from the start of the RoadSegment
+
+        int current_lane_id = 1;
+
+        for (auto &&lane_section_left : lane_section.left) {
+          for (auto &&road_marker : lane_section_left.road_marker) {
+              road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
+                start_position + road_marker.soffset,
+                current_lane_id,
+                road_marker.type,
+                road_marker.weigth,
+                road_marker.color,
+                // See OpenDRIVE Format Specification, Rev. 1.4
+                // Doc No.: VI2014.107 (5.3.7.2.1.1.4 Road Mark Record)
+                "standard", // material
+                road_marker.width,
+                string_2_lane_change_enum(road_marker.lane_change),
+                // @todo: "carla/opendrive/types.h" must be extended to parse the height
+                0.0);
+          }
+          ++current_lane_id;
+        }
+
+        current_lane_id = 0;
+        for (auto &&lane_section_center : lane_section.center) { // @todo: .[0]!!
+          for (auto &&road_marker : lane_section_center.road_marker) {
+              road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
+                start_position + road_marker.soffset,
+                current_lane_id,
+                road_marker.type,
+                road_marker.weigth,
+                road_marker.color,
+                // See OpenDRIVE Format Specification, Rev. 1.4
+                // Doc No.: VI2014.107 (5.3.7.2.1.1.4 Road Mark Record)
+                "standard", // material
+                road_marker.width,
+                string_2_lane_change_enum(road_marker.lane_change),
+                // @todo: "carla/opendrive/types.h" must be extended to parse the height
+                0.0);
+          }
+        }
+
+        current_lane_id = -1;
+        for (auto &&lane_section_right : lane_section.right) {
+          for (auto &&road_marker : lane_section_right.road_marker) {
+              road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
+                start_position + road_marker.soffset,
+                current_lane_id,
+                road_marker.type,
+                road_marker.weigth,
+                road_marker.color,
+                // See OpenDRIVE Format Specification, Rev. 1.4
+                // Doc No.: VI2014.107 (5.3.7.2.1.1.4 Road Mark Record)
+                "standard", // material
+                road_marker.width,
+                string_2_lane_change_enum(road_marker.lane_change),
+                // @todo: "carla/opendrive/types.h" must be extended to parse the height
+                0.0);
+          }
+          --current_lane_id;
+        }
+      }
+
+      // Add geometry information
       for (size_t i = 0; i < it->second->geometry_attributes.size(); ++i) {
         geom::Location loc;
         loc.x = it->second->geometry_attributes[i]->start_position_x;
@@ -302,7 +414,7 @@ namespace opendrive {
             carla::opendrive::types::GeometryAttributesArc *arc =
                 (carla::opendrive::types::GeometryAttributesArc *) it->second->geometry_attributes[i].get();
 
-            roadSegment.MakeGeometry<carla::road::element::GeometryArc>(arc->start_position,
+            road_segment.MakeGeometry<carla::road::element::GeometryArc>(arc->start_position,
                 arc->length,
                 -arc->heading,
                 loc,
@@ -315,7 +427,7 @@ namespace opendrive {
             carla::opendrive::types::GeometryAttributesLine *line =
                 (carla::opendrive::types::GeometryAttributesLine *) it->second->geometry_attributes[i].get();
 
-            roadSegment.MakeGeometry<carla::road::element::GeometryLine>(line->start_position,
+            road_segment.MakeGeometry<carla::road::element::GeometryLine>(line->start_position,
                 line->length,
                 -line->heading,
                 loc);
@@ -327,7 +439,7 @@ namespace opendrive {
             carla::opendrive::types::GeometryAttributesSpiral *spiral =
                 (carla::opendrive::types::GeometryAttributesSpiral *) it->second->geometry_attributes[i].get();
 
-            roadSegment.MakeGeometry<carla::road::element::GeometrySpiral>(spiral->start_position,
+            road_segment.MakeGeometry<carla::road::element::GeometrySpiral>(spiral->start_position,
                 spiral->length,
                 -spiral->heading,
                 loc,
@@ -343,7 +455,7 @@ namespace opendrive {
         }
       }
 
-      mapBuilder.AddRoadSegmentDefinition(roadSegment);
+      mapBuilder.AddRoadSegmentDefinition(road_segment);
     }
 
     return mapBuilder.Build();

--- a/LibCarla/source/carla/opendrive/OpenDrive.cpp
+++ b/LibCarla/source/carla/opendrive/OpenDrive.cpp
@@ -313,7 +313,7 @@ namespace opendrive {
           }
         };
 
-        double start_position = lane_section.start_position;
+        const auto lane_sec_s_offset = lane_section.start_position;
 
         // Create a new RoadInfoMarkRecord for each lane section. Each RoadInfoMarkRecord
         // will contain the actual distance from the start of the RoadSegment
@@ -321,7 +321,7 @@ namespace opendrive {
           // parse all left lane road marks
           for (auto &&road_marker : lane_section_left.road_marker) {
             road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
-              start_position + road_marker.soffset,
+              lane_sec_s_offset + road_marker.soffset,
               lane_section_left.attributes.id,
               road_marker.type,
               road_marker.weigth,
@@ -335,7 +335,7 @@ namespace opendrive {
           // parse all left lane width
           for (auto &&lane_width : lane_section_left.lane_width) {
             road_segment.MakeInfo<carla::road::element::RoadInfoLaneWidth>(
-              lane_width.soffset,                   // s
+              lane_sec_s_offset + lane_width.soffset,                   // s
               lane_section_left.attributes.id,      // lane_id
               lane_width.width,                     // a
               lane_width.slope,                     // b
@@ -349,7 +349,7 @@ namespace opendrive {
           // parse all center lane road marks
           for (auto &&road_marker : lane_section_center.road_marker) {
             road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
-              start_position + road_marker.soffset,
+              lane_sec_s_offset + road_marker.soffset,
               lane_section_center.attributes.id,
               road_marker.type,
               road_marker.weigth,
@@ -363,7 +363,7 @@ namespace opendrive {
           // parse all center lane width
           for (auto &&lane_width : lane_section_center.lane_width) {
             road_segment.MakeInfo<carla::road::element::RoadInfoLaneWidth>(
-              lane_width.soffset,                   // s
+              lane_sec_s_offset + lane_width.soffset,                   // s
               lane_section_center.attributes.id,    // lane_id
               lane_width.width,                     // a
               lane_width.slope,                     // b
@@ -376,7 +376,7 @@ namespace opendrive {
           // parse all right lane road marks
           for (auto &&road_marker : lane_section_right.road_marker) {
             road_segment.MakeInfo<carla::road::element::RoadInfoMarkRecord>(
-              start_position + road_marker.soffset,
+              lane_sec_s_offset + road_marker.soffset,
               lane_section_right.attributes.id,
               road_marker.type,
               road_marker.weigth,
@@ -390,7 +390,7 @@ namespace opendrive {
           // parse all right lane width
           for (auto &&lane_width : lane_section_right.lane_width) {
             road_segment.MakeInfo<carla::road::element::RoadInfoLaneWidth>(
-              lane_width.soffset,                   // s
+              lane_sec_s_offset + lane_width.soffset,                   // s
               lane_section_right.attributes.id,     // lane_id
               lane_width.width,                     // a
               lane_width.slope,                     // b

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -24,7 +24,7 @@ namespace parser {
       ParseLaneWidth(lane, currentLane.lane_width);
 
       ParseLaneLink(lane.child("link"), currentLane.link);
-      ParseLaneRoadMark(lane.child("roadMark"), currentLane.road_marker);
+      ParseLaneRoadMark(lane, currentLane.road_marker);
 
       out_lane.emplace_back(std::move(currentLane));
     }
@@ -83,40 +83,41 @@ namespace parser {
   void LaneParser::ParseLaneRoadMark(
       const pugi::xml_node &xmlNode,
       std::vector<types::LaneRoadMark> &out_lane_mark) {
-    if (xmlNode == nullptr) {
-      return;
-    }
-    types::LaneRoadMark roadMarker;
 
-    if (xmlNode.attribute("sOffset") != nullptr) {
-      roadMarker.soffset = std::stod(xmlNode.attribute("sOffset").value());
-    }
+    for (pugi::xml_node road_mark = xmlNode.child("roadMark");
+         road_mark; road_mark = road_mark.next_sibling("roadMark")) {
+      types::LaneRoadMark roadMarker;
 
-    if (xmlNode.attribute("width") != nullptr) {
-      roadMarker.width = std::stod(xmlNode.attribute("width").value());
-    }
+      if (road_mark.attribute("sOffset") != nullptr) {
+        roadMarker.soffset = std::stod(road_mark.attribute("sOffset").value());
+      }
 
-    if (xmlNode.attribute("type") != nullptr) {
-      roadMarker.type = xmlNode.attribute("type").value();
-    }
+      if (road_mark.attribute("width") != nullptr) {
+        roadMarker.width = std::stod(road_mark.attribute("width").value());
+      }
 
-    if (xmlNode.attribute("weight") != nullptr) {
-      roadMarker.weigth = xmlNode.attribute("weight").value();
-    }
+      if (road_mark.attribute("type") != nullptr) {
+        roadMarker.type = road_mark.attribute("type").value();
+      }
 
-    if (xmlNode.attribute("material") != nullptr) {
-      roadMarker.color = xmlNode.attribute("material").value();
-    }
+      if (road_mark.attribute("weight") != nullptr) {
+        roadMarker.weigth = road_mark.attribute("weight").value();
+      }
 
-    if (xmlNode.attribute("color") != nullptr) {
-      roadMarker.color = xmlNode.attribute("color").value();
-    }
+      if (road_mark.attribute("material") != nullptr) {
+        roadMarker.color = road_mark.attribute("material").value();
+      }
 
-    if (xmlNode.attribute("laneChange") != nullptr) {
-      roadMarker.lane_change = xmlNode.attribute("laneChange").value();
-    }
+      if (road_mark.attribute("color") != nullptr) {
+        roadMarker.color = road_mark.attribute("color").value();
+      }
 
-    out_lane_mark.emplace_back(roadMarker);
+      if (road_mark.attribute("laneChange") != nullptr) {
+        roadMarker.lane_change = road_mark.attribute("laneChange").value();
+      }
+
+      out_lane_mark.emplace_back(roadMarker);
+    }
   }
 
   void LaneParser::ParseLaneSpeed(

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -143,7 +143,7 @@ namespace parser {
     for (pugi::xml_node laneSection = xmlNode.child("laneOffset");
         laneSection;
         laneSection = laneSection.next_sibling("laneOffset")) {
-      laneParser.ParseLaneOffset(xmlNode.child("laneOffset"), out_lanes.lane_offset);
+      laneParser.ParseLaneOffset(laneSection, out_lanes.lane_offset);
     }
 
     for (pugi::xml_node laneSection = xmlNode.child("laneSection");

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -104,6 +104,10 @@ namespace parser {
       roadMarker.weigth = xmlNode.attribute("weight").value();
     }
 
+    if (xmlNode.attribute("material") != nullptr) {
+      roadMarker.color = xmlNode.attribute("material").value();
+    }
+
     if (xmlNode.attribute("color") != nullptr) {
       roadMarker.color = xmlNode.attribute("color").value();
     }

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -6,164 +6,160 @@
 
 #include "LaneParser.h"
 
-void carla::opendrive::parser::LaneParser::ParseLane(
-    const pugi::xml_node &xmlNode,
-    std::vector<carla::opendrive::types::LaneInfo> &out_lane) {
-  for (pugi::xml_node lane = xmlNode.child("lane"); lane; lane = lane.next_sibling("lane")) {
-    carla::opendrive::types::LaneInfo currentLane;
+namespace carla {
+namespace opendrive {
+namespace parser {
 
-    currentLane.attributes.type = lane.attribute("type").value();
-    currentLane.attributes.level = lane.attribute("level").value();
-    currentLane.attributes.id = std::atoi(lane.attribute("id").value());
+  void LaneParser::ParseLane(
+      const pugi::xml_node &xmlNode,
+      std::vector<types::LaneInfo> &out_lane) {
+    for (pugi::xml_node lane = xmlNode.child("lane"); lane; lane = lane.next_sibling("lane")) {
+      types::LaneInfo currentLane;
 
-    ParseLaneSpeed(lane, currentLane.lane_speed);
-    ParseLaneWidth(lane, currentLane.lane_width);
+      currentLane.attributes.type = lane.attribute("type").value();
+      currentLane.attributes.level = lane.attribute("level").value();
+      currentLane.attributes.id = std::atoi(lane.attribute("id").value());
 
-    ParseLaneLink(lane.child("link"), currentLane.link);
-    ParseLaneRoadMark(lane.child("roadMark"), currentLane.road_marker);
+      ParseLaneSpeed(lane, currentLane.lane_speed);
+      ParseLaneWidth(lane, currentLane.lane_width);
 
-    out_lane.emplace_back(std::move(currentLane));
-  }
-}
+      ParseLaneLink(lane.child("link"), currentLane.link);
+      ParseLaneRoadMark(lane.child("roadMark"), currentLane.road_marker);
 
-void carla::opendrive::parser::LaneParser::ParseLaneWidth(
-    const pugi::xml_node &xmlNode,
-    std::vector<carla::opendrive::types::LaneWidth> &out_lane_width) {
-  for (pugi::xml_node laneWidth = xmlNode.child("width");
-      laneWidth;
-      laneWidth = laneWidth.next_sibling("width")) {
-    carla::opendrive::types::LaneWidth laneWidthInfo;
-
-    laneWidthInfo.soffset = std::stod(laneWidth.attribute("sOffset").value());
-
-    laneWidthInfo.width = std::stod(laneWidth.attribute("a").value());
-    laneWidthInfo.slope = std::stod(laneWidth.attribute("b").value());
-
-    laneWidthInfo.vertical_curvature = std::stod(laneWidth.attribute("c").value());
-    laneWidthInfo.curvature_change = std::stod(laneWidth.attribute("d").value());
-
-    out_lane_width.emplace_back(laneWidthInfo);
-  }
-}
-
-void carla::opendrive::parser::LaneParser::ParseLaneLink(
-    const pugi::xml_node &xmlNode,
-    std::unique_ptr<carla::opendrive::types::LaneLink> &out_lane_link) {
-  const pugi::xml_node predecessorNode = xmlNode.child("predecessor");
-  const pugi::xml_node successorNode = xmlNode.child("successor");
-
-  out_lane_link =
-      (predecessorNode || successorNode) ? std::make_unique<opendrive::types::LaneLink>() : nullptr;
-  if (out_lane_link == nullptr) {
-    return;
+      out_lane.emplace_back(std::move(currentLane));
+    }
   }
 
-  out_lane_link->predecessor_id = predecessorNode ? std::atoi(predecessorNode.attribute("id").value()) : 0;
-  out_lane_link->successor_id = successorNode ? std::atoi(successorNode.attribute("id").value()) : 0;
-}
+  void LaneParser::ParseLaneWidth(
+      const pugi::xml_node &xmlNode,
+      std::vector<types::LaneWidth> &out_lane_width) {
+    for (pugi::xml_node laneWidth = xmlNode.child("width");
+        laneWidth;
+        laneWidth = laneWidth.next_sibling("width")) {
+      types::LaneWidth laneWidthInfo;
 
-void carla::opendrive::parser::LaneParser::ParseLaneOffset(
-    const pugi::xml_node &xmlNode,
-    std::vector<carla::opendrive::types::LaneOffset> &out_lane_offset) {
-  carla::opendrive::types::LaneOffset lanesOffset;
+      laneWidthInfo.soffset = std::stod(laneWidth.attribute("sOffset").value());
 
-  lanesOffset.s = std::stod(xmlNode.attribute("s").value());
-  lanesOffset.a = std::stod(xmlNode.attribute("a").value());
-  lanesOffset.b = std::stod(xmlNode.attribute("b").value());
-  lanesOffset.c = std::stod(xmlNode.attribute("c").value());
-  lanesOffset.d = std::stod(xmlNode.attribute("d").value());
+      laneWidthInfo.width = std::stod(laneWidth.attribute("a").value());
+      laneWidthInfo.slope = std::stod(laneWidth.attribute("b").value());
 
-  out_lane_offset.emplace_back(lanesOffset);
-}
+      laneWidthInfo.vertical_curvature = std::stod(laneWidth.attribute("c").value());
+      laneWidthInfo.curvature_change = std::stod(laneWidth.attribute("d").value());
 
-void carla::opendrive::parser::LaneParser::ParseLaneRoadMark(
-    const pugi::xml_node &xmlNode,
-    std::vector<carla::opendrive::types::LaneRoadMark> &out_lane_mark) {
-  if (xmlNode == nullptr) {
-    return;
-  }
-  carla::opendrive::types::LaneRoadMark roadMarker;
-
-  if (xmlNode.attribute("sOffset") != nullptr) {
-    roadMarker.soffset = std::stod(xmlNode.attribute("sOffset").value());
-  } else {
-    roadMarker.soffset = 0.0;
+      out_lane_width.emplace_back(laneWidthInfo);
+    }
   }
 
-  if (xmlNode.attribute("width") != nullptr) {
-    roadMarker.width = std::stod(xmlNode.attribute("width").value());
-  } else {
-    roadMarker.width = 0.0;
+  void LaneParser::ParseLaneLink(
+      const pugi::xml_node &xmlNode,
+      std::unique_ptr<types::LaneLink> &out_lane_link) {
+    const pugi::xml_node predecessorNode = xmlNode.child("predecessor");
+    const pugi::xml_node successorNode = xmlNode.child("successor");
+
+    out_lane_link =
+        (predecessorNode || successorNode) ? std::make_unique<opendrive::types::LaneLink>() : nullptr;
+    if (out_lane_link == nullptr) {
+      return;
+    }
+
+    out_lane_link->predecessor_id = predecessorNode ? std::atoi(predecessorNode.attribute("id").value()) : 0;
+    out_lane_link->successor_id = successorNode ? std::atoi(successorNode.attribute("id").value()) : 0;
   }
 
-  if (xmlNode.attribute("type") != nullptr) {
-    roadMarker.type = xmlNode.attribute("type").value();
-  } else {
-    roadMarker.type = "";
+  void LaneParser::ParseLaneOffset(
+      const pugi::xml_node &xmlNode,
+      std::vector<types::LaneOffset> &out_lane_offset) {
+    types::LaneOffset lanesOffset;
+
+    lanesOffset.s = std::stod(xmlNode.attribute("s").value());
+    lanesOffset.a = std::stod(xmlNode.attribute("a").value());
+    lanesOffset.b = std::stod(xmlNode.attribute("b").value());
+    lanesOffset.c = std::stod(xmlNode.attribute("c").value());
+    lanesOffset.d = std::stod(xmlNode.attribute("d").value());
+
+    out_lane_offset.emplace_back(lanesOffset);
   }
 
-  if (xmlNode.attribute("weight") != nullptr) {
-    roadMarker.weigth = xmlNode.attribute("weight").value();
-  } else {
-    roadMarker.weigth = "";
+  void LaneParser::ParseLaneRoadMark(
+      const pugi::xml_node &xmlNode,
+      std::vector<types::LaneRoadMark> &out_lane_mark) {
+    if (xmlNode == nullptr) {
+      return;
+    }
+    types::LaneRoadMark roadMarker;
+
+    if (xmlNode.attribute("sOffset") != nullptr) {
+      roadMarker.soffset = std::stod(xmlNode.attribute("sOffset").value());
+    }
+
+    if (xmlNode.attribute("width") != nullptr) {
+      roadMarker.width = std::stod(xmlNode.attribute("width").value());
+    }
+
+    if (xmlNode.attribute("type") != nullptr) {
+      roadMarker.type = xmlNode.attribute("type").value();
+    }
+
+    if (xmlNode.attribute("weight") != nullptr) {
+      roadMarker.weigth = xmlNode.attribute("weight").value();
+    }
+
+    if (xmlNode.attribute("color") != nullptr) {
+      roadMarker.color = xmlNode.attribute("color").value();
+    }
+
+    if (xmlNode.attribute("laneChange") != nullptr) {
+      roadMarker.lane_change = xmlNode.attribute("laneChange").value();
+    }
+
+    out_lane_mark.emplace_back(roadMarker);
   }
 
-  if (xmlNode.attribute("color") != nullptr) {
-    roadMarker.color = xmlNode.attribute("color").value();
-  } else {
-    roadMarker.color = "";
+  void LaneParser::ParseLaneSpeed(
+      const pugi::xml_node &xmlNode,
+      std::vector<types::LaneSpeed> &out_lane_speed) {
+    for (pugi::xml_node laneSpeed = xmlNode.child("speed");
+        laneSpeed;
+        laneSpeed = laneSpeed.next_sibling("speed")) {
+      types::LaneSpeed lane_speed = { 0.0, 0.0 };
+
+      lane_speed.soffset = std::stod(laneSpeed.attribute("sOffset").value());
+      lane_speed.max_speed = std::stod(laneSpeed.attribute("max").value());
+
+      out_lane_speed.emplace_back(lane_speed);
+    }
   }
 
-  if (xmlNode.attribute("laneChange") != nullptr) {
-    roadMarker.lange_change = xmlNode.attribute("laneChange").value();
-  } else {
-    roadMarker.lange_change = "";
+  void LaneParser::Parse(
+      const pugi::xml_node &xmlNode,
+      types::Lanes &out_lanes) {
+    LaneParser laneParser;
+
+    for (pugi::xml_node laneSection = xmlNode.child("laneOffset");
+        laneSection;
+        laneSection = laneSection.next_sibling("laneOffset")) {
+      laneParser.ParseLaneOffset(xmlNode.child("laneOffset"), out_lanes.lane_offset);
+    }
+
+    for (pugi::xml_node laneSection = xmlNode.child("laneSection");
+        laneSection;
+        laneSection = laneSection.next_sibling("laneSection")) {
+      types::LaneSection laneSec;
+      laneSec.start_position = std::stod(laneSection.attribute("s").value());
+
+      pugi::xml_node lane = laneSection.child("left");
+      laneParser.ParseLane(lane, laneSec.left);
+
+      lane = laneSection.child("center");
+      laneParser.ParseLane(lane, laneSec.center);
+
+      lane = laneSection.child("right");
+      laneParser.ParseLane(lane, laneSec.right);
+
+      out_lanes.lane_sections.emplace_back(std::move(laneSec));
+    }
   }
 
-  out_lane_mark.emplace_back(roadMarker);
-}
-
-void carla::opendrive::parser::LaneParser::ParseLaneSpeed(
-    const pugi::xml_node &xmlNode,
-    std::vector<carla::opendrive::types::LaneSpeed> &out_lane_speed) {
-  for (pugi::xml_node laneSpeed = xmlNode.child("speed");
-      laneSpeed;
-      laneSpeed = laneSpeed.next_sibling("speed")) {
-    carla::opendrive::types::LaneSpeed lane_speed = { 0.0, 0.0 };
-
-    lane_speed.soffset = std::stod(laneSpeed.attribute("sOffset").value());
-    lane_speed.max_speed = std::stod(laneSpeed.attribute("max").value());
-
-    out_lane_speed.emplace_back(lane_speed);
-  }
-}
-
-void carla::opendrive::parser::LaneParser::Parse(
-    const pugi::xml_node &xmlNode,
-    carla::opendrive::types::Lanes &out_lanes) {
-  carla::opendrive::parser::LaneParser laneParser;
-
-  for (pugi::xml_node laneSection = xmlNode.child("laneOffset");
-      laneSection;
-      laneSection = laneSection.next_sibling("laneOffset")) {
-    laneParser.ParseLaneOffset(xmlNode.child("laneOffset"), out_lanes.lane_offset);
-  }
-
-  for (pugi::xml_node laneSection = xmlNode.child("laneSection");
-      laneSection;
-      laneSection = laneSection.next_sibling("laneSection")) {
-    carla::opendrive::types::LaneSection laneSec;
-    laneSec.start_position = std::stod(laneSection.attribute("s").value());
-
-    pugi::xml_node lane = laneSection.child("left");
-    laneParser.ParseLane(lane, laneSec.left);
-
-    lane = laneSection.child("center");
-    laneParser.ParseLane(lane, laneSec.center);
-
-    lane = laneSection.child("right");
-    laneParser.ParseLane(lane, laneSec.right);
-
-    out_lanes.lane_sections.emplace_back(std::move(laneSec));
-  }
-}
+} // parser
+} // opendrive
+} // carla

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.h
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.h
@@ -19,35 +19,35 @@ namespace parser {
 
     void ParseLane(
         const pugi::xml_node &xmlNode,
-        std::vector<carla::opendrive::types::LaneInfo> &out_lane);
+        std::vector<types::LaneInfo> &out_lane);
 
     void ParseLaneSpeed(
         const pugi::xml_node &xmlNode,
-        std::vector<carla::opendrive::types::LaneSpeed> &out_lane_speed);
+        std::vector<types::LaneSpeed> &out_lane_speed);
 
     void ParseLaneLink(
         const pugi::xml_node &xmlNode,
-        std::unique_ptr<carla::opendrive::types::LaneLink> &out_lane_link);
+        std::unique_ptr<types::LaneLink> &out_lane_link);
 
     void ParseLaneOffset(
         const pugi::xml_node &xmlNode,
-        std::vector<carla::opendrive::types::LaneOffset> &out_lane_offset);
+        std::vector<types::LaneOffset> &out_lane_offset);
 
     void ParseLaneWidth(
         const pugi::xml_node &xmlNode,
-        std::vector<carla::opendrive::types::LaneWidth> &out_lane_width);
+        std::vector<types::LaneWidth> &out_lane_width);
 
     void ParseLaneRoadMark(
         const pugi::xml_node &xmlNode,
-        std::vector<carla::opendrive::types::LaneRoadMark> &out_lane_mark);
+        std::vector<types::LaneRoadMark> &out_lane_mark);
 
   public:
 
     static void Parse(
         const pugi::xml_node &xmlNode,
-        carla::opendrive::types::Lanes &out_lanes);
+        types::Lanes &out_lanes);
   };
 
-}
-}
-}
+} // parser
+} // opendrive
+} // carla

--- a/LibCarla/source/carla/opendrive/types.h
+++ b/LibCarla/source/carla/opendrive/types.h
@@ -67,9 +67,13 @@ namespace types {
     double width = 0.0;
 
     std::string type;
-    std::string weigth;
+    std::string weigth = "standard";
 
-    std::string color;
+    // See OpenDRIVE Format Specification, Rev. 1.4
+    // Doc No.: VI2014.107 (5.3.7.2.1.1.4 Road Mark Record)
+    std::string material = "standard";
+
+    std::string color = "white";
     std::string lane_change = "none";
   };
 

--- a/LibCarla/source/carla/opendrive/types.h
+++ b/LibCarla/source/carla/opendrive/types.h
@@ -63,14 +63,14 @@ namespace types {
   };
 
   struct LaneRoadMark {
-    double soffset;
-    double width;
+    double soffset = 0.0;
+    double width = 0.0;
 
     std::string type;
     std::string weigth;
 
     std::string color;
-    std::string lange_change;
+    std::string lane_change = "none";
   };
 
   struct LaneOffset {

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -20,7 +20,7 @@ namespace road {
   boost::optional<Waypoint> Map::GetWaypoint(const geom::Location &loc) const {
     Waypoint w = Waypoint(shared_from_this(), loc);
     auto d = geom::Math::Distance2D(w.ComputeTransform().location, loc);
-    const RoadInfoLane *inf = _data.GetRoad(w._road_id)->GetInfo<RoadInfoLane>(w._dist);
+    const auto inf = _data.GetRoad(w._road_id)->GetInfo<RoadInfoLane>(w._dist);
 
     if (d < inf->getLane(w._lane_id)->_width * 0.5) {
       return w;

--- a/LibCarla/source/carla/road/WaypointGenerator.cpp
+++ b/LibCarla/source/carla/road/WaypointGenerator.cpp
@@ -114,14 +114,7 @@ namespace road {
 
     DEBUG_ASSERT(this_lane_id != 0);
 
-    int new_lane_id;
-    if (this_lane_id <= 0) {
-      // road goes forward: decrease the lane id while avoiding returning lane 0
-      new_lane_id = this_lane_id - 1 == 0 ? -1 : this_lane_id - 1;
-    } else {
-      // road goes backward: increasing the lane id while avoiding returning lane 0
-      new_lane_id = this_lane_id + 1 == 0 ? 1 : this_lane_id + 1;
-    }
+    const int new_lane_id = (this_lane_id <= 0) ? this_lane_id - 1 : this_lane_id + 1;
 
     // check if that lane id exists on this distance
     const auto road = map->GetData().GetRoad(this_road_id);

--- a/LibCarla/source/carla/road/WaypointGenerator.cpp
+++ b/LibCarla/source/carla/road/WaypointGenerator.cpp
@@ -76,8 +76,10 @@ namespace road {
       const Waypoint &waypoint,
       double distance) {
     auto &map = waypoint._map;
-    const auto this_lane_id = waypoint.GetLaneId();
     const auto this_road_id = waypoint.GetRoadId();
+    const auto this_lane_id = waypoint.GetLaneId();
+
+    DEBUG_ASSERT(this_lane_id != 0);
 
     double distance_on_next_segment;
 
@@ -107,72 +109,58 @@ namespace road {
 
   boost::optional<Waypoint> WaypointGenerator::GetRight(const Waypoint &waypoint) {
     auto &map = waypoint._map;
-    const auto this_lane_id = waypoint.GetLaneId();
     const auto this_road_id = waypoint.GetRoadId();
+    const auto this_lane_id = waypoint.GetLaneId();
 
-    int new_lane_id = 0;
+    DEBUG_ASSERT(this_lane_id != 0);
 
+    int new_lane_id;
     if (this_lane_id <= 0) {
-      // road goes forward
-      // decrease the lane id while avoiding returning lane 0
+      // road goes forward: decrease the lane id while avoiding returning lane 0
       new_lane_id = this_lane_id - 1 == 0 ? -1 : this_lane_id - 1;
     } else {
-      // road goes backward
-      // increasing the lane id while avoiding returning lane 0
+      // road goes backward: increasing the lane id while avoiding returning lane 0
       new_lane_id = this_lane_id + 1 == 0 ? 1 : this_lane_id + 1;
     }
 
     // check if that lane id exists on this distance
     const auto road = map->GetData().GetRoad(this_road_id);
     const auto mark_record_vector = road->GetRoadInfoMarkRecord(waypoint._dist);
-    bool found = false;
     for (auto &&mark_record : mark_record_vector) {
       // find if the lane id exists
-      if (mark_record->GetLaneId() == this_lane_id) {
-        found = true;
-        break;
+      if (mark_record->GetLaneId() == new_lane_id) {
+        return Waypoint(map, this_road_id, new_lane_id, waypoint._dist);
       }
     }
-
-    if (found) {
-      return Waypoint(map, this_road_id, new_lane_id, waypoint._dist);
-    }
-    return boost::optional<Waypoint>{};
+    return boost::optional<Waypoint>();
   }
 
   boost::optional<Waypoint> WaypointGenerator::GetLeft(const Waypoint &waypoint) {
     auto &map = waypoint._map;
-      const auto this_lane_id = waypoint.GetLaneId();
     const auto this_road_id = waypoint.GetRoadId();
+    const auto this_lane_id = waypoint.GetLaneId();
 
-    int new_lane_id = 0;
+    DEBUG_ASSERT(this_lane_id != 0);
 
+    int new_lane_id;
     if (this_lane_id > 0) {
-      // road goes backward
-      // decrease the lane id while avoiding returning lane 0
+      // road goes backward: decrease the lane id while avoiding returning lane 0
       new_lane_id = this_lane_id - 1 == 0 ? -1 : this_lane_id - 1;
     } else {
-      // road goes forward
-      // increasing the lane id while avoiding returning lane 0
+      // road goes forward: increasing the lane id while avoiding returning lane 0
       new_lane_id = this_lane_id + 1 == 0 ? 1 : this_lane_id + 1;
     }
 
     // check if that lane id exists on this distance
     const auto road = map->GetData().GetRoad(this_road_id);
     const auto mark_record_vector = road->GetRoadInfoMarkRecord(waypoint._dist);
-    bool found = false;
     for (auto &&mark_record : mark_record_vector) {
       // find if the lane id exists
-      if (mark_record->GetLaneId() == this_lane_id) {
-        found = true;
-        break;
+      if (mark_record->GetLaneId() == new_lane_id) {
+        return Waypoint(map, this_road_id, new_lane_id, waypoint._dist);
       }
     }
-
-    if (found) {
-      return Waypoint(map, this_road_id, new_lane_id, waypoint._dist);
-    }
-    return boost::optional<Waypoint>{};
+    return boost::optional<Waypoint>();
   }
 
   std::vector<Waypoint> WaypointGenerator::GenerateAll(

--- a/LibCarla/source/carla/road/WaypointGenerator.h
+++ b/LibCarla/source/carla/road/WaypointGenerator.h
@@ -8,6 +8,8 @@
 
 #include "carla/road/element/Waypoint.h"
 
+#include <boost/optional.hpp>
+
 #include <utility>
 #include <vector>
 
@@ -32,6 +34,14 @@ namespace road {
     static std::vector<Waypoint> GetNext(
         const Waypoint &waypoint,
         double distance);
+
+    /// Return a waypoint at the lane of @a waypoint's right lane.
+    static boost::optional<Waypoint> GetRight(
+        const Waypoint &waypoint);
+
+    /// Return a waypoint at the lane of @a waypoint's left lane.
+    static boost::optional<Waypoint> GetLeft(
+        const Waypoint &waypoint);
 
     /// Generate all the waypoints in @a map separated by @a approx_distance.
     static std::vector<Waypoint> GenerateAll(

--- a/LibCarla/source/carla/road/element/RoadInfo.h
+++ b/LibCarla/source/carla/road/element/RoadInfo.h
@@ -58,8 +58,8 @@ namespace element {
       return _junction_id >= 0;
     }
 
-    void SetLanesOffset(double offset, double laneOffset) {
-      _lanes_offset.emplace_back(std::pair<double, double>(offset, laneOffset));
+    void SetLanesOffset(double start_pos, double lateral_offset) {
+      _lanes_offset.emplace_back(std::pair<double, double>(start_pos, lateral_offset));
     }
 
     /// @returns A vector of pairs where the first double represents the

--- a/LibCarla/source/carla/road/element/RoadInfo.h
+++ b/LibCarla/source/carla/road/element/RoadInfo.h
@@ -177,6 +177,7 @@ namespace element {
 
     friend MapBuilder;
 
+    // int is the lane id (-inf, inf)
     using lane_t = std::map<int, LaneInfo>;
     lane_t _lanes;
 
@@ -206,7 +207,7 @@ namespace element {
       for (lane_t::const_iterator it = _lanes.begin(); it != _lanes.end(); ++it) {
         switch (whichLanes) {
           case which_lane_e::Both: {
-            lanes_id.emplace_back(it->first);
+              lanes_id.emplace_back(it->first);
           } break;
 
           case which_lane_e::Left: {
@@ -223,11 +224,11 @@ namespace element {
         }
       }
 
-      // NOTE(Andrei): Sort the lanes IDs ascendent,
+      // Sort the lanes IDs ascendent,
       // going from 1 to n
       std::sort(lanes_id.begin(), lanes_id.end());
 
-      // NOTE(Andrei): For right lane the IDs are negative,
+      // For right lane the IDs are negative,
       // so reverse so sort order to haven them going
       // from -1 to -n
       if (whichLanes == which_lane_e::Right) {

--- a/LibCarla/source/carla/road/element/RoadInfo.h
+++ b/LibCarla/source/carla/road/element/RoadInfo.h
@@ -24,7 +24,7 @@ namespace element {
     virtual void AcceptVisitor(RoadInfoVisitor &) = 0;
 
     // distance from Road's start location
-    double d; // [meters]
+    double d; // [meters] @todo: change this to "s"
 
   protected:
 

--- a/LibCarla/source/carla/road/element/RoadInfoLaneOffset.h
+++ b/LibCarla/source/carla/road/element/RoadInfoLaneOffset.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/road/element/RoadInfo.h"
+#include "carla/geom/CubicPolynomial.h"
+
+namespace carla {
+namespace road {
+namespace element {
+
+  // The lane offset record defines a lateral shift of the lane reference
+  // line(which is usually identical to the road reference line). This may be
+  // used for an easy implementation of a (local)lateralshift of the lanes
+  // relative to the road’s referenceline. Especially the modeling of
+  // inner-city layouts or "2+1" cross-country road layouts can be
+  // facilitated considerably by this feature.
+  class RoadInfoLaneOffset : public RoadInfo {
+  public:
+
+    void AcceptVisitor(RoadInfoVisitor &v) final {
+      v.Visit(*this);
+    }
+
+    RoadInfoLaneOffset(
+        double s,
+        double a,
+        double b,
+        double c,
+        double d)
+      : RoadInfo(s),
+        _offset(a, b, c, d, s) {}
+
+    const geom::CubicPolynomial &GetPolynomial() const {
+      return _offset;
+    }
+
+    double ComputeOffset(const double &dist) const {
+      return _offset.Evaluate(dist);
+    }
+
+  private:
+
+    geom::CubicPolynomial _offset;
+
+  };
+
+} // namespace element
+} // namespace road
+} // namespace carla

--- a/LibCarla/source/carla/road/element/RoadInfoLaneOffset.h
+++ b/LibCarla/source/carla/road/element/RoadInfoLaneOffset.h
@@ -39,10 +39,6 @@ namespace element {
       return _offset;
     }
 
-    double ComputeOffset(const double &dist) const {
-      return _offset.Evaluate(dist);
-    }
-
   private:
 
     geom::CubicPolynomial _offset;

--- a/LibCarla/source/carla/road/element/RoadInfoLaneWidth.h
+++ b/LibCarla/source/carla/road/element/RoadInfoLaneWidth.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/road/element/RoadInfo.h"
+#include "carla/geom/CubicPolynomial.h"
+
+namespace carla {
+namespace road {
+namespace element {
+
+  // Lane Width RecordEach lane within a road’scross section can be provided
+  // with severalwidth entries. At least one entry must be defined for each
+  // lane, except for the center lane which is, per convention, of zero width.
+  // Each entry is valid until a new entry is defined. If multiple
+  // entries are defined for a lane, they must be listed in ascendingorder.
+  class RoadInfoLaneWidth : public RoadInfo {
+  public:
+
+    void AcceptVisitor(RoadInfoVisitor &v) final {
+      v.Visit(*this);
+    }
+
+    RoadInfoLaneWidth(
+        double s,
+        int lane_id,
+        double a,
+        double b,
+        double c,
+        double d)
+      : RoadInfo(s),
+        _lane_id(lane_id),
+        _width(a, b, c, d, s) {}
+
+    int GetLaneId() const {
+      return _lane_id;
+    }
+
+    const geom::CubicPolynomial &GetPolynomial() const {
+      return _width;
+    }
+
+    double GetA() const {
+      return _width.GetA();
+    }
+
+    double ComputeOffset(const double &dist) const {
+      return _width.Evaluate(dist);
+    }
+
+  private:
+
+    using signed_id = int;
+
+    signed_id _lane_id = 0;
+
+    geom::CubicPolynomial _width;
+
+  };
+
+} // namespace element
+} // namespace road
+} // namespace carla

--- a/LibCarla/source/carla/road/element/RoadInfoLaneWidth.h
+++ b/LibCarla/source/carla/road/element/RoadInfoLaneWidth.h
@@ -44,14 +44,6 @@ namespace element {
       return _width;
     }
 
-    double GetA() const {
-      return _width.GetA();
-    }
-
-    double ComputeOffset(const double &dist) const {
-      return _width.Evaluate(dist);
-    }
-
   private:
 
     using signed_id = int;

--- a/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
+++ b/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/road/element/RoadInfo.h"
+
+#include <unordered_map>
+#include <string>
+
+namespace carla {
+namespace road {
+namespace element {
+
+  // class RoadInfo;
+
+  // Each lane within a road cross section can be provided with several road
+  // markentries. The road mark information defines the style of the line at the
+  // lane’s outer border. For left lanes, this is the left border, for right
+  // lanes the right one. The style of the line separating left and right lanes
+  // is determined by the road mark entry for lane zero (i.e. the center lane)
+  class RoadInfoMarkRecord : public RoadInfo {
+  public:
+
+    void AcceptVisitor(RoadInfoVisitor &v) final {
+      v.Visit(*this);
+    }
+
+    /// Can be used as flags
+    enum class LaneChange : uint8_t {
+      None     = 0x00, //00
+      Increase = 0x01, //01
+      Decrease = 0x02, //10
+      Both     = 0x03  //11
+    };
+
+    RoadInfoMarkRecord(double d, int lane_id)
+      : RoadInfo(d),
+        _lane_id(lane_id),
+        _type(""),
+        _weight(""),
+        _color("white"),
+        _material("standard"),
+        _width(0.15),
+        _lane_change(LaneChange::None),
+        _height(0.0) {}
+
+    RoadInfoMarkRecord(
+        double d,
+        int lane_id,
+        std::string type,
+        std::string weight,
+        std::string color,
+        std::string material,
+        double width,
+        LaneChange lane_change,
+        double height)
+      : RoadInfo(d),
+        _lane_id(lane_id),
+        _type(type),
+        _weight(weight),
+        _color(color),
+        _material(material),
+        _width(width),
+        _lane_change(lane_change),
+        _height(height) {}
+
+    int GetLaneId() const {
+      return _lane_id;
+    }
+
+    std::string GetType() const {
+      return _type;
+    }
+
+    std::string GetWeight() const {
+      return _weight;
+    }
+
+    std::string GetColor() const {
+      return _color;
+    }
+
+    std::string GetMaterial() const {
+      return _material;
+    }
+
+    double GetWidth() const {
+      return _width;
+    }
+
+    LaneChange GetLaneChange() const {
+      return _lane_change;
+    }
+
+    double GetHeight() const {
+      return _height;
+    }
+
+  private:
+
+    using signed_id = int;
+
+    signed_id _lane_id = 0;
+
+    std::string _type;       // Type of the road mark
+    std::string _weight;     // Weight of the road mark
+    std::string _color;      // Color of the road mark
+    std::string _material;   // Material of the road mark (identifiers to be
+                             // defined, use "standard" for the moment
+    double _width;           // Width of the road mark –optional
+    LaneChange _lane_change; // Allow a lane change in the indicated direction
+                             // taking into account that lanes are numbered in
+                             // ascending order from right to left. If the
+                             // attributeis missing, “both” is assumedto be
+                             // valid.
+    double _height;          // Physical distance of top edge of road mark from
+                             // reference plane of the lane
+
+    // This map stores the MarkRecord of all lanes of the current LaneSection
+    // (keyed using the signed integer id from OpenDrive)
+    // std::unordered_map<signed_id, std::unique_ptr<MarkRecord>> _mark_records;
+  };
+
+} // namespace element
+} // namespace road
+} // namespace carla

--- a/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
+++ b/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
@@ -15,8 +15,6 @@ namespace carla {
 namespace road {
 namespace element {
 
-  // class RoadInfo;
-
   // Each lane within a road cross section can be provided with several road
   // markentries. The road mark information defines the style of the line at the
   // lane’s outer border. For left lanes, this is the left border, for right

--- a/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
+++ b/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
@@ -8,7 +8,6 @@
 
 #include "carla/road/element/RoadInfo.h"
 
-#include <unordered_map>
 #include <string>
 
 namespace carla {
@@ -117,10 +116,6 @@ namespace element {
                              // valid.
     double _height;          // Physical distance of top edge of road mark from
                              // reference plane of the lane
-
-    // This map stores the MarkRecord of all lanes of the current LaneSection
-    // (keyed using the signed integer id from OpenDrive)
-    // std::unordered_map<signed_id, std::unique_ptr<MarkRecord>> _mark_records;
   };
 
 } // namespace element

--- a/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
+++ b/LibCarla/source/carla/road/element/RoadInfoMarkRecord.h
@@ -69,19 +69,19 @@ namespace element {
       return _lane_id;
     }
 
-    std::string GetType() const {
+    const std::string &GetType() const {
       return _type;
     }
 
-    std::string GetWeight() const {
+    const std::string &GetWeight() const {
       return _weight;
     }
 
-    std::string GetColor() const {
+    const std::string &GetColor() const {
       return _color;
     }
 
-    std::string GetMaterial() const {
+    const std::string &GetMaterial() const {
       return _material;
     }
 

--- a/LibCarla/source/carla/road/element/RoadInfoVisitor.h
+++ b/LibCarla/source/carla/road/element/RoadInfoVisitor.h
@@ -18,7 +18,9 @@ namespace element {
   class RoadGeneralInfo;
   class RoadInfoVelocity;
   class RoadElevationInfo;
+  class RoadInfoLaneWidth;
   class RoadInfoMarkRecord;
+  class RoadInfoLaneOffset;
 
   class RoadInfoVisitor {
   public:
@@ -29,9 +31,13 @@ namespace element {
 
     virtual void Visit(RoadInfoVelocity &) {}
 
+    virtual void Visit(RoadElevationInfo &) {}
+
+    virtual void Visit(RoadInfoLaneWidth &) {}
+
     virtual void Visit(RoadInfoMarkRecord &) {}
 
-    virtual void Visit(RoadElevationInfo &) {}
+    virtual void Visit(RoadInfoLaneOffset &) {}
   };
 
   template <typename T, typename IT>

--- a/LibCarla/source/carla/road/element/RoadInfoVisitor.h
+++ b/LibCarla/source/carla/road/element/RoadInfoVisitor.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <iterator>
+#include <memory>
 
 namespace carla {
 namespace road {
@@ -16,14 +17,20 @@ namespace element {
   class RoadInfoLane;
   class RoadGeneralInfo;
   class RoadInfoVelocity;
+  class RoadInfoMarkRecord;
   class RoadElevationInfo;
 
   class RoadInfoVisitor {
   public:
 
     virtual void Visit(RoadInfoLane &) {}
+
     virtual void Visit(RoadGeneralInfo &) {}
+
     virtual void Visit(RoadInfoVelocity &) {}
+
+    virtual void Visit(RoadInfoMarkRecord &) {}
+
     virtual void Visit(RoadElevationInfo &) {}
   };
 
@@ -58,12 +65,12 @@ namespace element {
     }
 
     /// @todo to fix
-    T *operator*() const {
-      return static_cast<T *>(_it->get());
+    std::shared_ptr<T> operator*() const {
+      return std::static_pointer_cast<T>(*_it);
     }
 
-    T *operator->() const {
-      return &static_cast<T *>(_it->get());
+    std::shared_ptr<T> operator->() const {
+      return std::static_pointer_cast<T>(*_it);
     }
 
     bool operator!=(const RoadInfoIterator &rhs) const {

--- a/LibCarla/source/carla/road/element/RoadInfoVisitor.h
+++ b/LibCarla/source/carla/road/element/RoadInfoVisitor.h
@@ -17,8 +17,8 @@ namespace element {
   class RoadInfoLane;
   class RoadGeneralInfo;
   class RoadInfoVelocity;
-  class RoadInfoMarkRecord;
   class RoadElevationInfo;
+  class RoadInfoMarkRecord;
 
   class RoadInfoVisitor {
   public:

--- a/LibCarla/source/carla/road/element/RoadSegment.h
+++ b/LibCarla/source/carla/road/element/RoadSegment.h
@@ -93,22 +93,18 @@ namespace element {
     }
 
     /// Workaround where we must find a specific (RoadInfoMarkRecord) RoadInfo
-    /// that have lane_id info. In this case this info is used for selecting only
-    /// the nearest RoadInfos to the "dist" input.
+    /// that must have lane_id info. In this case this info is used for selecting
+    /// only the nearest RoadInfos to the "dist" input.
     std::vector<std::shared_ptr<const RoadInfoMarkRecord>> GetRoadInfoMarkRecord(
         double dist) const {
       auto mark_record_info = GetInfos<RoadInfoMarkRecord>(dist);
       std::vector<std::shared_ptr<const RoadInfoMarkRecord>> result;
-      // @todo: change to unordered_set
-      std::vector<int> already_visited;
+      std::unordered_set<int> inserted_lanes;
 
       for (auto &&mark_record : mark_record_info) {
         const int lane_id = mark_record->GetLaneId();
-        if (std::find(
-              already_visited.begin(),
-              already_visited.end(),
-              lane_id) == already_visited.end()) {
-          already_visited.emplace_back(lane_id);
+        const bool is_new_lane = inserted_lanes.insert(lane_id).second;
+        if (is_new_lane) {
           result.emplace_back(mark_record);
         }
       }
@@ -116,21 +112,18 @@ namespace element {
     }
 
     /// Workaround where we must find a specific (RoadInfoMarkRecord) RoadInfo
-    /// that have lane_id info. In this case this info is used for selecting only
-    /// the nearest RoadInfos to the "dist" input. But reversed!
+    /// that must have lane_id info. In this case this info is used for selecting
+    /// only the nearest RoadInfos to the "dist" input. But reversed!
     std::vector<std::shared_ptr<const RoadInfoMarkRecord>> GetRoadInfoMarkRecordReverse(
         double dist) const {
       auto mark_record_info = GetInfosReverse<RoadInfoMarkRecord>(dist);
       std::vector<std::shared_ptr<const RoadInfoMarkRecord>> result;
-      std::vector<int> already_visited;
+      std::unordered_set<int> inserted_lanes;
 
       for (auto &&mark_record : mark_record_info) {
         const int lane_id = mark_record->GetLaneId();
-        if (std::find(
-              already_visited.begin(),
-              already_visited.end(),
-              lane_id) == already_visited.end()) {
-          already_visited.emplace_back(lane_id);
+        const bool is_new_lane = inserted_lanes.insert(lane_id).second;
+        if (is_new_lane) {
           result.emplace_back(mark_record);
         }
       }

--- a/LibCarla/source/carla/road/element/RoadSegment.h
+++ b/LibCarla/source/carla/road/element/RoadSegment.h
@@ -9,6 +9,8 @@
 #include "carla/NonCopyable.h"
 #include "carla/geom/Location.h"
 #include "carla/road/element/RoadInfoMarkRecord.h"
+#include "carla/road/element/RoadInfoLaneWidth.h"
+#include "carla/road/element/RoadInfoLaneOffset.h"
 #include "carla/road/element/RoadInfo.h"
 #include "carla/road/element/Types.h"
 
@@ -125,6 +127,25 @@ namespace element {
         const bool is_new_lane = inserted_lanes.insert(lane_id).second;
         if (is_new_lane) {
           result.emplace_back(mark_record);
+        }
+      }
+      return result;
+    }
+
+    /// Workaround where we must find a specific (RoadInfoLaneWidth) RoadInfo
+    /// that must have lane_id info. In this case this info is used for selecting
+    /// only the nearest RoadInfos to the "dist" input.
+    std::vector<std::shared_ptr<const RoadInfoLaneWidth>> GetRoadInfoLaneWidth(
+        double dist) const {
+      auto lane_offset_info = GetInfos<RoadInfoLaneWidth>(dist);
+      std::vector<std::shared_ptr<const RoadInfoLaneWidth>> result;
+      std::unordered_set<int> inserted_lanes;
+
+      for (auto &&lane_offset : lane_offset_info) {
+        const int lane_id = lane_offset->GetLaneId();
+        const bool is_new_lane = inserted_lanes.insert(lane_id).second;
+        if (is_new_lane) {
+          result.emplace_back(lane_offset);
         }
       }
       return result;

--- a/LibCarla/source/carla/road/element/Waypoint.cpp
+++ b/LibCarla/source/carla/road/element/Waypoint.cpp
@@ -172,9 +172,14 @@ namespace element {
   }
 
   double Waypoint::GetLaneWidth() const {
-    const auto info = GetRoadSegment().GetInfo<RoadInfoLane>(_dist);
-    const auto lane_info = info != nullptr ? info->getLane(_lane_id) : nullptr;
-    return lane_info != nullptr ? lane_info->_width : 0.0;
+    const auto *road_segment = _map->GetData().GetRoad(_road_id);
+    const auto lane_width_info = road_segment->GetInfos<RoadInfoLaneWidth>(_dist);
+    for (auto &&lane : lane_width_info) {
+      if (lane->GetLaneId() == _lane_id) {
+        return lane->GetPolynomial().Evaluate(_dist);
+      }
+    }
+    return 0.0;
   }
 
   std::pair<RoadInfoMarkRecord, RoadInfoMarkRecord> Waypoint::GetMarkRecord() const {

--- a/LibCarla/source/carla/road/element/Waypoint.cpp
+++ b/LibCarla/source/carla/road/element/Waypoint.cpp
@@ -108,6 +108,10 @@ namespace element {
     return geom::Transform(dp.location, rot);
   }
 
+  const std::string &Waypoint::GetType() const {
+    return _map->GetData().GetRoad(_road_id)->GetInfo<RoadInfoLane>(_dist)->getLane(_lane_id)->_type;
+  }
+
   const RoadSegment &Waypoint::GetRoadSegment() const {
     const auto *road_segment = _map->GetData().GetRoad(_road_id);
     DEBUG_ASSERT(road_segment != nullptr);
@@ -127,7 +131,7 @@ namespace element {
 
   std::pair<RoadInfoMarkRecord, RoadInfoMarkRecord> Waypoint::GetMarkRecord() const {
     const auto lane_id_right = _lane_id;
-    // If the lane is bigger than 0, is on the backward lane,
+    // If the lane is bigger than 0, is a backward lane,
     // so the inner lane marking is the opposite one
     const auto lane_id_left = _lane_id <= 0 ? _lane_id + 1 : _lane_id - 1;
 

--- a/LibCarla/source/carla/road/element/Waypoint.h
+++ b/LibCarla/source/carla/road/element/Waypoint.h
@@ -37,6 +37,8 @@ namespace element {
       return _lane_id;
     }
 
+    const std::string &GetType() const;
+
     const RoadSegment &GetRoadSegment() const;
 
     bool IsIntersection() const;

--- a/LibCarla/source/carla/road/element/Waypoint.h
+++ b/LibCarla/source/carla/road/element/Waypoint.h
@@ -8,6 +8,7 @@
 
 #include "carla/geom/Transform.h"
 #include "carla/Memory.h"
+#include "carla/road/element/RoadInfoMarkRecord.h"
 #include "carla/road/element/RoadInfoList.h"
 #include "carla/road/element/Types.h"
 
@@ -36,13 +37,14 @@ namespace element {
       return _lane_id;
     }
 
-    RoadInfoList GetRoadInfo() const;
-
     const RoadSegment &GetRoadSegment() const;
 
     bool IsIntersection() const;
 
     double GetLaneWidth() const;
+
+    // Returns a Pair of RoadInfoMarkRecord Right and Left respectively
+    std::pair<RoadInfoMarkRecord, RoadInfoMarkRecord> GetMarkRecord() const;
 
   private:
 

--- a/LibCarla/source/test/common/test_road.cpp
+++ b/LibCarla/source/test/common/test_road.cpp
@@ -42,7 +42,7 @@ TEST(road, add_information) {
   auto map_ptr = builder.Build();
   Map &m = *map_ptr;
 
-  const RoadInfoVelocity *r = m.GetData().GetRoad(0)->GetInfo<RoadInfoVelocity>(0.0);
+  auto r = m.GetData().GetRoad(0)->GetInfo<RoadInfoVelocity>(0.0);
   ASSERT_EQ(r->velocity, 50.0);
   r = m.GetData().GetRoad(0)->GetInfo<RoadInfoVelocity>(2);
   ASSERT_EQ(r->velocity, 90.0);
@@ -198,6 +198,6 @@ TEST(road, get_information) {
   auto map_ptr = builder.Build();
   Map &m = *map_ptr;
 
-  const RoadInfoVelocity *r = m.GetData().GetRoad(0)->GetInfo<RoadInfoVelocity>(0.0);
+  const auto r = m.GetData().GetRoad(0)->GetInfo<RoadInfoVelocity>(0.0);
   (void)r;
 }

--- a/PythonAPI/lane_explorer.py
+++ b/PythonAPI/lane_explorer.py
@@ -129,13 +129,13 @@ def main():
 
             # check for available right driving lanes
             if current_w.lane_change & carla.LaneChange.Right:
-                right_w = current_w.right_lane()
+                right_w = current_w.get_right_lane()
                 if right_w and right_w.lane_type == 'driving':
                     potential_w += list(right_w.next(waypoint_separation))
 
             # check for available left driving lanes
             if current_w.lane_change & carla.LaneChange.Left:
-                left_w = current_w.left_lane()
+                left_w = current_w.get_left_lane()
                 if left_w and left_w.lane_type == 'driving':
                     potential_w += list(left_w.next(waypoint_separation))
 

--- a/PythonAPI/lane_explorer.py
+++ b/PythonAPI/lane_explorer.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+from __future__ import print_function
+
+import glob
+import os
+import sys
+
+try:
+    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+        sys.version_info.major,
+        sys.version_info.minor,
+        'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
+except IndexError:
+    pass
+
+import carla
+
+import argparse
+import math
+import random
+import time
+
+red = carla.Color(255, 0, 0)
+green = carla.Color(0, 255, 0)
+blue = carla.Color(47, 210, 231)
+cyan = carla.Color(0, 255, 255)
+yellow = carla.Color(255, 255, 0)
+orange = carla.Color(255, 162, 0)
+white = carla.Color(255, 255, 255)
+
+trail_life_time = 10
+waypoint_separation = 4
+
+
+def draw_transform(debug, trans, col=carla.Color(255, 0, 0), lt=-1):
+    yaw_in_rad = math.radians(trans.rotation.yaw)
+    pitch_in_rad = math.radians(trans.rotation.pitch)
+    p1 = carla.Location(
+        x=trans.location.x + math.cos(pitch_in_rad) * math.cos(yaw_in_rad),
+        y=trans.location.y + math.cos(pitch_in_rad) * math.sin(yaw_in_rad),
+        z=trans.location.z + math.sin(pitch_in_rad))
+    debug.draw_arrow(trans.location, p1, thickness=0.05, arrow_size=1.0, color=col, life_time=lt)
+
+
+def draw_waypoint_union(debug, w0, w1, color=carla.Color(255, 0, 0), lt=5):
+    debug.draw_line(
+        w0.transform.location + carla.Location(z=0.25),
+        w1.transform.location + carla.Location(z=0.25),
+        thickness=0.1, color=color, life_time=lt, persistent_lines=False)
+    debug.draw_point(w1.transform.location + carla.Location(z=0.25), 0.1, color, lt, False)
+
+
+def draw_waypoint_info(debug, w, lt=5):
+    w_loc = w.transform.location
+    debug.draw_string(w_loc + carla.Location(z=0.5), "lane: " + str(w.lane_id), False, yellow, lt)
+    debug.draw_string(w_loc + carla.Location(z=1.0), "road: " + str(w.road_id), False, blue, lt)
+    debug.draw_string(w_loc + carla.Location(z=-.5), str(w.lane_change), False, red, lt)
+
+
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        '--host',
+        metavar='H',
+        default='127.0.0.1',
+        help='IP of the host server (default: 127.0.0.1)')
+    argparser.add_argument(
+        '-p', '--port',
+        metavar='P',
+        default=2000,
+        type=int,
+        help='TCP port to listen to (default: 2000)')
+    argparser.add_argument(
+        '-x',
+        default=0.0,
+        type=float,
+        help='X start position (default: 0.0)')
+    argparser.add_argument(
+        '-y',
+        default=0.0,
+        type=float,
+        help='Y start position (default: 0.0)')
+    argparser.add_argument(
+        '-z',
+        default=0.0,
+        type=float,
+        help='Z start position (default: 0.0)')
+    argparser.add_argument(
+        '-s', '--seed',
+        metavar='S',
+        default=os.getpid(),
+        type=int,
+        help='Seed for the random path (default: program pid)')
+    argparser.add_argument(
+        '-t', '--tick-time',
+        metavar='T',
+        default=0.2,
+        type=float,
+        help='Tick time between updates (forward velocity) (default: 0.2)')
+    args = argparser.parse_args()
+
+    try:
+        client = carla.Client(args.host, args.port)
+        client.set_timeout(2.0)
+
+        world = client.get_world()
+        m = world.get_map()
+        debug = world.debug
+
+        random.seed(args.seed)
+        print("Seed: ", args.seed)
+
+        loc = carla.Location(args.x, args.y, args.z)
+        print("Initial location: ", loc)
+
+        current_w = m.get_waypoint(loc)
+
+        # main loop
+        while True:
+            # list of potential next waypoints
+            potential_w = list(current_w.next(waypoint_separation))
+
+            # check for available right driving lanes
+            if current_w.lane_change & carla.LaneChange.Right:
+                right_w = current_w.right_lane()
+                if right_w and right_w.lane_type == 'driving':
+                    potential_w += list(right_w.next(waypoint_separation))
+
+            # check for available left driving lanes
+            if current_w.lane_change & carla.LaneChange.Left:
+                left_w = current_w.left_lane()
+                if left_w and left_w.lane_type == 'driving':
+                    potential_w += list(left_w.next(waypoint_separation))
+
+            # choose a random waypoint to be the next
+            next_w = random.choice(potential_w)
+            potential_w.remove(next_w)
+
+            # Render some nice information, notice that you can't see the strings if you are using an editor camera
+            draw_waypoint_info(debug, current_w, trail_life_time)
+            draw_waypoint_union(debug, current_w, next_w, cyan if current_w.is_intersection else green, trail_life_time)
+            draw_transform(debug, current_w.transform, white, trail_life_time)
+
+            # print the remaining waypoints
+            for p in potential_w:
+                debug.draw_string(p.transform.location, str(p.lane_id), False, orange, trail_life_time)
+                draw_waypoint_union(debug, current_w, p, red, trail_life_time)
+                draw_transform(debug, p.transform, white, trail_life_time)
+
+            # update the current waypoint and sleep for some time
+            current_w = next_w
+            time.sleep(args.tick_time)
+
+    finally:
+        pass
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('\nExit by user.')
+    finally:
+        print('\nExit.')

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -64,10 +64,10 @@ void export_map() {
   ;
 
   enum_<cc::Waypoint::LaneChange>("LaneChange")
-      .value("None", cc::Waypoint::LaneChange::None)
-      .value("Right", cc::Waypoint::LaneChange::Right)
-      .value("Left", cc::Waypoint::LaneChange::Left)
-      .value("Both", cc::Waypoint::LaneChange::Both)
+    .value("None", cc::Waypoint::LaneChange::None)
+    .value("Right", cc::Waypoint::LaneChange::Right)
+    .value("Left", cc::Waypoint::LaneChange::Left)
+    .value("Both", cc::Waypoint::LaneChange::Both)
   ;
 
   class_<cc::Waypoint, boost::noncopyable, boost::shared_ptr<cc::Waypoint>>("Waypoint", no_init)

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -63,13 +63,23 @@ void export_map() {
     .def(self_ns::str(self_ns::self))
   ;
 
+  enum_<cc::Waypoint::LaneChange>("LaneChange")
+      .value("None", cc::Waypoint::LaneChange::None)
+      .value("Right", cc::Waypoint::LaneChange::Right)
+      .value("Left", cc::Waypoint::LaneChange::Left)
+      .value("Both", cc::Waypoint::LaneChange::Both)
+  ;
+
   class_<cc::Waypoint, boost::noncopyable, boost::shared_ptr<cc::Waypoint>>("Waypoint", no_init)
     .add_property("transform", CALL_RETURNING_COPY(cc::Waypoint, GetTransform))
     .add_property("is_intersection", &cc::Waypoint::IsIntersection)
     .add_property("lane_width", &cc::Waypoint::GetLaneWidth)
     .add_property("road_id", &cc::Waypoint::GetRoadId)
     .add_property("lane_id", &cc::Waypoint::GetLaneId)
+    .add_property("lane_change", &cc::Waypoint::GetLaneChange)
     .def("next", CALL_RETURNING_LIST_1(cc::Waypoint, Next, double), (args("distance")))
+    .def("right_lane", &cc::Waypoint::Right)
+    .def("left_lane", &cc::Waypoint::Left)
     .def(self_ns::str(self_ns::self))
   ;
 }

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -77,6 +77,7 @@ void export_map() {
     .add_property("road_id", &cc::Waypoint::GetRoadId)
     .add_property("lane_id", &cc::Waypoint::GetLaneId)
     .add_property("lane_change", &cc::Waypoint::GetLaneChange)
+    .add_property("lane_type", &cc::Waypoint::GetType)
     .def("next", CALL_RETURNING_LIST_1(cc::Waypoint, Next, double), (args("distance")))
     .def("right_lane", &cc::Waypoint::Right)
     .def("left_lane", &cc::Waypoint::Left)

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -79,8 +79,8 @@ void export_map() {
     .add_property("lane_change", &cc::Waypoint::GetLaneChange)
     .add_property("lane_type", &cc::Waypoint::GetType)
     .def("next", CALL_RETURNING_LIST_1(cc::Waypoint, Next, double), (args("distance")))
-    .def("right_lane", &cc::Waypoint::Right)
-    .def("left_lane", &cc::Waypoint::Left)
+    .def("get_right_lane", &cc::Waypoint::Right)
+    .def("get_left_lane", &cc::Waypoint::Left)
     .def(self_ns::str(self_ns::self))
   ;
 }


### PR DESCRIPTION
#### Description
Extended the waypoint API with new functions:
- `carla.Waypoint.lane_change`: Returns a `carla.LaneChange`.
- `carla.LaneChange`: A Python enum that tells whether traffic rules allow a lane change.
  + 0: `None`
  + 1: `Right`
  + 2: `Left`
  + 3: `Both`
  + Can be used as a flag i.e.:
    * `LaneChange.Right & LaneChange.None => False`
    * `LaneChange.Right & LaneChange.Left => False`
    * `LaneChange.Right & LaneChange.Both => True`
    * `LaneChange.Right & LaneChange.Right => True`
- `carla.Waypoint.lane_type`: Returns an string that codifies the type of the current lane, i.e.: `"driving", "bidirectional", "shoulder", "sidewalk", "median", "parking", "none", ...`
- `carla.Waypoint.right_lane()`: Returns another `carla.Waypoint` (although the rules allow the change or not) at the closest right neighbor lane. If there is no right lane, it returns `None`.
- `carla.Waypoint.left_lane()`: Returns another `carla.Waypoint` (although the rules allow the change or not) at the closest left neighbor lane. If there is no left lane, it returns `None`. Notice that if the new waypoint is on a different signed `lane_id`, it does mean that it's in the opposite direction.

<!-- Fixes #   If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 2.7 & 3.5
  * **Unreal Engine version(s):** 4.21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1320)
<!-- Reviewable:end -->
