### PR TITLE
Camera Scene Capture / Dept of Field / Mesh Distance Field

### DIFF
--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -28,7 +28,7 @@ r.DefaultFeature.AutoExposure=False
 r.CustomDepth=3
 r.Streaming.PoolSize=2000
 r.TextureStreaming=True
-r.GenerateMeshDistanceFields=False
+r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.EightBit=False
 r.DistanceFieldBuild.Compress=False
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -491,13 +491,6 @@ namespace SceneCaptureSensor_local_ns {
   {
     auto &PostProcessSettings = CaptureComponent2D.PostProcessSettings;
 
-    // Depth of field
-    PostProcessSettings.bOverride_DepthOfFieldMethod = true;
-    PostProcessSettings.DepthOfFieldMethod = EDepthOfFieldMethod::DOFM_CircleDOF;
-    PostProcessSettings.bOverride_DepthOfFieldFocalDistance = true;
-    PostProcessSettings.bOverride_DepthOfFieldDepthBlurAmount = true;
-    PostProcessSettings.bOverride_DepthOfFieldDepthBlurRadius = true;
-
     // Exposure
     PostProcessSettings.bOverride_AutoExposureMethod = true;
     PostProcessSettings.AutoExposureMethod = EAutoExposureMethod::AEM_Manual;
@@ -540,7 +533,7 @@ namespace SceneCaptureSensor_local_ns {
 
     // Ambient Occlusion
     PostProcessSettings.bOverride_AmbientOcclusionIntensity = true;
-    PostProcessSettings.AmbientOcclusionIntensity = 0.8f;
+    PostProcessSettings.AmbientOcclusionIntensity = 0.5f;
     PostProcessSettings.bOverride_AmbientOcclusionRadius	= true;
     PostProcessSettings.AmbientOcclusionRadius = 100.0f;
     PostProcessSettings.bOverride_AmbientOcclusionStaticFraction = true;
@@ -554,12 +547,11 @@ namespace SceneCaptureSensor_local_ns {
     PostProcessSettings.bOverride_AmbientOcclusionQuality = true;
     PostProcessSettings.AmbientOcclusionQuality = 100.0f;
 
-
     // Bloom
     PostProcessSettings.bOverride_BloomMethod = true;
     PostProcessSettings.BloomMethod = EBloomMethod::BM_SOG;
     PostProcessSettings.bOverride_BloomIntensity = true;
-    PostProcessSettings.BloomIntensity = 1.0f;
+    PostProcessSettings.BloomIntensity = 0.3f;
     PostProcessSettings.bOverride_BloomThreshold = true;
     PostProcessSettings.BloomThreshold = -1.0f;
   }


### PR DESCRIPTION
#### Description

- Remove Depth of Field to eliminate the blur it produces with nearby objects.
- Activate Mesh Distance Field
- Tweak PostProces values of CameraSceneCapture: Bloom and SSAO.
- Now Camera Spectator and Camera Scene Capture have a very similar render.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** UE4 22.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2173)
<!-- Reviewable:end -->
