### PR TITLE
Added Debug Render on Shipping Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
     - Added allow setting fixed frame-rate from client-side, now is part of `carla.WorldSettings`
     - Added `is_invincible` to walkers
   * Several optimizations to the RPC server, now supports a bigger load of async messages
+  * Updated DebugHelper to render on Shipping packages, it has also better performance
   * Updated OpenDriveActor to use the new Waypoint API
   * Removed deprecated code and content
   * Exposed waypoints and OpenDrive map to UE4 Blueprints

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -627,7 +627,7 @@ Class that provides drawing debug shapes.
         - `size` (_float_)  
         - `color` (_[carla.Color](#carla.Color)_)  
         - `life_time` (_float_)  
-        - `persistent_lines` (_bool_)  
+        - `persistent_lines` (_bool_) – _Deprecated, use `life_time=0` instead_.  
 - <a name="carla.DebugHelper.draw_line"></a>**<font color="#7fb800">draw_line</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**begin**</font>, <font color="#00a6ed">**end**</font>, <font color="#00a6ed">**thickness**=0.1f</font>, <font color="#00a6ed">**color**=(255,0,0)</font>, <font color="#00a6ed">**life_time**=-1.0f</font>, <font color="#00a6ed">**persistent_lines**=True</font>)  
     - **Parameters:**
         - `begin` (_[carla.Location](#carla.Location)_)  
@@ -635,7 +635,7 @@ Class that provides drawing debug shapes.
         - `thickness` (_float_)  
         - `color` (_[carla.Color](#carla.Color)_)  
         - `life_time` (_float_)  
-        - `persistent_lines` (_bool_)  
+        - `persistent_lines` (_bool_) – _Deprecated, use `life_time=0` instead_.  
 - <a name="carla.DebugHelper.draw_arrow"></a>**<font color="#7fb800">draw_arrow</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**begin**</font>, <font color="#00a6ed">**end**</font>, <font color="#00a6ed">**thickness**=0.1f</font>, <font color="#00a6ed">**arrow_size**=0.1f</font>, <font color="#00a6ed">**color**=(255,0,0)</font>, <font color="#00a6ed">**life_time**=-1.0f</font>, <font color="#00a6ed">**persistent_lines**=True</font>)  
     - **Parameters:**
         - `begin` (_[carla.Location](#carla.Location)_)  
@@ -644,7 +644,7 @@ Class that provides drawing debug shapes.
         - `arrow_size` (_float_)  
         - `color` (_[carla.Color](#carla.Color)_)  
         - `life_time` (_float_)  
-        - `persistent_lines` (_bool_)  
+        - `persistent_lines` (_bool_) – _Deprecated, use `life_time=0` instead_.  
 - <a name="carla.DebugHelper.draw_box"></a>**<font color="#7fb800">draw_box</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**box**</font>, <font color="#00a6ed">**rotation**</font>, <font color="#00a6ed">**thickness**=0.1f</font>, <font color="#00a6ed">**color**=(255,0,0)</font>, <font color="#00a6ed">**life_time**=-1.0f</font>, <font color="#00a6ed">**persistent_lines**=True</font>)  
     - **Parameters:**
         - `box` (_[carla.BoundingBox](#carla.BoundingBox)_)  
@@ -652,7 +652,7 @@ Class that provides drawing debug shapes.
         - `thickness` (_float_)  
         - `color` (_[carla.Color](#carla.Color)_)  
         - `life_time` (_float_)  
-        - `persistent_lines` (_bool_)  
+        - `persistent_lines` (_bool_) – _Deprecated, use `life_time=0` instead_.  
 - <a name="carla.DebugHelper.draw_string"></a>**<font color="#7fb800">draw_string</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**location**</font>, <font color="#00a6ed">**text**</font>, <font color="#00a6ed">**draw_shadow**=False</font>, <font color="#00a6ed">**color**=(255,0,0)</font>, <font color="#00a6ed">**life_time**=-1.0f</font>, <font color="#00a6ed">**persistent_lines**=True</font>)  
     - **Parameters:**
         - `location` (_[carla.Location](#carla.Location)_)  
@@ -660,7 +660,7 @@ Class that provides drawing debug shapes.
         - `draw_shadow` (_bool_)  
         - `color` (_[carla.Color](#carla.Color)_)  
         - `life_time` (_float_)  
-        - `persistent_lines` (_bool_)  
+        - `persistent_lines` (_bool_) – _Deprecated, set a high `life_time` instead_.  
 
 ---
 

--- a/PythonAPI/docs/world.yml
+++ b/PythonAPI/docs/world.yml
@@ -324,6 +324,8 @@
       - param_name: persistent_lines
         type: bool
         default: True
+        doc: >
+          _Deprecated, use `life_time=0` instead_
       doc: >
     # --------------------------------------
     - def_name: draw_line
@@ -344,6 +346,8 @@
       - param_name: persistent_lines
         type: bool
         default: True
+        doc: >
+          _Deprecated, use `life_time=0` instead_
       doc: >
     # --------------------------------------
     - def_name: draw_arrow
@@ -367,6 +371,8 @@
       - param_name: persistent_lines
         type: bool
         default: True
+        doc: >
+          _Deprecated, use `life_time=0` instead_
       doc: >
     # --------------------------------------
     - def_name: draw_box
@@ -387,25 +393,30 @@
       - param_name: persistent_lines
         type: bool
         default: True
+        doc: >
+          _Deprecated, use `life_time=0` instead_
       doc: >
     # --------------------------------------
     - def_name: draw_string
       params: 
-        - param_name: location
-          type: carla.Location
-        - param_name: text
-          type: str
-        - param_name: draw_shadow
-          type: bool
-          default: False
-        - param_name: color
-          type: carla.Color
-          default: (255,0,0)
-        - param_name: life_time 
-          type: float
-          default: -1.0f
-        - param_name: persistent_lines
-          type: bool
-          default: true
+      - param_name: location
+        type: carla.Location
+      - param_name: text
+        type: str
+      - param_name: draw_shadow
+        type: bool
+        default: False
+      - param_name: color
+        type: carla.Color
+        default: (255,0,0)
+      - param_name: life_time
+        type: float
+        default: -1.0f
+      - param_name: persistent_lines
+        type: bool
+        default: true
+        doc: >
+          _Deprecated, set a high `life_time` instead_
+      doc: >
     # --------------------------------------
 ...

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -6,6 +6,7 @@
 
 #include "Carla.h"
 #include "Carla/Game/CarlaGameModeBase.h"
+#include "Carla/Game/CarlaHUD.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/WeatherParameters.h>
@@ -21,6 +22,9 @@ ACarlaGameModeBase::ACarlaGameModeBase(const FObjectInitializer& ObjectInitializ
   Episode = CreateDefaultSubobject<UCarlaEpisode>(TEXT("Episode"));
 
   Recorder = CreateDefaultSubobject<ACarlaRecorder>(TEXT("Recorder"));
+
+  // HUD
+  HUDClass = ACarlaHUD::StaticClass();
 
   TaggerDelegate = CreateDefaultSubobject<UTaggerDelegate>(TEXT("TaggerDelegate"));
   CarlaSettingsDelegate = CreateDefaultSubobject<UCarlaSettingsDelegate>(TEXT("CarlaSettingsDelegate"));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaHUD.h"
+
+void ACarlaHUD::DrawHUD()
+{
+  Super::DrawHUD();
+
+  double Now = FPlatformTime::Seconds();
+  int ScreenWidth = 0;
+  int ScreenHeight = 0;
+
+  auto Player = GetOwningPlayerController();
+  if (Player == nullptr)
+  {
+    UE_LOG(LogCarla, Error, TEXT("Can't find player controller!"));
+    return;
+  }
+
+  // get viewport size for culling
+  Player->GetViewportSize(ScreenWidth, ScreenHeight);
+
+  int i = 0;
+  while (i < StringList.Num())
+  {
+    // project position from camera
+    FVector2D Screen;
+    Player->ProjectWorldLocationToScreen(StringList[i].Location, Screen, true);
+    if (Screen.X >= 0 && Screen.Y >= 0 && Screen.X < ScreenWidth && Screen.Y < ScreenHeight)
+    {
+      // draw text
+      DrawText(StringList[i].Str, StringList[i].Color, Screen.X, Screen.Y, nullptr, 1.0f, false);
+    }
+
+    // check to remove the string
+    if (Now >= StringList[i].TimeToDie)
+    {
+      // remove the string
+      StringList.RemoveAt(i);
+    }
+    else
+      ++i;
+  }
+}
+
+void ACarlaHUD::AddHUDString(FString Str, FVector Location, FColor Color, double LifeTime)
+{
+  double Now = FPlatformTime::Seconds();
+  HUDString Obj { Str, Location, Color, Now + LifeTime };
+  StringList.Add(std::move(Obj));
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
@@ -10,10 +10,6 @@ void ACarlaHUD::DrawHUD()
 {
   Super::DrawHUD();
 
-  double Now = FPlatformTime::Seconds();
-  int ScreenWidth = 0;
-  int ScreenHeight = 0;
-
   auto Player = GetOwningPlayerController();
   if (Player == nullptr)
   {
@@ -22,8 +18,11 @@ void ACarlaHUD::DrawHUD()
   }
 
   // get viewport size for culling
+  int ScreenWidth = 0;
+  int ScreenHeight = 0;
   Player->GetViewportSize(ScreenWidth, ScreenHeight);
 
+  double Now = FPlatformTime::Seconds();
   int i = 0;
   while (i < StringList.Num())
   {
@@ -39,7 +38,6 @@ void ACarlaHUD::DrawHUD()
     // check to remove the string
     if (Now >= StringList[i].TimeToDie)
     {
-      // remove the string
       StringList.RemoveAt(i);
     }
     else
@@ -47,7 +45,7 @@ void ACarlaHUD::DrawHUD()
   }
 }
 
-void ACarlaHUD::AddHUDString(FString Str, FVector Location, FColor Color, double LifeTime)
+void ACarlaHUD::AddHUDString(const FString Str, const FVector Location, const FColor Color, double LifeTime)
 {
   double Now = FPlatformTime::Seconds();
   HUDString Obj { Str, Location, Color, Now + LifeTime };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "Containers/Array.h"
+#include "GameFramework/HUD.h"
+
+#include "CarlaHUD.generated.h"
+
+struct HUDString
+{
+  FString Str { "" };
+  FVector Location;
+  FColor Color;
+  double TimeToDie;
+};
+
+/// Class to draw on HUD
+UCLASS()
+class CARLA_API ACarlaHUD : public AHUD
+{
+  GENERATED_BODY()
+
+public:
+
+  ACarlaHUD(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer)
+  {
+    PrimaryActorTick.bCanEverTick = false;
+  }
+
+  virtual void DrawHUD() override;
+
+  void AddHUDString(FString Str, FVector Location, FColor Color, double LifeTime);
+
+private:
+  TArray<HUDString> StringList;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
@@ -35,7 +35,7 @@ public:
 
   virtual void DrawHUD() override;
 
-  void AddHUDString(FString Str, FVector Location, FColor Color, double LifeTime);
+  void AddHUDString(const FString Str, const FVector Location, const FColor Color, double LifeTime);
 
 private:
   TArray<HUDString> StringList;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -159,14 +159,14 @@ struct FShapeVisitor
 
   void operator()(const Shape::String &Str) const
   {
-    DrawDebugString(
-        World,
-        Str.location,
-        carla::rpc::ToFString(Str.text),
-        nullptr,
-        Color,
-        LifeTime,
-        Str.draw_shadow);
+    auto PlayerController = UGameplayStatics::GetPlayerController(World, 0);
+    if (PlayerController == nullptr)
+    {
+      UE_LOG(LogCarla, Error, TEXT("Can't find player controller!"));
+      return;
+    }
+    ACarlaHUD *Hud = Cast<ACarlaHUD>(PlayerController->GetHUD());
+    Hud->AddHUDString(carla::rpc::ToFString(Str.text), Str.location, Color, LifeTime);
   }
 
 private:

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -8,6 +8,7 @@
 #include "Carla/Util/DebugShapeDrawer.h"
 
 #include "DrawDebugHelpers.h"
+#include "Components/LineBatchComponent.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/DebugShape.h>
@@ -22,31 +23,29 @@ struct FShapeVisitor
     : World(&InWorld),
       Color(InColor),
       LifeTime(InLifeTime),
-      bPersistentLines(bInPersistentLines) {}
+      bPersistentLines(bInPersistentLines)
+  {}
 
   void operator()(const Shape::Point &Point) const
   {
-    DrawDebugPoint(
-        World,
+    World->PersistentLineBatcher->DrawPoint(
         Point.location,
-        1e2f * Point.size,
         Color,
-        bPersistentLines,
-        LifeTime,
-        DepthPriority);
+        1e2f * Point.size,
+        SDPG_World,
+        LifeTime);
   }
 
   void operator()(const Shape::Line &Line) const
   {
-    DrawDebugLine(
-        World,
-        Line.begin,
-        Line.end,
-        Color,
-        bPersistentLines,
-        LifeTime,
-        DepthPriority,
-        1e2f * Line.thickness);
+    World->PersistentLineBatcher->DrawLines(TArray<FBatchedLine>({
+        FBatchedLine(
+            Line.begin,
+            Line.end,
+            Color,
+            LifeTime,
+            1e2f * Line.thickness,
+            SDPG_World)}));
   }
 
   void operator()(const Shape::Arrow &Arrow) const

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -107,10 +107,9 @@ struct FShapeVisitor
     B[0] = -Extent;
     B[1] =  Extent;
 
-    int32 i, j;
-    for( i=0; i<2; i++ )
+    for(int32 i = 0; i < 2; ++i)
     {
-      for( j=0; j<2; j++ )
+      for(int32 j = 0; j < 2; ++j)
       {
         P.X=B[i].X;
         Q.X=B[i].X;


### PR DESCRIPTION
#### Description
Currently, we can only render debug helpers on UE4 Editor and Debug Packages.
This PR changes that, so now you can use `debug.draw_point`, `debug.draw_line`, `debug.draw_box`, `debug.draw_arrow`, and `debug.draw_string` in Shipping packages too.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **Unreal Engine version(s):** 4.22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1874)
<!-- Reviewable:end -->
