### PR TITLE
Fix Windows build

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
@@ -17,22 +17,16 @@ void ACarlaHUD::DrawHUD()
     return;
   }
 
-  // get viewport size for culling
-  int ScreenWidth = 0;
-  int ScreenHeight = 0;
-  Player->GetViewportSize(ScreenWidth, ScreenHeight);
-
   double Now = FPlatformTime::Seconds();
   int i = 0;
   while (i < StringList.Num())
   {
     // project position from camera
     FVector2D Screen;
-    Player->ProjectWorldLocationToScreen(StringList[i].Location, Screen, true);
-    if (Screen.X >= 0 && Screen.Y >= 0 && Screen.X < ScreenWidth && Screen.Y < ScreenHeight)
+    if (Player->ProjectWorldLocationToScreen(StringList[i].Location, Screen, true))
     {
       // draw text
-      DrawText(StringList[i].Str, StringList[i].Color, Screen.X, Screen.Y, nullptr, 1.0f, false);
+      DrawText(StringList[i].Str, StringList[i].Color, Screen.X, Screen.Y);
     }
 
     // check to remove the string

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-// Workaround to fix Windows conflict: Windows change the name of some functions (DrawText, LoadLibrary...)
+// Workaround to fix Windows conflict: Windows changes the name of some functions (DrawText, LoadLibrary...)
 // with Unicode / ANSI versions for his own API (DrawTextW, DrawTextA, LoadLibraryW, LoadLibraryA...).
-// But the changes are global for the compiler. Deep in headers, windows has something like:
+// But the changes are global for the compiler. Deep in headers, Windows has something like:
 // #ifdef UNICODE
 //   #define DrawText  DrawTextW
 //   #define LoadLibrary LoadLibraryW
@@ -16,9 +16,9 @@
 //   #define DrawText  DrawTextA
 //   #define LoadLibrary LoadLibraryA
 // #endif
-// Then linker tries to find function DrawTextW on external DLL and an unresolved external error happens because
-// Unreal has no the function DrawTextW, it has just DrawText.
-// We fix that just undefining the function that conflicts by name with the Windows API Unicode.
+// Then the linker tries to find the function DrawTextW on an external DLL and an unresolved external error happens because
+// Unreal has no function DrawTextW, it has just DrawText.
+// We can fix that by just undefining the function that conflicts with the name of the Windows API in Unicode.
 #undef DrawText
 
 #include "Containers/Array.h"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.h
@@ -6,6 +6,21 @@
 
 #pragma once
 
+// Workaround to fix Windows conflict: Windows change the name of some functions (DrawText, LoadLibrary...)
+// with Unicode / ANSI versions for his own API (DrawTextW, DrawTextA, LoadLibraryW, LoadLibraryA...).
+// But the changes are global for the compiler. Deep in headers, windows has something like:
+// #ifdef UNICODE
+//   #define DrawText  DrawTextW
+//   #define LoadLibrary LoadLibraryW
+// #else
+//   #define DrawText  DrawTextA
+//   #define LoadLibrary LoadLibraryA
+// #endif
+// Then linker tries to find function DrawTextW on external DLL and an unresolved external error happens because
+// Unreal has no the function DrawTextW, it has just DrawText.
+// We fix that just undefining the function that conflicts by name with the Windows API Unicode.
+#undef DrawText
+
 #include "Containers/Array.h"
 #include "GameFramework/HUD.h"
 


### PR DESCRIPTION
#### Description

See https://github.com/carla-simulator/carla/issues/1894 for more details about the problem.

I a few words, the problem is that windows compilers change the name of some functions (those who use strings mainly) depending if they need to use UNICODE or ANSI strings. For UNICODE the function name is the same but ending with 'W', and for ANSI they end with 'A'. So, for example the function DrawText() of the windows API will change to DrawTextW() or DrawTextA() transparently.

That modification is made by the compiler using some kind of #DEFINE preprocessors, and that means that the name of the function changes globally in all the code. The problem is that if we need to load that exact function like DrawText() from a non windows DLL (like UE4Editor-Engine.dll from Unreal), the compiler at the end will try to load DrawTextW() or DrawTextA(), and that will fail with a linker error similar to:

`
error LNK2019: unresolved external symbol "__declspec(dllimport) public: void __cdecl AHUD::DrawTextW(...)"
`

So, to avoid that we found the way of #UNDEF those function names that gets in conflict with the windows translation, doing for example #UNDEF DrawText()

We also add a little fix for the strings shown on screen, because depending of the camera orientation they were shown at position 0,0.

Fixes #  1894

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** Any
  * **Unreal Engine version(s):** 4.22.1

#### Possible Drawbacks

Those functions that we UNDEF will not work if we try to use them as windows API, unless you directly use the 'W' or 'A' versions instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/1910)
<!-- Reviewable:end -->
