### PR TITLE
Bernatx/recorder anim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Latest
 
+  * Recorder fixes:
+    - Actors at start of playback could interpolate positions from its current position instead than the recorded position, making some fast sliding effect during 1 frame.
+    - Camera following in playback was not working if a new map was needed to load.
+    - API function 'show_recorder_file_info' was showing the wrong parent id.
   * New recorder features:
     - Added optional parameter to show more details about a recorder file (related to `show_recorder_file_info.py`)
     - Added playback speed (slow/fast motion) for the replayer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
     - Actors at start of playback could interpolate positions from its current position instead than the recorded position, making some fast sliding effect during 1 frame.
     - Camera following in playback was not working if a new map was needed to load.
     - API function 'show_recorder_file_info' was showing the wrong parent id.
+    - Script 'start_recording.py' now properly saves destruction of actors at stop.
   * New recorder features:
     - Added optional parameter to show more details about a recorder file (related to `show_recorder_file_info.py`)
     - Added playback speed (slow/fast motion) for the replayer
     - We can use an absolute path for the recorded files (to choose where to 'write to' or 'read from')
+    - New data recorded to replay animations:
+      - Wheels of vehicles are animated (steering, throttle, handbrake), also bikes and cycles
+      - Walkers animation is simulated in playback (through speed of walker), so they walk properly.
   * Fixed Lidar effectiveness bug in manual_control.py
   * Added C++ client example using LibCarla
 

--- a/PythonAPI/examples/spawn_npc.py
+++ b/PythonAPI/examples/spawn_npc.py
@@ -57,6 +57,11 @@ def main():
         '--safe',
         action='store_true',
         help='avoid spawning vehicles prone to accidents')
+    argparser.add_argument(
+        '--filter',
+        metavar='PATTERN',
+        default='vehicle.*',
+        help='actor filter (default: "vehicle.*")')
     args = argparser.parse_args()
 
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -68,7 +73,7 @@ def main():
     try:
 
         world = client.get_world()
-        blueprints = world.get_blueprint_library().filter('vehicle.*')
+        blueprints = world.get_blueprint_library().filter(args.filter)
 
         if args.safe:
             blueprints = [x for x in blueprints if int(x.get_attribute('number_of_wheels')) == 4]

--- a/PythonAPI/examples/start_recording.py
+++ b/PythonAPI/examples/start_recording.py
@@ -138,7 +138,7 @@ def main():
     finally:
 
         print('\ndestroying %d actors' % len(actor_list))
-        client.apply_batch([carla.command.DestroyActor(x) for x in actor_list])
+        client.apply_batch_sync([carla.command.DestroyActor(x) for x in actor_list])
 
         print("Stop recording")
         client.stop_recorder()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -4,12 +4,12 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-// #include "Carla.h"
+#include "Carla/Actor/ActorDescription.h"
+#include "Carla/Walker/WalkerControl.h"
+#include "Carla/Walker/WalkerController.h"
+
 #include "CarlaRecorder.h"
 #include "CarlaReplayerHelper.h"
-#include "Carla/Actor/ActorDescription.h"
-#include "Carla/Walker/WalkerController.h"
-#include "Carla/Walker/WalkerControl.h"
 
 #include <ctime>
 #include <sstream>

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -8,6 +8,8 @@
 #include "CarlaRecorder.h"
 #include "CarlaReplayerHelper.h"
 #include "Carla/Actor/ActorDescription.h"
+#include "Carla/Walker/WalkerController.h"
+#include "Carla/Walker/WalkerControl.h"
 
 #include <ctime>
 #include <sstream>
@@ -67,39 +69,23 @@ void ACarlaRecorder::Tick(float DeltaSeconds)
     for (auto It = Registry.begin(); It != Registry.end(); ++It)
     {
       FActorView View = *It;
-      AActor *Actor;
+
       switch (View.GetActorType())
       {
-        // save the transform of all vehicles and walkers
+        // save the transform of all vehicles
         case FActorView::ActorType::Vehicle:
+          AddActorPosition(View);
+          break;
+
+        // save the transform of all walkers
         case FActorView::ActorType::Walker:
-          // get position of the vehicle
-          Actor = View.GetActor();
-          check(Actor != nullptr);
-          AddPosition(CarlaRecorderPosition
-          {
-            View.GetActorId(),
-            Actor->GetTransform().GetTranslation(),
-            Actor->GetTransform().GetRotation().Euler()
-          });
+          AddActorPosition(View);
+          AddWalkerAnimation(View);
           break;
 
         // save the state of each traffic light
         case FActorView::ActorType::TrafficLight:
-          // get states
-          Actor = View.GetActor();
-          check(Actor != nullptr);
-          auto TrafficLight = Cast<ATrafficLightBase>(Actor);
-          if (TrafficLight != nullptr)
-          {
-            AddState(CarlaRecorderStateTrafficLight
-            {
-              View.GetActorId(),
-              TrafficLight->GetTimeIsFrozen(),
-              TrafficLight->GetElapsedTime(),
-              static_cast<char>(TrafficLight->GetTrafficLightState())
-            });
-          }
+          AddTrafficLightState(View);
           break;
       }
     }
@@ -124,6 +110,63 @@ void ACarlaRecorder::Disable(void)
 {
   PrimaryActorTick.bCanEverTick = false;
   Enabled = false;
+}
+
+void ACarlaRecorder::AddActorPosition(FActorView &View)
+{
+  AActor *Actor = View.GetActor();
+  check(Actor != nullptr);
+
+  // get position of the vehicle
+  AddPosition(CarlaRecorderPosition
+  {
+    View.GetActorId(),
+    Actor->GetTransform().GetTranslation(),
+    Actor->GetTransform().GetRotation().Euler()
+  });
+}
+
+void ACarlaRecorder::AddWalkerAnimation(FActorView &View)
+{
+  AActor *Actor = View.GetActor();
+  check(Actor != nullptr);
+
+  if (!Actor->IsPendingKill())
+  {
+    // check to set speed in walkers
+    auto Walker = Cast<APawn>(Actor);
+    if (Walker)
+    {
+      auto Controller = Cast<AWalkerController>(Walker->GetController());
+      if (Controller != nullptr)
+      {
+        AddAnimWalker(CarlaRecorderAnimWalker
+        {
+          View.GetActorId(),
+          Controller->GetWalkerControl().Speed
+        });
+      }
+    }
+  }
+}
+
+void ACarlaRecorder::AddTrafficLightState(FActorView &View)
+{
+  AActor *Actor = View.GetActor();
+  check(Actor != nullptr);
+
+  // get states
+  auto TrafficLight = Cast<ATrafficLightBase>(Actor);
+  if (TrafficLight != nullptr)
+  {
+    AddState(CarlaRecorderStateTrafficLight
+    {
+      View.GetActorId(),
+      TrafficLight->GetTimeIsFrozen(),
+      TrafficLight->GetElapsedTime(),
+      static_cast<char>(TrafficLight->GetTrafficLightState())
+    });
+  }
 }
 
 std::string ACarlaRecorder::Start(std::string Name, FString MapName)
@@ -189,6 +232,7 @@ void ACarlaRecorder::Clear(void)
   Collisions.Clear();
   Positions.Clear();
   States.Clear();
+  Walkers.Clear();
 }
 
 void ACarlaRecorder::Write(double DeltaSeconds)
@@ -199,13 +243,18 @@ void ACarlaRecorder::Write(double DeltaSeconds)
   // start
   Frames.WriteStart(File);
 
-  // write data
+  // events
   EventsAdd.Write(File);
   EventsDel.Write(File);
   EventsParent.Write(File);
   Collisions.Write(File);
+
+  // positions and states
   Positions.Write(File);
   States.Write(File);
+
+  // animations
+  Walkers.Write(File);
 
   // end
   Frames.WriteEnd(File);
@@ -283,6 +332,14 @@ void ACarlaRecorder::AddState(const CarlaRecorderStateTrafficLight &State)
   if (Enabled)
   {
     States.Add(State);
+  }
+}
+
+void ACarlaRecorder::AddAnimWalker(const CarlaRecorderAnimWalker &Walker)
+{
+  if (Enabled)
+  {
+    Walkers.Add(Walker);
   }
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -16,6 +16,7 @@
 #include "CarlaRecorderCollision.h"
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderState.h"
+#include "CarlaRecorderAnimWalker.h"
 #include "CarlaRecorderQuery.h"
 #include "CarlaReplayer.h"
 #include "Carla/Actor/ActorDescription.h"
@@ -34,7 +35,9 @@ enum class CarlaRecorderPacketId : uint8_t
   EventParent,
   Collision,
   Position,
-  State
+  State,
+  AnimVehicle,
+  AnimWalker
 };
 
 /// Recorder for the simulation
@@ -78,6 +81,8 @@ public:
   void AddPosition(const CarlaRecorderPosition &Position);
 
   void AddState(const CarlaRecorderStateTrafficLight &State);
+
+  void AddAnimWalker(const CarlaRecorderAnimWalker &Walker);
 
   // set episode
   void SetEpisode(UCarlaEpisode *ThisEpisode)
@@ -127,6 +132,7 @@ private:
   CarlaRecorderCollisions Collisions;
   CarlaRecorderPositions Positions;
   CarlaRecorderStates States;
+  CarlaRecorderAnimWalkers Walkers;
 
   // replayer
   CarlaReplayer Replayer;
@@ -135,5 +141,7 @@ private:
   CarlaRecorderQuery Query;
 
   void AddExistingActors(void);
-
+  void AddActorPosition(FActorView &View);
+  void AddWalkerAnimation(FActorView &View);
+  void AddTrafficLightState(FActorView &View);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -8,19 +8,21 @@
 
 // #include "GameFramework/Actor.h"
 #include <fstream>
-#include "CarlaRecorderInfo.h"
-#include "CarlaRecorderFrames.h"
+
+#include "Carla/Actor/ActorDescription.h"
+
+#include "CarlaRecorderAnimVehicle.h"
+#include "CarlaRecorderAnimWalker.h"
+#include "CarlaRecorderCollision.h"
 #include "CarlaRecorderEventAdd.h"
 #include "CarlaRecorderEventDel.h"
 #include "CarlaRecorderEventParent.h"
-#include "CarlaRecorderCollision.h"
+#include "CarlaRecorderFrames.h"
+#include "CarlaRecorderInfo.h"
 #include "CarlaRecorderPosition.h"
-#include "CarlaRecorderState.h"
-#include "CarlaRecorderAnimVehicle.h"
-#include "CarlaRecorderAnimWalker.h"
 #include "CarlaRecorderQuery.h"
+#include "CarlaRecorderState.h"
 #include "CarlaReplayer.h"
-#include "Carla/Actor/ActorDescription.h"
 
 #include "CarlaRecorder.generated.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -16,6 +16,7 @@
 #include "CarlaRecorderCollision.h"
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderState.h"
+#include "CarlaRecorderAnimVehicle.h"
 #include "CarlaRecorderAnimWalker.h"
 #include "CarlaRecorderQuery.h"
 #include "CarlaReplayer.h"
@@ -82,6 +83,8 @@ public:
 
   void AddState(const CarlaRecorderStateTrafficLight &State);
 
+  void AddAnimVehicle(const CarlaRecorderAnimVehicle &Vehicle);
+
   void AddAnimWalker(const CarlaRecorderAnimWalker &Walker);
 
   // set episode
@@ -132,6 +135,7 @@ private:
   CarlaRecorderCollisions Collisions;
   CarlaRecorderPositions Positions;
   CarlaRecorderStates States;
+  CarlaRecorderAnimVehicles Vehicles;
   CarlaRecorderAnimWalkers Walkers;
 
   // replayer
@@ -143,5 +147,6 @@ private:
   void AddExistingActors(void);
   void AddActorPosition(FActorView &View);
   void AddWalkerAnimation(FActorView &View);
+  void AddVehicleAnimation(FActorView &View);
   void AddTrafficLightState(FActorView &View);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimVehicle.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaRecorder.h"
+#include "CarlaRecorderAnimVehicle.h"
+#include "CarlaRecorderHelpers.h"
+
+void CarlaRecorderAnimVehicle::Write(std::ofstream &OutFile)
+{
+  // database id
+  WriteValue<uint32_t>(OutFile, this->DatabaseId);
+  WriteValue<float>(OutFile, this->Steering);
+  WriteValue<float>(OutFile, this->Throttle);
+  WriteValue<float>(OutFile, this->Brake);
+  WriteValue<bool>(OutFile, this->bHandbrake);
+  WriteValue<int32_t>(OutFile, this->Gear);
+}
+void CarlaRecorderAnimVehicle::Read(std::ifstream &InFile)
+{
+  // database id
+  ReadValue<uint32_t>(InFile, this->DatabaseId);
+  ReadValue<float>(InFile, this->Steering);
+  ReadValue<float>(InFile, this->Throttle);
+  ReadValue<float>(InFile, this->Brake);
+  ReadValue<bool>(InFile, this->bHandbrake);
+  ReadValue<int32_t>(InFile, this->Gear);
+}
+
+// ---------------------------------------------
+
+void CarlaRecorderAnimVehicles::Clear(void)
+{
+  Vehicles.clear();
+}
+
+void CarlaRecorderAnimVehicles::Add(const CarlaRecorderAnimVehicle &Vehicle)
+{
+  Vehicles.push_back(Vehicle);
+}
+
+void CarlaRecorderAnimVehicles::Write(std::ofstream &OutFile)
+{
+  // write the packet id
+  WriteValue<char>(OutFile, static_cast<char>(CarlaRecorderPacketId::AnimVehicle));
+
+  std::streampos PosStart = OutFile.tellp();
+
+  // write a dummy packet size
+  uint32_t Total = 0;
+  WriteValue<uint32_t>(OutFile, Total);
+
+  // write total records
+  Total = Vehicles.size();
+  WriteValue<uint16_t>(OutFile, Total);
+
+  for (uint16_t i=0; i<Total; ++i)
+    Vehicles[i].Write(OutFile);
+
+  // write the real packet size
+  std::streampos PosEnd = OutFile.tellp();
+  Total = PosEnd - PosStart - sizeof(uint32_t);
+  OutFile.seekp(PosStart, std::ios::beg);
+  WriteValue<uint32_t>(OutFile, Total);
+  OutFile.seekp(PosEnd, std::ios::beg);
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimVehicle.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <fstream>
+#include <vector>
+
+#pragma pack(push, 1)
+struct CarlaRecorderAnimVehicle
+{
+  uint32_t DatabaseId;
+  float Steering;
+  float Throttle;
+  float Brake;
+  bool bHandbrake;
+  int32_t Gear;
+
+  void Read(std::ifstream &InFile);
+
+  void Write(std::ofstream &OutFile);
+
+};
+#pragma pack(pop)
+
+class CarlaRecorderAnimVehicles
+{
+public:
+
+  void Add(const CarlaRecorderAnimVehicle &InObj);
+
+  void Clear(void);
+
+  void Write(std::ofstream &OutFile);
+
+private:
+
+  std::vector<CarlaRecorderAnimVehicle> Vehicles;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimWalker.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimWalker.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaRecorder.h"
+#include "CarlaRecorderAnimWalker.h"
+#include "CarlaRecorderHelpers.h"
+
+void CarlaRecorderAnimWalker::Write(std::ofstream &OutFile)
+{
+  // database id
+  WriteValue<uint32_t>(OutFile, this->DatabaseId);
+  WriteValue<float>(OutFile, this->Speed);
+}
+void CarlaRecorderAnimWalker::Read(std::ifstream &InFile)
+{
+  // database id
+  ReadValue<uint32_t>(InFile, this->DatabaseId);
+  ReadValue<float>(InFile, this->Speed);
+}
+
+// ---------------------------------------------
+
+void CarlaRecorderAnimWalkers::Clear(void)
+{
+  Walkers.clear();
+}
+
+void CarlaRecorderAnimWalkers::Add(const CarlaRecorderAnimWalker &Walker)
+{
+  Walkers.push_back(Walker);
+}
+
+void CarlaRecorderAnimWalkers::Write(std::ofstream &OutFile)
+{
+  // write the packet id
+  WriteValue<char>(OutFile, static_cast<char>(CarlaRecorderPacketId::AnimWalker));
+
+  // write the packet size
+  uint32_t Total = 2 + Walkers.size() * sizeof(CarlaRecorderAnimWalker);
+  WriteValue<uint32_t>(OutFile, Total);
+
+  // write total records
+  Total = Walkers.size();
+  WriteValue<uint16_t>(OutFile, Total);
+
+  // write records
+  if (Total > 0)
+  {
+    OutFile.write(reinterpret_cast<const char *>(Walkers.data()),
+        Walkers.size() * sizeof(CarlaRecorderAnimWalker));
+  }
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimWalker.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderAnimWalker.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <fstream>
+#include <vector>
+
+#pragma pack(push, 1)
+struct CarlaRecorderAnimWalker
+{
+  uint32_t DatabaseId;
+  float Speed;
+
+  void Read(std::ifstream &InFile);
+
+  void Write(std::ofstream &OutFile);
+
+};
+#pragma pack(pop)
+
+class CarlaRecorderAnimWalkers
+{
+public:
+
+  void Add(const CarlaRecorderAnimWalker &InObj);
+
+  void Clear(void);
+
+  void Write(std::ofstream &OutFile);
+
+private:
+
+  std::vector<CarlaRecorderAnimWalker> Walkers;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -219,6 +219,27 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
           SkipPacket();
         break;
 
+      // walker animations
+      case static_cast<char>(CarlaRecorderPacketId::AnimWalker):
+        if (bShowAll)
+        {
+          ReadValue<uint16_t>(File, Total);
+          if (Total > 0 && !bFramePrinted)
+          {
+            PrintFrame(Info);
+            bFramePrinted = true;
+          }
+          Info << " Walker animations: " << Total << std::endl;
+          for (i = 0; i < Total; ++i)
+          {
+            Walker.Read(File);
+            Info << "  Walker id " << Walker.DatabaseId << ": speed " << Walker.Speed << std::endl;
+          }
+        }
+        else
+          SkipPacket();
+        break;
+
       // frame end
       case static_cast<char>(CarlaRecorderPacketId::FrameEnd):
         // do nothing, it is empty

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -152,7 +152,7 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
         for (i = 0; i < Total; ++i)
         {
           EventParent.Read(File);
-          Info << " Parenting " << EventParent.DatabaseId << " with " << EventParent.DatabaseId <<
+          Info << " Parenting " << EventParent.DatabaseId << " with " << EventParent.DatabaseIdParent <<
             " (parent)\n";
         }
         break;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -219,6 +219,27 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
           SkipPacket();
         break;
 
+      // vehicle animations
+      case static_cast<char>(CarlaRecorderPacketId::AnimVehicle):
+        if (bShowAll)
+        {
+          ReadValue<uint16_t>(File, Total);
+          if (Total > 0 && !bFramePrinted)
+          {
+            PrintFrame(Info);
+            bFramePrinted = true;
+          }
+          Info << " Vehicle animations: " << Total << std::endl;
+          for (i = 0; i < Total; ++i)
+          {
+            Vehicle.Read(File);
+            Info << "  Vehicle id " << Vehicle.DatabaseId << ": Steering " << Vehicle.Steering << " Throttle " << Vehicle.Throttle << " Brake " << Vehicle.Brake << " Handbrake " << Vehicle.bHandbrake << " Gear " << Vehicle.Gear << std::endl;
+          }
+        }
+        else
+          SkipPacket();
+        break;
+
       // walker animations
       case static_cast<char>(CarlaRecorderPacketId::AnimWalker):
         if (bShowAll)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
@@ -7,15 +7,16 @@
 #pragma once
 
 #include <fstream>
-#include "CarlaRecorderInfo.h"
-#include "CarlaRecorderFrames.h"
+
+#include "CarlaRecorderAnimWalker.h"
+#include "CarlaRecorderCollision.h"
 #include "CarlaRecorderEventAdd.h"
 #include "CarlaRecorderEventDel.h"
 #include "CarlaRecorderEventParent.h"
-#include "CarlaRecorderCollision.h"
+#include "CarlaRecorderFrames.h"
+#include "CarlaRecorderInfo.h"
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderState.h"
-#include "CarlaRecorderAnimWalker.h"
 
 class CarlaRecorderQuery
 {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
@@ -49,6 +49,7 @@ private:
   CarlaRecorderPosition Position;
   CarlaRecorderCollision Collision;
   CarlaRecorderStateTrafficLight StateTraffic;
+  CarlaRecorderAnimVehicle Vehicle;
   CarlaRecorderAnimWalker Walker;
 
   // read next header packet

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
@@ -15,6 +15,7 @@
 #include "CarlaRecorderCollision.h"
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderState.h"
+#include "CarlaRecorderAnimWalker.h"
 
 class CarlaRecorderQuery
 {
@@ -48,6 +49,7 @@ private:
   CarlaRecorderPosition Position;
   CarlaRecorderCollision Collision;
   CarlaRecorderStateTrafficLight StateTraffic;
+  CarlaRecorderAnimWalker Walker;
 
   // read next header packet
   bool ReadHeader(void);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -318,6 +318,14 @@ void CarlaReplayer::ProcessToTime(double Time, bool IsFirstTime)
           SkipPacket();
         break;
 
+      // vehicle animation
+      case static_cast<char>(CarlaRecorderPacketId::AnimVehicle):
+        if (bFrameFound)
+          ProcessAnimVehicle();
+        else
+          SkipPacket();
+        break;
+
       // walker animation
       case static_cast<char>(CarlaRecorderPacketId::AnimWalker):
         if (bFrameFound)
@@ -490,6 +498,22 @@ void CarlaReplayer::ProcessStates(void)
           TEXT("callback state traffic light %d called but didn't work"),
           StateTrafficLight.DatabaseId);
     }
+  }
+}
+
+void CarlaReplayer::ProcessAnimVehicle(void)
+{
+  uint16_t i, Total;
+  CarlaRecorderAnimVehicle Vehicle;
+  std::stringstream Info;
+
+  // read Total Vehicles
+  ReadValue<uint16_t>(File, Total);
+  for (i = 0; i < Total; ++i)
+  {
+    Vehicle.Read(File);
+    Vehicle.DatabaseId = MappedId[Vehicle.DatabaseId];
+    Helper.ProcessReplayerAnimVehicle(Vehicle);
   }
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -119,13 +119,13 @@ private:
   void Rewind(void);
 
   // processing packets
-  void ProcessToTime(double Time);
+  void ProcessToTime(double Time, bool IsFirstTime = false);
 
   void ProcessEventsAdd(void);
   void ProcessEventsDel(void);
   void ProcessEventsParent(void);
 
-  void ProcessPositions(void);
+  void ProcessPositions(bool IsFirstTime = false);
 
   void ProcessStates(void);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -130,8 +130,8 @@ private:
   void ProcessStates(void);
 
   // positions
-  void UpdatePositions(double Per);
+  void UpdatePositions(double Per, double DeltaTime);
 
-  void InterpolatePosition(const CarlaRecorderPosition &Start, const CarlaRecorderPosition &End, double Per);
+  void InterpolatePosition(const CarlaRecorderPosition &Start, const CarlaRecorderPosition &End, double Per, double DeltaTime);
 
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -129,6 +129,8 @@ private:
 
   void ProcessStates(void);
 
+  void ProcessAnimWalker(void);
+
   // positions
   void UpdatePositions(double Per, double DeltaTime);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -129,6 +129,7 @@ private:
 
   void ProcessStates(void);
 
+  void ProcessAnimVehicle(void);
   void ProcessAnimWalker(void);
 
   // positions

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -180,10 +180,14 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
 
   if (result.first != 0)
   {
-    // disable physics
-    SetActorSimulatePhysics(result.second, false);
-    // disable autopilot
-    SetActorAutopilot(result.second, false);
+    // disable physics and autopilot on vehicles
+    if (result.second.GetActorType() == FActorView::ActorType::Vehicle)
+    {
+      // disable physics
+      SetActorSimulatePhysics(result.second, false);
+      // disable autopilot
+      SetActorAutopilot(result.second, false);
+    }
   }
 
   return std::make_pair(result.first, result.second.GetActorId());
@@ -364,11 +368,14 @@ bool CarlaReplayerHelper::ProcessReplayerFinish(bool bApplyAutopilot)
   auto registry = Episode->GetActorRegistry();
   for (auto ActorView : registry)
   {
-    // enable physics
-    SetActorSimulatePhysics(ActorView, true);
-    // autopilot
-    if (bApplyAutopilot)
-      SetActorAutopilot(ActorView, true);
+    // enable physics only on vehicles
+    if (ActorView.GetActorType() == FActorView::ActorType::Vehicle)
+    {
+      SetActorSimulatePhysics(ActorView, true);
+      // autopilot
+      if (bApplyAutopilot)
+        SetActorAutopilot(ActorView, true);
+    }
   }
   return true;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -259,6 +259,7 @@ bool CarlaReplayerHelper::ProcessReplayerPosition(CarlaRecorderPosition Pos1, Ca
     // set new transform
     FTransform Trans(Rotation, Location, FVector(1, 1, 1));
     Actor->SetActorTransform(Trans, false, nullptr, ETeleportType::None);
+    // Actor->SetActorTransform(Trans, false, nullptr, ETeleportType::TeleportPhysics);
     return true;
   }
   return false;
@@ -335,6 +336,31 @@ bool CarlaReplayerHelper::ProcessReplayerStateTrafficLight(CarlaRecorderStateTra
     return true;
   }
   return false;
+}
+
+// set the animation for Vehicles
+void CarlaReplayerHelper::ProcessReplayerAnimVehicle(CarlaRecorderAnimVehicle Vehicle)
+{
+  check(Episode != nullptr);
+  AActor *Actor = Episode->GetActorRegistry().Find(Vehicle.DatabaseId).GetActor();
+  if (Actor && !Actor->IsPendingKill())
+  {
+    auto Veh = Cast<ACarlaWheeledVehicle>(Actor);
+    if (Veh == nullptr)
+    {
+      return;
+    }
+
+    FVehicleControl Control;
+    Control.Throttle = Vehicle.Throttle;
+    Control.Steer = Vehicle.Steering;
+    Control.Brake = Vehicle.Brake;
+    Control.bHandBrake = Vehicle.bHandbrake;
+    Control.bReverse = (Vehicle.Gear < 0);
+    Control.Gear = Vehicle.Gear;
+    Control.bManualGearShift = false;
+    Veh->ApplyVehicleControl(Control, EVehicleInputPriority::User);
+  }
 }
 
 // set the animation for walkers

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -4,11 +4,11 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#include "CarlaReplayerHelper.h"
-#include "Carla/Actor/ActorView.h"
 #include "Carla/Actor/ActorDescription.h"
-#include "Carla/Walker/WalkerController.h"
+#include "Carla/Actor/ActorView.h"
 #include "Carla/Walker/WalkerControl.h"
+#include "Carla/Walker/WalkerController.h"
+#include "CarlaReplayerHelper.h"
 
 // create or reuse an actor for replaying
 std::pair<int, FActorView>CarlaReplayerHelper::TryToCreateReplayerActor(
@@ -242,58 +242,19 @@ bool CarlaReplayerHelper::ProcessReplayerPosition(CarlaRecorderPosition Pos1, Ca
       // assign position 1
       Location = FVector(Pos1.Location);
       Rotation = FRotator::MakeFromEuler(Pos1.Rotation);
-      // reset velocities
-      // ResetVelocities(Actor);
     }
     else
     {
       // interpolate positions
       Location = FMath::Lerp(FVector(Pos1.Location), FVector(Pos2.Location), Per);
       Rotation = FMath::Lerp(FRotator::MakeFromEuler(Pos1.Rotation), FRotator::MakeFromEuler(Pos2.Rotation), Per);
-      // apply new velocities
-      // FVector Vel((Location - FVector(Pos1.Location)) / DeltaTime);
-      // FVector Rot((Rotation - FRotator::MakeFromEuler(Pos1.Rotation)).Euler() / DeltaTime);
-      // SetVelocities(Actor, Vel, Rot);
-      // UE_LOG(LogCarla, Log, TEXT("Set velocities for %d at [%f,%f,%f] [%f,%f,%f]"), Pos1.DatabaseId, Vel.X, Vel.Y, Vel.Z, Rot.X, Rot.Y, Rot.Z);
     }
     // set new transform
     FTransform Trans(Rotation, Location, FVector(1, 1, 1));
     Actor->SetActorTransform(Trans, false, nullptr, ETeleportType::None);
-    // Actor->SetActorTransform(Trans, false, nullptr, ETeleportType::TeleportPhysics);
     return true;
   }
   return false;
-}
-
-// reset velocity vectors on actor
-void CarlaReplayerHelper::ResetVelocities(AActor *Actor)
-{
-  if (Actor && !Actor->IsPendingKill())
-  {
-    auto RootComponent = Cast<UPrimitiveComponent>(Actor->GetRootComponent());
-    if (RootComponent != nullptr)
-    {
-      FVector Vector(0, 0, 0);
-      // reset velocities
-      RootComponent->SetPhysicsLinearVelocity(Vector, false, "None");
-      RootComponent->SetPhysicsAngularVelocityInDegrees(Vector, false, "None");
-    }
-  }
-}
-
-// apply new velocities
-void CarlaReplayerHelper::SetVelocities(AActor *Actor, FVector Linear, FVector Angular)
-{
-  if (Actor && !Actor->IsPendingKill())
-  {
-    auto RootComponent = Cast<UPrimitiveComponent>(Actor->GetRootComponent());
-    if (RootComponent != nullptr)
-    {
-      // velocities
-      RootComponent->SetPhysicsLinearVelocity(Linear, false, "None");
-      RootComponent->SetPhysicsAngularVelocityInDegrees(Angular, false, "None");
-    }
-  }
 }
 
 // reposition the camera
@@ -379,7 +340,6 @@ void CarlaReplayerHelper::ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walk
         FWalkerControl Control;
         Control.Speed = Walker.Speed;
         Controller->ApplyWalkerControl(Control);
-        // UE_LOG(LogCarla, Log, TEXT("Set Speed for %f"), Control.Speed);
      }
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -259,9 +259,6 @@ bool CarlaReplayerHelper::ProcessReplayerPosition(CarlaRecorderPosition Pos1, Ca
     // set new transform
     FTransform Trans(Rotation, Location, FVector(1, 1, 1));
     Actor->SetActorTransform(Trans, false, nullptr, ETeleportType::None);
-    // play walker animation
-    FVector Vel((Location - FVector(Pos1.Location)) / DeltaTime);
-    SetWalkerSpeedForAnimation(Actor, Vel);
     return true;
   }
   return false;
@@ -294,27 +291,6 @@ void CarlaReplayerHelper::SetVelocities(AActor *Actor, FVector Linear, FVector A
       // velocities
       RootComponent->SetPhysicsLinearVelocity(Linear, false, "None");
       RootComponent->SetPhysicsAngularVelocityInDegrees(Angular, false, "None");
-    }
-  }
-}
-
-// set speed of walker to force animation to play
-void CarlaReplayerHelper::SetWalkerSpeedForAnimation(AActor *Actor, FVector Linear)
-{
-  if (Actor && !Actor->IsPendingKill())
-  {
-    // check to set speed in walkers
-    auto Walker = Cast<APawn>(Actor);
-    if (Walker)
-    {
-      auto Controller = Cast<AWalkerController>(Walker->GetController());
-      if (Controller != nullptr)
-      {
-        FWalkerControl Control;
-        Control.Speed = Linear.Size();
-        Controller->ApplyWalkerControl(Control);
-        // UE_LOG(LogCarla, Log, TEXT("Set Speed for %f"), Control.Speed);
-     }
     }
   }
 }
@@ -359,6 +335,28 @@ bool CarlaReplayerHelper::ProcessReplayerStateTrafficLight(CarlaRecorderStateTra
     return true;
   }
   return false;
+}
+
+// set the animation for walkers
+void CarlaReplayerHelper::ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walker)
+{
+  check(Episode != nullptr);
+  AActor *Actor = Episode->GetActorRegistry().Find(Walker.DatabaseId).GetActor();
+  if (Actor && !Actor->IsPendingKill())
+  {
+    auto Wal = Cast<APawn>(Actor);
+    if (Wal)
+    {
+      auto Controller = Cast<AWalkerController>(Wal->GetController());
+      if (Controller != nullptr)
+      {
+        FWalkerControl Control;
+        Control.Speed = Walker.Speed;
+        Controller->ApplyWalkerControl(Control);
+        // UE_LOG(LogCarla, Log, TEXT("Set Speed for %f"), Control.Speed);
+     }
+    }
+  }
 }
 
 // replay finish

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -35,7 +35,7 @@ public:
   bool ProcessReplayerEventParent(uint32_t ChildId, uint32_t ParentId);
 
   // reposition actors
-  bool ProcessReplayerPosition(CarlaRecorderPosition Pos1, CarlaRecorderPosition Pos2, double Per);
+  bool ProcessReplayerPosition(CarlaRecorderPosition Pos1, CarlaRecorderPosition Pos2, double Per, double DeltaTime);
 
   // replay event for traffic light state
   bool ProcessReplayerStateTrafficLight(CarlaRecorderStateTrafficLight State);
@@ -64,5 +64,9 @@ private:
   bool SetActorAutopilot(FActorView &ActorView, bool bEnabled);
   // reset velocity vectors on actor
   void ResetVelocities(AActor *Actor);
+  // apply new velocities
+  void SetVelocities(AActor *Actor, FVector Linear, FVector Angular);
+  // set speed of walker to force animation to play
+  void SetWalkerSpeedForAnimation(AActor *Actor, FVector Linear);
 
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -40,6 +40,9 @@ public:
   // replay event for traffic light state
   bool ProcessReplayerStateTrafficLight(CarlaRecorderStateTrafficLight State);
 
+  // set the animation for Vehicles
+  void ProcessReplayerAnimVehicle(CarlaRecorderAnimVehicle Vehicle);
+
   // set the animation for walkers
   void ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walker);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -68,8 +68,4 @@ private:
   bool SetActorSimulatePhysics(FActorView &ActorView, bool bEnabled);
   // enable / disable autopilot for an actor
   bool SetActorAutopilot(FActorView &ActorView, bool bEnabled);
-  // reset velocity vectors on actor
-  void ResetVelocities(AActor *Actor);
-  // apply new velocities
-  void SetVelocities(AActor *Actor, FVector Linear, FVector Angular);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -40,6 +40,9 @@ public:
   // replay event for traffic light state
   bool ProcessReplayerStateTrafficLight(CarlaRecorderStateTrafficLight State);
 
+  // set the animation for walkers
+  void ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walker);
+
   // replay finish
   bool ProcessReplayerFinish(bool bApplyAutopilot);
 
@@ -66,7 +69,4 @@ private:
   void ResetVelocities(AActor *Actor);
   // apply new velocities
   void SetVelocities(AActor *Actor, FVector Linear, FVector Angular);
-  // set speed of walker to force animation to play
-  void SetWalkerSpeedForAnimation(AActor *Actor, FVector Linear);
-
 };


### PR DESCRIPTION
#### Description

##### Added new features to the recorder:

 - For vehicles, the wheels are recorded and replayed correctly in function of the steering, thruttle and brake applied.

- For walkers, they walk with full animation on playback

##### There are some bug fixes in the recorder system:

- Fixing the camera following when a new map is loaded by the recorder. 

The wrong variable was used in that case ('FollowingId' instead of the 'ThisFollowingId')

- Fixing positions at start of replayer if another replayer was play. 

The second time the replayer is called, the actors were interpolated with its previous position and the new one, but at the beginning the previous position was where the previous replayer leaves the actor, so the actors were interpolated from its current position and the new position they need to go, and the effect was that the actors were sliding fast to its new position for a short time (only in 1 frame).

- The API function 'show_recorder_file_info' was showing the wrong parent id of an actor.

It was showing the same id than the child actor because was using the wrong field name ('DatabaseId' instead of 'DatabaseIdParent').

- Some fixes in the 'start_recording.py' script, that was not recording properly the actors destruction at end of the script execution.

#### Where has this been tested?

  * **Platform(s):** Linux 16.04
  * **Python version(s):** 2.7 , 3.7
  * **Unreal Engine version(s):** 4.21

#### Possible Drawbacks

The recorded files created before this update, can be replayed but the animation will not play.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1568)
<!-- Reviewable:end -->
