### PR TITLE
Stop pedestrians after a recorded session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Bugfix about recorder query system
   * Fixed problem when vehicles enable autopilot after a replayer, now it works better.
+    - When a recorded session finish replaying, all vehicles will continue in autopilot, and all pedestrians will stop.
   * Vulkan support: Changed project settings to make vulkan default on linux and updated make script to allow user to select opengl
   * Add ability to set motion blur settings for rgb camera in sensor python blueprint
   * Improved visual quality of the screen capture for the rgb sensor

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -111,7 +111,7 @@ AActor *CarlaReplayerHelper::FindTrafficLightAt(FVector Location)
 }
 
 // enable / disable physics for an actor
-bool CarlaReplayerHelper::SetActorSimulatePhysics(FActorView &ActorView, bool bEnabled)
+bool CarlaReplayerHelper::SetActorSimulatePhysics(const FActorView &ActorView, bool bEnabled)
 {
   if (!ActorView.IsValid())
   {
@@ -128,7 +128,7 @@ bool CarlaReplayerHelper::SetActorSimulatePhysics(FActorView &ActorView, bool bE
 }
 
 // enable / disable autopilot for an actor
-bool CarlaReplayerHelper::SetActorAutopilot(FActorView &ActorView, bool bEnabled, bool bKeepState)
+bool CarlaReplayerHelper::SetActorAutopilot(const FActorView &ActorView, bool bEnabled, bool bKeepState)
 {
   if (!ActorView.IsValid())
   {
@@ -328,7 +328,7 @@ bool CarlaReplayerHelper::ProcessReplayerFinish(bool bApplyAutopilot)
 {
   // set autopilot and physics to all AI vehicles
   auto registry = Episode->GetActorRegistry();
-  for (auto ActorView : registry)
+  for (const FActorView &ActorView : registry)
   {
     // enable physics only on vehicles
     switch (ActorView.GetActorType())
@@ -353,7 +353,7 @@ bool CarlaReplayerHelper::ProcessReplayerFinish(bool bApplyAutopilot)
   return true;
 }
 
-void CarlaReplayerHelper::SetActorVelocity(FActorView ActorView, FVector Velocity)
+void CarlaReplayerHelper::SetActorVelocity(const FActorView &ActorView, FVector Velocity)
 {
   if (!ActorView.IsValid())
   {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -53,7 +53,7 @@ public:
   bool SetCameraPosition(uint32_t Id, FVector Offset, FQuat Rotation);
 
   // set the velocity of the actor
-  void SetActorVelocity(FActorView ActorView, FVector Velocity);
+  void SetActorVelocity(const FActorView &ActorView, FVector Velocity);
 
   // set the animation speed for walkers
   void SetWalkerSpeed(uint32_t ActorId, float Speed);
@@ -71,7 +71,7 @@ private:
   AActor *FindTrafficLightAt(FVector Location);
 
   // enable / disable physics for an actor
-  bool SetActorSimulatePhysics(FActorView &ActorView, bool bEnabled);
+  bool SetActorSimulatePhysics(const FActorView &ActorView, bool bEnabled);
   // enable / disable autopilot for an actor
-  bool SetActorAutopilot(FActorView &ActorView, bool bEnabled, bool bKeepState = false);
+  bool SetActorAutopilot(const FActorView &ActorView, bool bEnabled, bool bKeepState = false);
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -52,6 +52,12 @@ public:
   // set the camera position to follow an actor
   bool SetCameraPosition(uint32_t Id, FVector Offset, FQuat Rotation);
 
+  // set the velocity of the actor
+  void SetActorVelocity(FActorView ActorView, FVector Velocity);
+
+  // set the animation speed for walkers
+  void SetWalkerSpeed(uint32_t ActorId, float Speed);
+
 private:
 
   UCarlaEpisode *Episode {nullptr};


### PR DESCRIPTION
#### Description

At the end of a replayed session we make all the vehicles continue in autopilot, and also all pedestrians will be stop to avoid roaming without control. In the future the pedestrians could be enabled in autopilot also, walking at random positions.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2 & 3
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1764)
<!-- Reviewable:end -->
