### PR TITLE
Fixed agent crashes due to API changes in is_within_distance_ahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * New python clients:
     - `weather.py`: allows weather changes using the new weather parameters
   * Fixed typos
+  * Fixed agent failures due to API changes in is_within_distance_ahead()
 
 ## CARLA 0.9.7
   * Upgraded parameters of Unreal/CarlaUE4/Config/DefaultInput.ini to prevent mouse freeze

--- a/PythonAPI/carla/agents/navigation/agent.py
+++ b/PythonAPI/carla/agents/navigation/agent.py
@@ -95,9 +95,8 @@ class Agent(object):
                     object_waypoint.lane_id != ego_vehicle_waypoint.lane_id:
                 continue
 
-            loc = traffic_light.get_location()
-            if is_within_distance_ahead(loc, ego_vehicle_location,
-                                        self._vehicle.get_transform().rotation.yaw,
+            if is_within_distance_ahead(traffic_light.get_transform(),
+                                        self._vehicle.get_transform(),
                                         self._proximity_threshold):
                 if traffic_light.state == carla.TrafficLightState.Red:
                     return (True, traffic_light)
@@ -184,9 +183,8 @@ class Agent(object):
                     target_vehicle_waypoint.lane_id != ego_vehicle_waypoint.lane_id:
                 continue
 
-            loc = target_vehicle.get_location()
-            if is_within_distance_ahead(loc, ego_vehicle_location,
-                                        self._vehicle.get_transform().rotation.yaw,
+            if is_within_distance_ahead(target_vehicle.get_transform(),
+                                        self._vehicle.get_transform(),
                                         self._proximity_threshold):
                 return (True, target_vehicle)
 


### PR DESCRIPTION
Fixed agent crashes due to API changes in is_within_distance_ahead. This is urgently required for the agents in ScenarioRunner to have ScenarioRunner be compatible with 0.9.7

#### Where has this been tested?
  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.x

#### Possible Drawbacks
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2386)
<!-- Reviewable:end -->
