### PR TITLE
Allow removing on tick callbacks and fixes to client-side sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   * API extension: added `WorldSnapshot` that contains a list of `ActorSnapshot`, allows capturings a "still image" of the world at a single frame
   * API extension: `world.tick()` now synchronizes with the simulator and returns the id of the newly started frame
   * API extension: `world.apply_settings(settings)` now synchronizes with the simulator and returns the id of the frame when the settings took effect
+  * API extension: added `world.remove_on_tick(id)` to allow removing on tick callbacks
   * API change: Rename `frame_count` and `frame_number` as `frame`, old members are kept as deprecated
   * API change: `world.wait_for_tick()` now returns a `carla.WorldSnapshot`
   * API change: the callback of `world.on_tick(callback)` now receives a `carla.WorldSnapshot`

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -41,7 +41,8 @@
 - `spawn_actor(blueprint, transform, attach_to=None)`
 - `try_spawn_actor(blueprint, transform, attach_to=None, attachment_type=carla.AttachmentType.Rigid)`
 - `wait_for_tick(seconds=1.0) -> carla.WorldSnapshot`
-- `on_tick(callback)`
+- `on_tick(callback) -> id of the callback`
+- `remove_on_tick(id)`
 - `tick() -> int (id of the newly started frame)`
 
 ## `carla.WorldSettings`

--- a/LibCarla/source/carla/client/GnssSensor.cpp
+++ b/LibCarla/source/carla/client/GnssSensor.cpp
@@ -8,6 +8,7 @@
 #include "carla/Logging.h"
 #include "carla/client/Map.h"
 #include "carla/client/detail/Simulator.h"
+#include "carla/geom/GeoLocation.h"
 #include "carla/sensor/data/GnssEvent.h"
 
 #include <exception>
@@ -15,58 +16,77 @@
 namespace carla {
 namespace client {
 
-  GnssSensor::~GnssSensor() = default;
+  // ===========================================================================
+  // -- GnssCallback -----------------------------------------------------------
+  // ===========================================================================
 
-  void GnssSensor::Listen(CallbackFunctionType callback) {
-    if (IsListening()) {
-      log_error(GetDisplayId(), ": already listening");
-      return;
-    }
+  class GnssCallback {
+  public:
 
-    if (GetParent() == nullptr) {
-      throw_exception(std::runtime_error(GetDisplayId() + ": not attached to vehicle"));
-      return;
-    }
+    GnssCallback(
+        ActorId sensor_id,
+        geom::GeoLocation geo_reference,
+        Sensor::CallbackFunctionType &&user_callback)
+      : _sensor_id(sensor_id),
+        _geo_reference(geo_reference),
+        _callback(std::move(user_callback)) {}
 
-    SharedPtr<Map> map = GetWorld().GetMap();
-    DEBUG_ASSERT(map != nullptr);
-    _geo_reference = map->GetGeoReference();
+    void operator()(const WorldSnapshot &snapshot) const;
 
-    auto self = boost::static_pointer_cast<GnssSensor>(shared_from_this());
+  private:
 
-    log_debug(GetDisplayId(), ": subscribing to tick event");
-    _callback_id = GetEpisode().Lock()->RegisterOnTickEvent([
-        cb=std::move(callback),
-        weak_self=WeakPtr<GnssSensor>(self)](const auto &snapshot) {
-      auto self = weak_self.lock();
-      if (self != nullptr) {
-        auto data = self->TickGnssSensor(snapshot.GetTimestamp());
-        if (data != nullptr) {
-          cb(std::move(data));
-        }
-      }
-    });
-  }
+    ActorId _sensor_id;
 
-  SharedPtr<sensor::SensorData> GnssSensor::TickGnssSensor(
-      const Timestamp &timestamp) {
+    geom::GeoLocation _geo_reference;
+
+    Sensor::CallbackFunctionType _callback;
+  };
+
+  void GnssCallback::operator()(const WorldSnapshot &snapshot) const {
     try {
-      return MakeShared<sensor::data::GnssEvent>(
-               timestamp.frame,
-               timestamp.elapsed_seconds,
-               GetTransform(),
-               _geo_reference.Transform(GetLocation()));
+      auto actor_snapshot = snapshot.Find(_sensor_id);
+      if (actor_snapshot.has_value()) {
+        auto transform = actor_snapshot->transform;
+        _callback(MakeShared<sensor::data::GnssEvent>(
+            snapshot.GetTimestamp().frame,
+            snapshot.GetTimestamp().elapsed_seconds,
+            transform,
+            _geo_reference.Transform(transform.location)));
+      }
     } catch (const std::exception &e) {
       log_error("GnssSensor:", e.what());
-      Stop();
-      return nullptr;
+    }
+  }
+
+  // ===========================================================================
+  // -- GnssSensor -------------------------------------------------------------
+  // ===========================================================================
+
+  GnssSensor::~GnssSensor() {
+    Stop();
+  }
+
+  void GnssSensor::Listen(CallbackFunctionType callback) {
+    auto episode = GetEpisode().Lock();
+    SharedPtr<Map> map = episode->GetCurrentMap();
+    DEBUG_ASSERT(map != nullptr);
+
+    const size_t callback_id = episode->RegisterOnTickEvent(GnssCallback(
+        GetId(),
+        map->GetGeoReference(),
+        std::move(callback)));
+
+    const size_t previous = _callback_id.exchange(callback_id);
+    if (previous != 0u) {
+      episode->RemoveOnTickEvent(previous);
     }
   }
 
   void GnssSensor::Stop() {
-    if (_callback_id.has_value()) {
-      GetEpisode().Lock()->RemoveOnTickEvent(*_callback_id);
-      _callback_id = boost::none;
+    const size_t previous = _callback_id.exchange(0u);
+    auto episode = GetEpisode().TryLock();
+    if ((previous != 0u) && (episode != nullptr)) {
+      episode->RemoveOnTickEvent(previous);
     }
   }
 

--- a/LibCarla/source/carla/client/GnssSensor.h
+++ b/LibCarla/source/carla/client/GnssSensor.h
@@ -6,9 +6,8 @@
 #pragma once
 
 #include "carla/client/ClientSideSensor.h"
-#include "carla/geom/GeoLocation.h"
 
-#include <boost/optional.hpp>
+#include <atomic>
 
 namespace carla {
 namespace client {
@@ -35,16 +34,12 @@ namespace client {
     /// Return whether this Sensor instance is currently listening to the
     /// associated sensor in the simulator.
     bool IsListening() const override {
-      return _callback_id.has_value();
+      return _callback_id != 0u;
     }
 
   private:
 
-    SharedPtr<sensor::SensorData> TickGnssSensor(const Timestamp &timestamp);
-
-    geom::GeoLocation _geo_reference;
-
-    boost::optional<size_t> _callback_id;
+    std::atomic_size_t _callback_id{0u};
   };
 
 } // namespace client

--- a/LibCarla/source/carla/client/GnssSensor.h
+++ b/LibCarla/source/carla/client/GnssSensor.h
@@ -5,16 +5,18 @@
 
 #pragma once
 
-#include "carla/client/Sensor.h"
+#include "carla/client/ClientSideSensor.h"
 #include "carla/geom/GeoLocation.h"
+
+#include <boost/optional.hpp>
 
 namespace carla {
 namespace client {
 
-  class GnssSensor final : public Sensor {
+  class GnssSensor final : public ClientSideSensor {
   public:
 
-    using Sensor::Sensor;
+    using ClientSideSensor::ClientSideSensor;
 
     ~GnssSensor();
 
@@ -33,7 +35,7 @@ namespace client {
     /// Return whether this Sensor instance is currently listening to the
     /// associated sensor in the simulator.
     bool IsListening() const override {
-      return _is_listening;
+      return _callback_id.has_value();
     }
 
   private:
@@ -42,7 +44,7 @@ namespace client {
 
     geom::GeoLocation _geo_reference;
 
-    bool _is_listening = false;
+    boost::optional<size_t> _callback_id;
   };
 
 } // namespace client

--- a/LibCarla/source/carla/client/LaneInvasionSensor.cpp
+++ b/LibCarla/source/carla/client/LaneInvasionSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -10,6 +10,7 @@
 #include "carla/client/Map.h"
 #include "carla/client/Vehicle.h"
 #include "carla/client/detail/Simulator.h"
+#include "carla/geom/Location.h"
 #include "carla/geom/Math.h"
 #include "carla/sensor/data/LaneInvasionEvent.h"
 
@@ -17,6 +18,10 @@
 
 namespace carla {
 namespace client {
+
+  // ===========================================================================
+  // -- Static local methods ---------------------------------------------------
+  // ===========================================================================
 
   static geom::Location Rotate(float yaw, const geom::Location &location) {
     yaw *= geom::Math::Pi<float>() / 180.0f;
@@ -28,80 +33,150 @@ namespace client {
         location.z};
   }
 
-  static std::array<geom::Location, 4u> GetVehicleBounds(const Vehicle &vehicle) {
-    const auto &box = vehicle.GetBoundingBox();
-    const auto &transform = vehicle.GetTransform();
+  // ===========================================================================
+  // -- LaneInvasionCallback ---------------------------------------------------
+  // ===========================================================================
+
+  class LaneInvasionCallback {
+  public:
+
+    LaneInvasionCallback(
+        const Vehicle &vehicle,
+        SharedPtr<Map> &&map,
+        Sensor::CallbackFunctionType &&user_callback)
+      : _parent(vehicle.GetId()),
+        _parent_bounding_box(vehicle.GetBoundingBox()),
+        _map(std::move(map)),
+        _callback(std::move(user_callback)) {
+      DEBUG_ASSERT(_map != nullptr);
+    }
+
+    void Tick(const WorldSnapshot &snapshot) const;
+
+  private:
+
+    struct Bounds {
+      size_t frame;
+      std::array<geom::Location, 4u> corners;
+    };
+
+    std::shared_ptr<const Bounds> MakeBounds(
+        size_t frame,
+        const geom::Transform &vehicle_transform) const;
+
+    ActorId _parent;
+
+    geom::BoundingBox _parent_bounding_box;
+
+    SharedPtr<const Map> _map;
+
+    Sensor::CallbackFunctionType _callback;
+
+    mutable AtomicSharedPtr<const Bounds> _bounds;
+  };
+
+  void LaneInvasionCallback::Tick(const WorldSnapshot &snapshot) const {
+    // Make sure the parent is alive.
+    auto parent = snapshot.Find(_parent);
+    if (!parent) {
+      return;
+    }
+
+    auto next = MakeBounds(snapshot.GetFrame(), parent->transform);
+    auto prev = _bounds.load();
+
+    // First frame it'll be null.
+    if ((prev == nullptr) && _bounds.compare_exchange(&prev, next)) {
+      return;
+    }
+
+    // Make sure the distance is long enough.
+    constexpr float distance_threshold = 10.0f * std::numeric_limits<float>::epsilon();
+    for (auto i = 0u; i < 4u; ++i) {
+      if ((next->corners[i] - prev->corners[i]).Length() < distance_threshold) {
+        return;
+      }
+    }
+
+    // Make sure the current frame is up-to-date.
+    do {
+      if (prev->frame >= next->frame) {
+        return;
+      }
+    } while (!_bounds.compare_exchange(&prev, next));
+
+    // Finally it's safe to compute the crossed lanes.
+    std::vector<road::element::LaneMarking> crossed_lanes;
+    for (auto i = 0u; i < 4u; ++i) {
+      const auto lanes = _map->CalculateCrossedLanes(prev->corners[i], next->corners[i]);
+      crossed_lanes.insert(crossed_lanes.end(), lanes.begin(), lanes.end());
+    }
+
+    if (!crossed_lanes.empty()) {
+      _callback(MakeShared<sensor::data::LaneInvasionEvent>(
+          snapshot.GetTimestamp().frame,
+          snapshot.GetTimestamp().elapsed_seconds,
+          parent->transform,
+          _parent,
+          std::move(crossed_lanes)));
+    }
+  }
+
+  std::shared_ptr<const LaneInvasionCallback::Bounds> LaneInvasionCallback::MakeBounds(
+      const size_t frame,
+      const geom::Transform &transform) const {
+    const auto &box = _parent_bounding_box;
     const auto location = transform.location + box.location;
     const auto yaw = transform.rotation.yaw;
-    return {
+    return std::make_shared<Bounds>(Bounds{frame, {
         location + Rotate(yaw, geom::Location( box.extent.x,  box.extent.y, 0.0f)),
         location + Rotate(yaw, geom::Location(-box.extent.x,  box.extent.y, 0.0f)),
         location + Rotate(yaw, geom::Location( box.extent.x, -box.extent.y, 0.0f)),
-        location + Rotate(yaw, geom::Location(-box.extent.x, -box.extent.y, 0.0f))};
+        location + Rotate(yaw, geom::Location(-box.extent.x, -box.extent.y, 0.0f))}});
   }
 
-  LaneInvasionSensor::~LaneInvasionSensor() = default;
+  // ===========================================================================
+  // -- LaneInvasionSensor -----------------------------------------------------
+  // ===========================================================================
+
+  LaneInvasionSensor::~LaneInvasionSensor() {
+    Stop();
+  }
 
   void LaneInvasionSensor::Listen(CallbackFunctionType callback) {
-    if (IsListening()) {
-      log_error(GetDisplayId(), ": already listening");
+    auto vehicle = boost::dynamic_pointer_cast<Vehicle>(GetParent());
+    if (vehicle == nullptr) {
+      log_error(GetDisplayId(), ": not attached to a vehicle");
       return;
     }
 
-    _vehicle = boost::dynamic_pointer_cast<Vehicle>(GetParent());
-    if (_vehicle == nullptr) {
-      log_error(GetDisplayId(), ": not attached to vehicle");
-      return;
-    }
+    auto episode = GetEpisode().Lock();
+    SharedPtr<Map> map = episode->GetCurrentMap();
 
-    _map = GetWorld().GetMap();
-    DEBUG_ASSERT(_map != nullptr);
+    auto cb = std::make_shared<LaneInvasionCallback>(
+        *vehicle,
+        episode->GetCurrentMap(),
+        std::move(callback));
 
-    auto self = boost::static_pointer_cast<LaneInvasionSensor>(shared_from_this());
-
-    log_debug(GetDisplayId(), ": subscribing to tick event");
-    _callback_id = GetEpisode().Lock()->RegisterOnTickEvent([
-        cb=std::move(callback),
-        weak_self=WeakPtr<LaneInvasionSensor>(self)](const auto &snapshot) {
-      auto self = weak_self.lock();
-      if (self != nullptr) {
-        auto data = self->TickLaneInvasionSensor(snapshot.GetTimestamp());
-        if (data != nullptr) {
-          cb(std::move(data));
-        }
+    const size_t callback_id = episode->RegisterOnTickEvent([cb=std::move(cb)](const auto &snapshot) {
+      try {
+        cb->Tick(snapshot);
+      } catch (const std::exception &e) {
+        log_error("LaneInvasionSensor:", e.what());
       }
     });
+
+    const size_t previous = _callback_id.exchange(callback_id);
+    if (previous != 0u) {
+      episode->RemoveOnTickEvent(previous);
+    }
   }
 
   void LaneInvasionSensor::Stop() {
-    if (_callback_id.has_value()) {
-      GetEpisode().Lock()->RemoveOnTickEvent(*_callback_id);
-      _callback_id = boost::none;
-    }
-  }
-
-  SharedPtr<sensor::SensorData> LaneInvasionSensor::TickLaneInvasionSensor(
-      const Timestamp &timestamp) {
-    try {
-      const auto new_bounds = GetVehicleBounds(*_vehicle);
-      std::vector<road::element::LaneMarking> crossed_lanes;
-      for (auto i = 0u; i < _bounds.size(); ++i) {
-        const auto lanes = _map->CalculateCrossedLanes(_bounds[i], new_bounds[i]);
-        crossed_lanes.insert(crossed_lanes.end(), lanes.begin(), lanes.end());
-      }
-      _bounds = new_bounds;
-      return crossed_lanes.empty() ?
-          nullptr :
-          MakeShared<sensor::data::LaneInvasionEvent>(
-              timestamp.frame,
-              timestamp.elapsed_seconds,
-              _vehicle->GetTransform(),
-              _vehicle,
-              crossed_lanes);
-    } catch (const std::exception &e) {
-      log_error("LaneInvasionSensor:", e.what());
-      Stop();
-      return nullptr;
+    const size_t previous = _callback_id.exchange(0u);
+    auto episode = GetEpisode().TryLock();
+    if ((previous != 0u) && (episode != nullptr)) {
+      episode->RemoveOnTickEvent(previous);
     }
   }
 

--- a/LibCarla/source/carla/client/LaneInvasionSensor.h
+++ b/LibCarla/source/carla/client/LaneInvasionSensor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -7,11 +7,8 @@
 #pragma once
 
 #include "carla/client/ClientSideSensor.h"
-#include "carla/geom/Location.h"
 
-#include <boost/optional.hpp>
-
-#include <array>
+#include <atomic>
 
 namespace carla {
 namespace client {
@@ -29,31 +26,24 @@ namespace client {
     /// Register a @a callback to be executed each time a new measurement is
     /// received.
     ///
-    /// @warning This function should not be called twice.
-    /// @todo This is different from other sensors.
+    /// @warning Calling this function on a sensor that is already listening
+    /// steals the data stream from the previously set callback. Note that
+    /// several instances of Sensor (even in different processes) may point to
+    /// the same sensor in the simulator.
     void Listen(CallbackFunctionType callback) override;
 
     /// Stop listening for new measurements.
-    /// @throw Not implemented error.
     void Stop() override;
 
     /// Return whether this Sensor instance is currently listening to the
     /// associated sensor in the simulator.
     bool IsListening() const override {
-      return _callback_id.has_value();
+      return _callback_id != 0u;
     }
 
   private:
 
-    SharedPtr<sensor::SensorData> TickLaneInvasionSensor(const Timestamp &timestamp);
-
-    SharedPtr<Map> _map;
-
-    SharedPtr<Vehicle> _vehicle;
-
-    std::array<geom::Location, 4u> _bounds;
-
-    boost::optional<size_t> _callback_id;
+    std::atomic_size_t _callback_id{0u};
   };
 
 } // namespace client

--- a/LibCarla/source/carla/client/LaneInvasionSensor.h
+++ b/LibCarla/source/carla/client/LaneInvasionSensor.h
@@ -9,6 +9,8 @@
 #include "carla/client/ClientSideSensor.h"
 #include "carla/geom/Location.h"
 
+#include <boost/optional.hpp>
+
 #include <array>
 
 namespace carla {
@@ -38,20 +40,20 @@ namespace client {
     /// Return whether this Sensor instance is currently listening to the
     /// associated sensor in the simulator.
     bool IsListening() const override {
-      return _is_listening;
+      return _callback_id.has_value();
     }
 
   private:
 
     SharedPtr<sensor::SensorData> TickLaneInvasionSensor(const Timestamp &timestamp);
 
-    bool _is_listening = false;
-
     SharedPtr<Map> _map;
 
     SharedPtr<Vehicle> _vehicle;
 
     std::array<geom::Location, 4u> _bounds;
+
+    boost::optional<size_t> _callback_id;
   };
 
 } // namespace client

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -97,8 +97,12 @@ namespace client {
     return _episode.Lock()->WaitForTick(timeout);
   }
 
-  void World::OnTick(std::function<void(WorldSnapshot)> callback) {
+  size_t World::OnTick(std::function<void(WorldSnapshot)> callback) {
     return _episode.Lock()->RegisterOnTickEvent(std::move(callback));
+  }
+
+  void World::RemoveOnTick(size_t callback_id) {
+    _episode.Lock()->RemoveOnTickEvent(callback_id);
   }
 
   uint64_t World::Tick() {

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -104,7 +104,12 @@ namespace client {
     WorldSnapshot WaitForTick(time_duration timeout) const;
 
     /// Register a @a callback to be called every time a world tick is received.
-    void OnTick(std::function<void(WorldSnapshot)> callback);
+    ///
+    /// @return ID of the callback, use it to remove the callback.
+    size_t OnTick(std::function<void(WorldSnapshot)> callback);
+
+    /// Remove a callback registered with OnTick.
+    void RemoveOnTick(size_t callback_id);
 
     /// Signal the simulator to continue to next tick (only has effect on
     /// synchronous mode).

--- a/LibCarla/source/carla/client/WorldSnapshot.h
+++ b/LibCarla/source/carla/client/WorldSnapshot.h
@@ -26,6 +26,10 @@ namespace client {
       return _state->GetEpisodeId();
     }
 
+    size_t GetFrame() const {
+      return GetTimestamp().frame;
+    }
+
     /// Get timestamp of this snapshot.
     const Timestamp &GetTimestamp() const {
       return _state->GetTimestamp();

--- a/LibCarla/source/carla/client/detail/CallbackList.h
+++ b/LibCarla/source/carla/client/detail/CallbackList.h
@@ -31,6 +31,7 @@ namespace detail {
 
     size_t Push(CallbackType &&callback) {
       auto id = ++_counter;
+      DEBUG_ASSERT(id != 0u);
       _list.Push(Item{id, std::move(callback)});
       return id;
     }

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -71,8 +71,12 @@ namespace detail {
       return _snapshot.WaitFor(timeout);
     }
 
-    void RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
-      _on_tick_callbacks.RegisterCallback(std::move(callback));
+    size_t RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
+      return _on_tick_callbacks.Push(std::move(callback));
+    }
+
+    void RemoveOnTickEvent(size_t id) {
+      _on_tick_callbacks.Remove(id);
     }
 
   private:

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -140,9 +140,14 @@ namespace detail {
 
     WorldSnapshot WaitForTick(time_duration timeout);
 
-    void RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
+    size_t RegisterOnTickEvent(std::function<void(WorldSnapshot)> callback) {
       DEBUG_ASSERT(_episode != nullptr);
-      _episode->RegisterOnTickEvent(std::move(callback));
+      return _episode->RegisterOnTickEvent(std::move(callback));
+    }
+
+    void RemoveOnTickEvent(size_t id) {
+      DEBUG_ASSERT(_episode != nullptr);
+      _episode->RemoveOnTickEvent(id);
     }
 
     uint64_t Tick();

--- a/LibCarla/source/carla/client/detail/WalkerNavigation.h
+++ b/LibCarla/source/carla/client/detail/WalkerNavigation.h
@@ -41,7 +41,7 @@ namespace detail {
       while (i < list->size()) {
         if ((*list)[i].walker == walker_id &&
         (*list)[i].controller == controller_id) {
-          _walkers.Delete(i);
+          _walkers.DeleteByIndex(i);
           break;
         }
         ++i;

--- a/LibCarla/source/carla/sensor/data/LaneInvasionEvent.cpp
+++ b/LibCarla/source/carla/sensor/data/LaneInvasionEvent.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/sensor/data/LaneInvasionEvent.h"
+
+#include "carla/Exception.h"
+#include "carla/client/detail/Simulator.h"
+
+namespace carla {
+namespace sensor {
+namespace data {
+
+  SharedPtr<client::Actor> LaneInvasionEvent::GetActor() const {
+    auto episode = GetEpisode().Lock();
+    auto description = episode->GetActorById(_parent);
+    if (!description.has_value()) {
+      throw_exception(std::runtime_error("LaneInvasionEvent: parent already dead"));
+    }
+    return episode->MakeActor(*description);
+  }
+
+} // namespace data
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/data/LaneInvasionEvent.h
+++ b/LibCarla/source/carla/sensor/data/LaneInvasionEvent.h
@@ -6,8 +6,11 @@
 
 #pragma once
 
-#include "carla/road/element/LaneMarking.h"
 #include "carla/sensor/SensorData.h"
+
+#include "carla/client/Actor.h"
+#include "carla/road/element/LaneMarking.h"
+#include "carla/rpc/ActorId.h"
 
 #include <vector>
 
@@ -25,16 +28,14 @@ namespace data {
         size_t frame,
         double timestamp,
         const rpc::Transform &sensor_transform,
-        SharedPtr<client::Actor> self_actor,
+        ActorId parent,
         std::vector<LaneMarking> crossed_lane_markings)
       : SensorData(frame, timestamp, sensor_transform),
-        _self_actor(std::move(self_actor)),
+        _parent(parent),
         _crossed_lane_markings(std::move(crossed_lane_markings)) {}
 
     /// Get "self" actor. Actor that invaded another lane.
-    SharedPtr<client::Actor> GetActor() const {
-      return _self_actor;
-    }
+    SharedPtr<client::Actor> GetActor() const;
 
     /// List of lane markings that have been crossed.
     const std::vector<LaneMarking> &GetCrossedLaneMarkings() const {
@@ -43,7 +44,7 @@ namespace data {
 
   private:
 
-    SharedPtr<client::Actor> _self_actor;
+    ActorId _parent;
 
     std::vector<LaneMarking> _crossed_lane_markings;
   };

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -52,8 +52,8 @@ static auto WaitForTick(const carla::client::World &world, double seconds) {
   return world.WaitForTick(TimeDurationFromSeconds(seconds));
 }
 
-static void OnTick(carla::client::World &self, boost::python::object callback) {
-  self.OnTick(MakeCallback(std::move(callback)));
+static size_t OnTick(carla::client::World &self, boost::python::object callback) {
+  return self.OnTick(MakeCallback(std::move(callback)));
 }
 
 static auto GetActorsById(carla::client::World &self, const boost::python::list &actor_ids) {
@@ -145,6 +145,7 @@ void export_world() {
     .def("try_spawn_actor", SPAWN_ACTOR_WITHOUT_GIL(TrySpawnActor))
     .def("wait_for_tick", &WaitForTick, (arg("seconds")=10.0))
     .def("on_tick", &OnTick, (arg("callback")))
+    .def("remove_on_tick", &cc::World::RemoveOnTick, (arg("callback_id")))
     .def("tick", CALL_WITHOUT_GIL(cc::World, Tick))
     .def(self_ns::str(self_ns::self))
   ;


### PR DESCRIPTION
I have added an ID to the callbacks so they can be removed

```py
id = world.on_tick(lambda x: do_something())
# ...
world.remove_on_tick(id)
```

I also finally made client-side sensors deregister their callbacks when they're stopped (there was no way of stopping these sensors before). While doing so I noticed that any exception thrown was ignored, actually a lot of exception were thrown all the time due to race conditions between callbacks. Basically, their "tick" is called simultaneously from different threads, and they were not taking this into account. This was specially bad for the lane invasion sensor since its measurements depend on previous measurements.

I have fixed them by making sure either the shared data is const or is properly synchronized using atomics.

Now they no longer throw exceptions and its safe to stop them, also calling listen a second time replaces the previous callback as server-side sensors do.

Fix #1273.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1865)
<!-- Reviewable:end -->
