### PR TITLE
Add gamma value as attribute to RGB camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Script 'start_recording.py' now properly saves destruction of actors at stop.
   * API extension: add attachment type "SpringArm" for cinematic cameras
   * API extension: waypoint's `junction_id` that returns de OpenDrive identifier of the current junction
+  * API extension: add gamma value as attribute to RGB camera
   * API change: deprecated waypoint's `is_intersection`, now is `is_junction`
   * Removed deprecated code and content
   * New recorder features:

--- a/Docs/cameras_and_sensors.md
+++ b/Docs/cameras_and_sensors.md
@@ -60,11 +60,12 @@ The "RGB" camera acts as a regular camera capturing images from the scene.
 
 | Blueprint attribute | Type  | Default | Description |
 | ------------------- | ----  | ------- | ----------- |
+| `sensor_tick`       | float | 0.0     | Seconds between sensor captures (ticks) |
 | `image_size_x`      | int   | 800     | Image width in pixels |
 | `image_size_y`      | int   | 600     | Image height in pixels  |
 | `fov`               | float | 90.0    | Horizontal field of view in degrees |
 | `enable_postprocess_effects` | bool | True | Whether the post-process effect in the scene affect the image |
-| `sensor_tick`       | float | 0.0     | Seconds between sensor captures (ticks) |
+| `gamma`             | float | 2.2     | Target gamma value of the camera |
 | `motion_blur_intensity`       | float | 0.45 | Strength of motion blur. 1 is max and 0 is off |
 | `motion_blur_max_distortion`  | float | 0.35 | Max distortion caused by motion blur, in percent of the screen width, 0 is off |
 | `motion_blur_min_object_screen_size`  | float | 0.1 | Percentage of screen width objects must have for motion blur, lower value means less draw calls

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -320,6 +320,12 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     PostProccess.RecommendedValues = { TEXT("true") };
     PostProccess.bRestrictToRecommended = false;
 
+    FActorVariation Gamma;
+    Gamma.Id = TEXT("gamma");
+    Gamma.Type = EActorAttributeType::Float;
+    Gamma.RecommendedValues = { TEXT("2.2") };
+    Gamma.bRestrictToRecommended = false;
+
     // Motion Blur
     FActorVariation MBIntesity;
     MBIntesity.Id = TEXT("motion_blur_intensity");
@@ -339,7 +345,8 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     MBMinObjectScreenSize.RecommendedValues = { TEXT("0.1") };
     MBMinObjectScreenSize.bRestrictToRecommended = false;
 
-    Definition.Variations.Append({PostProccess, MBIntesity, MBMaxDistortion, MBMinObjectScreenSize});
+    Definition.Variations.Append(
+        {PostProccess, Gamma, MBIntesity, MBMaxDistortion, MBMinObjectScreenSize});
   }
 
   Success = CheckActorDefinition(Definition);
@@ -781,6 +788,8 @@ void UActorBlueprintFunctionLibrary::SetCamera(
         ActorAttributeToBool(
         Description.Variations["enable_postprocess_effects"],
         true));
+    Camera->SetTargetGamma(
+        RetrieveActorAttributeToFloat("gamma", Description.Variations, 2.2f));
     Camera->SetMotionBlurIntensity(
         RetrieveActorAttributeToFloat("motion_blur_intensity", Description.Variations, 0.5f));
     Camera->SetMotionBlurMaxDistortion(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -179,7 +179,7 @@ void ASceneCaptureSensor::BeginPlay()
 
   if (bEnablePostProcessingEffects)
   {
-    CaptureRenderTarget->TargetGamma = 2.2f;
+    CaptureRenderTarget->TargetGamma = TargetGamma;
   }
 
   check(IsValid(CaptureComponent2D) && !CaptureComponent2D->IsPendingKill());

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -68,6 +68,18 @@ public:
   float GetFOVAngle() const;
 
   UFUNCTION(BlueprintCallable)
+  void SetTargetGamma(float InTargetGamma)
+  {
+    TargetGamma = InTargetGamma;
+  }
+
+  UFUNCTION(BlueprintCallable)
+  float GetTargetGamma() const
+  {
+    return TargetGamma;
+  }
+
+  UFUNCTION(BlueprintCallable)
   void SetMotionBlurIntensity(float Intensity);
 
   UFUNCTION(BlueprintCallable)
@@ -128,6 +140,9 @@ private:
   /// Whether to render the post-processing effects present in the scene.
   UPROPERTY(EditAnywhere)
   bool bEnablePostProcessingEffects = true;
+
+  UPROPERTY(EditAnywhere)
+  float TargetGamma = 2.2f;
 
   /// Render target necessary for scene capture.
   UPROPERTY(EditAnywhere)


### PR DESCRIPTION
#### Description

Add new attribute to RGB camera blueprint: "gamma". It controls the target gamma of the render target of the camera. Defaults to 2.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1720)
<!-- Reviewable:end -->
