### PR TITLE
Enabling texture streaming and adding support for texture streaming t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Latest
 
+  * Enabled texture streaming for scene captures
+    - Enabled texture streaming in the Unreal project settings
+    - Changed the scene capture to register its camera with Unreal's texture streamer every tick to enable texture streaming
   * Bugfix about recorder query system
   * Fixed problem when vehicles enable autopilot after a replayer, now it works better.
   * Vulkan support: Changed project settings to make vulkan default on linux and updated make script to allow user to select opengl
-  * Updated scene capture sensor to add it's camera as a view to unreal's texture streamer each tick to enable texture streaming
   * Add ability to set motion blur settings for rgb camera in sensor python blueprint
   * Improved visual quality of the screen capture for the rgb sensor
     - Enabled Temporal AA for screen captures with no post-processing to prevent jaggies during motion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Bugfix about recorder query system
   * Fixed problem when vehicles enable autopilot after a replayer, now it works better.
   * Vulkan support: Changed project settings to make vulkan default on linux and updated make script to allow user to select opengl
+  * Updated scene capture sensor to add it's camera as a view to unreal's texture streamer each tick to enable texture streaming
   * Add ability to set motion blur settings for rgb camera in sensor python blueprint
   * Improved visual quality of the screen capture for the rgb sensor
     - Enabled Temporal AA for screen captures with no post-processing to prevent jaggies during motion

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -87,3 +87,13 @@ PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
 
 
+[/Script/LinuxTargetPlatform.LinuxTargetSettings]
+SpatializationPlugin=
+ReverbPlugin=
+OcclusionPlugin=
+-TargetedRHIs=SF_VULKAN_SM5
+-TargetedRHIs=GLSL_430
++TargetedRHIs=SF_VULKAN_SM5
++TargetedRHIs=GLSL_430
+
+

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -2,7 +2,6 @@
 bSmoothFrameRate=false
 SmoothedFrameRateRange=(LowerBound=(Type="ERangeBoundTypes::Inclusive",Value=22),UpperBound=(Type="ERangeBoundTypes::Exclusive",Value=120))
 
-
 [/Script/HardwareTargeting.HardwareTargetingSettings]
 TargetedHardwareClass=Desktop
 AppliedTargetedHardwareClass=Desktop
@@ -85,7 +84,6 @@ SyncSceneSmoothingFactor=0.000000
 InitialAverageFrameRate=0.016667
 PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
-
 
 [/Script/LinuxTargetPlatform.LinuxTargetSettings]
 SpatializationPlugin=

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -28,7 +28,7 @@ r.DefaultFeature.AmbientOcclusionStaticFraction=False
 r.DefaultFeature.AutoExposure=False
 r.CustomDepth=3
 r.Streaming.PoolSize=2000
-r.TextureStreaming=False
+r.TextureStreaming=True
 r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.EightBit=False
 r.DistanceFieldBuild.Compress=False
@@ -85,14 +85,5 @@ SyncSceneSmoothingFactor=0.000000
 InitialAverageFrameRate=0.016667
 PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
-
-[/Script/LinuxTargetPlatform.LinuxTargetSettings]
-SpatializationPlugin=
-ReverbPlugin=
-OcclusionPlugin=
--TargetedRHIs=SF_VULKAN_SM5
--TargetedRHIs=GLSL_430
-+TargetedRHIs=SF_VULKAN_SM5
-+TargetedRHIs=GLSL_430
 
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -179,7 +179,7 @@ void ASceneCaptureSensor::Tick(float DeltaTime)
 {
   Super::Tick(DeltaTime);
   // Add the view information every tick. Its only used for one tick and then removed by the streamer.
-  IStreamingManager::Get().AddViewInformation( DrawFrustum->GetComponentLocation(), ImageWidth, ImageWidth / FMath::Tan( CaptureComponent2D->FOVAngle ) );
+  IStreamingManager::Get().AddViewInformation( CaptureComponent2D->GetComponentLocation(), ImageWidth, ImageWidth / FMath::Tan( CaptureComponent2D->FOVAngle ) );
 }
 
 void ASceneCaptureSensor::EndPlay(const EEndPlayReason::Type EndPlayReason)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -14,6 +14,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "Engine/TextureRenderTarget2D.h"
 #include "HighResScreenshot.h"
+#include "ContentStreaming.h"
 
 static auto SCENE_CAPTURE_COUNTER = 0u;
 
@@ -172,6 +173,13 @@ void ASceneCaptureSensor::BeginPlay()
       bEnablePostProcessingEffects);
 
   Super::BeginPlay();
+}
+
+void ASceneCaptureSensor::Tick(float DeltaTime)
+{
+  Super::Tick(DeltaTime);
+  // Add the view information every tick. Its only used for one tick and then removed by the streamer.
+  IStreamingManager::Get().AddViewInformation( DrawFrustum->GetComponentLocation(), ImageWidth, ImageWidth / FMath::Tan( CaptureComponent2D->FOVAngle ) );
 }
 
 void ASceneCaptureSensor::EndPlay(const EEndPlayReason::Type EndPlayReason)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -117,6 +117,8 @@ protected:
 
   virtual void BeginPlay() override;
 
+  virtual void Tick(float DeltaTime) override;
+
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
   virtual void SetUpSceneCaptureComponent(USceneCaptureComponent2D &SceneCapture) {}


### PR DESCRIPTION
…o scene captures

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Scene captures now have support for texture streaming. Their view information is now registered with Unreal's streamer each tick. This also takes the texture size and FOV into account. I turned texture streaming on in project settings. Our texture pool is 2000mb. This can be increased but should be fine. 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 3.5
  * **Unreal Engine version(s):** Unreal 4.22.2

#### Possible Drawbacks
With texture streaming back on, there might be side effects. Reviewers should test the hell out of it.

To test texture streaming on scene capture, its best to reduce the texture pool size to 20mb and compare textures between scene capture camera when the main camera is very far below the map (ensures higher mips not loaded for it) and the main camera. Texture pool size can be set by following Unreal console command:
 r.Streaming.PoolSize=1500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1721)
<!-- Reviewable:end -->
