### PR TITLE
Adding world snapshot to Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   * API extension: add gamma value as attribute to RGB camera
   * API extension: add `world.get_actor(id)` to find a single actor by id
   * API extension: add `carla.WeatherParameters.Default` for a default (tailor-made for each town) weather profile
+  * API extension: added `WorldSnapshot` that contains a list of `ActorSnapshot`, allows capturings a "still image" of the world at a single frame
+  * API change: `world.wait_for_tick()` now returns a `carla.WorldSnapshot`
+  * API change: the callback of `world.on_tick(callback)` now receives a `carla.WorldSnapshot`
   * API change: deprecated waypoint's `is_intersection`, now is `is_junction`
   * API update: solve the problem of RuntimeError: std::bad_cast described here: #1125 (comment)
   * Removed deprecated code and content

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -50,6 +50,21 @@
 - `__eq__(other)`
 - `__ne__(other)`
 
+## `carla.WorldSnapshot`
+
+- `id`
+- `timestamp`
+- `frame_count [deprecated: use timestamp]`
+- `elapsed_seconds [deprecated: use timestamp]`
+- `delta_seconds [deprecated: use timestamp]`
+- `platform_timestamp [deprecated: use timestamp]`
+- `has_actor(actor_id) -> bool`
+- `find(actor_id) -> carla.ActorSnapshot`
+- `__len()__`
+- `__iter()__`
+- `__eq(other)__`
+- `__ne(other)__`
+
 ## `carla.DebugHelper`
 
 - `draw_point(location, size=0.1, color=carla.Color(), life_time=-1.0, persistent_lines=True)`
@@ -126,6 +141,16 @@
 - `add_impulse(vector)`
 - `set_simulate_physics(enabled=True)`
 - `destroy()`
+- `__str__()`
+
+## `carla.ActorSnapshot`
+
+- `id`
+- `get_location()`
+- `get_transform()`
+- `get_velocity()`
+- `get_angular_velocity()`
+- `get_acceleration()`
 - `__str__()`
 
 ## `carla.Vehicle(carla.Actor)`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -39,7 +39,7 @@
 - `get_actors(actor_ids=None) -> carla.ActorList`
 - `spawn_actor(blueprint, transform, attach_to=None)`
 - `try_spawn_actor(blueprint, transform, attach_to=None, attachment_type=carla.AttachmentType.Rigid)`
-- `wait_for_tick(seconds=1.0)`
+- `wait_for_tick(seconds=1.0) -> carla.WorldSnapshot`
 - `on_tick(callback)`
 - `tick()`
 

--- a/LibCarla/source/carla/client/ActorSnapshot.h
+++ b/LibCarla/source/carla/client/ActorSnapshot.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/geom/Transform.h"
+#include "carla/geom/Vector3D.h"
+#include "carla/rpc/ActorId.h"
+#include "carla/sensor/data/ActorDynamicState.h"
+
+namespace carla {
+namespace client {
+
+  struct ActorSnapshot {
+    ActorId id = 0u;
+    geom::Transform transform;
+    geom::Vector3D velocity;
+    geom::Vector3D angular_velocity;
+    geom::Vector3D acceleration;
+    sensor::data::ActorDynamicState::TypeDependentState state;
+  };
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/GnssSensor.cpp
+++ b/LibCarla/source/carla/client/GnssSensor.cpp
@@ -37,10 +37,10 @@ namespace client {
     log_debug(GetDisplayId(), ": subscribing to tick event");
     GetEpisode().Lock()->RegisterOnTickEvent([
         cb=std::move(callback),
-        weak_self=WeakPtr<GnssSensor>(self)](const auto &timestamp) {
+        weak_self=WeakPtr<GnssSensor>(self)](const auto &snapshot) {
       auto self = weak_self.lock();
       if (self != nullptr) {
-        auto data = self->TickGnssSensor(timestamp);
+        auto data = self->TickGnssSensor(snapshot.GetTimestamp());
         if (data != nullptr) {
           cb(std::move(data));
         }

--- a/LibCarla/source/carla/client/LaneInvasionSensor.cpp
+++ b/LibCarla/source/carla/client/LaneInvasionSensor.cpp
@@ -62,10 +62,10 @@ namespace client {
     log_debug(GetDisplayId(), ": subscribing to tick event");
     GetEpisode().Lock()->RegisterOnTickEvent([
         cb=std::move(callback),
-        weak_self=WeakPtr<LaneInvasionSensor>(self)](const auto &timestamp) {
+        weak_self=WeakPtr<LaneInvasionSensor>(self)](const auto &snapshot) {
       auto self = weak_self.lock();
       if (self != nullptr) {
-        auto data = self->TickLaneInvasionSensor(timestamp);
+        auto data = self->TickLaneInvasionSensor(snapshot.GetTimestamp());
         if (data != nullptr) {
           cb(std::move(data));
         }

--- a/LibCarla/source/carla/client/TrafficLight.cpp
+++ b/LibCarla/source/carla/client/TrafficLight.cpp
@@ -16,7 +16,7 @@ namespace client {
   }
 
   rpc::TrafficLightState TrafficLight::GetState() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.state;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.state;
   }
 
   void TrafficLight::SetGreenTime(float green_time) {
@@ -24,7 +24,7 @@ namespace client {
   }
 
   float TrafficLight::GetGreenTime() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.green_time;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.green_time;
   }
 
   void TrafficLight::SetYellowTime(float yellow_time) {
@@ -32,7 +32,7 @@ namespace client {
   }
 
   float TrafficLight::GetYellowTime() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.yellow_time;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.yellow_time;
   }
 
   void TrafficLight::SetRedTime(float red_time) {
@@ -40,11 +40,11 @@ namespace client {
   }
 
   float TrafficLight::GetRedTime() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.red_time;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.red_time;
   }
 
   float TrafficLight::GetElapsedTime() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.elapsed_time;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.elapsed_time;
   }
 
   void TrafficLight::Freeze(bool freeze) {
@@ -52,12 +52,12 @@ namespace client {
   }
 
   bool TrafficLight::IsFrozen() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.time_is_frozen;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.time_is_frozen;
   }
 
   uint32_t TrafficLight::GetPoleIndex()
   {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.traffic_light_data.pole_index;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.pole_index;
   }
 
   std::vector<SharedPtr<TrafficLight>> TrafficLight::GetGroupTrafficLights() {

--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -44,7 +44,7 @@ namespace client {
   }
 
   Vehicle::Control Vehicle::GetControl() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.vehicle_data.control;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.control;
   }
 
   Vehicle::PhysicsControl Vehicle::GetPhysicsControl() const {
@@ -52,19 +52,19 @@ namespace client {
   }
 
   float Vehicle::GetSpeedLimit() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.vehicle_data.speed_limit;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.speed_limit;
   }
 
   rpc::TrafficLightState Vehicle::GetTrafficLightState() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.vehicle_data.traffic_light_state;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.traffic_light_state;
   }
 
   bool Vehicle::IsAtTrafficLight() {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.vehicle_data.has_traffic_light;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.has_traffic_light;
   }
 
   SharedPtr<TrafficLight> Vehicle::GetTrafficLight() const {
-    auto id = GetEpisode().Lock()->GetActorDynamicState(*this).state.vehicle_data.traffic_light_id;
+    auto id = GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.traffic_light_id;
     return boost::static_pointer_cast<TrafficLight>(GetWorld().GetActor(id));
   }
 

--- a/LibCarla/source/carla/client/Walker.cpp
+++ b/LibCarla/source/carla/client/Walker.cpp
@@ -19,7 +19,7 @@ namespace client {
   }
 
   Walker::Control Walker::GetWalkerControl() const {
-    return GetEpisode().Lock()->GetActorDynamicState(*this).state.walker_control;
+    return GetEpisode().Lock()->GetActorSnapshot(*this).state.walker_control;
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -89,11 +89,11 @@ namespace client {
     }
   }
 
-  Timestamp World::WaitForTick(time_duration timeout) const {
+  WorldSnapshot World::WaitForTick(time_duration timeout) const {
     return _episode.Lock()->WaitForTick(timeout);
   }
 
-  void World::OnTick(std::function<void(Timestamp)> callback) {
+  void World::OnTick(std::function<void(WorldSnapshot)> callback) {
     return _episode.Lock()->RegisterOnTickEvent(std::move(callback));
   }
 

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -45,6 +45,10 @@ namespace client {
     _episode.Lock()->SetWeatherParameters(weather);
   }
 
+  WorldSnapshot World::GetSnapshot() const {
+    return _episode.Lock()->GetWorldSnapshot();
+  }
+
   SharedPtr<Actor> World::GetActor(ActorId id) const {
     auto simulator = _episode.Lock();
     auto description = simulator->GetActorById(id);

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -10,6 +10,7 @@
 #include "carla/Time.h"
 #include "carla/client/DebugHelper.h"
 #include "carla/client/Timestamp.h"
+#include "carla/client/WorldSnapshot.h"
 #include "carla/client/detail/EpisodeProxy.h"
 #include "carla/geom/Transform.h"
 #include "carla/rpc/Actor.h"
@@ -63,6 +64,9 @@ namespace client {
 
     /// Change the weather in the simulation.
     void SetWeather(const rpc::WeatherParameters &weather);
+
+    /// Return a snapshot of the world at this moment.
+    WorldSnapshot GetSnapshot() const;
 
     /// Find actor by id, return nullptr if not found.
     SharedPtr<Actor> GetActor(ActorId id) const;

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -95,10 +95,10 @@ namespace client {
         rpc::AttachmentType attachment_type = rpc::AttachmentType::Rigid) noexcept;
 
     /// Block calling thread until a world tick is received.
-    Timestamp WaitForTick(time_duration timeout) const;
+    WorldSnapshot WaitForTick(time_duration timeout) const;
 
     /// Register a @a callback to be called every time a world tick is received.
-    void OnTick(std::function<void(Timestamp)> callback);
+    void OnTick(std::function<void(WorldSnapshot)> callback);
 
     /// Signal the simulator to continue to next tick (only has effect on
     /// synchronous mode).

--- a/LibCarla/source/carla/client/WorldSnapshot.h
+++ b/LibCarla/source/carla/client/WorldSnapshot.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/client/Timestamp.h"
+#include "carla/client/ActorSnapshot.h"
+#include "carla/client/detail/EpisodeState.h"
+
+#include <boost/optional.hpp>
+
+namespace carla {
+namespace client {
+
+  class WorldSnapshot {
+  public:
+
+    /// Get the id of the episode associated with this world.
+    uint64_t GetId() const {
+      return _state->GetEpisodeId();
+    }
+
+    /// Get timestamp of this snapshot.
+    const Timestamp &GetTimestamp() const {
+      return _state->GetTimestamp();
+    }
+
+    /// Check if an actor is present in this snapshot.
+    bool Contains(ActorId actor_id) const {
+      return _state->ContainsActorSnapshot(actor_id);
+    }
+
+    /// Find an ActorSnapshot by id.
+    boost::optional<ActorSnapshot> Find(ActorId actor_id) const {
+      return _state->GetActorSnapshotIfPresent(actor_id);
+    }
+
+    /// Return number of ActorSnapshots present in this WorldSnapshot.
+    size_t size() const {
+      return _state->size();
+    }
+
+    /// Return a begin iterator to the list of ActorSnapshots.
+    auto begin() const {
+      return _state->begin();
+    }
+
+    /// Return a past-the-end iterator to the list of ActorSnapshots.
+    auto end() const {
+      return _state->end();
+    }
+
+    bool operator==(const WorldSnapshot &rhs) const {
+      return GetTimestamp() == rhs.GetTimestamp();
+    }
+
+    bool operator!=(const WorldSnapshot &rhs) const {
+      return !(*this == rhs);
+    }
+
+  private:
+
+    friend class detail::Simulator;
+
+    explicit WorldSnapshot(std::shared_ptr<const detail::EpisodeState> &&state)
+      : _state(std::move(state)) {}
+
+    std::shared_ptr<const detail::EpisodeState> _state;
+  };
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/WorldSnapshot.h
+++ b/LibCarla/source/carla/client/WorldSnapshot.h
@@ -18,6 +18,9 @@ namespace client {
   class WorldSnapshot {
   public:
 
+    WorldSnapshot(std::shared_ptr<const detail::EpisodeState> state)
+      : _state(std::move(state)) {}
+
     /// Get the id of the episode associated with this world.
     uint64_t GetId() const {
       return _state->GetEpisodeId();
@@ -62,11 +65,6 @@ namespace client {
     }
 
   private:
-
-    friend class detail::Simulator;
-
-    explicit WorldSnapshot(std::shared_ptr<const detail::EpisodeState> &&state)
-      : _state(std::move(state)) {}
 
     std::shared_ptr<const detail::EpisodeState> _state;
   };

--- a/LibCarla/source/carla/client/detail/Episode.cpp
+++ b/LibCarla/source/carla/client/detail/Episode.cpp
@@ -57,7 +57,7 @@ namespace detail {
         auto prev = self->GetState();
         do {
           if (prev->GetFrameCount() >= next->GetFrameCount()) {
-            self->_on_tick_callbacks.Call(next->GetTimestamp());
+            self->_on_tick_callbacks.Call(next);
             return;
           }
         } while (!self->_state.compare_exchange(&prev, next));
@@ -67,8 +67,8 @@ namespace detail {
         }
 
         // Notify waiting threads and do the callbacks.
-        self->_timestamp.SetValue(next->GetTimestamp());
-        self->_on_tick_callbacks.Call(next->GetTimestamp());
+        self->_snapshot.SetValue(next);
+        self->_on_tick_callbacks.Call(next);
       }
     });
   }

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -10,6 +10,7 @@
 #include "carla/NonCopyable.h"
 #include "carla/RecurrentSharedFuture.h"
 #include "carla/client/Timestamp.h"
+#include "carla/client/WorldSnapshot.h"
 #include "carla/client/detail/CachedActorList.h"
 #include "carla/client/detail/CallbackList.h"
 #include "carla/client/detail/EpisodeState.h"
@@ -57,11 +58,11 @@ namespace detail {
 
     std::vector<rpc::Actor> GetActors();
 
-    boost::optional<Timestamp> WaitForState(time_duration timeout) {
-      return _timestamp.WaitFor(timeout);
+    boost::optional<WorldSnapshot> WaitForState(time_duration timeout) {
+      return _snapshot.WaitFor(timeout);
     }
 
-    void RegisterOnTickEvent(std::function<void(Timestamp)> callback) {
+    void RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
       _on_tick_callbacks.RegisterCallback(std::move(callback));
     }
 
@@ -77,9 +78,9 @@ namespace detail {
 
     CachedActorList _actors;
 
-    CallbackList<Timestamp> _on_tick_callbacks;
+    CallbackList<WorldSnapshot> _on_tick_callbacks;
 
-    RecurrentSharedFuture<Timestamp> _timestamp;
+    RecurrentSharedFuture<WorldSnapshot> _snapshot;
 
     const streaming::Token _token;
   };

--- a/LibCarla/source/carla/client/detail/EpisodeState.cpp
+++ b/LibCarla/source/carla/client/detail/EpisodeState.cpp
@@ -22,7 +22,8 @@ namespace detail {
       DEBUG_ONLY(auto result = )
       _actors.emplace(
           actor.id,
-          ActorState{
+          ActorSnapshot{
+              actor.id,
               actor.transform,
               actor.velocity,
               actor.angular_velocity,

--- a/LibCarla/source/carla/client/detail/EpisodeState.h
+++ b/LibCarla/source/carla/client/detail/EpisodeState.h
@@ -9,8 +9,8 @@
 #include "carla/Iterator.h"
 #include "carla/ListView.h"
 #include "carla/NonCopyable.h"
+#include "carla/client/ActorSnapshot.h"
 #include "carla/client/Timestamp.h"
-#include "carla/sensor/data/ActorDynamicState.h"
 #include "carla/sensor/data/RawEpisodeState.h"
 
 #include <memory>
@@ -25,14 +25,6 @@ namespace detail {
     : std::enable_shared_from_this<EpisodeState>,
       private NonCopyable {
   public:
-
-    struct ActorState {
-      geom::Transform transform;
-      geom::Vector3D velocity;
-      geom::Vector3D angular_velocity;
-      geom::Vector3D acceleration;
-      sensor::data::ActorDynamicState::TypeDependentState state;
-    };
 
     explicit EpisodeState(uint64_t episode_id) : _episode_id(episode_id) {}
 
@@ -50,8 +42,8 @@ namespace detail {
       return _timestamp;
     }
 
-    ActorState GetActorState(ActorId id) const {
-      ActorState state;
+    ActorSnapshot GetActorSnapshot(ActorId id) const {
+      ActorSnapshot state;
       auto it = _actors.find(id);
       if (it != _actors.end()) {
         state = it->second;
@@ -73,7 +65,7 @@ namespace detail {
 
     const Timestamp _timestamp;
 
-    std::unordered_map<ActorId, ActorState> _actors;
+    std::unordered_map<ActorId, ActorSnapshot> _actors;
   };
 
 } // namespace detail

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -95,7 +95,7 @@ namespace detail {
   // -- Tick -------------------------------------------------------------------
   // ===========================================================================
 
-  Timestamp Simulator::WaitForTick(time_duration timeout) {
+  WorldSnapshot Simulator::WaitForTick(time_duration timeout) {
     DEBUG_ASSERT(_episode != nullptr);
     auto result = _episode->WaitForState(timeout);
     if (!result.has_value()) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -14,6 +14,7 @@
 #include "carla/client/TrafficLight.h"
 #include "carla/client/Vehicle.h"
 #include "carla/client/Walker.h"
+#include "carla/client/WorldSnapshot.h"
 #include "carla/client/detail/ActorFactory.h"
 #include "carla/client/detail/Client.h"
 #include "carla/client/detail/Episode.h"
@@ -78,6 +79,17 @@ namespace detail {
     }
 
     EpisodeProxy GetCurrentEpisode();
+
+    /// @}
+    // =========================================================================
+    /// @name World snapshot
+    // =========================================================================
+    /// @{
+
+    WorldSnapshot GetWorldSnapshot() const {
+      DEBUG_ASSERT(_episode != nullptr);
+      return WorldSnapshot{_episode->GetState()};
+    }
 
     /// @}
     // =========================================================================

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -215,21 +215,25 @@ namespace detail {
 
     bool DestroyActor(Actor &actor);
 
-    auto GetActorDynamicState(const Actor &actor) const {
+    ActorSnapshot GetActorSnapshot(ActorId actor_id) const {
       DEBUG_ASSERT(_episode != nullptr);
-      return _episode->GetState()->GetActorState(actor.GetId());
+      return _episode->GetState()->GetActorSnapshot(actor_id);
+    }
+
+    ActorSnapshot GetActorSnapshot(const Actor &actor) const {
+      return GetActorSnapshot(actor.GetId());
     }
 
     geom::Location GetActorLocation(const Actor &actor) const {
-      return GetActorDynamicState(actor).transform.location;
+      return GetActorSnapshot(actor).transform.location;
     }
 
     geom::Transform GetActorTransform(const Actor &actor) const {
-      return GetActorDynamicState(actor).transform;
+      return GetActorSnapshot(actor).transform;
     }
 
     geom::Vector3D GetActorVelocity(const Actor &actor) const {
-      return GetActorDynamicState(actor).velocity;
+      return GetActorSnapshot(actor).velocity;
     }
 
     void SetActorVelocity(const Actor &actor, const geom::Vector3D &vector) {
@@ -237,7 +241,7 @@ namespace detail {
     }
 
     geom::Vector3D GetActorAngularVelocity(const Actor &actor) const {
-      return GetActorDynamicState(actor).angular_velocity;
+      return GetActorSnapshot(actor).angular_velocity;
     }
 
     void SetActorAngularVelocity(const Actor &actor, const geom::Vector3D &vector) {
@@ -249,7 +253,7 @@ namespace detail {
     }
 
     geom::Vector3D GetActorAcceleration(const Actor &actor) const {
-      return GetActorDynamicState(actor).acceleration;
+      return GetActorSnapshot(actor).acceleration;
     }
 
     void SetActorLocation(Actor &actor, const geom::Location &location) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -137,9 +137,9 @@ namespace detail {
     // =========================================================================
     /// @{
 
-    Timestamp WaitForTick(time_duration timeout);
+    WorldSnapshot WaitForTick(time_duration timeout);
 
-    void RegisterOnTickEvent(std::function<void(Timestamp)> callback) {
+    void RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
       DEBUG_ASSERT(_episode != nullptr);
       _episode->RegisterOnTickEvent(std::move(callback));
     }

--- a/LibCarla/source/carla/sensor/SensorData.h
+++ b/LibCarla/source/carla/sensor/SensorData.h
@@ -11,7 +11,6 @@
 #include "carla/sensor/RawData.h"
 
 /// @todo This shouldn't be exposed in this namespace.
-#include "carla/client/World.h"
 #include "carla/client/detail/EpisodeProxy.h"
 
 namespace carla {

--- a/PythonAPI/carla/source/libcarla/Snapshot.cpp
+++ b/PythonAPI/carla/source/libcarla/Snapshot.cpp
@@ -43,6 +43,12 @@ void export_snapshot() {
   class_<cc::WorldSnapshot>("WorldSnapshot", no_init)
     .add_property("id", &cc::WorldSnapshot::GetId)
     .add_property("timestamp", CALL_RETURNING_COPY(cc::WorldSnapshot, GetTimestamp))
+    /// Deprecated, use timestamp @{
+    .add_property("frame_count", +[](const cc::WorldSnapshot &self) { return self.GetTimestamp().frame_count; })
+    .add_property("elapsed_seconds", +[](const cc::WorldSnapshot &self) { return self.GetTimestamp().elapsed_seconds; })
+    .add_property("delta_seconds", +[](const cc::WorldSnapshot &self) { return self.GetTimestamp().delta_seconds; })
+    .add_property("platform_timestamp", +[](const cc::WorldSnapshot &self) { return self.GetTimestamp().platform_timestamp; })
+    /// @}
     .def("has_actor", &cc::WorldSnapshot::Contains, (arg("actor_id")))
     .def("find", CALL_RETURNING_OPTIONAL_1(cc::WorldSnapshot, Find, carla::ActorId), (arg("actor_id")))
     .def("__len__", &cc::WorldSnapshot::size)

--- a/PythonAPI/carla/source/libcarla/Snapshot.cpp
+++ b/PythonAPI/carla/source/libcarla/Snapshot.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include <carla/PythonUtil.h>
+#include <carla/client/Actor.h>
+#include <carla/client/ActorList.h>
+#include <carla/client/World.h>
+
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+namespace carla {
+namespace client {
+
+  std::ostream &operator<<(std::ostream &out, const ActorSnapshot &snapshot) {
+    out << "ActorSnapshot(id=" << std::to_string(snapshot.id);
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const WorldSnapshot &snapshot) {
+    out << "WorldSnapshot(id=" << std::to_string(snapshot.GetId());
+    return out;
+  }
+
+} // namespace client
+} // namespace carla
+
+void export_snapshot() {
+  using namespace boost::python;
+  namespace cc = carla::client;
+
+  class_<cc::ActorSnapshot>("ActorSnapshot", no_init)
+    .def_readonly("id", &cc::ActorSnapshot::id)
+    .def("get_transform", +[](const cc::ActorSnapshot &self) { return self.transform; })
+    .def("get_velocity", +[](const cc::ActorSnapshot &self) { return self.velocity; })
+    .def("get_angular_velocity", +[](const cc::ActorSnapshot &self) { return self.angular_velocity; })
+    .def("get_acceleration", +[](const cc::ActorSnapshot &self) { return self.acceleration; })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<cc::WorldSnapshot>("WorldSnapshot", no_init)
+    .add_property("id", &cc::WorldSnapshot::GetId)
+    .add_property("timestamp", CALL_RETURNING_COPY(cc::WorldSnapshot, GetTimestamp))
+    .def("has_actor", &cc::WorldSnapshot::Contains, (arg("actor_id")))
+    .def("find", CALL_RETURNING_OPTIONAL_1(cc::WorldSnapshot, Find, carla::ActorId), (arg("actor_id")))
+    .def("__len__", &cc::WorldSnapshot::size)
+    .def("__iter__", range(&cc::WorldSnapshot::begin, &cc::WorldSnapshot::end))
+    .def("__eq__", &cc::WorldSnapshot::operator==)
+    .def("__ne__", &cc::WorldSnapshot::operator!=)
+    .def(self_ns::str(self_ns::self))
+  ;
+}

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -135,6 +135,7 @@ void export_world() {
     .def("apply_settings", &cc::World::ApplySettings)
     .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, GetWeather))
     .def("set_weather", &cc::World::SetWeather)
+    .def("get_snapshot", &cc::World::GetSnapshot)
     .def("get_actor", CONST_CALL_WITHOUT_GIL_1(cc::World, GetActor, carla::ActorId), (arg("actor_id")))
     .def("get_actors", CONST_CALL_WITHOUT_GIL(cc::World, GetActors))
     .def("get_actors", &GetActorsById, (arg("actor_ids")))

--- a/PythonAPI/carla/source/libcarla/libcarla.cpp
+++ b/PythonAPI/carla/source/libcarla/libcarla.cpp
@@ -83,7 +83,7 @@
       return optional.has_value() ? boost::python::object(*optional) : boost::python::object(); \
     }
 
-#define CALL_RETURNING_OPTIONAL_1(cls, fn, T1_) +[](const cls &self, T1_) { \
+#define CALL_RETURNING_OPTIONAL_1(cls, fn, T1_) +[](const cls &self, T1_ t1) { \
       auto optional = self.fn(std::forward<T1_>(t1)); \
       return optional.has_value() ? boost::python::object(*optional) : boost::python::object(); \
     }
@@ -163,6 +163,7 @@ static auto MakeCallback(boost::python::object callback) {
 #include "Map.cpp"
 #include "Sensor.cpp"
 #include "SensorData.cpp"
+#include "Snapshot.cpp"
 #include "Weather.cpp"
 #include "World.cpp"
 #include "Commands.cpp"
@@ -177,6 +178,7 @@ BOOST_PYTHON_MODULE(libcarla) {
   export_actor();
   export_sensor();
   export_sensor_data();
+  export_snapshot();
   export_weather();
   export_world();
   export_map();

--- a/PythonAPI/examples/automatic_control.py
+++ b/PythonAPI/examples/automatic_control.py
@@ -753,8 +753,7 @@ def game_loop(args):
                 return
 
             # as soon as the server is ready continue!
-            if not world.world.wait_for_tick(10.0):
-                continue
+            world.world.wait_for_tick(10.0)
 
             world.tick(clock)
             world.render(display)

--- a/PythonAPI/examples/dynamic_weather.py
+++ b/PythonAPI/examples/dynamic_weather.py
@@ -132,7 +132,7 @@ def main():
     elapsed_time = 0.0
 
     while True:
-        timestamp = world.wait_for_tick(seconds=30.0)
+        timestamp = world.wait_for_tick(seconds=30.0).timestamp
         elapsed_time += timestamp.delta_seconds
         if elapsed_time > update_freq:
             weather.tick(speed_factor * elapsed_time)

--- a/PythonAPI/examples/synchronous_mode.py
+++ b/PythonAPI/examples/synchronous_mode.py
@@ -118,7 +118,7 @@ def main():
 
             clock.tick()
             world.tick()
-            ts = world.wait_for_tick()
+            ts = world.wait_for_tick().timestamp
 
             if frame is not None:
                 if ts.frame_count != frame + 1:

--- a/PythonAPI/examples/vehicle_gallery.py
+++ b/PythonAPI/examples/vehicle_gallery.py
@@ -49,7 +49,7 @@ def main():
 
             angle = 0
             while angle < 356:
-                timestamp = world.wait_for_tick()
+                timestamp = world.wait_for_tick().timestamp
                 angle += timestamp.delta_seconds * 60.0
                 spectator.set_transform(get_transform(vehicle.get_location(), angle - 90))
 

--- a/PythonAPI/test/smoke/__init__.py
+++ b/PythonAPI/test/smoke/__init__.py
@@ -30,3 +30,20 @@ class SmokeTest(unittest.TestCase):
 
     def tearDown(self):
         self.client = None
+
+
+class SyncSmokeTest(SmokeTest):
+    def setUp(self):
+        super(SyncSmokeTest, self).setUp()
+        self.world = self.client.get_world()
+        self.settings = self.world.get_settings()
+        settings = carla.WorldSettings(
+            no_rendering_mode=False,
+            synchronous_mode=True)
+        self.world.apply_settings(settings)
+
+    def tearDown(self):
+        self.world.apply_settings(self.settings)
+        self.settings = None
+        self.world = None
+        super(SyncSmokeTest, self).tearDown()

--- a/PythonAPI/test/smoke/test_map.py
+++ b/PythonAPI/test/smoke/test_map.py
@@ -21,7 +21,6 @@ class TestMap(SmokeTest):
         random.shuffle(map_names)
         for map_name in map_names:
             if map_name != '/Game/Carla/Maps/BaseMap/BaseMap':
-                print(map_name)
                 world = self.client.load_world(map_name)
                 m = world.get_map()
                 self.assertEqual(map_name.split('/')[-1], m.name)

--- a/PythonAPI/test/smoke/test_snapshot.py
+++ b/PythonAPI/test/smoke/test_snapshot.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+import carla
+import random
+
+from . import SyncSmokeTest
+
+
+class TestSnapshot(SyncSmokeTest):
+    def test_spawn_points(self):
+        self.world = self.client.reload_world()
+        spawn_points = self.world.get_map().get_spawn_points()[:20]
+        vehicles = self.world.get_blueprint_library().filter('vehicle.*')
+        batch = [(random.choice(vehicles), t) for t in spawn_points]
+        batch = [carla.command.SpawnActor(*args) for args in batch]
+        response = self.client.apply_batch_sync(batch)
+
+        self.assertFalse(any(x.error for x in response))
+        ids = [x.actor_id for x in response]
+        self.assertEqual(len(ids), len(spawn_points))
+
+        self.world.tick()
+        snapshot = self.world.wait_for_tick()
+
+        self.assertTrue(snapshot == self.world.get_snapshot())
+
+        actors = self.world.get_actors()
+        self.assertTrue(all(snapshot.has_actor(x.id) for x in actors))
+
+        for actor_id, t0 in zip(ids, spawn_points):
+            actor_snapshot = snapshot.find(actor_id)
+            self.assertIsNotNone(actor_snapshot)
+            t1 = actor_snapshot.get_transform()
+            self.assertAlmostEqual(t0.location.x, t1.location.x, places=2)
+            self.assertAlmostEqual(t0.location.y, t1.location.y, places=2)
+            self.assertAlmostEqual(t0.location.z, t1.location.z, places=2)
+            self.assertAlmostEqual(t0.rotation.pitch, t1.rotation.pitch, places=2)
+            self.assertAlmostEqual(t0.rotation.yaw, t1.rotation.yaw, places=2)
+            self.assertAlmostEqual(t0.rotation.roll, t1.rotation.roll, places=2)

--- a/PythonAPI/test/smoke/test_sync.py
+++ b/PythonAPI/test/smoke/test_sync.py
@@ -4,7 +4,7 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
-from . import SmokeTest
+from . import SyncSmokeTest
 
 import carla
 
@@ -14,22 +14,7 @@ except ImportError:
     import Queue as queue
 
 
-class TestSynchronousMode(SmokeTest):
-    def setUp(self):
-        super(TestSynchronousMode, self).setUp()
-        self.world = self.client.get_world()
-        self.settings = self.world.get_settings()
-        settings = carla.WorldSettings(
-            no_rendering_mode=False,
-            synchronous_mode=True)
-        self.world.apply_settings(settings)
-
-    def tearDown(self):
-        self.world.apply_settings(self.settings)
-        self.settings = None
-        self.world = None
-        super(TestSynchronousMode, self).tearDown()
-
+class TestSynchronousMode(SyncSmokeTest):
     def test_reloading_map(self):
         settings = carla.WorldSettings(
             no_rendering_mode=False,

--- a/PythonAPI/test/smoke/test_sync.py
+++ b/PythonAPI/test/smoke/test_sync.py
@@ -51,7 +51,7 @@ class TestSynchronousMode(SmokeTest):
 
             for _ in range(0, 100):
                 self.world.tick()
-                ts = self.world.wait_for_tick()
+                ts = self.world.wait_for_tick().timestamp
 
                 if frame is not None:
                     self.assertEqual(ts.frame_count, frame + 1)


### PR DESCRIPTION
#### Description

A world snapshot represents the state of every actor in the simulation at a single frame, a sort of still image of the world with a timestamp. This is meant to solve all the synchronization issues when retrieving actor locations, now is possible to record the location of every actor and make sure all of them were captured at the same frame without the need of using synchronous mode. It can also be used to remove the flickering in scripts like no-rendering mode.

This is a concept that already existed internally but wasn't exposed in the API. It actually doesn't add any overhead at it simply returns a reference to the episode state that is kept internally. For some more context see https://github.com/carla-simulator/carla/issues/1274#issuecomment-465567495.

```py
# Retrieve a snapshot of the world at this point in time.
world_snapshot = world.get_snapshot()

# Wait for the next tick and retrieve the snapshot of the tick.
world_snapshot = world.wait_for_tick()

# Register a callback to get called every time we receive a new snapshot.
world.on_tick(lambda world_snapshot: do_something(world_snapshot))
```

This is a **change in the API**, now tick related functions pass a world snapshot instead of a timestamp. However, I added the same properties the timestamp had to the snapshot (as deprecated), so no need to change client code yet (though it should be changed cause eventually we'll remove these properties).

The world snapshot contains a timestamp and a list of actor snapshots. Actor snapshots do not allow to operate on the actor directly as they only contain data about the physical state of the actor, but you can use their id to retrieve the actual actor. And the other way around, you can look up snapshots by id (_average O(1)_ complexity).

```py
timestamp = world_snapshot.timestamp
timestamp.frame_count
timestamp.elapsed_seconds
timestamp.delta_seconds
timestamp.platform_timestamp


for actor_snapshot in world_snapshot:
    actor_snapshot.get_transform()
    actor_snapshot.get_velocity()
    actor_snapshot.get_angular_velocity()
    actor_snapshot.get_acceleration()

    actual_actor = world.get_actor(actor_snapshot.id)


actor_snapshot = world_snapshot.find(actual_actor.id)
```

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1776)
<!-- Reviewable:end -->
