### PR TITLE
Fix ActorList.Filter(...) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest Changes
 
+  * Fix ActorList returned by ActorList.Filter(...)
   * Add --rolename to manual_control.py
   * Migrate Content to AWS
   * Adding a parser to represent the map as a connected graph of waypoints.

--- a/LibCarla/source/carla/client/ActorList.cpp
+++ b/LibCarla/source/carla/client/ActorList.cpp
@@ -29,11 +29,11 @@ namespace client {
     return nullptr;
   }
 
-  ActorList ActorList::Filter(const std::string &wildcard_pattern) const {
-    ActorList filtered{_episode, {}};
+  SharedPtr<ActorList> ActorList::Filter(const std::string &wildcard_pattern) const {
+    SharedPtr<ActorList> filtered (new ActorList(_episode, {}));
     for (auto &&actor : _actors) {
       if (StringUtil::Match(actor.GetTypeId(), wildcard_pattern)) {
-        filtered._actors.push_back(actor);
+        filtered->_actors.push_back(actor);
       }
     }
     return filtered;

--- a/LibCarla/source/carla/client/ActorList.h
+++ b/LibCarla/source/carla/client/ActorList.h
@@ -31,7 +31,7 @@ namespace client {
     SharedPtr<Actor> Find(ActorId actor_id) const;
 
     /// Filters a list of Actor with type id matching @a wildcard_pattern.
-    ActorList Filter(const std::string &wildcard_pattern) const;
+    SharedPtr<ActorList> Filter(const std::string &wildcard_pattern) const;
 
     SharedPtr<Actor> operator[](size_t pos) const {
       return _actors[pos].Get(_episode, shared_from_this());


### PR DESCRIPTION
 - change return type to SharedPtr<ActorList>
 - this fixes tr1::bad_weak_ptr when using / iterating filtered list


#### Description
Iterating a ActorList aquired by anotherActorList->Filter(...) cause tr1::bad_weak_ptr exceptions to be thrown.
Changing the return type to SharedPtr<ActionList> fixes that issue.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** 4.21

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1445)
<!-- Reviewable:end -->
