### PR TITLE
Bugfixes about recorder:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Latest
 
+  * Recorder fixes:
+    - Actors at start of playback could interpolate positions from its current position instead than the recorded position, making some fast sliding effect during 1 frame.
+    - Camera following in playback was not working if a new map was needed to load.
+    - API function 'show_recorder_file_info' was showing the wrong parent id.
   * New recorder features:
     - Added optional parameter to show more details about a recorder file (related to `show_recorder_file_info.py`)
     - Added playback speed (slow/fast motion) for the replayer

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -152,7 +152,7 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
         for (i = 0; i < Total; ++i)
         {
           EventParent.Read(File);
-          Info << " Parenting " << EventParent.DatabaseId << " with " << EventParent.DatabaseId <<
+          Info << " Parenting " << EventParent.DatabaseId << " with " << EventParent.DatabaseIdParent <<
             " (parent)\n";
         }
         break;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -119,13 +119,13 @@ private:
   void Rewind(void);
 
   // processing packets
-  void ProcessToTime(double Time);
+  void ProcessToTime(double Time, bool IsFirstTime = false);
 
   void ProcessEventsAdd(void);
   void ProcessEventsDel(void);
   void ProcessEventsParent(void);
 
-  void ProcessPositions(void);
+  void ProcessPositions(bool IsFirstTime = false);
 
   void ProcessStates(void);
 


### PR DESCRIPTION
#### Description

There are some bug fixes in the recorder system:

1) Fixing the camera following when a new map is loaded by the recorder. 

The wrong variable was used in that case ('FollowingId' instead of the 'ThisFollowingId')

2) Fixing positions at start of replayer if another replayer was play. 

The second time the replayer is called, the actors were interpolated with its previous position and the new one, but at the beginning the previous position was where the previous replayer leaves the actor, so the actors were interpolated from its current position and the new position they need to go, and the effect was that the actors were sliding fast to its new position for a short time (only in 1 frame).

3) The API function 'show_recorder_file_info' was showing the wrong parent id of an actor.

It was showing the same id than the child actor because was using the wrong field name ('DatabaseId' instead of 'DatabaseIdParent').

Fixes #  

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** 2.7 and 3.7
  * **Unreal Engine version(s):** 4.21

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1537)
<!-- Reviewable:end -->
