### PR TITLE
Fix Low / Epic quality levels transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## latest
+  * Fixed Low/Epic quality settings transition
+
 ## CARLA 0.9.7
   * Upgraded parameters of Unreal/CarlaUE4/Config/DefaultInput.ini to prevent mouse freeze
   * Add build variant with AD RSS library integration with RSS sensor and result visualisation


### PR DESCRIPTION
#### Description

This PR will fix the transition from Epic / Low quality settings. 

Two problems were found in version Carla 0.9.7:

First, Unreal was writing the last quality settings to a file in /Saved/ folder and was reading and applying those settings without taking care of the desired quality settings that the user could specify.
We have fixed this thanks to the help of BenAscent who pointed the way to disable the writing of those settings.

Second, when enabling low-quality settings, the autoexposure was disabled but a value of Exposure Compensation of 4.5 was applied what made the image brighter than usual. We fixed that forcing autoexposure to be enabled also at low-quality level.

Fixes #2336, #2335

#### Where has this been tested?

  * **Platform(s):** Ubuntu and Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

If you had the problem of bright image in low-quality settings, probably you will need to remove the /Saved/ folder because there Unreal has written the last quality settings. Just clean that folder and run again with any Epic or Low quality settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2352)
<!-- Reviewable:end -->
