### PR TITLE
Set vulkan as default graphics api for linux. Changed make files to allow user to start …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Vulkan support: Changed project settings to make vulkan default but opengl can be selected using the make script
   * Upgraded to Unreal Engine 4.22
   * Recorder fixes:
     - Actors at start of playback could interpolate positions from its current position instead than the recorded position, making some fast sliding effect during 1 frame.

--- a/Docs/configuring_the_simulation.md
+++ b/Docs/configuring_the_simulation.md
@@ -81,7 +81,7 @@ environment variable `DISPLAY` to empty
 
 ```sh
 # Linux
-DISPLAY= ./CarlaUE4.sh
+DISPLAY= ./CarlaUE4.sh --use-opengl
 ```
 
 This launches the simulator without simulator window, of course you can still

--- a/Docs/configuring_the_simulation.md
+++ b/Docs/configuring_the_simulation.md
@@ -76,12 +76,12 @@ environment variable `DISPLAY` to empty
     **DISPLAY= only works with OpenGL**<br>
     Vulkan is now the default graphics API used by Unreal Engine and CARLA on
     Linux. Unreal Engine currently crashes when Vulkan is used when running off-screen.
-    Therefore the --use-opengl flag must be added to force the engine to use OpenGL instead.
+    Therefore the -opengl flag must be added to force the engine to use OpenGL instead.
     We hope that this is issue is addressed by Epic in the near future.
 
 ```sh
 # Linux
-DISPLAY= ./CarlaUE4.sh --use-opengl
+DISPLAY= ./CarlaUE4.sh -opengl
 ```
 
 This launches the simulator without simulator window, of course you can still

--- a/Docs/configuring_the_simulation.md
+++ b/Docs/configuring_the_simulation.md
@@ -77,7 +77,7 @@ environment variable `DISPLAY` to empty
     Vulkan is now the default graphics API used by Unreal Engine and CARLA on
     Linux. Unreal Engine currently crashes when Vulkan is used when running off-screen.
     Therefore the -opengl flag must be added to force the engine to use OpenGL instead.
-    We hope that this is issue is addressed by Epic in the near future.
+    We hope that this issue is addressed by Epic in the near future.
 
 ```sh
 # Linux

--- a/Docs/configuring_the_simulation.md
+++ b/Docs/configuring_the_simulation.md
@@ -72,6 +72,13 @@ Running off-screen
 In Linux, you can force the simulator to run off-screen by setting the
 environment variable `DISPLAY` to empty
 
+!!! important
+    **DISPLAY= only works with OpenGL**<br>
+    Vulkan is now the default graphics API used by Unreal Engine and CARLA on
+    Linux. Unreal Engine currently crashes when Vulkan is used when running off-screen.
+    Therefore the --use-opengl flag must be added to force the engine to use OpenGL instead.
+    We hope that this is issue is addressed by Epic in the near future.
+
 ```sh
 # Linux
 DISPLAY= ./CarlaUE4.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
 
         stage('Smoke Tests') {
             steps {
-                sh 'DISPLAY= ./Dist/*/LinuxNoEditor/CarlaUE4.sh --use-opengl --carla-rpc-port=3654 --carla-streaming-port=0 -nosound > CarlaUE4.log &'
+                sh 'DISPLAY= ./Dist/*/LinuxNoEditor/CarlaUE4.sh -opengl --carla-rpc-port=3654 --carla-streaming-port=0 -nosound > CarlaUE4.log &'
                 sh 'make smoke_tests ARGS="--xml"'
                 sh 'make run-examples ARGS="localhost 3654"'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
 
         stage('Smoke Tests') {
             steps {
-                sh 'DISPLAY= ./Dist/*/LinuxNoEditor/CarlaUE4.sh --carla-rpc-port=3654 --carla-streaming-port=0 -nosound > CarlaUE4.log &'
+                sh 'DISPLAY= ./Dist/*/LinuxNoEditor/CarlaUE4.sh --use-opengl --carla-rpc-port=3654 --carla-streaming-port=0 -nosound > CarlaUE4.log &'
                 sh 'make smoke_tests ARGS="--xml"'
                 sh 'make run-examples ARGS="localhost 3654"'
             }

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -40,14 +40,6 @@ RuntimeGeneration=Static
 [/Script/AIModule.CrowdManager]
 MaxAgents=1000
 
-[/Script/LinuxTargetPlatform.LinuxTargetSettings]
-SpatializationPlugin=
-ReverbPlugin=
-OcclusionPlugin=
--TargetedRHIs=SF_VULKAN_SM5
--TargetedRHIs=GLSL_430
-+TargetedRHIs=GLSL_430
-
 [/Script/Engine.PhysicsSettings]
 DefaultGravityZ=-980.000000
 DefaultTerminalVelocity=4000.000000
@@ -55,7 +47,6 @@ DefaultFluidFriction=0.300000
 SimulateScratchMemorySize=262144
 RagdollAggregateThreshold=4
 TriangleMeshTriangleMinAreaThreshold=5.000000
-bEnableAsyncScene=False
 bEnableShapeSharing=False
 bEnablePCM=False
 bEnableStabilization=False
@@ -88,8 +79,17 @@ bSubsteppingAsync=False
 MaxSubstepDeltaTime=0.016667
 MaxSubsteps=6
 SyncSceneSmoothingFactor=0.000000
-AsyncSceneSmoothingFactor=0.990000
 InitialAverageFrameRate=0.016667
 PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
+
+[/Script/LinuxTargetPlatform.LinuxTargetSettings]
+SpatializationPlugin=
+ReverbPlugin=
+OcclusionPlugin=
+-TargetedRHIs=SF_VULKAN_SM5
+-TargetedRHIs=GLSL_430
++TargetedRHIs=SF_VULKAN_SM5
++TargetedRHIs=GLSL_430
+
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -15,7 +15,7 @@
 #if PLATFORM_WINDOWS
 #  define CARLA_WITH_VULKAN_SUPPORT 1
 #else
-#  define CARLA_WITH_VULKAN_SUPPORT 0
+#  define CARLA_WITH_VULKAN_SUPPORT 1
 #endif
 
 // =============================================================================

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -18,7 +18,7 @@ fi
 
 DOC_STRING="Build and launch CarlaUE4."
 
-USAGE_STRING="Usage: $0 [-h|--help] [--build] [--rebuild] [--launch] [--clean] [--hard-clean]"
+USAGE_STRING="Usage: $0 [-h|--help] [--build] [--rebuild] [--launch] [--clean] [--hard-clean] [--use-opengl]"
 
 REMOVE_INTERMEDIATE=false
 HARD_CLEAN=false
@@ -26,8 +26,9 @@ BUILD_CARLAUE4=false
 LAUNCH_UE4_EDITOR=false
 
 GDB=
+RHI="-vulkan"
 
-OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,use-opengl -n 'parse-options' -- "$@"`
 
 if [ $? != 0 ] ; then echo "$USAGE_STRING" ; exit 2 ; fi
 
@@ -54,6 +55,9 @@ while true; do
     --hard-clean )
       REMOVE_INTERMEDIATE=true;
       HARD_CLEAN=true;
+      shift ;;
+    --use-opengl )
+      RHI="-opengl";
       shift ;;
     -h | --help )
       echo "$DOC_STRING"
@@ -138,7 +142,7 @@ fi
 if ${LAUNCH_UE4_EDITOR} ; then
 
   log "Launching UE4Editor..."
-  ${GDB} ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${PWD}/CarlaUE4.uproject"
+  ${GDB} ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${PWD}/CarlaUE4.uproject" ${RHI}
 
 else
 

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -18,7 +18,7 @@ fi
 
 DOC_STRING="Build and launch CarlaUE4."
 
-USAGE_STRING="Usage: $0 [-h|--help] [--build] [--rebuild] [--launch] [--clean] [--hard-clean] [--use-opengl]"
+USAGE_STRING="Usage: $0 [-h|--help] [--build] [--rebuild] [--launch] [--clean] [--hard-clean] [--opengl]"
 
 REMOVE_INTERMEDIATE=false
 HARD_CLEAN=false
@@ -28,7 +28,7 @@ LAUNCH_UE4_EDITOR=false
 GDB=
 RHI="-vulkan"
 
-OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,use-opengl -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl -n 'parse-options' -- "$@"`
 
 if [ $? != 0 ] ; then echo "$USAGE_STRING" ; exit 2 ; fi
 
@@ -56,7 +56,7 @@ while true; do
       REMOVE_INTERMEDIATE=true;
       HARD_CLEAN=true;
       shift ;;
-    --use-opengl )
+    --opengl )
       RHI="-opengl";
       shift ;;
     -h | --help )


### PR DESCRIPTION
…unreal editor with vulkan or opengl


#### Description
Since Unreal 4.21, Unreal picks Vulkan instead of OpenGL as the default graphics API for Linux. If Vulkan is not installed on the user's system or the graphics driver or gpu does not support it, then Unreal will detect this automatically and use OpenGl 4.5 instead. Vulkan is a lower level graphics API and performs better than OpenGL. Users who enable it should see a significant increase in fps when running the simulator. 

To use Vulkan, install on your system along with latest graphics driver using the following tutorial:
https://linuxconfig.org/install-and-test-vulkan-on-linux
Currently 415 is the latest driver so replace 396 with 415.
vulkaninfo | less command can be used to check that vulkan is working on your system. You should be able to see details about your graphics card.

This PR updates the Unreal project settings to add Vulkan to the list of RHIs. Unreal should pick Vulkan instead of OpenGL by default once vulkan is installed on your system.


Note: This change only effects Linux. DirectX 11/12 is used on Windows and Unreal does not support Vulkan on Windows currently.


#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** irrelevant
  * **Unreal Engine version(s):** 4.22.1
  * **GPUs:** GTX 1080 and RTX 2070 

#### Possible Drawbacks

GPUs below NVidia 900 series may be better off using OpenGL. If this is the case, OpenGL can be enabled when launching the unreal editor with the CARLA make script by doing the following:
make launch ARGS=--use-opengl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1639)
<!-- Reviewable:end -->
