### PR TITLE
Vehicle controller fixes

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
@@ -94,7 +94,7 @@ AWheeledVehicleAIController::AWheeledVehicleAIController(const FObjectInitialize
 AWheeledVehicleAIController::~AWheeledVehicleAIController() {}
 
 // =============================================================================
-// -- APlayerController --------------------------------------------------------
+// -- AController --------------------------------------------------------------
 // =============================================================================
 
 void AWheeledVehicleAIController::OnPossess(APawn *aPawn)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.cpp
@@ -135,11 +135,9 @@ void AWheeledVehicleAIController::Tick(const float DeltaTime)
     return;
   }
 
-  TickAutopilotController();
-
   if (bAutopilotEnabled)
   {
-    Vehicle->ApplyVehicleControl(AutopilotControl, EVehicleInputPriority::Autopilot);
+    Vehicle->ApplyVehicleControl(TickAutopilotController(), EVehicleInputPriority::Autopilot);
   }
   else if (!bControlIsSticky)
   {
@@ -215,13 +213,13 @@ void AWheeledVehicleAIController::SetFixedRoute(
 // -- AI -----------------------------------------------------------------------
 // =============================================================================
 
-void AWheeledVehicleAIController::TickAutopilotController()
+FVehicleControl AWheeledVehicleAIController::TickAutopilotController()
 {
 #if WITH_EDITOR // This happens in simulation mode in editor.
   if (Vehicle == nullptr)
   {
     bAutopilotEnabled = false;
-    return;
+    return {};
   }
 #endif // WITH_EDITOR
 
@@ -259,6 +257,8 @@ void AWheeledVehicleAIController::TickAutopilotController()
     Throttle = Move(Speed);
   }
 
+  FVehicleControl AutopilotControl;
+
   if (Throttle < 0.001f)
   {
     AutopilotControl.Brake = 1.0f;
@@ -270,6 +270,8 @@ void AWheeledVehicleAIController::TickAutopilotController()
     AutopilotControl.Throttle = Throttle;
   }
   AutopilotControl.Steer = Steering;
+
+  return AutopilotControl;
 }
 
 float AWheeledVehicleAIController::GoToNextTargetLocation(FVector &Direction)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.h
@@ -8,7 +8,7 @@
 
 #include <queue>
 
-#include "GameFramework/PlayerController.h"
+#include "GameFramework/Controller.h"
 
 #include "Traffic/TrafficLightState.h"
 #include "Vehicle/VehicleControl.h"
@@ -21,7 +21,7 @@ class URoadMap;
 
 /// Wheeled vehicle controller with optional AI.
 UCLASS()
-class CARLA_API AWheeledVehicleAIController : public APlayerController
+class CARLA_API AWheeledVehicleAIController final : public AController
 {
   GENERATED_BODY()
 
@@ -38,7 +38,7 @@ public:
 
   /// @}
   // ===========================================================================
-  /// @name APlayerController overrides
+  /// @name Controller overrides
   // ===========================================================================
   /// @{
 
@@ -73,12 +73,6 @@ public:
   const ACarlaWheeledVehicle *GetPossessedVehicle() const
   {
     return Vehicle;
-  }
-
-  UFUNCTION(Category = "Wheeled Vehicle Controller", BlueprintCallable)
-  virtual bool IsPossessingThePlayer() const
-  {
-    return false;
   }
 
   /// @}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/WheeledVehicleAIController.h
@@ -210,20 +210,10 @@ public:
   void SetFixedRoute(const TArray<FVector> &Locations, bool bOverwriteCurrent = true);
 
   /// @}
-  // ===========================================================================
-  /// @name AI
-  // ===========================================================================
-  /// @{
-
-  UFUNCTION(Category = "Wheeled Vehicle Controller", BlueprintCallable)
-  const FVehicleControl &GetAutopilotControl() const
-  {
-    return AutopilotControl;
-  }
 
 private:
 
-  void TickAutopilotController();
+  FVehicleControl TickAutopilotController();
 
   /// Returns steering value.
   float GoToNextTargetLocation(FVector &Direction);
@@ -271,8 +261,6 @@ private:
 
   UPROPERTY()
   ATrafficLightBase *TrafficLight;
-
-  FVehicleControl AutopilotControl;
 
   std::queue<FVector> TargetLocations;
 };


### PR DESCRIPTION
*  `AWheeledVehicleAIController` derive from `AController` instead of `APlayerController` to avoid having player overhead.
* Tick autopilot only if autopilot is enabled. We've been carrying this since 0.8.x version where it was always required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1726)
<!-- Reviewable:end -->
