### PR TITLE
Include debug info in packaged version

### DIFF
--- a/Unreal/CarlaUE4/Config/DefaultGame.ini
+++ b/Unreal/CarlaUE4/Config/DefaultGame.ini
@@ -24,7 +24,7 @@ BuildConfiguration=PPBC_Development
 StagingDirectory=(Path="")
 FullRebuild=False
 ForDistribution=False
-IncludeDebugFiles=False
+IncludeDebugFiles=True
 BlueprintNativizationMethod=Disabled
 bIncludeNativizedAssetsInProjectGeneration=False
 UsePakFile=True

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -69,8 +69,7 @@ if $DO_PACKAGE ; then
       -project="${PWD}/CarlaUE4.uproject" \
       -nocompileeditor -nop4 -cook -stage -archive -package \
       -clientconfig=Development -ue4exe=UE4Editor \
-      -prereqs -nodebuginfo \
-      -targetplatform=Linux -build -utf8output \
+      -prereqs -targetplatform=Linux -build -utf8output \
       -archivedirectory="${BUILD_FOLDER}"
 
   popd >/dev/null


### PR DESCRIPTION
#### Description

Include debug information in the packaged build, this will help us a lot debugging as we get now a complete call stack.

Just to be sure, I have run the benchmark with and without debug symbols and there no noticeable loss.

[benchmark_debug.log](https://github.com/carla-simulator/carla/files/3198975/benchmark_debug.log)
[benchmark_no_debug.log](https://github.com/carla-simulator/carla/files/3198976/benchmark_no_debug.log)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1659)
<!-- Reviewable:end -->
