### PR TITLE
Fixed pixel per meter size and enabled more zoom out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   * Fixed wrong units in VehiclePhysicsControl's center of mass
   * Several optimizations to the RPC server, now supports a bigger load of async messages
   * Exposed 'is_invincible' for pedestrians
-  * Added sidewalks and improved lane markings in `no_rendering_mode.py`
+  * Fixed bug related with Pygame error of surface too large, added sidewalks and improved lane markings in `no_rendering_mode.py`
 
 ## CARLA 0.9.5
 

--- a/PythonAPI/examples/no_rendering_mode.py
+++ b/PythonAPI/examples/no_rendering_mode.py
@@ -449,6 +449,15 @@ class MapImage(object):
         self.width = max(max_x - min_x, max_y - min_y)
         self._world_offset = (min_x, min_y)
 
+        # Maximum size of a Pygame surface
+        width_in_pixels = (1 << 14) - 1
+
+        # Adapt Pixels per meter to make world fit in surface
+        surface_pixel_per_meter = int(width_in_pixels / self.width)
+        if surface_pixel_per_meter > PIXELS_PER_METER:
+          surface_pixel_per_meter = PIXELS_PER_METER
+
+        self._pixels_per_meter = surface_pixel_per_meter
         width_in_pixels = int(self._pixels_per_meter * self.width)
 
         self.big_map_surface = pygame.Surface((width_in_pixels, width_in_pixels)).convert()

--- a/PythonAPI/examples/no_rendering_mode.py
+++ b/PythonAPI/examples/no_rendering_mode.py
@@ -455,7 +455,7 @@ class MapImage(object):
         # Adapt Pixels per meter to make world fit in surface
         surface_pixel_per_meter = int(width_in_pixels / self.width)
         if surface_pixel_per_meter > PIXELS_PER_METER:
-          surface_pixel_per_meter = PIXELS_PER_METER
+            surface_pixel_per_meter = PIXELS_PER_METER
 
         self._pixels_per_meter = surface_pixel_per_meter
         width_in_pixels = int(self._pixels_per_meter * self.width)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
Fixes a bug related with a Pygame limitations. Pygame tends to throw an error when the surface size is too large, so now the towns are adapted to the maximum size of a Pygame surface. Also, more zoom out will be provided. 

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04LTS
  * **Python version(s):** 2.7.12 and 3.5.2
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1657)
<!-- Reviewable:end -->
