### PR TITLE
Resolve hostname for streaming client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Latest Changes
+  * Allow usage of hostname for carla::Client and resolve them to IP address
+
 ## CARLA 0.9.4
 
   * Added recording and playback functionality

--- a/LibCarla/source/carla/streaming/EndPoint.h
+++ b/LibCarla/source/carla/streaming/EndPoint.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/udp.hpp>
@@ -71,14 +72,18 @@ namespace detail {
     return boost::asio::ip::make_address("127.0.0.1");
   }
 
-  static inline auto make_address(const char *address) {
-    return std::strcmp("localhost", address) == 0 ?
-        make_localhost_address() :
-        boost::asio::ip::make_address(address);
-  }
-
   static inline auto make_address(const std::string &address) {
-    return make_address(address.c_str());
+    boost::asio::io_service io_service;
+    boost::asio::ip::tcp::resolver resolver(io_service);
+    boost::asio::ip::tcp::resolver::query query(address, "");
+    boost::asio::ip::tcp::resolver::iterator iter = resolver.resolve(query);
+    boost::asio::ip::tcp::resolver::iterator end;
+    while (iter != end)
+    {
+      boost::asio::ip::tcp::endpoint endpoint = *iter++;
+      return endpoint.address();
+    }
+    return boost::asio::ip::make_address(address);
   }
 
   template <typename Protocol>


### PR DESCRIPTION
 - Allows usage of hostnames instead of IP addresses only
   with carla::Client

#### Description

carla::Client (and all derived Python clients) can now use hostnames as parameter for the simulator host and not just IP addresses.

#### Where has this been tested?

  * **Platform(s): Ubuntu 16.04
  * **Python version(s): Python 2.7
  * **Unreal Engine version(s): - 

#### Possible Drawbacks

Not aware of any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1326)
<!-- Reviewable:end -->
