### PR TITLE
Add transmission gears access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Add access to vehicle transmission details
   * Add access to vehicle physics brake values
   * Enabled texture streaming for scene captures
     - Enabled texture streaming in the Unreal project settings

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -275,6 +275,14 @@
 - `__eq__(other)`
 - `__ne__(other)`
 
+## `carla.GearPhysicsControl`
+
+- `ratio`
+- `down_ratio`
+- `up_ratio`
+- `__eq__(other)`
+- `__ne__(other)`
+
 ## `carla.VehiclePhysicsControl`
 
 - `torque_curve`
@@ -286,6 +294,8 @@
 - `use_gear_autobox`
 - `gear_switch_time`
 - `clutch_strength`
+- `final_ratio`
+- `forward_gears`
 - `mass`
 - `drag_coefficient`
 - `center_of_mass`

--- a/Docs/python_api_tutorial.md
+++ b/Docs/python_api_tutorial.md
@@ -198,7 +198,7 @@ Also, physics control properties can be tuned for vehicles and its wheels
 vehicle.apply_physics_control(carla.VehiclePhysicsControl(max_rpm = 5000.0, center_of_mass = carla.Vector3D(0.0, 0.0, 0.0), torque_curve=[[0,400],[5000,400]]))
 ```
 
-These properties are controlled through a `VehiclePhysicsControl` object, which also contains a property to control each wheel's physics through a `WheelPhysicsControl` object.
+These properties are controlled through a `VehiclePhysicsControl` object, which also contains a property to control each wheel's physics through a `WheelPhysicsControl` object and the gearbox details via `GearPhysicsControl`.
 
 ```py
 carla.VehiclePhysicsControl(
@@ -211,6 +211,7 @@ carla.VehiclePhysicsControl(
     use_gear_autobox,
     gear_switch_time,
     clutch_strength,
+
     mass,
     drag_coefficient,
     center_of_mass,
@@ -228,6 +229,9 @@ Where:
 - *use_gear_autobox*: If true, the vehicle will have automatic transmission
 - *gear_switch_time*: Switching time between gears
 - *clutch_strength*: The clutch strength of the vehicle. Measured in Kgm^2/s
+
+- *final_ratio*: The fixed ratio from transmission to wheels.
+- *forward_gears*: List of `GearPhysicsControl` objects.
 
 - *mass*: The mass of the vehicle measured in Kg
 - *drag_coefficient*: Drag coefficient of the vehicle's chassis
@@ -254,6 +258,16 @@ Where:
 - *max_handbrake_torque*: The maximum handbrake torque in Nm.
 - *position*: The position of the wheel.
 
+```py
+carla.GearPhysicsControl(
+    ratio,
+    down_ratio,
+    up_ratio)
+```
+Where:
+- *ratio*: The transmission ratio of this gear.
+- *down_ratio*: The level of RPM (in relation to MaxRPM) where the gear autobox initiates shifting down.
+- *up_ratio*: The level of RPM (in relation to MaxRPM) where the gear autobox initiates shifting up.
 
 Our vehicles also come with a handy autopilot
 

--- a/LibCarla/source/carla/rpc/GearPhysicsControl.h
+++ b/LibCarla/source/carla/rpc/GearPhysicsControl.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+
+namespace carla {
+namespace rpc {
+
+  class GearPhysicsControl {
+  public:
+
+    GearPhysicsControl() = default;
+
+    GearPhysicsControl(
+    float in_ratio,
+    float in_down_ratio,
+    float in_up_ratio)
+      : ratio(in_ratio),
+        down_ratio(in_down_ratio),
+        up_ratio(in_up_ratio) {}
+
+    float ratio = 1.0f;
+    float down_ratio = 0.5f;
+    float up_ratio = 0.65f;
+
+    bool operator!=(const GearPhysicsControl &rhs) const {
+      return
+      ratio != rhs.ratio ||
+      down_ratio != rhs.down_ratio ||
+      up_ratio != rhs.up_ratio;
+    }
+
+    bool operator==(const GearPhysicsControl &rhs) const {
+      return !(*this != rhs);
+    }
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    GearPhysicsControl(const FGearPhysicsControl &Gear)
+      : ratio(Gear.Ratio),
+        down_ratio(Gear.DownRatio),
+        up_ratio(Gear.UpRatio) {}
+
+    operator FGearPhysicsControl() const {
+      FGearPhysicsControl Gear;
+      Gear.Ratio = ratio;
+      Gear.DownRatio = down_ratio;
+      Gear.UpRatio = up_ratio;
+      return Gear;
+    }
+#endif
+
+    MSGPACK_DEFINE_ARRAY(ratio,
+    down_ratio,
+    up_ratio)
+  };
+
+}
+}

--- a/LibCarla/source/carla/rpc/VehiclePhysicsControl.h
+++ b/LibCarla/source/carla/rpc/VehiclePhysicsControl.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
+// Copyright (c) 2019 Intel Corporation
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
@@ -9,6 +10,7 @@
 #include "carla/MsgPack.h"
 #include "carla/geom/Location.h"
 #include "carla/geom/Vector2D.h"
+#include "carla/rpc/GearPhysicsControl.h"
 #include "carla/rpc/WheelPhysicsControl.h"
 
 #include <string>
@@ -32,6 +34,8 @@ namespace rpc {
         bool in_use_gear_autobox,
         float in_gear_switch_time,
         float in_clutch_strength,
+        float in_final_ratio,
+        std::vector<GearPhysicsControl> &in_forward_gears,
 
         float in_mass,
         float in_drag_coefficient,
@@ -47,11 +51,21 @@ namespace rpc {
         use_gear_autobox(in_use_gear_autobox),
         gear_switch_time(in_gear_switch_time),
         clutch_strength(in_clutch_strength),
+        final_ratio(in_final_ratio),
+        forward_gears(in_forward_gears),
         mass(in_mass),
         drag_coefficient(in_drag_coefficient),
         center_of_mass(in_center_of_mass),
         steering_curve(in_steering_curve),
         wheels(in_wheels) {}
+
+    const std::vector<GearPhysicsControl> &GetForwardGears() const {
+      return forward_gears;
+    }
+
+    void SetForwardGears(std::vector<GearPhysicsControl> &in_forward_gears) {
+      forward_gears = in_forward_gears;
+    }
 
     const std::vector<WheelPhysicsControl> &GetWheels() const {
       return wheels;
@@ -87,6 +101,8 @@ namespace rpc {
     bool use_gear_autobox = true;
     float gear_switch_time = 0.5f;
     float clutch_strength = 10.0f;
+    float final_ratio = 4.0f;
+    std::vector<GearPhysicsControl> forward_gears;
 
     float mass = 1000.0f;
     float drag_coefficient = 0.3f;
@@ -106,6 +122,8 @@ namespace rpc {
         use_gear_autobox != rhs.use_gear_autobox ||
         gear_switch_time != rhs.gear_switch_time ||
         clutch_strength != rhs.clutch_strength ||
+        final_ratio != rhs.final_ratio ||
+        forward_gears != rhs.forward_gears ||
 
         mass != rhs.mass ||
         drag_coefficient != rhs.drag_coefficient ||
@@ -138,6 +156,11 @@ namespace rpc {
       use_gear_autobox = Control.bUseGearAutoBox;
       gear_switch_time = Control.GearSwitchTime;
       clutch_strength = Control.ClutchStrength;
+      final_ratio = Control.FinalRatio;
+      forward_gears = std::vector<GearPhysicsControl>();
+      for (const auto &Gear : Control.ForwardGears) {
+        forward_gears.push_back(GearPhysicsControl(Gear));
+      }
 
       // Vehicle Setup
       mass = Control.Mass;
@@ -154,7 +177,7 @@ namespace rpc {
 
       // Wheels Setup
       wheels = std::vector<WheelPhysicsControl>();
-      for (auto Wheel : Control.Wheels) {
+      for (const auto &Wheel : Control.Wheels) {
         wheels.push_back(WheelPhysicsControl(Wheel));
       }
     }
@@ -164,7 +187,7 @@ namespace rpc {
 
       // Engine Setup
       FRichCurve TorqueCurve;
-      for (auto point : torque_curve) {
+      for (const auto &point : torque_curve) {
         TorqueCurve.AddKey(point.x, point.y);
       }
       Control.TorqueCurve = TorqueCurve;
@@ -178,6 +201,13 @@ namespace rpc {
       Control.bUseGearAutoBox = use_gear_autobox;
       Control.GearSwitchTime = gear_switch_time;
       Control.ClutchStrength = clutch_strength;
+      Control.FinalRatio = final_ratio;
+      TArray<FGearPhysicsControl> ForwardGears;
+      for (const auto &gear : forward_gears) {
+        ForwardGears.Add(FGearPhysicsControl(gear));
+      }
+      Control.ForwardGears = ForwardGears;
+
 
       // Vehicle Setup
       Control.Mass = mass;
@@ -185,7 +215,7 @@ namespace rpc {
 
       // Transmission Setup
       FRichCurve SteeringCurve;
-      for (auto point : steering_curve) {
+      for (const auto &point : steering_curve) {
         SteeringCurve.AddKey(point.x, point.y);
       }
       Control.SteeringCurve = SteeringCurve;
@@ -194,7 +224,7 @@ namespace rpc {
 
       // Wheels Setup
       TArray<FWheelPhysicsControl> Wheels;
-      for (auto wheel : wheels) {
+      for (const auto &wheel : wheels) {
         Wheels.Add(FWheelPhysicsControl(wheel));
       }
       Control.Wheels = Wheels;
@@ -213,6 +243,8 @@ namespace rpc {
         use_gear_autobox,
         gear_switch_time,
         clutch_strength,
+        final_ratio,
+        forward_gears,
         mass,
         drag_coefficient,
         center_of_mass,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
+// Copyright (c) 2019 Intel Corporation
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
@@ -231,6 +232,22 @@ FVehiclePhysicsControl ACarlaWheeledVehicle::GetVehiclePhysicsControl()
   PhysicsControl.bUseGearAutoBox = Vehicle4W->TransmissionSetup.bUseGearAutoBox;
   PhysicsControl.GearSwitchTime = Vehicle4W->TransmissionSetup.GearSwitchTime;
   PhysicsControl.ClutchStrength = Vehicle4W->TransmissionSetup.ClutchStrength;
+  PhysicsControl.FinalRatio = Vehicle4W->TransmissionSetup.FinalRatio;
+
+  TArray<FGearPhysicsControl> ForwardGears;
+
+  for (const auto &Gear : Vehicle4W->TransmissionSetup.ForwardGears)
+  {
+    FGearPhysicsControl GearPhysicsControl;
+
+    GearPhysicsControl.Ratio = Gear.Ratio;
+    GearPhysicsControl.UpRatio = Gear.UpRatio;
+    GearPhysicsControl.DownRatio = Gear.DownRatio;
+
+    ForwardGears.Add(GearPhysicsControl);
+  }
+
+  PhysicsControl.ForwardGears = ForwardGears;
 
   // Vehicle Setup
   PhysicsControl.Mass = Vehicle4W->Mass;
@@ -294,6 +311,24 @@ void ACarlaWheeledVehicle::ApplyVehiclePhysicsControl(const FVehiclePhysicsContr
   Vehicle4W->TransmissionSetup.bUseGearAutoBox = PhysicsControl.bUseGearAutoBox;
   Vehicle4W->TransmissionSetup.GearSwitchTime = PhysicsControl.GearSwitchTime;
   Vehicle4W->TransmissionSetup.ClutchStrength = PhysicsControl.ClutchStrength;
+  Vehicle4W->TransmissionSetup.FinalRatio = PhysicsControl.FinalRatio;
+
+  TArray<FVehicleGearData> ForwardGears;
+
+  for (const auto &Gear : PhysicsControl.ForwardGears)
+  {
+    FVehicleGearData GearData;
+
+    GearData.Ratio = Gear.Ratio;
+    GearData.UpRatio = Gear.UpRatio;
+    GearData.DownRatio = Gear.DownRatio;
+
+    ForwardGears.Add(GearData);
+  }
+
+  Vehicle4W->TransmissionSetup.ForwardGears = ForwardGears;
+
+
 
   // Vehicle Setup
   Vehicle4W->Mass = PhysicsControl.Mass;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/VehiclePhysicsControl.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/VehiclePhysicsControl.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
+// Copyright (c) 2019 Intel Corporation
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
@@ -8,6 +9,21 @@
 
 #include "Vehicle/WheelPhysicsControl.h"
 #include "VehiclePhysicsControl.generated.h"
+
+USTRUCT(BlueprintType)
+struct FGearPhysicsControl
+{
+  GENERATED_USTRUCT_BODY()
+
+  UPROPERTY(Category = "Gear Physics Control", EditAnywhere, BlueprintReadWrite)
+  float Ratio = 1.0f;
+
+  UPROPERTY(Category = "Gear Physics Control", EditAnywhere, BlueprintReadWrite)
+  float DownRatio = 0.5f;
+
+  UPROPERTY(Category = "Gear Physics Control", EditAnywhere, BlueprintReadWrite)
+  float UpRatio = 0.65f;
+};
 
 USTRUCT(BlueprintType)
 struct CARLA_API FVehiclePhysicsControl
@@ -43,6 +59,12 @@ struct CARLA_API FVehiclePhysicsControl
 
   UPROPERTY(Category = "Vehicle Engine Physics Control", EditAnywhere, BlueprintReadWrite)
   float ClutchStrength = 0.0f;
+
+  UPROPERTY(Category = "Vehicle Engine Physics Control", EditAnywhere, BlueprintReadWrite)
+  float FinalRatio = 1.0f;
+
+  UPROPERTY(Category = "Vehicle Engine Physics Control", EditAnywhere, BlueprintReadWrite)
+  TArray<FGearPhysicsControl> ForwardGears;
 
   // Vehicle Setup
   UPROPERTY(Category = "Vehicle Engine Physics Control", EditAnywhere, BlueprintReadWrite)


### PR DESCRIPTION
#### Description

Proper calculation of vehicle acceleration require transmission details like the gear ratios.
This adds read and write access from LibCarla and PythonAPI.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** Python 2.7
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1813)
<!-- Reviewable:end -->
