### PR TITLE
Add waypoint id and s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Latest Changes
   * Allow usage of hostname for carla::Client and resolve them to IP address
   * Added `map.transform_to_geolocation` to transform Location to GNSS GeoLocation
+  * Added `id` property to waypoints, uniquely identifying waypoints up to half centimetre precision
+  * Added OpenDrive's road offset `s` as property to waypoints
   * Fixed python client DLL error on Windows
 
 ## CARLA 0.9.4

--- a/LibCarla/source/carla/client/Waypoint.h
+++ b/LibCarla/source/carla/client/Waypoint.h
@@ -8,8 +8,9 @@
 
 #include "carla/Memory.h"
 #include "carla/NonCopyable.h"
-#include "carla/road/element/Waypoint.h"
 #include "carla/road/element/RoadInfoMarkRecord.h"
+#include "carla/road/element/Waypoint.h"
+#include "carla/road/element/WaypointHash.h"
 
 namespace carla {
 namespace client {
@@ -30,6 +31,14 @@ namespace client {
     };
 
     ~Waypoint();
+
+    /// Returns an unique Id identifying this waypoint.
+    ///
+    /// The Id takes into account OpenDrive's road Id, lane Id, and s distance
+    /// on its road segment up to half-centimetre precision.
+    uint64_t GetId() const {
+      return road::element::WaypointHash()(_waypoint);
+    }
 
     const geom::Transform &GetTransform() const {
       return _transform;

--- a/LibCarla/source/carla/client/Waypoint.h
+++ b/LibCarla/source/carla/client/Waypoint.h
@@ -60,6 +60,10 @@ namespace client {
       return _waypoint.GetLaneId();
     }
 
+    double GetDistance() const {
+      return _waypoint.GetDistance();
+    }
+
     std::string GetType() const {
       return _waypoint.GetType();
     }

--- a/LibCarla/source/carla/road/element/RoadInfo.h
+++ b/LibCarla/source/carla/road/element/RoadInfo.h
@@ -8,8 +8,9 @@
 
 #include "carla/road/element/RoadInfoVisitor.h"
 
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace carla {
 namespace road {

--- a/LibCarla/source/carla/road/element/Waypoint.h
+++ b/LibCarla/source/carla/road/element/Waypoint.h
@@ -37,6 +37,10 @@ namespace element {
       return _lane_id;
     }
 
+    double GetDistance() const {
+      return _dist;
+    }
+
     const std::string &GetType() const;
 
     const RoadSegment &GetRoadSegment() const;

--- a/LibCarla/source/carla/road/element/WaypointHash.cpp
+++ b/LibCarla/source/carla/road/element/WaypointHash.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/road/element/WaypointHash.h"
+
+#include "carla/road/element/Waypoint.h"
+
+#include <boost/container_hash/hash.hpp>
+
+namespace carla {
+namespace road {
+namespace element {
+
+  uint64_t WaypointHash::operator()(const Waypoint &waypoint) const {
+    uint64_t seed = 0u;
+    boost::hash_combine(seed, waypoint.GetRoadId());
+    boost::hash_combine(seed, waypoint.GetLaneId());
+    boost::hash_combine(seed, static_cast<float>(std::floor(waypoint.GetDistance() * 200.0)));
+    return seed;
+  }
+
+} // namespace element
+} // namespace road
+} // namespace carla

--- a/LibCarla/source/carla/road/element/WaypointHash.h
+++ b/LibCarla/source/carla/road/element/WaypointHash.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <cstdint>
+
+namespace carla {
+namespace road {
+namespace element {
+
+  class Waypoint;
+
+  struct WaypointHash {
+
+    using argument_type = Waypoint;
+
+    using result_type = uint64_t;
+
+    /// Generates an unique id for @a waypoint based on its road_id, lane_id,
+    /// and "s" offset. The "s" offset is truncated to half centimetre
+    /// precision.
+    uint64_t operator()(const Waypoint &waypoint) const;
+  };
+
+} // namespace element
+} // namespace road
+} // namespace carla

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -78,6 +78,7 @@ void export_map() {
   ;
 
   class_<cc::Waypoint, boost::noncopyable, boost::shared_ptr<cc::Waypoint>>("Waypoint", no_init)
+    .add_property("id", &cc::Waypoint::GetId)
     .add_property("transform", CALL_RETURNING_COPY(cc::Waypoint, GetTransform))
     .add_property("is_intersection", &cc::Waypoint::IsIntersection)
     .add_property("lane_width", &cc::Waypoint::GetLaneWidth)

--- a/PythonAPI/source/libcarla/Map.cpp
+++ b/PythonAPI/source/libcarla/Map.cpp
@@ -84,6 +84,7 @@ void export_map() {
     .add_property("lane_width", &cc::Waypoint::GetLaneWidth)
     .add_property("road_id", &cc::Waypoint::GetRoadId)
     .add_property("lane_id", &cc::Waypoint::GetLaneId)
+    .add_property("s", &cc::Waypoint::GetDistance)
     .add_property("lane_change", &cc::Waypoint::GetLaneChange)
     .add_property("lane_type", &cc::Waypoint::GetType)
     .def("next", CALL_RETURNING_LIST_1(cc::Waypoint, Next, double), (args("distance")))


### PR DESCRIPTION
#### Description

Added a hash function for waypoints taking into account its road_id, lane_id, and "s" offset. The "s" offset is truncated to half centimetre precision.

I have also added the "s" property to waypoints, that was the last piece missing to uniquely identify a waypoint in the OpenDrive format.

#### Possible Drawbacks

Theoretically, the hash could have collisions as we are hashing to 64 bits, but unlikely enough, about 1 in 10^5 for the typical amount of waypoints you can generate in our cities. There aren't collisions in our current towns, I tested to be sure :grin:.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1365)
<!-- Reviewable:end -->
