### PR TITLE
Fix cleanup local_planner when used by other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Added `id` property to waypoints, uniquely identifying waypoints up to half centimetre precision
   * Added OpenDrive's road offset `s` as property to waypoints
   * Fixed python client DLL error on Windows
+  * Fixed cleanup of local_planner when used by other modules
 
 ## CARLA 0.9.4
 

--- a/PythonAPI/agents/navigation/local_planner.py
+++ b/PythonAPI/agents/navigation/local_planner.py
@@ -79,8 +79,14 @@ class LocalPlanner(object):
         self.init_controller(opt_dict)
 
     def __del__(self):
-        self._vehicle.destroy()
+        if self._vehicle:
+            self._vehicle.destroy()
         print("Destroying ego-vehicle!")
+
+
+    def reset_vehicle(self):
+        self._vehicle = None
+        print("Resetting ego-vehicle!")
 
     def init_controller(self, opt_dict):
         """


### PR DESCRIPTION
If the local_planner is used by other Python modules the cleanup causes
a destruction of the actor, handed over to the local_planner. As this
may be undesired, an additional reset_vehicle() method was added to the
local_planner.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check`
  - [x] If relevant, update CHANGELOG.md with your changes

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7, 3.5
  * **Unreal Engine version(s):** 4.21

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1396)
<!-- Reviewable:end -->
