### PR TITLE
Fix vehicles missing the route if autopilot enabled too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   * Fixed geo-reference of Town01 and Town07
   * Fixed floating pillars in Town04
   * Fixed floating building in Town03
+  * Fixed vehicles missing the route if autopilot enabled too late
   * Enhanced stop triggers options
 
 ## CARLA 0.9.4

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.cpp
@@ -120,6 +120,33 @@ void ARoutePlanner::CleanRoute()
   Probabilities.Empty();
 }
 
+void ARoutePlanner::AssignRandomRoute(AWheeledVehicleAIController &Controller) const
+{
+  if (!Controller.IsPendingKill() && (Controller.GetRandomEngine() != nullptr))
+  {
+    auto *RandomEngine = Controller.GetRandomEngine();
+    auto *Route = PickARoute(*RandomEngine, Routes, Probabilities);
+
+    TArray<FVector> WayPoints;
+    const auto Size = Route->GetNumberOfSplinePoints();
+    if (Size > 1)
+    {
+      WayPoints.Reserve(Size);
+      for (auto i = 1; i < Size; ++i)
+      {
+        WayPoints.Add(Route->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::World));
+      }
+
+      Controller.SetFixedRoute(WayPoints);
+    }
+    else
+    {
+      UE_LOG(LogCarla, Error, TEXT("ARoutePlanner '%s' has a route with zero way-points."), *GetName());
+    }
+  }
+
+}
+
 void ARoutePlanner::Init()
 {
   if (Routes.Num() < 1)
@@ -170,27 +197,9 @@ void ARoutePlanner::OnTriggerBeginOverlap(
     const FHitResult & /*SweepResult*/)
 {
   auto *Controller = GetVehicleController(OtherActor);
-  auto *RandomEngine = (Controller != nullptr ? Controller->GetRandomEngine() : nullptr);
-  if (RandomEngine != nullptr)
+  if (Controller != nullptr)
   {
-    auto *Route = PickARoute(*RandomEngine, Routes, Probabilities);
-
-    TArray<FVector> WayPoints;
-    const auto Size = Route->GetNumberOfSplinePoints();
-    if (Size > 1)
-    {
-      WayPoints.Reserve(Size);
-      for (auto i = 1; i < Size; ++i)
-      {
-        WayPoints.Add(Route->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::World));
-      }
-
-      Controller->SetFixedRoute(WayPoints);
-    }
-    else
-    {
-      UE_LOG(LogCarla, Error, TEXT("ARoutePlanner '%s' has a route with zero way-points."), *GetName());
-    }
+    AssignRandomRoute(*Controller);
   }
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/RoutePlanner.h
@@ -13,6 +13,8 @@
 
 #include "RoutePlanner.generated.h"
 
+class AWheeledVehicleAIController;
+
 /// Assign a random route to every ACarlaWheeledVehicle entering the trigger
 /// volume. Routes must be added in editor after placing this actor into the
 /// world. Spline tangents are ignored, only locations are taken into account
@@ -40,6 +42,8 @@ public:
   void AddRoute(float probability, const TArray<FVector> &routePoints);
 
   void CleanRoute();
+
+  void AssignRandomRoute(AWheeledVehicleAIController &Controller) const;
 
 protected:
 


### PR DESCRIPTION
#### Description

If the simulator is running at high FPS the following snippet may fail

```py
vehicle = world.spawn_actor(bp, transform)
vehicle.set_autopilot()
```

The reason, currently we use a finely tuned combination of trigger boxes and spawn points placed on top of them(*), if the "set autopilot" message arrives after the vehicle has fallen inside the trigger box the waypoints are not assigned to its controller.

I've made the controllers check if they're inside a route planner when the autopilot is enabled, and retrieve a route if so.

(*) Workaround for reusing the old autopilot we newer OpenDrive based navigation.

#### Possible Drawbacks

This adds quite some overhead to the "set autopilot" function, but isn't called very often. Hopefully we'll get rid of the old autopilot system soon anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1482)
<!-- Reviewable:end -->
