### PR TITLE
Fix resolving host "localhost"

### DIFF
--- a/LibCarla/source/carla/streaming/EndPoint.h
+++ b/LibCarla/source/carla/streaming/EndPoint.h
@@ -75,7 +75,7 @@ namespace detail {
   static inline auto make_address(const std::string &address) {
     boost::asio::io_service io_service;
     boost::asio::ip::tcp::resolver resolver(io_service);
-    boost::asio::ip::tcp::resolver::query query(address, "");
+    boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), address, "", boost::asio::ip::tcp::resolver::query::canonical_name);
     boost::asio::ip::tcp::resolver::iterator iter = resolver.resolve(query);
     boost::asio::ip::tcp::resolver::iterator end;
     while (iter != end)


### PR DESCRIPTION
#### Description

Fixes resolving "localhost" host for Carla client.
This canonical name for a local loopback was no longer resolvable
with the latest changes allowing hostname lookup.

#### Where has this been tested?

  * **Platform(s):** Ubunutu 16.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** 

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1354)
<!-- Reviewable:end -->
