### PR TITLE
BugFix: python3 "no module named carla" error was fixed

### DIFF
--- a/PythonAPI/automatic_control.py
+++ b/PythonAPI/automatic_control.py
@@ -66,9 +66,8 @@ except ImportError:
 # -- find carla module ---------------------------------------------------------
 # ==============================================================================
 try:
-    sys.path.append(glob.glob('**/carla-*%d.%d-%s.egg' % (
+   sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/dynamic_weather.py
+++ b/PythonAPI/dynamic_weather.py
@@ -18,9 +18,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/lane_explorer.py
+++ b/PythonAPI/lane_explorer.py
@@ -13,9 +13,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/manual_control.py
+++ b/PythonAPI/manual_control.py
@@ -54,9 +54,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/carla-*%d.%d-%s.egg' % (
+   sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/manual_control_steeringwheel.py
+++ b/PythonAPI/manual_control_steeringwheel.py
@@ -31,9 +31,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/carla-*%d.%d-%s.egg' % (
+   sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/no_rendering_mode.py
+++ b/PythonAPI/no_rendering_mode.py
@@ -39,9 +39,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/carla-*%d.%d-%s.egg' % (
+   sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/performance_benchmark.py
+++ b/PythonAPI/performance_benchmark.py
@@ -34,9 +34,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/carla-*%d.%d-%s.egg' % (
+   sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/show_recorder_actors_blocked.py
+++ b/PythonAPI/show_recorder_actors_blocked.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/show_recorder_collisions.py
+++ b/PythonAPI/show_recorder_collisions.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/show_recorder_file_info.py
+++ b/PythonAPI/show_recorder_file_info.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/spawn_npc.py
+++ b/PythonAPI/spawn_npc.py
@@ -13,9 +13,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/start_recording.py
+++ b/PythonAPI/start_recording.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/start_replaying.py
+++ b/PythonAPI/start_replaying.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/synchronous_mode.py
+++ b/PythonAPI/synchronous_mode.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/test/smoke/__init__.py
+++ b/PythonAPI/test/smoke/__init__.py
@@ -10,9 +10,8 @@ import sys
 import unittest
 
 try:
-    sys.path.append(glob.glob('../../dist/carla-*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('../../dist/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/test/test_connection.py
+++ b/PythonAPI/test/test_connection.py
@@ -13,9 +13,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('../dist/carla-*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('../dist/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/test/unit/__init__.py
+++ b/PythonAPI/test/unit/__init__.py
@@ -9,9 +9,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('../../dist/carla-*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('../../dist/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/tutorial.py
+++ b/PythonAPI/tutorial.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass

--- a/PythonAPI/vehicle_gallery.py
+++ b/PythonAPI/vehicle_gallery.py
@@ -11,9 +11,8 @@ import os
 import sys
 
 try:
-    sys.path.append(glob.glob('**/*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('**/*%d.*-%s.egg' % (
         sys.version_info.major,
-        sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])
 except IndexError:
     pass


### PR DESCRIPTION
I've fixed "No module named carla" error. 
This error occurs the wrong import. So i've fixed the import path
Issue: #990  #1372  #1137 
I have tested on
Linux distribution:
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.2 LTS
Release:	18.04
Codename:	bionic

Python versions:
Python2.7
Python3.7

Unreal versions:
Unreal4.18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1400)
<!-- Reviewable:end -->
