### PR TITLE
added -c to wget to recover the interrupted download

### DIFF
--- a/Update.sh
+++ b/Update.sh
@@ -63,7 +63,7 @@ function download_content {
     aria2c -j16 -x16 --input-file=.aria2c.input
     rm -f .aria2c.input
   else
-    wget ${CONTENT_LINK} -O Content.tar.gz
+    wget -c ${CONTENT_LINK} -O Content.tar.gz
   fi
   tar -xvzf Content.tar.gz -C Content
   rm Content.tar.gz


### PR DESCRIPTION
the update is a very costly operation and it downloads ~6gb every time. 
many time this download get interrupted and again the same file needs to be downloaded from the beginning.
to avoid this  -c argument is added to `wget`.
this will help in continuing download from the point it was interrupted previously.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1559)
<!-- Reviewable:end -->
