### PR TITLE
Bernatx/recorder bugfix2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Latest
-
   * Upgraded to Unreal Engine 4.22
   * Recorder fixes:
+    - Fixed a possible crash if an actor is respawned before the episode is ready when a new map is loaded automatically.
     - Actors at start of playback could interpolate positions from its current position instead than the recorded position, making some fast sliding effect during 1 frame.
     - Camera following in playback was not working if a new map was needed to load.
     - API function 'show_recorder_file_info' was showing the wrong parent id.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -201,9 +201,6 @@ void UCarlaEpisode::InitializeAtBeginPlay()
       ActorDispatcher->RegisterActor(*Actor, Description);
     }
   }
-
-  // check if replayer is waiting to autostart
-  Recorder->GetReplayer()->CheckPlayAfterMapLoaded();
 }
 
 void UCarlaEpisode::EndPlay(void)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -108,6 +108,10 @@ void ACarlaGameModeBase::BeginPlay()
 
   Episode->InitializeAtBeginPlay();
   GameInstance->NotifyBeginEpisode(*Episode);
+
+  /// @todo Recorder should not tick here, FCarlaEngine should do it.
+  // check if replayer is waiting to autostart
+  if (Recorder) Recorder->GetReplayer()->CheckPlayAfterMapLoaded();
 }
 
 void ACarlaGameModeBase::Tick(float DeltaSeconds)


### PR DESCRIPTION
#### Description

When using a recorded LOG file that needs to load a new map, actors were spawned before the Episode pointer was set and an assert was firing, ending the simulation. That problem has been fixed, just changing the order where the Episode pointer is set and then spawning the actors that the replayer needs to create.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.4
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

None
