### PR TITLE
Adding Ignore Hero to Replayer (Issue 1769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   * Fixed incorrect doppler velocity for RADAR sensor
   * Fixed documentation links
   * Upgraded Boost to 1.72.0
+  * Recorder feature:
+    - Added an option (-i) when replaying a session to ignore the hero vehicles
 
 ## CARLA 0.9.7
   * Upgraded parameters of Unreal/CarlaUE4/Config/DefaultInput.ini to prevent mouse freeze

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -88,6 +88,10 @@ namespace client {
       _simulator->SetReplayerTimeFactor(time_factor);
     }
 
+    void SetReplayerIgnoreHero(bool ignore_hero) {
+      _simulator->SetReplayerIgnoreHero(ignore_hero);
+    }
+
     void ApplyBatch(
         std::vector<rpc::Command> commands,
         bool do_tick_cue = false) const {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -319,6 +319,10 @@ namespace detail {
     _pimpl->AsyncCall("set_replayer_time_factor", time_factor);
   }
 
+  void Client::SetReplayerIgnoreHero(bool ignore_hero) {
+    _pimpl->AsyncCall("set_replayer_ignore_hero", ignore_hero);
+  }
+
   void Client::SubscribeToStream(
       const streaming::Token &token,
       std::function<void(Buffer)> callback) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -199,6 +199,8 @@ namespace detail {
 
     void SetReplayerTimeFactor(double time_factor);
 
+    void SetReplayerIgnoreHero(bool ignore_hero);
+
     void SubscribeToStream(
         const streaming::Token &token,
         std::function<void(Buffer)> callback);

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -372,6 +372,10 @@ namespace detail {
       _client.SetReplayerTimeFactor(time_factor);
     }
 
+    void SetReplayerIgnoreHero(bool ignore_hero) {
+      _client.SetReplayerIgnoreHero(ignore_hero);
+    }
+
     /// @}
     // =========================================================================
     /// @name Operations with sensors

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -132,6 +132,7 @@ void export_client() {
     .def("show_recorder_actors_blocked", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderActorsBlocked, std::string, double, double), (arg("name"), arg("min_time"), arg("min_distance")))
     .def("replay_file", CALL_WITHOUT_GIL_4(cc::Client, ReplayFile, std::string, double, double, uint32_t), (arg("name"), arg("time_start"), arg("duration"), arg("follow_id")))
     .def("set_replayer_time_factor", &cc::Client::SetReplayerTimeFactor, (arg("time_factor")))
+    .def("set_replayer_ignore_hero", &cc::Client::SetReplayerIgnoreHero, (arg("ignore_hero")))
     .def("apply_batch", &ApplyBatchCommands, (arg("commands"), arg("do_tick")=false))
     .def("apply_batch_sync", &ApplyBatchCommandsSync, (arg("commands"), arg("do_tick")=false))
   ;

--- a/PythonAPI/examples/start_replaying.py
+++ b/PythonAPI/examples/start_replaying.py
@@ -51,7 +51,7 @@ def main():
         type=float,
         help='duration (default: 0.0)')
     argparser.add_argument(
-        '-f', '--recorder_filename',
+        '-f', '--recorder-filename',
         metavar='F',
         default="test1.log",
         help='recorder filename (test1.log)')
@@ -62,13 +62,13 @@ def main():
         type=int,
         help='camera follows an actor (ex: 82)')
     argparser.add_argument(
-        '-x', '--time_factor',
+        '-x', '--time-factor',
         metavar='X',
         default=1.0,
         type=float,
         help='time factor (default 1.0)')
     argparser.add_argument(
-        '-i', '--ignore_hero',
+        '-i', '--ignore-hero',
         action='store_true',
         help='ignore hero vehicles')
     args = argparser.parse_args()

--- a/PythonAPI/examples/start_replaying.py
+++ b/PythonAPI/examples/start_replaying.py
@@ -67,6 +67,10 @@ def main():
         default=1.0,
         type=float,
         help='time factor (default 1.0)')
+    argparser.add_argument(
+        '-i', '--ignore_hero',
+        action='store_true',
+        help='ignore hero vehicles')
     args = argparser.parse_args()
 
     try:
@@ -74,7 +78,13 @@ def main():
         client = carla.Client(args.host, args.port)
         client.set_timeout(60.0)
 
+        # set the time factor for the replayer
         client.set_replayer_time_factor(args.time_factor)
+
+        # set to ignore the hero vehicles or not
+        client.set_replayer_ignore_hero(args.ignore_hero)
+
+        # replay the session
         print(client.replay_file(args.recorder_filename, args.start, args.duration, args.camera))
 
     finally:

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -54,6 +54,11 @@ inline void ACarlaRecorder::SetReplayerTimeFactor(double TimeFactor)
   Replayer.SetTimeFactor(TimeFactor);
 }
 
+inline void ACarlaRecorder::SetReplayerIgnoreHero(bool IgnoreHero)
+{
+  Replayer.SetIgnoreHero(IgnoreHero);
+}
+
 void ACarlaRecorder::Tick(float DeltaSeconds)
 {
   Super::Tick(DeltaSeconds);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -112,8 +112,11 @@ public:
   std::string ShowFileInfo(std::string Name, bool bShowAll = false);
   std::string ShowFileCollisions(std::string Name, char Type1, char Type2);
   std::string ShowFileActorsBlocked(std::string Name, double MinTime = 30, double MinDistance = 10);
+
+  // replayer
   std::string ReplayFile(std::string Name, double TimeStart, double Duration, uint32_t FollowId);
   void SetReplayerTimeFactor(double TimeFactor);
+  void SetReplayerIgnoreHero(bool IgnoreHero);
 
   void Tick(float DeltaSeconds) final;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -79,9 +79,9 @@ public:
   }
 
   // set ignore hero
-  void SetIgnoreHero(bool MyIgnoreHero)
+  void SetIgnoreHero(bool InIgnoreHero)
   {
-    IgnoreHero = MyIgnoreHero;
+    IgnoreHero = InIgnoreHero;
   }
 
   // check if after a map is loaded, we need to replay
@@ -116,7 +116,7 @@ private:
   double TimeFactor { 1.0 };
   // ignore hero vehicles
   bool IgnoreHero { false };
-  std::unordered_map<uint32_t, bool> IsHero;
+  std::unordered_map<uint32_t, bool> IsHeroMap;
 
   // utils
   bool ReadHeader();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -78,6 +78,12 @@ public:
     TimeFactor = NewTimeFactor;
   }
 
+  // set ignore hero
+  void SetIgnoreHero(bool MyIgnoreHero)
+  {
+    IgnoreHero = MyIgnoreHero;
+  }
+
   // check if after a map is loaded, we need to replay
   void CheckPlayAfterMapLoaded(void);
 
@@ -108,6 +114,9 @@ private:
   uint32_t FollowId;
   // speed (time factor)
   double TimeFactor { 1.0 };
+  // ignore hero vehicles
+  bool IgnoreHero { false };
+  std::unordered_map<uint32_t, bool> IsHero;
 
   // utils
   bool ReadHeader();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -26,7 +26,8 @@ public:
       FVector Location,
       FVector Rotation,
       CarlaRecorderActorDescription Description,
-      uint32_t DesiredId);
+      uint32_t DesiredId,
+      bool bIgnoreHero);
 
   // replay event for removing actor
   bool ProcessReplayerEventDel(uint32_t DatabaseId);
@@ -47,7 +48,7 @@ public:
   void ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walker);
 
   // replay finish
-  bool ProcessReplayerFinish(bool bApplyAutopilot);
+  bool ProcessReplayerFinish(bool bApplyAutopilot, bool bIgnoreHero, std::unordered_map<uint32_t, bool> &IsHero);
 
   // set the camera position to follow an actor
   bool SetCameraPosition(uint32_t Id, FVector Offset, FQuat Rotation);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -894,6 +894,13 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
+  BIND_SYNC(set_replayer_ignore_hero) << [this](bool ignore_hero) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    Episode->GetRecorder()->SetReplayerIgnoreHero(ignore_hero);
+    return R<void>::Success();
+  };
+
   // ~~ Draw debug shapes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(draw_debug_shape) << [this](const cr::DebugShape &shape) -> R<void>


### PR DESCRIPTION
#### Description

A new parameter has been added at the time of replaying a session, where you can choose if the recorded hero vehicles will be replayed or not. If they are not, then they can drive freely while the recorder system is replaying all other vehicles. That allows to the hero vehicles to test different strategies while the simulation is the same every time.

The parameter is the `-i` or `--ignore_hero`
For example: `./start_replaying.py -f recorded.log -i`

Fixes # 1605
Fixes # 1769

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.7
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

Take care with the collisions, because the replayed vehicles will not react to collisions from the hero, and they will maintain always the recorded position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1807)
<!-- Reviewable:end -->
