### PR TITLE
Spawn actors in batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
   * Fixed vehicles missing the route if autopilot enabled too late
   * Enhanced stop triggers options
   * Fixed division by zero in is_within_distance_ahead()
+  * Added new carla.command.SpawnActor to spawn actors in batch
+  * Added method `client.apply_batch_sync` that waits for server response
+  * Updated `spawn_npc.py` to spawn vehicles in batch
 
 ## CARLA 0.9.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   * Fixed division by zero in is_within_distance_ahead()
   * Added new carla.command.SpawnActor to spawn actors in batch
   * Added method `client.apply_batch_sync` that waits for server response
+  * Added optional argument "actor_ids" to world.get_actors to request only the actors with the ids provided
   * Updated `spawn_npc.py` to spawn vehicles in batch
 
 ## CARLA 0.9.4

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -21,6 +21,7 @@
 - `show_recorder_collisions(string filename, char category1, char category2)`
 - `show_recorder_actors_blocked(string filename, float min_time, float min_distance)`
 - `apply_batch(commands, do_tick=False)`
+- `apply_batch_sync(commands, do_tick=False) -> list(carla.command.Response)`
 
 ## `carla.World`
 
@@ -470,47 +471,69 @@ Static presets
 
 # module `carla.command`
 
+`carla.command.FutureActor` (not yet spawned actor handler)
+
+## `carla.command.Response`
+
+- `actor_id`
+- `error` -> str|empty
+- `has_error()`
+
+## `carla.command.SpawnActor`
+
+- `__init__(blueprint, transform, parent=None)`
+- `then(command)`
+
 ## `carla.command.DestroyActor`
 
+- `__init__(actor)`
 - `actor_id`
 
 ## `carla.command.ApplyVehicleControl`
 
+- `__init__(actor, control)`
 - `actor_id`
 - `control`
 
 ## `carla.command.ApplyWalkerControl`
 
+- `__init__(actor, control)`
 - `actor_id`
 - `control`
 
 ## `carla.command.ApplyTransform`
 
+- `__init__(actor, transform)`
 - `actor_id`
 - `transform`
 
 ## `carla.command.ApplyVelocity`
 
+- `__init__(actor, velocity)`
 - `actor_id`
 - `velocity`
 
 ## `carla.command.ApplyAngularVelocity`
 
+- `__init__(actor, angular_velocity)`
 - `actor_id`
 - `angular_velocity`
 
 
 ## `carla.command.ApplyImpulse`
 
+- `__init__(actor, impulse)`
 - `actor_id`
 - `impulse`
 
 ## `carla.command.SetSimulatePhysics`
 
+- `__init__(actor, bool)`
 - `actor_id`
 - `enabled`
 
 ## `carla.command.SetAutopilot`
 
+- `__init__(actor, bool)`
 - `actor_id`
 - `enabled`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -34,7 +34,7 @@
 - `apply_settings(world_settings)`
 - `get_weather()`
 - `set_weather(weather_parameters)`
-- `get_actors()`
+- `get_actors(actor_ids=None) -> carla.ActorList`
 - `spawn_actor(blueprint, transform, attach_to=None)`
 - `try_spawn_actor(blueprint, transform, attach_to=None)`
 - `wait_for_tick(seconds=1.0)`

--- a/LibCarla/source/carla/Overload.h
+++ b/LibCarla/source/carla/Overload.h
@@ -30,11 +30,36 @@ namespace detail {
     using T::operator();
   };
 
+  template<typename T>
+  struct Recursive {
+
+    explicit Recursive(T &&func) : _func(std::move(func)) {}
+
+    template<typename... Ts>
+    auto operator()(Ts &&... arguments) const {
+      return _func(*this, std::forward<Ts>(arguments)...);
+    }
+
+  private:
+
+    T _func;
+  };
+
 } // namespace detail
+
+  template <typename FuncT>
+  inline static auto MakeRecursive(FuncT &&func) {
+    return detail::Recursive<FuncT>(std::forward<FuncT>(func));
+  }
 
   template <typename... FuncTs>
   inline static auto MakeOverload(FuncTs &&... fs) {
     return detail::Overload<FuncTs...>(std::forward<FuncTs>(fs)...);
+  }
+
+  template <typename... FuncTs>
+  inline static auto MakeRecursiveOverload(FuncTs &&... fs) {
+    return MakeRecursive(MakeOverload(std::forward<FuncTs>(fs)...));
   }
 
 } // namespace carla

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -84,8 +84,16 @@ namespace client {
       return _simulator->ReplayFile(name, start, duration, follow_id);
     }
 
-    void ApplyBatch(std::vector<rpc::Command> commands, bool do_tick_cue = false) const {
+    void ApplyBatch(
+        std::vector<rpc::Command> commands,
+        bool do_tick_cue = false) const {
       _simulator->ApplyBatch(std::move(commands), do_tick_cue);
+    }
+
+    std::vector<rpc::CommandResponse> ApplyBatchSync(
+        std::vector<rpc::Command> commands,
+        bool do_tick_cue = false) const {
+      return _simulator->ApplyBatchSync(std::move(commands), do_tick_cue);
     }
 
   private:

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -51,6 +51,12 @@ namespace client {
                                   _episode.Lock()->GetAllTheActorsInTheEpisode()}};
   }
 
+  SharedPtr<ActorList> World::GetActors(const std::vector<ActorId> &actor_ids) const {
+    return SharedPtr<ActorList>{new ActorList{
+                                  _episode,
+                                  _episode.Lock()->GetActorsById(actor_ids)}};
+  }
+
   SharedPtr<Actor> World::SpawnActor(
       const ActorBlueprint &blueprint,
       const geom::Transform &transform,

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -66,6 +66,9 @@ namespace client {
     /// Return a list with all the actors currently present in the world.
     SharedPtr<ActorList> GetActors() const;
 
+    /// Return a list with the actors requested by ActorId.
+    SharedPtr<ActorList> GetActors(const std::vector<ActorId> &actor_ids) const;
+
     /// Spawn an actor into the world based on the @a blueprint provided at @a
     /// transform. If a @a parent is provided, the actor is attached to
     /// @a parent.

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -13,6 +13,7 @@
 #include "carla/rpc/Actor.h"
 #include "carla/rpc/ActorDefinition.h"
 #include "carla/rpc/Command.h"
+#include "carla/rpc/CommandResponse.h"
 #include "carla/rpc/EpisodeInfo.h"
 #include "carla/rpc/EpisodeSettings.h"
 #include "carla/rpc/MapInfo.h"
@@ -189,7 +190,13 @@ namespace detail {
 
     void DrawDebugShape(const rpc::DebugShape &shape);
 
-    void ApplyBatch(std::vector<rpc::Command> commands, bool do_tick_cue);
+    void ApplyBatch(
+        std::vector<rpc::Command> commands,
+        bool do_tick_cue);
+
+    std::vector<rpc::CommandResponse> ApplyBatchSync(
+        std::vector<rpc::Command> commands,
+        bool do_tick_cue);
 
     void SendTickCue();
 

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -15,6 +15,8 @@
 #include "carla/client/detail/EpisodeState.h"
 #include "carla/rpc/EpisodeInfo.h"
 
+#include <vector>
+
 namespace carla {
 namespace client {
 namespace detail {
@@ -48,6 +50,8 @@ namespace detail {
     void RegisterActor(rpc::Actor actor) {
       _actors.Insert(std::move(actor));
     }
+
+    std::vector<rpc::Actor> GetActorsById(const std::vector<ActorId> &actor_ids);
 
     std::vector<rpc::Actor> GetActors();
 

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -350,6 +350,10 @@ namespace detail {
       _client.ApplyBatch(std::move(commands), do_tick_cue);
     }
 
+    auto ApplyBatchSync(std::vector<rpc::Command> commands, bool do_tick_cue) {
+      return _client.ApplyBatchSync(std::move(commands), do_tick_cue);
+    }
+
     /// @}
 
   private:

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -171,6 +171,11 @@ namespace detail {
     // =========================================================================
     /// @{
 
+    std::vector<rpc::Actor> GetActorsById(const std::vector<ActorId> &actor_ids) const {
+      DEBUG_ASSERT(_episode != nullptr);
+      return _episode->GetActorsById(actor_ids);
+    }
+
     std::vector<rpc::Actor> GetAllTheActorsInTheEpisode() const {
       DEBUG_ASSERT(_episode != nullptr);
       return _episode->GetActors();

--- a/LibCarla/source/carla/rpc/Command.h
+++ b/LibCarla/source/carla/rpc/Command.h
@@ -30,6 +30,22 @@ namespace rpc {
 
   public:
 
+    struct SpawnActor : CommandBase<SpawnActor> {
+      SpawnActor() = default;
+      SpawnActor(ActorDescription description, const geom::Transform &transform)
+        : description(std::move(description)),
+          transform(transform) {}
+      SpawnActor(ActorDescription description, const geom::Transform &transform, ActorId parent)
+        : description(std::move(description)),
+          transform(transform),
+          parent(parent) {}
+      ActorDescription description;
+      geom::Transform transform;
+      boost::optional<ActorId> parent;
+      std::vector<Command> do_after;
+      MSGPACK_DEFINE_ARRAY(description, transform, parent, do_after);
+    };
+
     struct DestroyActor : CommandBase<DestroyActor> {
       DestroyActor() = default;
       DestroyActor(ActorId id) : actor(id) {}
@@ -102,6 +118,7 @@ namespace rpc {
     };
 
     using CommandType = boost::variant<
+        SpawnActor,
         DestroyActor,
         ApplyVehicleControl,
         ApplyWalkerControl,

--- a/LibCarla/source/carla/rpc/CommandResponse.h
+++ b/LibCarla/source/carla/rpc/CommandResponse.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/rpc/ActorId.h"
+#include "carla/rpc/Response.h"
+
+namespace carla {
+namespace rpc {
+
+  using CommandResponse = Response<ActorId>;
+
+} // namespace rpc
+} // namespace carla

--- a/PythonAPI/carla/source/libcarla/Commands.cpp
+++ b/PythonAPI/carla/source/libcarla/Commands.cpp
@@ -6,6 +6,7 @@
 
 #include <carla/PythonUtil.h>
 #include <carla/rpc/Command.h>
+#include <carla/rpc/CommandResponse.h>
 
 namespace command_impl {
 
@@ -55,6 +56,16 @@ void export_commands() {
 
   // This is a handler for passing to "SpawnActor.then" commands.
   submodule_scope.attr("FutureActor") = 0u;
+
+  class_<cr::CommandResponse>("Response", no_init)
+    .add_property("actor_id", +[](const cr::CommandResponse &self) {
+      return self.HasError() ? 0u : self.Get();
+    })
+    .add_property("error", +[](const cr::CommandResponse &self) {
+      return self.HasError() ? self.GetError().What() : std::string("");
+    })
+    .def("has_error", &cr::CommandResponse::HasError)
+  ;
 
   class_<cr::Command::SpawnActor>("SpawnActor")
     .def(

--- a/PythonAPI/carla/source/libcarla/Commands.cpp
+++ b/PythonAPI/carla/source/libcarla/Commands.cpp
@@ -7,63 +7,97 @@
 #include <carla/PythonUtil.h>
 #include <carla/rpc/Command.h>
 
+namespace command_impl {
+
+  template <typename T>
+  const T &Convert(const T &in) {
+    return in;
+  }
+
+  carla::rpc::ActorId Convert(const boost::shared_ptr<carla::client::Actor> &actor) {
+    return actor->GetId();
+  }
+
+  carla::rpc::ActorDescription Convert(const carla::client::ActorBlueprint &blueprint) {
+    return blueprint.MakeActorDescription();
+  }
+
+  template <typename... ArgsT>
+  static boost::python::object CustomInit(boost::python::object self, ArgsT... args) {
+    return self.attr("__init__")(Convert(args)...);
+  }
+
+} // namespace command_impl
+
 void export_commands() {
   using namespace boost::python;
-  namespace cr = carla::rpc;
+  namespace cc = carla::client;
   namespace cg = carla::geom;
+  namespace cr = carla::rpc;
+
+  using ActorPtr = boost::shared_ptr<cc::Actor>;
 
   object command_module(handle<>(borrowed(PyImport_AddModule("libcarla.command"))));
   scope().attr("command") = command_module;
   scope io_scope = command_module;
 
   class_<cr::Command::DestroyActor>("DestroyActor")
+    .def("__init__", &command_impl::CustomInit<ActorPtr>, (arg("actor")))
     .def(init<cr::ActorId>((arg("actor_id"))))
     .def_readwrite("actor_id", &cr::Command::DestroyActor::actor)
   ;
 
   class_<cr::Command::ApplyVehicleControl>("ApplyVehicleControl")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cr::VehicleControl>, (arg("actor"), arg("control")))
     .def(init<cr::ActorId, cr::VehicleControl>((arg("actor_id"), arg("control"))))
     .def_readwrite("actor_id", &cr::Command::ApplyVehicleControl::actor)
     .def_readwrite("control", &cr::Command::ApplyVehicleControl::control)
   ;
 
   class_<cr::Command::ApplyWalkerControl>("ApplyWalkerControl")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cr::WalkerControl>, (arg("actor"), arg("control")))
     .def(init<cr::ActorId, cr::WalkerControl>((arg("actor_id"), arg("control"))))
     .def_readwrite("actor_id", &cr::Command::ApplyWalkerControl::actor)
     .def_readwrite("control", &cr::Command::ApplyWalkerControl::control)
   ;
 
   class_<cr::Command::ApplyTransform>("ApplyTransform")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cg::Transform>, (arg("actor"), arg("transform")))
     .def(init<cr::ActorId, cg::Transform>((arg("actor_id"), arg("transform"))))
     .def_readwrite("actor_id", &cr::Command::ApplyTransform::actor)
     .def_readwrite("transform", &cr::Command::ApplyTransform::transform)
   ;
 
   class_<cr::Command::ApplyVelocity>("ApplyVelocity")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cg::Vector3D>, (arg("actor"), arg("velocity")))
     .def(init<cr::ActorId, cg::Vector3D>((arg("actor_id"), arg("velocity"))))
     .def_readwrite("actor_id", &cr::Command::ApplyVelocity::actor)
     .def_readwrite("velocity", &cr::Command::ApplyVelocity::velocity)
   ;
 
   class_<cr::Command::ApplyAngularVelocity>("ApplyAngularVelocity")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cg::Vector3D>, (arg("actor"), arg("angular_velocity")))
     .def(init<cr::ActorId, cg::Vector3D>((arg("actor_id"), arg("angular_velocity"))))
     .def_readwrite("actor_id", &cr::Command::ApplyAngularVelocity::actor)
     .def_readwrite("angular_velocity", &cr::Command::ApplyAngularVelocity::angular_velocity)
   ;
 
   class_<cr::Command::ApplyImpulse>("ApplyImpulse")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cg::Vector3D>, (arg("actor"), arg("impulse")))
     .def(init<cr::ActorId, cg::Vector3D>((arg("actor_id"), arg("impulse"))))
     .def_readwrite("actor_id", &cr::Command::ApplyImpulse::actor)
     .def_readwrite("impulse", &cr::Command::ApplyImpulse::impulse)
   ;
 
   class_<cr::Command::SetSimulatePhysics>("SetSimulatePhysics")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, bool>, (arg("actor"), arg("enabled")))
     .def(init<cr::ActorId, bool>((arg("actor_id"), arg("enabled"))))
     .def_readwrite("actor_id", &cr::Command::SetSimulatePhysics::actor)
     .def_readwrite("enabled", &cr::Command::SetSimulatePhysics::enabled)
   ;
 
   class_<cr::Command::SetAutopilot>("SetAutopilot")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, bool>, (arg("actor"), arg("enabled")))
     .def(init<cr::ActorId, bool>((arg("actor_id"), arg("enabled"))))
     .def_readwrite("actor_id", &cr::Command::SetAutopilot::actor)
     .def_readwrite("enabled", &cr::Command::SetAutopilot::enabled)

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -56,6 +56,14 @@ static void OnTick(carla::client::World &self, boost::python::object callback) {
   self.OnTick(MakeCallback(std::move(callback)));
 }
 
+static auto GetActorsById(carla::client::World &self, const boost::python::list &actor_ids) {
+  std::vector<carla::ActorId> ids{
+      boost::python::stl_input_iterator<carla::ActorId>(actor_ids),
+      boost::python::stl_input_iterator<carla::ActorId>()};
+  carla::PythonUtil::ReleaseGIL unlock;
+  return self.GetActors(ids);
+}
+
 void export_world() {
   using namespace boost::python;
   namespace cc = carla::client;
@@ -118,6 +126,7 @@ void export_world() {
     .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, GetWeather))
     .def("set_weather", &cc::World::SetWeather)
     .def("get_actors", CONST_CALL_WITHOUT_GIL(cc::World, GetActors))
+    .def("get_actors", &GetActorsById, (arg("actor_ids")))
     .def("spawn_actor", SPAWN_ACTOR_WITHOUT_GIL(SpawnActor))
     .def("try_spawn_actor", SPAWN_ACTOR_WITHOUT_GIL(TrySpawnActor))
     .def("wait_for_tick", &WaitForTick, (arg("seconds")=10.0))

--- a/PythonAPI/examples/spawn_npc.py
+++ b/PythonAPI/examples/spawn_npc.py
@@ -23,8 +23,8 @@ except IndexError:
 import carla
 
 import argparse
+import logging
 import random
-import time
 
 
 def main():
@@ -59,6 +59,8 @@ def main():
         help='avoid spawning vehicles prone to accidents')
     args = argparser.parse_args()
 
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+
     actor_list = []
     client = carla.Client(args.host, args.port)
     client.set_timeout(2.0)
@@ -73,48 +75,47 @@ def main():
             blueprints = [x for x in blueprints if not x.id.endswith('isetta')]
             blueprints = [x for x in blueprints if not x.id.endswith('carlacola')]
 
-        def try_spawn_random_vehicle_at(transform):
+        spawn_points = world.get_map().get_spawn_points()
+        number_of_spawn_points = len(spawn_points)
+
+        if args.number_of_vehicles < number_of_spawn_points:
+            random.shuffle(spawn_points)
+        elif args.number_of_vehicles > number_of_spawn_points:
+            msg = 'requested %d vehicles, but could only find %d spawn points'
+            logging.warning(msg, args.number_of_vehicles, number_of_spawn_points)
+            args.number_of_vehicles = number_of_spawn_points
+
+        # @todo cannot import these directly.
+        SpawnActor = carla.command.SpawnActor
+        SetAutopilot = carla.command.SetAutopilot
+        FutureActor = carla.command.FutureActor
+
+        batch = []
+        for n, transform in enumerate(spawn_points):
+            if n >= args.number_of_vehicles:
+                break
             blueprint = random.choice(blueprints)
             if blueprint.has_attribute('color'):
                 color = random.choice(blueprint.get_attribute('color').recommended_values)
                 blueprint.set_attribute('color', color)
             blueprint.set_attribute('role_name', 'autopilot')
-            vehicle = world.try_spawn_actor(blueprint, transform)
-            if vehicle is not None:
-                actor_list.append(vehicle)
-                vehicle.set_autopilot()
-                print('spawned %r at %s' % (vehicle.type_id, transform.location))
-                return True
-            return False
+            batch.append(SpawnActor(blueprint, transform).then(SetAutopilot(FutureActor, True)))
 
-        # @todo Needs to be converted to list to be shuffled.
-        spawn_points = list(world.get_map().get_spawn_points())
-        random.shuffle(spawn_points)
+        for response in client.apply_batch_sync(batch):
+            if response.error:
+                logging.error(response.error)
+            else:
+                actor_list.append(response.actor_id)
 
-        print('found %d spawn points.' % len(spawn_points))
-
-        count = args.number_of_vehicles
-
-        for spawn_point in spawn_points:
-            if try_spawn_random_vehicle_at(spawn_point):
-                count -= 1
-            if count <= 0:
-                break
-
-        while count > 0:
-            time.sleep(args.delay)
-            if try_spawn_random_vehicle_at(random.choice(spawn_points)):
-                count -= 1
-
-        print('spawned %d vehicles, press Ctrl+C to exit.' % args.number_of_vehicles)
+        print('spawned %d vehicles, press Ctrl+C to exit.' % len(actor_list))
 
         while True:
-            time.sleep(10)
+            world.wait_for_tick()
 
     finally:
 
         print('\ndestroying %d actors' % len(actor_list))
-        client.apply_batch([carla.command.DestroyActor(x.id) for x in actor_list])
+        client.apply_batch([carla.command.DestroyActor(x) for x in actor_list])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Description

Added methods to spawn actor in batch mode, reducing the number of accidents related to vehicles spawning on top of each other.

  * Added new `carla.command.SpawnActor` to spawn actors in batch
  * Added method `client.apply_batch_sync` that waits for server response
  * Updated `spawn_npc.py` to spawn vehicles in batch

The `SpawnActor` command also accepts queuing commands to be applied to the newly spawned actor.
```py
batch.append(
    SpawnActor(blueprint, transform).then(
        SetAutopilot(FutureActor, True)).then(
            ApplyVelocity(FutureActor, Vector3D(z=5))))
```

 `spawn_npc.py` has been updated to spawn all the vehicles in batch, but now it does not support spawning more vehicles than spawn points. This is probably a good thing due to the amount of accidents that it was producing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1489)
<!-- Reviewable:end -->
