### PR TITLE
Zlib correctly statically linked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest Changes
   * Allow usage of hostname for carla::Client and resolve them to IP address
+  * Fixed python client DLL error on Windows
 
 ## CARLA 0.9.4
 

--- a/Util/InstallersWin/install_libpng.bat
+++ b/Util/InstallersWin/install_libpng.bat
@@ -122,7 +122,8 @@ if not exist "%LIBPNG_INSTALL_DIR%\include" (
     mkdir "%LIBPNG_INSTALL_DIR%\include"
 )
 
-lib /nologo /MACHINE:X64 /LTCG /OUT:"%LIBPNG_INSTALL_DIR%\lib\libpng.lib" /LIBPATH:"%ZLIB_INST_DIR%\lib" "*.obj" "zlib.lib"
+lib /nologo /MACHINE:X64 /LTCG /OUT:"%LIBPNG_INSTALL_DIR%\lib\libpng.lib"^
+ /LIBPATH:"%ZLIB_INST_DIR%\lib" "*.obj" "zlibstatic.lib"
 
 copy "%LIBPNG_SOURCE_DIR%\png.h" "%LIBPNG_INSTALL_DIR%\include\png.h"
 copy "%LIBPNG_SOURCE_DIR%\pngconf.h" "%LIBPNG_INSTALL_DIR%\include\pngconf.h"


### PR DESCRIPTION
#### Description
Some people had issues with the following error while running the client:
```
ImportError: DLL load failed: The specified module could not be found.
```
This is an issue with `zlib` that was not correctly statically linked.
A workaround was putting a x64 `zlib.dll` on `carla/PythonAPI` folder.
This is not necessary anymore because `zlib` is correctly statically linked now.

Fixes #1345

#### Where has this been tested?

  * **Platform(s):** Win10
  * **Python version(s):** 3.x
  * **Unreal Engine version(s):** -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1350)
<!-- Reviewable:end -->
