### PR TITLE
Add NoopSerializer for sensors that do not send data

### DIFF
--- a/LibCarla/source/carla/sensor/SensorRegistry.h
+++ b/LibCarla/source/carla/sensor/SensorRegistry.h
@@ -18,6 +18,7 @@
 #include "carla/sensor/s11n/EpisodeStateSerializer.h"
 #include "carla/sensor/s11n/ImageSerializer.h"
 #include "carla/sensor/s11n/LidarSerializer.h"
+#include "carla/sensor/s11n/NoopSerializer.h"
 #include "carla/sensor/s11n/ObstacleDetectionEventSerializer.h"
 
 // 2. Add a forward-declaration of the sensor here.
@@ -38,6 +39,9 @@ namespace sensor {
 
   /// Contains a registry of all the sensors available and allows serializing
   /// and deserializing sensor data for the types registered.
+  ///
+  /// Use s11n::NoopSerializer if the sensor does not send data (sensors that
+  /// work only on client-side).
   using SensorRegistry = CompositeSerializer<
     std::pair<FWorldObserver *, s11n::EpisodeStateSerializer>,
     std::pair<ASceneCaptureCamera *, s11n::ImageSerializer>,
@@ -45,8 +49,8 @@ namespace sensor {
     std::pair<ASemanticSegmentationCamera *, s11n::ImageSerializer>,
     std::pair<ARayCastLidar *, s11n::LidarSerializer>,
     std::pair<ACollisionSensor *, s11n::CollisionEventSerializer>,
-    std::pair<AGnssSensor *, s11n::ImageSerializer>,
-    std::pair<ALaneInvasionSensor *, s11n::ImageSerializer>,
+    std::pair<AGnssSensor *, s11n::NoopSerializer>,
+    std::pair<ALaneInvasionSensor *, s11n::NoopSerializer>,
     std::pair<AObstacleDetectionSensor *, s11n::ObstacleDetectionEventSerializer>
   >;
 

--- a/LibCarla/source/carla/sensor/s11n/CollisionEventSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/CollisionEventSerializer.cpp
@@ -11,7 +11,7 @@ namespace carla {
 namespace sensor {
 namespace s11n {
 
-  SharedPtr<SensorData> CollisionEventSerializer::Deserialize(RawData data) {
+  SharedPtr<SensorData> CollisionEventSerializer::Deserialize(RawData &&data) {
     return SharedPtr<SensorData>(new data::CollisionEvent(std::move(data)));
   }
 

--- a/LibCarla/source/carla/sensor/s11n/CollisionEventSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/CollisionEventSerializer.h
@@ -50,7 +50,7 @@ namespace s11n {
       return MsgPack::Pack(Data{self_actor, other_actor, normal_impulse});
     }
 
-    static SharedPtr<SensorData> Deserialize(RawData data);
+    static SharedPtr<SensorData> Deserialize(RawData &&data);
   };
 
 } // namespace s11n

--- a/LibCarla/source/carla/sensor/s11n/EpisodeStateSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/EpisodeStateSerializer.cpp
@@ -12,7 +12,7 @@ namespace carla {
 namespace sensor {
 namespace s11n {
 
-  SharedPtr<SensorData> EpisodeStateSerializer::Deserialize(RawData data) {
+  SharedPtr<SensorData> EpisodeStateSerializer::Deserialize(RawData &&data) {
     return SharedPtr<data::RawEpisodeState>(new data::RawEpisodeState{std::move(data)});
   }
 

--- a/LibCarla/source/carla/sensor/s11n/EpisodeStateSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/EpisodeStateSerializer.h
@@ -46,7 +46,7 @@ namespace s11n {
       return std::move(buffer);
     }
 
-    static SharedPtr<SensorData> Deserialize(RawData data);
+    static SharedPtr<SensorData> Deserialize(RawData &&data);
   };
 
 } // namespace s11n

--- a/LibCarla/source/carla/sensor/s11n/ImageSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/ImageSerializer.cpp
@@ -12,7 +12,7 @@ namespace carla {
 namespace sensor {
 namespace s11n {
 
-  SharedPtr<SensorData> ImageSerializer::Deserialize(RawData data) {
+  SharedPtr<SensorData> ImageSerializer::Deserialize(RawData &&data) {
     auto image = SharedPtr<data::Image>(new data::Image{std::move(data)});
     // Set alpha of each pixel in the buffer to max to make it 100% opaque
     for (auto &pixel : *image) {

--- a/LibCarla/source/carla/sensor/s11n/ImageSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/ImageSerializer.h
@@ -40,7 +40,7 @@ namespace s11n {
     template <typename Sensor>
     static Buffer Serialize(const Sensor &sensor, Buffer &&bitmap);
 
-    static SharedPtr<SensorData> Deserialize(RawData data);
+    static SharedPtr<SensorData> Deserialize(RawData &&data);
   };
 
   template <typename Sensor>

--- a/LibCarla/source/carla/sensor/s11n/LidarSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/LidarSerializer.cpp
@@ -12,7 +12,7 @@ namespace carla {
 namespace sensor {
 namespace s11n {
 
-  SharedPtr<SensorData> LidarSerializer::Deserialize(RawData data) {
+  SharedPtr<SensorData> LidarSerializer::Deserialize(RawData &&data) {
     return SharedPtr<data::LidarMeasurement>(
         new data::LidarMeasurement{std::move(data)});
   }

--- a/LibCarla/source/carla/sensor/s11n/LidarSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/LidarSerializer.h
@@ -74,7 +74,7 @@ namespace s11n {
         const LidarMeasurement &measurement,
         Buffer &&bitmap);
 
-    static SharedPtr<SensorData> Deserialize(RawData data);
+    static SharedPtr<SensorData> Deserialize(RawData &&data);
   };
 
   // ===========================================================================

--- a/LibCarla/source/carla/sensor/s11n/NoopSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/NoopSerializer.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/sensor/s11n/NoopSerializer.h"
+
+#include "carla/Exception.h"
+
+namespace carla {
+namespace sensor {
+namespace s11n {
+
+  SharedPtr<SensorData> NoopSerializer::Deserialize(RawData &&) {
+    throw_exception(std::runtime_error("NoopSerializer: Invalid data received."));
+  }
+
+} // namespace s11n
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/s11n/NoopSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/NoopSerializer.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/Memory.h"
+#include "carla/sensor/RawData.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace carla {
+namespace sensor {
+
+  class SensorData;
+
+namespace s11n {
+
+  /// Dummy serializer that blocks all the data. Use it as serializer for
+  /// client-side sensors that do not send any data.
+  class NoopSerializer {
+  public:
+
+    [[ noreturn ]] static SharedPtr<SensorData> Deserialize(RawData &&data);
+  };
+
+} // namespace s11n
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/s11n/ObstacleDetectionEventSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/ObstacleDetectionEventSerializer.cpp
@@ -11,7 +11,7 @@ namespace carla {
 namespace sensor {
 namespace s11n {
 
-  SharedPtr<SensorData> ObstacleDetectionEventSerializer::Deserialize(RawData data) {
+  SharedPtr<SensorData> ObstacleDetectionEventSerializer::Deserialize(RawData &&data) {
     return SharedPtr<SensorData>(new data::ObstacleDetectionEvent(std::move(data)));
   }
 

--- a/LibCarla/source/carla/sensor/s11n/ObstacleDetectionEventSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/ObstacleDetectionEventSerializer.h
@@ -49,7 +49,7 @@ namespace s11n {
       return MsgPack::Pack(Data{self_actor, other_actor, distance});
     }
 
-    static SharedPtr<SensorData> Deserialize(RawData data);
+    static SharedPtr<SensorData> Deserialize(RawData &&data);
   };
 
 } // namespace s11n


### PR DESCRIPTION
#### Description

Make the code a bit more expressive by adding a No-op serializer. Client-side sensors can be added to the registry using this serializer to make sure that they don't send any data.

Also, pass all the raw-data by r-value ref, a bit more efficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1760)
<!-- Reviewable:end -->
