### PR TITLE
Add 0.9.6 windows realease

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ branch contains the latest fixes and features, for the latest stable code may be
 best to switch to the `stable` branch.
 
 Then follow the instruction at [How to build on Linux][buildlinuxlink] or
-[How to build on Windows][buildwindowslink].
+[How to build on Windows][buildwindowslink](experimenta; Build for windows exist V_0.9.6).
+Some tips for build on windows exist [here][https://github.com/carla-simulator/carla/issues/2098].
 
 Unfortunately we don't have official instructions to build on Mac yet, please
 check the progress at [issue #150][issue150].

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ branch contains the latest fixes and features, for the latest stable code may be
 best to switch to the `stable` branch.
 
 Then follow the instruction at [How to build on Linux][buildlinuxlink] or
-[How to build on Windows][buildwindowslink](experimenta; Build for windows exist V_0.9.6).
-Some tips for build on windows exist [here][https://github.com/carla-simulator/carla/issues/2098].
+[How to build on Windows][buildwindowslink](Experimental build for Windows exist <0.9.6>).
+Some tips for build on windows exist [here](https://github.com/carla-simulator/carla/issues/2098).
 
 Unfortunately we don't have official instructions to build on Mac yet, please
 check the progress at [issue #150][issue150].


### PR DESCRIPTION
Recently I build Carla for windows with 0.9.6 version source code and Unreal 4.22.
my experience exists [here](https://github.com/carla-simulator/carla/issues/2098)
if I upload binary files (about 4 gigs) on Google drive, would you put it in release part of the repository for other people use?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2108)
<!-- Reviewable:end -->
