### PR TITLE
Expose waypoints API to UE4 Blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   * Corrected Latitude in WGS84 reprojection code such that Latitudes increase as one move north in Carla worlds
   * Register user props in fbx format, make them available in Carla Blueprint Library and spawnable.
   * Exposed 'is_invincible' for pedestrians
+  * Fixed XODR files can be found now anywhere in content
   * Fixed bug related with Pygame error of surface too large, added sidewalks and improved lane markings in `no_rendering_mode.py`
   * Physics:
     - Added Friction Trigger Boxes for simulating, for example, slippery surfaces in any region of the map defined by users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   * Corrected Latitude in WGS84 reprojection code such that Latitudes increase as one move north in Carla worlds
   * Register user props in fbx format, make them available in Carla Blueprint Library and spawnable.
   * Exposed 'is_invincible' for pedestrians
+  * Exposed waypoints and OpenDrive map to UE4 Blueprints
   * Fixed XODR files can be found now anywhere in content
   * Fixed bug related with Pygame error of surface too large, added sidewalks and improved lane markings in `no_rendering_mode.py`
   * Physics:

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -459,6 +459,7 @@ namespace road {
   }
 
   std::vector<Waypoint> Map::GenerateWaypoints(const double distance) const {
+    RELEASE_ASSERT(distance > 0.0);
     std::vector<Waypoint> result;
     for (const auto &pair : _data.GetRoads()) {
       const auto &road = pair.second;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/FBXImport/MapProcessCommandlet.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/FBXImport/MapProcessCommandlet.h
@@ -7,7 +7,7 @@
 #include <Misc/PackageName.h>
 #include "CoreMinimal.h"
 #include <Runtime/Engine/Classes/Engine/ObjectLibrary.h>
-#include <OpenDriveActor.h>
+#include "Carla/OpenDrive/OpenDriveActor.h"
 #if WITH_EDITORONLY_DATA
 #include <Developer/AssetTools/Public/IAssetTools.h>
 #include <Developer/AssetTools/Public/AssetToolsModule.h>

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaStatics.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaStatics.cpp
@@ -7,6 +7,8 @@
 #include "Carla.h"
 #include "Carla/Game/CarlaStatics.h"
 
+#include "Runtime/Core/Public/HAL/FileManagerGeneric.h"
+
 TArray<FString> UCarlaStatics::GetAllMapNames()
 {
   TArray<FString> TmpStrList, MapNameList;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
@@ -71,3 +71,23 @@ FString UOpenDrive::LoadXODR(const FString &MapName)
 
   return Content;
 }
+
+UOpenDriveMap *UOpenDrive::LoadOpenDriveMap(const FString &MapName)
+{
+  UOpenDriveMap *Map = nullptr;
+  auto XODRContent = LoadXODR(MapName);
+  if (!XODRContent.IsEmpty())
+  {
+    Map = NewObject<UOpenDriveMap>();
+    Map->Load(XODRContent);
+  }
+  return Map;
+}
+
+UOpenDriveMap *UOpenDrive::LoadCurrentOpenDriveMap(const UObject *WorldContextObject)
+{
+  UWorld *World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+  return World != nullptr ?
+      LoadOpenDriveMap(World->GetMapName()) :
+      nullptr;
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
@@ -1,11 +1,11 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "Carla.h"
-#include "Carla/Util/OpenDrive.h"
+#include "Carla/OpenDrive/OpenDrive.h"
 
 #include "Runtime/Core/Public/HAL/FileManagerGeneric.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "Carla/OpenDrive/OpenDriveMap.h"
+
 #include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "OpenDrive.generated.h"
@@ -17,10 +19,22 @@ class CARLA_API UOpenDrive : public UBlueprintFunctionLibrary
 
 public:
 
+  /// Find the path to the XODR file associated to MapName. Return empty if no
+  /// such file is found.
   static FString FindPathToXODRFile(const FString &MapName);
 
   /// Return the OpenDrive XML associated to @a MapName, or empty if the file
   /// is not found.
   UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
   static FString LoadXODR(const FString &MapName);
+
+  /// Load OpenDriveMap associated to the given MapName. Return nullptr if no
+  /// XODR can be found with same MapName.
+  UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
+  static UOpenDriveMap *LoadOpenDriveMap(const FString &MapName);
+
+  /// Load OpenDriveMap associated to the currently loaded map. Return nullptr
+  /// if no XODR can be found that matches the current map.
+  UFUNCTION(BlueprintPure, Category="CARLA|OpenDrive", meta=(WorldContext="WorldContextObject"))
+  static UOpenDriveMap *LoadCurrentOpenDriveMap(const UObject *WorldContextObject);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
@@ -1,13 +1,13 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "Carla.h"
-#include "Carla/OpenDriveActor.h"
+#include "Carla/OpenDrive/OpenDriveActor.h"
 
-#include "Carla/Util/OpenDrive.h"
+#include "Carla/OpenDrive/OpenDrive.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/geom/Math.h>

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "Carla.h"
+#include "Carla/OpenDrive/OpenDriveMap.h"
+
+#include <compiler/disable-ue4-macros.h>
+#include <carla/opendrive/OpenDriveParser.h>
+#include <carla/rpc/String.h>
+#include <compiler/enable-ue4-macros.h>
+
+namespace UOpenDriveMap_Private {
+
+  template <typename RangeT>
+  static auto GetSize(const RangeT &Range)
+  {
+    return Range.size();
+  }
+
+  template <typename T>
+  static auto GetSize(const TArray<T> &Array)
+  {
+    return Array.Num();
+  }
+
+
+  template <typename T, typename RangeT, typename FuncT>
+  static TArray<T> TransformToTArray(RangeT &&Range, FuncT &&TransformFunction)
+  {
+    TArray<T> Result;
+    Result.Reserve(GetSize(Range));
+    for (auto &&Item : Range)
+    {
+      Result.Emplace(TransformFunction(Item));
+    }
+    return Result;
+  }
+
+  template <typename T, typename RangeT>
+  static TArray<T> TransformToTArray(RangeT &&Range)
+  {
+    return TransformToTArray<T>(
+        std::forward<RangeT>(Range),
+        [](auto &&Item) { return T{Item}; });
+  }
+
+} // namespace UOpenDriveMap_Private
+
+UOpenDriveMap::UOpenDriveMap(const FObjectInitializer &ObjectInitializer)
+  : Super(ObjectInitializer) {}
+
+bool UOpenDriveMap::Load(const FString &XODRContent)
+{
+  auto ResultMap = carla::opendrive::OpenDriveParser::Load(
+      carla::rpc::FromFString(XODRContent));
+  if (ResultMap)
+  {
+    Map = std::move(*ResultMap);
+  }
+  return HasMap();
+}
+
+FWaypoint UOpenDriveMap::GetClosestWaypointOnRoad(FVector Location, bool &Success) const
+{
+  check(HasMap());
+  auto Result = Map->GetClosestWaypointOnRoad(Location);
+  Success = Result.has_value();
+  return Result.has_value() ? FWaypoint{*Result} : FWaypoint{};
+}
+
+TArray<FWaypoint> UOpenDriveMap::GenerateWaypoints(float ApproxDistance) const
+{
+  check(HasMap());
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FWaypoint>(Map->GenerateWaypoints(1e2f * ApproxDistance));
+}
+
+TArray<FWaypointConnection> UOpenDriveMap::GenerateTopology() const
+{
+  check(HasMap());
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FWaypointConnection>(Map->GenerateTopology(), [](auto &&Item) {
+    return FWaypointConnection{FWaypoint{Item.first}, FWaypoint{Item.second}};
+  });
+}
+
+TArray<FWaypoint> UOpenDriveMap::GenerateWaypointsOnRoadEntries() const
+{
+  check(HasMap());
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FWaypoint>(Map->GenerateWaypointsOnRoadEntries());
+}
+
+FVector UOpenDriveMap::ComputeLocation(FWaypoint Waypoint) const
+{
+  return ComputeTransform(Waypoint).GetLocation();
+}
+
+TArray<FVector> UOpenDriveMap::ComputeLocations(const TArray<FWaypoint> &Waypoints) const
+{
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FVector>(Waypoints, [this](auto &&Waypoint) {
+    return ComputeLocation(Waypoint);
+  });
+}
+
+FTransform UOpenDriveMap::ComputeTransform(FWaypoint Waypoint) const
+{
+  check(HasMap());
+  using namespace UOpenDriveMap_Private;
+  return Map->ComputeTransform(Waypoint.Waypoint);
+}
+
+TArray<FTransform> UOpenDriveMap::ComputeTransforms(const TArray<FWaypoint> &Waypoints) const
+{
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FTransform>(Waypoints, [this](auto &&Waypoint) {
+    return ComputeTransform(Waypoint);
+  });
+}
+
+TArray<FWaypoint> UOpenDriveMap::GetNext(FWaypoint Waypoint, float Distance) const
+{
+  check(HasMap());
+  using namespace UOpenDriveMap_Private;
+  return TransformToTArray<FWaypoint>(Map->GetNext(Waypoint.Waypoint, 1e2f * Distance));
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.cpp
@@ -73,6 +73,11 @@ FWaypoint UOpenDriveMap::GetClosestWaypointOnRoad(FVector Location, bool &Succes
 
 TArray<FWaypoint> UOpenDriveMap::GenerateWaypoints(float ApproxDistance) const
 {
+  if (ApproxDistance < 1.0f)
+  {
+    UE_LOG(LogCarla, Error, TEXT("GenerateWaypoints: Please provide an ApproxDistance greater than 1 centimetre."));
+    return {};
+  }
   check(HasMap());
   using namespace UOpenDriveMap_Private;
   return TransformToTArray<FWaypoint>(Map->GenerateWaypoints(1e2f * ApproxDistance));
@@ -124,6 +129,11 @@ TArray<FTransform> UOpenDriveMap::ComputeTransforms(const TArray<FWaypoint> &Way
 
 TArray<FWaypoint> UOpenDriveMap::GetNext(FWaypoint Waypoint, float Distance) const
 {
+  if (Distance < 1.0f)
+  {
+    UE_LOG(LogCarla, Error, TEXT("GetNext: Please provide a Distance greater than 1 centimetre."));
+    return {};
+  }
   check(HasMap());
   using namespace UOpenDriveMap_Private;
   return TransformToTArray<FWaypoint>(Map->GetNext(Waypoint.Waypoint, 1e2f * Distance));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <compiler/disable-ue4-macros.h>
+#include <carla/road/Map.h>
+#include <compiler/enable-ue4-macros.h>
+
+#include "OpenDriveMap.generated.h"
+
+USTRUCT(BlueprintType)
+struct CARLA_API FWaypoint
+{
+  GENERATED_BODY()
+
+  carla::road::element::Waypoint Waypoint;
+};
+
+USTRUCT(BlueprintType)
+struct CARLA_API FWaypointConnection
+{
+  GENERATED_BODY()
+
+  UPROPERTY(BlueprintReadWrite)
+  FWaypoint Start;
+
+  UPROPERTY(BlueprintReadWrite)
+  FWaypoint End;
+};
+
+/// Helper class for exposing CARLA OpenDrive API to blueprints.
+UCLASS(BlueprintType, Blueprintable)
+class CARLA_API UOpenDriveMap : public UObject
+{
+  GENERATED_BODY()
+
+public:
+
+  UOpenDriveMap(const FObjectInitializer &ObjectInitializer);
+
+  /// Return whether this map has been initialized.
+  UFUNCTION(BlueprintCallable)
+  bool HasMap() const
+  {
+    return Map.IsSet();
+  }
+
+  /// Load this map with an OpenDrive (XODR) file.
+  UFUNCTION(BlueprintCallable)
+  bool Load(const FString &XODRContent);
+
+  /// Given a location, return the closest point on the centre of a lane.
+  UFUNCTION(BlueprintCallable)
+  FWaypoint GetClosestWaypointOnRoad(FVector Location, bool &Success) const;
+
+  /// Generate waypoints all over the map at an approximated distance.
+  UFUNCTION(BlueprintCallable)
+  TArray<FWaypoint> GenerateWaypoints(float ApproxDistance) const;
+
+  /// Generate the minimum set of waypoints that define the topology of this
+  /// map. The waypoints are placed at the entrance of each lane.
+  UFUNCTION(BlueprintCallable)
+  TArray<FWaypointConnection> GenerateTopology() const;
+
+  /// Generate waypoints on each lane at the start of each road.
+  UFUNCTION(BlueprintCallable)
+  TArray<FWaypoint> GenerateWaypointsOnRoadEntries() const;
+
+  /// Compute the location of a waypoint.
+  UFUNCTION(BlueprintCallable)
+  FVector ComputeLocation(FWaypoint Waypoint) const;
+
+  /// Compute the locations of an array of waypoints.
+  UFUNCTION(BlueprintCallable)
+  TArray<FVector> ComputeLocations(const TArray<FWaypoint> &Waypoints) const;
+
+  /// Compute the transform of a waypoint. The X-axis is directed towards the
+  /// direction of the road at that waypoint.
+  UFUNCTION(BlueprintCallable)
+  FTransform ComputeTransform(FWaypoint Waypoint) const;
+
+  /// Compute the transforms of an array of waypoints.
+  UFUNCTION(BlueprintCallable)
+  TArray<FTransform> ComputeTransforms(const TArray<FWaypoint> &Waypoints) const;
+
+  /// Return the list of waypoints at a given distance such that a vehicle at
+  /// waypoint could drive to.
+  UFUNCTION(BlueprintCallable)
+  TArray<FWaypoint> GetNext(FWaypoint Waypoint, float Distance) const;
+
+private:
+
+  TOptional<carla::road::Map> Map;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveMap.h
@@ -59,7 +59,7 @@ public:
 
   /// Generate waypoints all over the map at an approximated distance.
   UFUNCTION(BlueprintCallable)
-  TArray<FWaypoint> GenerateWaypoints(float ApproxDistance) const;
+  TArray<FWaypoint> GenerateWaypoints(float ApproxDistance = 100.0f) const;
 
   /// Generate the minimum set of waypoints that define the topology of this
   /// map. The waypoints are placed at the entrance of each lane.
@@ -90,7 +90,7 @@ public:
   /// Return the list of waypoints at a given distance such that a vehicle at
   /// waypoint could drive to.
   UFUNCTION(BlueprintCallable)
-  TArray<FWaypoint> GetNext(FWaypoint Waypoint, float Distance) const;
+  TArray<FWaypoint> GetNext(FWaypoint Waypoint, float Distance = 100.0f) const;
 
 private:
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDriveActor.cpp
@@ -136,7 +136,7 @@ void AOpenDriveActor::BuildRoutes(FString MapName)
 
   // As the OpenDrive file has the same name as level, build the path to the
   // xodr file using the lavel name and the game content directory.
-  const FString XodrContent = FOpenDrive::Load(MapName);
+  const FString XodrContent = UOpenDrive::LoadXODR(MapName);
 
   auto map = carla::opendrive::OpenDriveParser::Load(carla::rpc::FromFString(XodrContent));
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -195,7 +195,7 @@ void FCarlaServer::FPimpl::BindActions()
   BIND_SYNC(get_map_info) << [this]() -> R<cr::MapInfo>
   {
     REQUIRE_CARLA_EPISODE();
-    auto FileContents = FOpenDrive::Load(Episode->GetMapName());
+    auto FileContents = UOpenDrive::LoadXODR(Episode->GetMapName());
     const auto &SpawnPoints = Episode->GetRecommendedSpawnPoints();
     return cr::MapInfo{
       cr::FromFString(Episode->GetMapName()),

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -7,8 +7,8 @@
 #include "Carla.h"
 #include "Carla/Server/CarlaServer.h"
 
+#include "Carla/OpenDrive/OpenDrive.h"
 #include "Carla/Util/DebugShapeDrawer.h"
-#include "Carla/Util/OpenDrive.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 #include "Carla/Walker/WalkerController.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.cpp
@@ -9,7 +9,7 @@
 
 #include "Runtime/Core/Public/HAL/FileManagerGeneric.h"
 
-static FString FOpenDrive_FindPathToXODRFile(const FString &InMapName)
+FString UOpenDrive::FindPathToXODRFile(const FString &InMapName)
 {
   FString MapName = InMapName;
 #if WITH_EDITOR
@@ -50,9 +50,9 @@ static FString FOpenDrive_FindPathToXODRFile(const FString &InMapName)
   return FilesFound.Num() > 0 ? FilesFound[0u] : FString{};
 }
 
-FString FOpenDrive::Load(const FString &MapName)
+FString UOpenDrive::LoadXODR(const FString &MapName)
 {
-  const auto FilePath = FOpenDrive_FindPathToXODRFile(MapName);
+  const auto FilePath = FindPathToXODRFile(MapName);
 
   FString Content;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.h
@@ -10,7 +10,7 @@ class FOpenDrive
 {
 public:
 
-  /// Return the OpenDrive XML associated to @a MapName, or empty if the such
-  /// file wasn't serialized.
-  static FString Load(FString MapName);
+  /// Return the OpenDrive XML associated to @a MapName, or empty if the file
+  /// is not found.
+  static FString Load(const FString &MapName);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/OpenDrive.h
@@ -6,11 +6,21 @@
 
 #pragma once
 
-class FOpenDrive
+#include "Kismet/BlueprintFunctionLibrary.h"
+
+#include "OpenDrive.generated.h"
+
+UCLASS()
+class CARLA_API UOpenDrive : public UBlueprintFunctionLibrary
 {
+  GENERATED_BODY()
+
 public:
+
+  static FString FindPathToXODRFile(const FString &MapName);
 
   /// Return the OpenDrive XML associated to @a MapName, or empty if the file
   /// is not found.
-  static FString Load(const FString &MapName);
+  UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
+  static FString LoadXODR(const FString &MapName);
 };


### PR DESCRIPTION
#### Description

Created a new class "OpenDriveMap" accessible from blueprints that allows generating and operating on waypoints, similar to LibCarla's `road::Map`.

Also fixes that OpenDrive files were only loaded if the file was stored at a specific folder, now first searches in this default location, if not found then searches anywhere in contents.

![image](https://user-images.githubusercontent.com/4332953/58431445-11095580-80ae-11e9-9efe-6441e5d75173.png)

![image](https://user-images.githubusercontent.com/4332953/58431449-1797cd00-80ae-11e9-96e1-a9764b01398f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1684)
<!-- Reviewable:end -->
