### PR TITLE
Allow attaching actors with a spring arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Camera following in playback was not working if a new map was needed to load.
     - API function 'show_recorder_file_info' was showing the wrong parent id.
     - Script 'start_recording.py' now properly saves destruction of actors at stop.
+  * API extension: add attachment type "SpringArm" for cinematic cameras
   * API extension: waypoint's `junction_id` that returns de OpenDrive identifier of the current junction
   * API change: deprecated waypoint's `is_intersection`, now is `is_junction`
   * Removed deprecated code and content

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -37,7 +37,7 @@
 - `set_weather(weather_parameters)`
 - `get_actors(actor_ids=None) -> carla.ActorList`
 - `spawn_actor(blueprint, transform, attach_to=None)`
-- `try_spawn_actor(blueprint, transform, attach_to=None)`
+- `try_spawn_actor(blueprint, transform, attach_to=None, attachment_type=carla.AttachmentType.Rigid)`
 - `wait_for_tick(seconds=1.0)`
 - `on_tick(callback)`
 - `tick()`
@@ -468,6 +468,11 @@ Static presets
 - `Depth`
 - `LogarithmicDepth`
 - `CityScapesPalette`
+
+## `carla.AttachmentType`
+
+- `Rigid`
+- `SpringArm`
 
 ## `carla.ActorAttributeType`
 

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -60,16 +60,18 @@ namespace client {
   SharedPtr<Actor> World::SpawnActor(
       const ActorBlueprint &blueprint,
       const geom::Transform &transform,
-      Actor *parent_actor) {
-    return _episode.Lock()->SpawnActor(blueprint, transform, parent_actor);
+      Actor *parent_actor,
+      rpc::AttachmentType attachment_type) {
+    return _episode.Lock()->SpawnActor(blueprint, transform, parent_actor, attachment_type);
   }
 
   SharedPtr<Actor> World::TrySpawnActor(
       const ActorBlueprint &blueprint,
       const geom::Transform &transform,
-      Actor *parent_actor) noexcept {
+      Actor *parent_actor,
+      rpc::AttachmentType attachment_type) noexcept {
     try {
-      return SpawnActor(blueprint, transform, parent_actor);
+      return SpawnActor(blueprint, transform, parent_actor, attachment_type);
     } catch (const std::exception &e) {
       return nullptr;
     }

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -13,6 +13,7 @@
 #include "carla/client/detail/EpisodeProxy.h"
 #include "carla/geom/Transform.h"
 #include "carla/rpc/Actor.h"
+#include "carla/rpc/AttachmentType.h"
 #include "carla/rpc/EpisodeSettings.h"
 #include "carla/rpc/VehiclePhysicsControl.h"
 #include "carla/rpc/WeatherParameters.h"
@@ -75,14 +76,16 @@ namespace client {
     SharedPtr<Actor> SpawnActor(
         const ActorBlueprint &blueprint,
         const geom::Transform &transform,
-        Actor *parent = nullptr);
+        Actor *parent = nullptr,
+        rpc::AttachmentType attachment_type = rpc::AttachmentType::Rigid);
 
     /// Same as SpawnActor but return nullptr on failure instead of throwing an
     /// exception.
     SharedPtr<Actor> TrySpawnActor(
         const ActorBlueprint &blueprint,
         const geom::Transform &transform,
-        Actor *parent = nullptr) noexcept;
+        Actor *parent = nullptr,
+        rpc::AttachmentType attachment_type = rpc::AttachmentType::Rigid) noexcept;
 
     /// Block calling thread until a world tick is received.
     Timestamp WaitForTick(time_duration timeout) const;

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -188,11 +188,13 @@ namespace detail {
   rpc::Actor Client::SpawnActorWithParent(
       const rpc::ActorDescription &description,
       const geom::Transform &transform,
-      rpc::ActorId parent) {
+      rpc::ActorId parent,
+      rpc::AttachmentType attachment_type) {
     return _pimpl->CallAndWait<rpc::Actor>("spawn_actor_with_parent",
         description,
         transform,
-        parent);
+        parent,
+        attachment_type);
   }
 
   bool Client::DestroyActor(rpc::ActorId actor) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -12,6 +12,7 @@
 #include "carla/geom/Transform.h"
 #include "carla/rpc/Actor.h"
 #include "carla/rpc/ActorDefinition.h"
+#include "carla/rpc/AttachmentType.h"
 #include "carla/rpc/Command.h"
 #include "carla/rpc/CommandResponse.h"
 #include "carla/rpc/EpisodeInfo.h"
@@ -107,7 +108,8 @@ namespace detail {
     rpc::Actor SpawnActorWithParent(
         const rpc::ActorDescription &description,
         const geom::Transform &transform,
-        rpc::ActorId parent);
+        rpc::ActorId parent,
+        rpc::AttachmentType attachment_type);
 
     bool DestroyActor(rpc::ActorId actor);
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -130,13 +130,15 @@ namespace detail {
       const ActorBlueprint &blueprint,
       const geom::Transform &transform,
       Actor *parent,
+      rpc::AttachmentType attachment_type,
       GarbageCollectionPolicy gc) {
     rpc::Actor actor;
     if (parent != nullptr) {
       actor = _client.SpawnActorWithParent(
           blueprint.MakeActorDescription(),
           transform,
-          parent->GetId());
+          parent->GetId(),
+          attachment_type);
     } else {
       actor = _client.SpawnActor(
           blueprint.MakeActorDescription(),

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -189,6 +189,7 @@ namespace detail {
         const ActorBlueprint &blueprint,
         const geom::Transform &transform,
         Actor *parent = nullptr,
+        rpc::AttachmentType attachment_type = rpc::AttachmentType::Rigid,
         GarbageCollectionPolicy gc = GarbageCollectionPolicy::Inherit);
 
     bool DestroyActor(Actor &actor);

--- a/LibCarla/source/carla/rpc/AttachmentType.h
+++ b/LibCarla/source/carla/rpc/AttachmentType.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+
+#include <cstdint>
+
+namespace carla {
+namespace rpc {
+
+  enum class AttachmentType : uint8_t {
+    Rigid,
+    SpringArm,
+
+    SIZE,
+    INVALID
+  };
+
+} // namespace rpc
+} // namespace carla
+
+MSGPACK_ADD_ENUM(carla::rpc::AttachmentType);

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -105,15 +105,25 @@ void export_world() {
     .def(self_ns::str(self_ns::self))
   ;
 
+  enum_<cr::AttachmentType>("AttachmentType")
+    .value("Rigid", cr::AttachmentType::Rigid)
+    .value("SpringArm", cr::AttachmentType::SpringArm)
+  ;
+
 #define SPAWN_ACTOR_WITHOUT_GIL(fn) +[]( \
         cc::World &self, \
         const cc::ActorBlueprint &blueprint, \
         const cg::Transform &transform, \
-        cc::Actor *parent) { \
+        cc::Actor *parent, \
+        cr::AttachmentType attachment_type) { \
       carla::PythonUtil::ReleaseGIL unlock; \
-      return self.fn(blueprint, transform, parent); \
+      return self.fn(blueprint, transform, parent, attachment_type); \
     }, \
-    (arg("blueprint"), arg("transform"), arg("attach_to")=carla::SharedPtr<cc::Actor>())
+    ( \
+      arg("blueprint"), \
+      arg("transform"), \
+      arg("attach_to")=carla::SharedPtr<cc::Actor>(), \
+      arg("attachment_type")=cr::AttachmentType::Rigid)
 
   class_<cc::World>("World", no_init)
     .add_property("id", &cc::World::GetId)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -135,12 +135,12 @@ carla::rpc::Actor UCarlaEpisode::SerializeActor(FActorView ActorView) const
   return Actor;
 }
 
-void UCarlaEpisode::AttachActors(AActor *Child, AActor *Parent)
+void UCarlaEpisode::AttachActors(
+    AActor *Child,
+    AActor *Parent,
+    EAttachmentType InAttachmentType)
 {
-  check(Child != nullptr);
-  check(Parent != nullptr);
-  Child->AttachToActor(Parent, FAttachmentTransformRules::KeepRelativeTransform);
-  Child->SetOwner(Parent);
+  UActorAttacher::AttachActors(Child, Parent, InAttachmentType);
 
   // recorder event
   if (Recorder->IsEnabled())

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -11,6 +11,7 @@
 #include "Carla/Sensor/WorldObserver.h"
 #include "Carla/Server/CarlaServer.h"
 #include "Carla/Settings/EpisodeSettings.h"
+#include "Carla/Util/ActorAttacher.h"
 #include "Carla/Weather/Weather.h"
 
 #include "GameFramework/Pawn.h"
@@ -213,7 +214,10 @@ public:
   ///
   /// @pre Actors cannot be null.
   UFUNCTION(BlueprintCallable)
-  void AttachActors(AActor *Child, AActor *Parent);
+  void AttachActors(
+      AActor *Child,
+      AActor *Parent,
+      EAttachmentType InAttachmentType = EAttachmentType::Rigid);
 
   /// @copydoc FActorDispatcher::DestroyActor(AActor*)
   UFUNCTION(BlueprintCallable)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ActorAttacher.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ActorAttacher.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "Carla.h"
+#include "Carla/Util/ActorAttacher.h"
+
+#include "GameFramework/SpringArmComponent.h"
+
+static void UActorAttacher_AttachActorsWithSpringArm(
+    AActor *Child,
+    AActor *Parent)
+{
+  auto SpringArm = NewObject<USpringArmComponent>(Parent);
+
+  // Child location negated to compensate for the spring arm rotation (rotated
+  // from the "other end" of the arm).
+  const auto ChildLocation = -Child->GetActorLocation();
+  Child->SetActorLocation(FVector::ZeroVector);
+
+  // Adding Z-offset to avoid colliding against the ground on bumpy terrain.
+  SpringArm->TargetOffset = FVector(0.0f, 0.0f, 30.0f);
+  SpringArm->bDoCollisionTest = true;
+
+  FRotator LookAt = FRotationMatrix::MakeFromX(ChildLocation).Rotator();
+  SpringArm->SetRelativeRotation(LookAt);
+  SpringArm->SetupAttachment(Parent->GetRootComponent());
+
+  SpringArm->TargetArmLength = ChildLocation.Size();
+  SpringArm->bEnableCameraRotationLag = true;
+  SpringArm->CameraRotationLagSpeed = 8.0f;
+
+  SpringArm->bInheritPitch = false;
+  SpringArm->bInheritRoll = false;
+  SpringArm->bInheritYaw = true;
+
+  SpringArm->AttachToComponent(
+      Parent->GetRootComponent(),
+      FAttachmentTransformRules::KeepRelativeTransform);
+  SpringArm->RegisterComponent();
+
+  auto ChildComp = NewObject<UChildActorComponent>(Parent);
+  ChildComp->SetupAttachment(
+      SpringArm,
+      USpringArmComponent::SocketName);
+  Child->AttachToComponent(
+      ChildComp,
+      FAttachmentTransformRules::KeepRelativeTransform);
+  ChildComp->RegisterComponent();
+}
+
+void UActorAttacher::AttachActors(
+    AActor *Child,
+    AActor *Parent,
+    const EAttachmentType AttachmentType)
+{
+  check(Child != nullptr);
+  check(Parent != nullptr);
+
+  switch (AttachmentType)
+  {
+    case EAttachmentType::Rigid:
+      Child->AttachToActor(Parent, FAttachmentTransformRules::KeepRelativeTransform);
+      break;
+    case EAttachmentType::SpringArm:
+      UActorAttacher_AttachActorsWithSpringArm(Child, Parent);
+      break;
+    default:
+      UE_LOG(LogCarla, Fatal, TEXT("Invalid attachment type"));
+  }
+
+  Child->SetOwner(Parent);
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ActorAttacher.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ActorAttacher.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <compiler/disable-ue4-macros.h>
+#include <carla/rpc/AttachmentType.h>
+#include <compiler/enable-ue4-macros.h>
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+
+#include "ActorAttacher.generated.h"
+
+#define CARLA_ENUM_FROM_RPC(e) static_cast<uint8>(carla::rpc::AttachmentType:: e)
+
+UENUM(BlueprintType)
+enum class EAttachmentType : uint8
+{
+  Rigid      = CARLA_ENUM_FROM_RPC(Rigid)      UMETA(DisplayName = "Rigid"),
+  SpringArm  = CARLA_ENUM_FROM_RPC(SpringArm)  UMETA(DisplayName = "SpringArm"),
+
+  SIZE      UMETA(Hidden),
+  INVALID   UMETA(Hidden)
+};
+
+static_assert(
+    static_cast<uint8>(EAttachmentType::SIZE) == static_cast<uint8>(carla::rpc::AttachmentType::SIZE),
+    "Please keep these two enums in sync.");
+
+#undef CARLA_ENUM_FROM_RPC
+
+UCLASS()
+class CARLA_API UActorAttacher : public UBlueprintFunctionLibrary
+{
+  GENERATED_BODY()
+
+public:
+
+  UFUNCTION(BlueprintCallable, Category="CARLA|Actor Attacher")
+  static void AttachActors(AActor *Child, AActor *Parent, EAttachmentType AttachmentType);
+};


### PR DESCRIPTION
#### Description

Added a new attachment mode "Spring Arm" for a more cinematic feeling.

https://youtu.be/Iwfn58NJpTE

It can be specified when spawning an actor

```py
camera = world.spawn_actor(
        camera_blueprint, 
        transform, 
        attach_to=vehicle,
        attachment_type=carla.AttachmentType.SpringArm)
```

If not specified, `attachment_type` defaults to `carla.AttachmentType.Rigid`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1682)
<!-- Reviewable:end -->
