### PR TITLE
Set up RootComponent in ASensor

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/GnssSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/GnssSensor.cpp
@@ -5,7 +5,6 @@
 
 #include "Carla.h"
 #include "Carla/Sensor/GnssSensor.h"
-#include "StaticMeshResources.h"
 
 FActorDefinition AGnssSensor::GetSensorDefinition()
 {
@@ -16,11 +15,4 @@ AGnssSensor::AGnssSensor(const FObjectInitializer &ObjectInitializer)
   : Super(ObjectInitializer)
 {
   PrimaryActorTick.bCanEverTick = false;
-
-  auto MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("RootComponent"));
-  MeshComp->SetCollisionProfileName(UCollisionProfile::NoCollision_ProfileName);
-  MeshComp->bHiddenInGame = true;
-  MeshComp->CastShadow = false;
-  MeshComp->PostPhysicsComponentTick.bCanEverTick = false;
-  RootComponent = MeshComp;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/GnssSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/GnssSensor.h
@@ -23,5 +23,4 @@ public:
   static FActorDefinition GetSensorDefinition();
 
   AGnssSensor(const FObjectInitializer &ObjectInitializer);
-
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LaneInvasionSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LaneInvasionSensor.cpp
@@ -5,7 +5,6 @@
 
 #include "Carla.h"
 #include "Carla/Sensor/LaneInvasionSensor.h"
-#include "StaticMeshResources.h"
 
 FActorDefinition ALaneInvasionSensor::GetSensorDefinition()
 {
@@ -16,11 +15,4 @@ ALaneInvasionSensor::ALaneInvasionSensor(const FObjectInitializer &ObjectInitial
   : Super(ObjectInitializer)
 {
   PrimaryActorTick.bCanEverTick = false;
-
-  auto MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("RootComponent"));
-  MeshComp->SetCollisionProfileName(UCollisionProfile::NoCollision_ProfileName);
-  MeshComp->bHiddenInGame = true;
-  MeshComp->CastShadow = false;
-  MeshComp->PostPhysicsComponentTick.bCanEverTick = false;
-  RootComponent = MeshComp;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LaneInvasionSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LaneInvasionSensor.h
@@ -23,5 +23,4 @@ public:
   static FActorDefinition GetSensorDefinition();
 
   ALaneInvasionSensor(const FObjectInitializer &ObjectInitializer);
-
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ObstacleDetectionSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ObstacleDetectionSensor.cpp
@@ -17,13 +17,6 @@ AObstacleDetectionSensor::AObstacleDetectionSensor(const FObjectInitializer &Obj
   : Super(ObjectInitializer)
 {
   PrimaryActorTick.bCanEverTick = true;
-
-  auto MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("RootComponent"));
-  MeshComp->SetCollisionProfileName(UCollisionProfile::NoCollision_ProfileName);
-  MeshComp->bHiddenInGame = true;
-  MeshComp->CastShadow = false;
-  MeshComp->PostPhysicsComponentTick.bCanEverTick = false;
-  RootComponent = MeshComp;
 }
 
 FActorDefinition AObstacleDetectionSensor::GetSensorDefinition()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ObstacleDetectionSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ObstacleDetectionSensor.h
@@ -47,5 +47,4 @@ private:
   bool bOnlyDynamics = false;
 
   bool bDebugLineTrace = false;
-
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastLidar.cpp
@@ -12,7 +12,6 @@
 #include "DrawDebugHelpers.h"
 #include "Engine/CollisionProfile.h"
 #include "Runtime/Engine/Classes/Kismet/KismetMathLibrary.h"
-#include "StaticMeshResources.h"
 
 FActorDefinition ARayCastLidar::GetSensorDefinition()
 {
@@ -23,13 +22,6 @@ ARayCastLidar::ARayCastLidar(const FObjectInitializer& ObjectInitializer)
   : Super(ObjectInitializer)
 {
   PrimaryActorTick.bCanEverTick = true;
-
-  auto MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("RootComponent"));
-  MeshComp->SetCollisionProfileName(UCollisionProfile::NoCollision_ProfileName);
-  MeshComp->bHiddenInGame = true;
-  MeshComp->CastShadow = false;
-  MeshComp->PostPhysicsComponentTick.bCanEverTick = false;
-  RootComponent = MeshComp;
 }
 
 void ARayCastLidar::Set(const FActorDescription &ActorDescription)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -115,8 +115,6 @@ public:
 
 protected:
 
-  virtual void PostActorCreated() override;
-
   virtual void BeginPlay() override;
 
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
@@ -124,10 +122,6 @@ protected:
   virtual void SetUpSceneCaptureComponent(USceneCaptureComponent2D &SceneCapture) {}
 
 private:
-
-  /// Used to synchronize the DrawFrustumComponent with the
-  /// SceneCaptureComponent2D settings.
-  void UpdateDrawFrustum();
 
   /// Image width in pixels.
   UPROPERTY(EditAnywhere)
@@ -151,12 +145,4 @@ private:
   /// Scene capture component.
   UPROPERTY(EditAnywhere)
   USceneCaptureComponent2D *CaptureComponent2D = nullptr;
-
-  /// To display the 3d camera in the editor.
-  UPROPERTY()
-  UStaticMeshComponent *MeshComp = nullptr;
-
-  /// To allow drawing the camera frustum in the editor.
-  UPROPERTY()
-  UDrawFrustumComponent *DrawFrustum = nullptr;
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
@@ -23,6 +23,8 @@ class CARLA_API ASensor : public AActor
 
 public:
 
+  ASensor(const FObjectInitializer &ObjectInitializer);
+
   void SetEpisode(const UCarlaEpisode &InEpisode)
   {
     Episode = &InEpisode;
@@ -45,6 +47,8 @@ public:
   }
 
 protected:
+
+  void PostActorCreated() override;
 
   void EndPlay(EEndPlayReason::Type EndPlayReason) override;
 


### PR DESCRIPTION
#### Description

Set up the `RootComponent` in `ASensor` so we don't need to set it up on each individual sensor. Forgetting to set up the root component results in difficult to track bugs (e.g. sensor not having a transform), this way we make sure every sensor has a root component. Moreover, they will be displayed in editor (though for the moment all of them look like cameras).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1758)
<!-- Reviewable:end -->
