### PR TITLE
Disable Mesh Distance Fields

### DIFF
--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -28,7 +28,7 @@ r.DefaultFeature.AutoExposure=False
 r.CustomDepth=3
 r.Streaming.PoolSize=2000
 r.TextureStreaming=True
-r.GenerateMeshDistanceFields=True
+r.GenerateMeshDistanceFields=False
 r.DistanceFieldBuild.EightBit=False
 r.DistanceFieldBuild.Compress=False
 


### PR DESCRIPTION
#### Description

We have been forced to disable the Mesh Distance Fields. They have appeared many weird shadows for all towns. Another reason is that we don't have control over them. At last, we decided to disabled for this release and to research more.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** UE4 22.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2286)
<!-- Reviewable:end -->
