### PR TITLE
Migrate Content to AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Install
 *.workspace
 *CodeCompletionFolders.txt
 *CodeLitePreProcessor.txt
+.aria2c.input
 .codelite
 .gdb_history
 .gtest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Latest Changes
-  * Adding a parser to represent the map as a connected graph of waypoints. 
+
+  * Migrate Content to AWS
+  * Adding a parser to represent the map as a connected graph of waypoints.
   * Allow user to disable rendering and set the server timeout from the command line
   * Add timestamp to SensorData
   * Allow usage of hostname for carla::Client and resolve them to IP address

--- a/Update.sh
+++ b/Update.sh
@@ -60,7 +60,7 @@ function download_content {
   mkdir -p Content
   if hash aria2c 2>/dev/null; then
     echo -e "${CONTENT_LINK}\n\tout=Content.tar.gz" > .aria2c.input
-    aria2c -j12 -x12 --input-file=.aria2c.input
+    aria2c -j16 -x16 --input-file=.aria2c.input
     rm -f .aria2c.input
   else
     wget ${CONTENT_LINK} Content.tar.gz

--- a/Update.sh
+++ b/Update.sh
@@ -46,7 +46,8 @@ pushd "$SCRIPT_DIR" >/dev/null
 
 CONTENT_FOLDER=$SCRIPT_DIR/Unreal/CarlaUE4/Content/Carla
 
-CONTENT_GDRIVE_ID=$(tac $SCRIPT_DIR/Util/ContentVersions.txt | egrep -m 1 . | rev | cut -d' ' -f1 | rev)
+CONTENT_ID=$(tac $SCRIPT_DIR/Util/ContentVersions.txt | egrep -m 1 . | rev | cut -d' ' -f1 | rev)
+CONTENT_LINK=http://carla-assets-internal.s3.amazonaws.com/Content/${CONTENT_ID}.tar.gz
 
 VERSION_FILE=${CONTENT_FOLDER}/.version
 
@@ -57,11 +58,11 @@ function download_content {
   fi
   mkdir -p $CONTENT_FOLDER
   mkdir -p Content
-  ./Util/download_from_gdrive.py $CONTENT_GDRIVE_ID Content.tar.gz
+  wget ${CONTENT_LINK} Content.tar.gz
   tar -xvzf Content.tar.gz -C Content
   rm Content.tar.gz
   mv Content/* $CONTENT_FOLDER
-  echo "$CONTENT_GDRIVE_ID" > "$VERSION_FILE"
+  echo "$CONTENT_ID" > "$VERSION_FILE"
   echo "Content updated successfully."
 }
 
@@ -72,7 +73,7 @@ function download_content {
 if $SKIP_DOWNLOAD ; then
   echo "Skipping 'Content' update. Please manually download the package from"
   echo
-  echo "  https://drive.google.com/open?id=$CONTENT_GDRIVE_ID"
+  echo "  ${CONTENT_LINK}"
   echo
   echo "and extract it under Unreal/CarlaUE4/Content/Carla."
   exit 0
@@ -81,7 +82,7 @@ fi
 if [[ -d "$CONTENT_FOLDER/.git" ]]; then
   echo "Using git version of 'Content', skipping update."
 elif [[ -f "$CONTENT_FOLDER/.version" ]]; then
-  if [ "$CONTENT_GDRIVE_ID" == `cat $VERSION_FILE` ]; then
+  if [ "$CONTENT_ID" == `cat $VERSION_FILE` ]; then
     echo "Content is up-to-date."
   else
     download_content

--- a/Update.sh
+++ b/Update.sh
@@ -58,7 +58,13 @@ function download_content {
   fi
   mkdir -p $CONTENT_FOLDER
   mkdir -p Content
-  wget ${CONTENT_LINK} Content.tar.gz
+  if hash aria2c 2>/dev/null; then
+    echo -e "${CONTENT_LINK}\n\tout=Content.tar.gz" > .aria2c.input
+    aria2c -j12 -x12 --input-file=.aria2c.input
+    rm -f .aria2c.input
+  else
+    wget ${CONTENT_LINK} Content.tar.gz
+  fi
   tar -xvzf Content.tar.gz -C Content
   rm Content.tar.gz
   mv Content/* $CONTENT_FOLDER

--- a/Util/BuildTools/Setup.bat
+++ b/Util/BuildTools/Setup.bat
@@ -164,7 +164,7 @@ rem ============================================================================
 FOR /F "tokens=2" %%i in (%VERSION_FILE%) do (
     set HASH=%%i
 )
-set URL=https://drive.google.com/open?id=%HASH%
+set URL=http://carla-assets-internal.s3.amazonaws.com/Content/%HASH%.tar.gz
 
 FOR /F "tokens=1 delims=:" %%i in (%VERSION_FILE%) do (
     set ASSETS_VERSION=%%i

--- a/Util/ContentVersions.txt
+++ b/Util/ContentVersions.txt
@@ -2,7 +2,9 @@
 # in the list it's picked up by the Setup.sh script to download the last version
 # of the contents.
 #
-# You can direct download with https://drive.google.com/open?id=PUT_FILE_ID_HERE
+# You can download it directly from
+#
+#     https://drive.google.com/open?id=PUT_FILE_ID_HERE
 
 0.5.4: 0B2HFV-VuKn3PYUFFanlmZ2VMTW8
 0.6.0: 1Gw8sw01hDEV4FtpHEZZwvS-6XN0jmaLT
@@ -18,3 +20,11 @@
 0.9.2: 1RKRGB22U5t80q4zwYXBJvxQXhzNjaaDf
 0.9.3: 1jJlStNHpey62CrMkWVfmtQcJGO7PaD0R
 0.9.4: 10Tc0DMXpfH7W28zwagXsVTjpkhGx3Klz
+
+# Newer asset Content is stored in AWS.
+#
+# You can download it directly from
+#
+#     http://carla-assets-internal.s3.amazonaws.com/Content/PUT_FILE_ID_HERE.tar.gz
+
+Latest: 20190319_7f836a8


### PR DESCRIPTION
#### Description

Migrated Update.sh to download the Content from AWS. Download is a bit slower than Google Drive, but should solve issues related to reaching download quota limit each weekend.

If installed, it will use `aria2c` to speed up download, otherwise wget.

In parallel to this I have created a Jenkins pipeline to the Content repo that automatically uploads the package to AWS.

* Fixes #1180.
* Maybe #84?

#### Possible Drawbacks

Uhm possibly a lot, but let's try and see how it works, rolling back to Google Drive is fairly easy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1415)
<!-- Reviewable:end -->
