### PR TITLE
Added to BoundingBox methods Contains, GetWorldVertices and GetLocalVertices 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## latest
+  * Added new methods to BoundingBox: contains, get_local_vertices and get_world_vertices.
   * New weather system: night time, fog, rain ripples, and now wind affects vegetation and rain (not car physics)
   * Fixed Low/Epic quality settings transition
   * Enabled Mesh distance fields

--- a/Docs/bp_library.md
+++ b/Docs/bp_library.md
@@ -711,81 +711,95 @@ Check out our [blueprint tutorial](../python_api_tutorial/#blueprints).
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0002</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0003</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0004</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0005</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0006</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0007</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0008</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0009</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0010</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0011</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0012</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0013</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>
 - **<font color="#498efc">walker.pedestrian.0014</font>**  
     - **Attributes:**
         - `age` (_String_)
         - `gender` (_String_)
         - `is_invincible` (_Bool_)<sub>_ – Modifiable_</sub>
         - `role_name` (_String_)<sub>_ – Modifiable_</sub>
+        - `speed` (_Float_)<sub>_ – Modifiable_</sub>

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -457,19 +457,19 @@ So, if you want to know the _X bounding box size_, you can just do `extent.x * 2
         - `location` (_[carla.Location](#carla.Location)_)  
         - `extent` (_[carla.Vector3D](#carla.Vector3D)_)  
 - <a name="carla.BoundingBox.contains"></a>**<font color="#7fb800">contains</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**world_point**</font>, <font color="#00a6ed">**transform**</font>)  
-Returns whether a point in world space is inside this BoundingBox.  
+Returns **True** if a point passed in world space is inside this bounding box.  
     - **Parameters:**
-        - `world_point` (_[carla.Location](#carla.Location)_) – The point in world space to be checked whether it is inside this [carla.BoundingBox](#carla.BoundingBox) or.  
-        - `transform` (_[carla.Transform](#carla.Transform)_) – The [carla.Transform](#carla.Transform) that transforms from this [carla.BoundingBox](#carla.BoundingBox) space to world space.  
+        - `world_point` (_[carla.Location](#carla.Location)_) – The point in world space to be checked.  
+        - `transform` (_[carla.Transform](#carla.Transform)_) – Contains location and rotation needed to convert this object's local space to world space.  
     - **Return:** _bool_  
 - <a name="carla.BoundingBox.get_local_vertices"></a>**<font color="#7fb800">get_local_vertices</font>**(<font color="#00a6ed">**self**</font>)  
-Returns the vertices of this [carla.BoundingBox](#carla.BoundingBox) in local space.  
-    - **Return:** _a list of [carla.Location](#carla.Location)_  
+Returns a list containing the locations of this object's vertices in local space.  
+    - **Return:** _list([carla.Location](#carla.Location))_  
 - <a name="carla.BoundingBox.get_world_vertices"></a>**<font color="#7fb800">get_world_vertices</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**transform**</font>)  
-Returns the vertices of this [carla.BoundingBox](#carla.BoundingBox) in world space.  
+Returns a list containing the locations of this object's vertices in world space.  
     - **Parameters:**
-        - `transform` (_[carla.Transform](#carla.Transform)_) – The [carla.Transform](#carla.Transform) that transforms from this [carla.BoundingBox](#carla.BoundingBox) space to world space.  
-    - **Return:** _a list of [carla.Location](#carla.Location)_  
+        - `transform` (_[carla.Transform](#carla.Transform)_) – Contains location and rotation needed to convert this object's local space to world space.  
+    - **Return:** _list([carla.Location](#carla.Location))_  
 - <a name="carla.BoundingBox.__eq__"></a>**<font color="#7fb800">\__eq__</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**other**</font>)  
     - **Parameters:**
         - `other` (_[carla.BoundingBox](#carla.BoundingBox)_)  

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -448,7 +448,7 @@ Bounding box helper class.
 - <a name="carla.BoundingBox.location"></a>**<font color="#f8805a">location</font>** (_[carla.Location](#carla.Location)_)  
 The center of the bounding box relative to its parent actor.  
 - <a name="carla.BoundingBox.extent"></a>**<font color="#f8805a">extent</font>** (_[carla.Vector3D](#carla.Vector3D)_)  
-It contains the vector from the center of the bounding box to one of the vertex of the box.  
+It contains the vector from the center of the bounding box to one of the vertex of the box.
 So, if you want to know the _X bounding box size_, you can just do `extent.x * 2`.  
 
 <h3>Methods</h3>
@@ -456,6 +456,20 @@ So, if you want to know the _X bounding box size_, you can just do `extent.x * 2
     - **Parameters:**
         - `location` (_[carla.Location](#carla.Location)_)  
         - `extent` (_[carla.Vector3D](#carla.Vector3D)_)  
+- <a name="carla.BoundingBox.contains"></a>**<font color="#7fb800">contains</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**world_point**</font>, <font color="#00a6ed">**transform**</font>)  
+Returns whether a point in world space is inside this BoundingBox.  
+    - **Parameters:**
+        - `world_point` (_[carla.Location](#carla.Location)_) – The point in world space to be checked whether it is inside this [carla.BoundingBox](#carla.BoundingBox) or.  
+        - `transform` (_[carla.Transform](#carla.Transform)_) – The [carla.Transform](#carla.Transform) that transforms from this [carla.BoundingBox](#carla.BoundingBox) space to world space.  
+    - **Return:** _bool_  
+- <a name="carla.BoundingBox.get_local_vertices"></a>**<font color="#7fb800">get_local_vertices</font>**(<font color="#00a6ed">**self**</font>)  
+Returns the vertices of this [carla.BoundingBox](#carla.BoundingBox) in local space.  
+    - **Return:** _a list of [carla.Location](#carla.Location)_  
+- <a name="carla.BoundingBox.get_world_vertices"></a>**<font color="#7fb800">get_world_vertices</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**transform**</font>)  
+Returns the vertices of this [carla.BoundingBox](#carla.BoundingBox) in world space.  
+    - **Parameters:**
+        - `transform` (_[carla.Transform](#carla.Transform)_) – The [carla.Transform](#carla.Transform) that transforms from this [carla.BoundingBox](#carla.BoundingBox) space to world space.  
+    - **Return:** _a list of [carla.Location](#carla.Location)_  
 - <a name="carla.BoundingBox.__eq__"></a>**<font color="#7fb800">\__eq__</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**other**</font>)  
     - **Parameters:**
         - `other` (_[carla.BoundingBox](#carla.BoundingBox)_)  
@@ -737,7 +751,7 @@ Distance in meters from the sensor to the detection position.
 ## carla.Rotation<a name="carla.Rotation"></a> <sub><sup>_class_</sup></sub>
 Class that represents a 3D rotation. All rotation angles are stored in degrees.
 
-![UE4_Rotation](https://d26ilriwvtzlb.cloudfront.net/8/83/BRMC_9.jpg)   _Unreal Engine's standard (from [UE4 docs](https://wiki.unrealengine.com/Blueprint_Rotating_Movement_Component))_.  
+![UE4_Rotation](https://d26ilriwvtzlb.cloudfront.net/8/83/BRMC_9.jpg) _Unreal Engine's standard (from [UE4 docs](https://wiki.unrealengine.com/Blueprint_Rotating_Movement_Component))_.  
 
 <h3>Instance Variables</h3>
 - <a name="carla.Rotation.pitch"></a>**<font color="#f8805a">pitch</font>** (_float_)  

--- a/LibCarla/source/carla/geom/BoundingBox.h
+++ b/LibCarla/source/carla/geom/BoundingBox.h
@@ -8,8 +8,11 @@
 
 #include "carla/Debug.h"
 #include "carla/MsgPack.h"
+#include "carla/geom/Transform.h"
 #include "carla/geom/Location.h"
 #include "carla/geom/Vector3D.h"
+
+#include <array>
 
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 #  include "Carla/Util/BoundingBox.h"
@@ -23,6 +26,10 @@ namespace geom {
 
     BoundingBox() = default;
 
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
     explicit BoundingBox(const Location &in_location, const Vector3D &in_extent)
       : location(in_location),
         extent(in_extent) {}
@@ -30,8 +37,59 @@ namespace geom {
     explicit BoundingBox(const Vector3D &in_extent)
       : extent(in_extent) {}
 
-    Location location;
-    Vector3D extent;
+    Location location;  ///< Center of the BoundingBox in local space
+    Vector3D extent;    ///< Half the size of the BoundingBox  in local space
+
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
+
+    /**
+     * Whether this BoundingBox contains @a in_world_point in world space.
+     * @param in_world_point the point in world space that you want to query whether it is inside or not.
+     * @param in_bbox_to_world_transform the transformation from BoundingBox space to World space.
+     */
+    bool Contains(const Location &in_world_point, const Transform &in_bbox_to_world_transform) const {
+        auto point_in_bbox_space = in_world_point;
+        in_bbox_to_world_transform.InverseTransformPoint(point_in_bbox_space);
+        point_in_bbox_space -= location;
+
+        return  point_in_bbox_space.x >= -extent.x && point_in_bbox_space.x <= extent.x &&
+                point_in_bbox_space.y >= -extent.y && point_in_bbox_space.y <= extent.y &&
+                point_in_bbox_space.z >= -extent.z && point_in_bbox_space.z <= extent.z;
+    }
+
+    /**
+     *  Returns the positions of the 8 vertices of this BoundingBox in local space.
+     */
+    std::array<Location, 8> GetLocalVertices() const {
+        return {{
+            location + Location(-extent.x,-extent.y,-extent.z),
+            location + Location(-extent.x,-extent.y, extent.z),
+            location + Location(-extent.x, extent.y,-extent.z),
+            location + Location(-extent.x, extent.y, extent.z),
+            location + Location( extent.x,-extent.y,-extent.z),
+            location + Location( extent.x,-extent.y, extent.z),
+            location + Location( extent.x, extent.y,-extent.z),
+            location + Location( extent.x, extent.y, extent.z)
+        }};
+    }
+
+    /**
+     * Returns the positions of the 8 vertices of this BoundingBox in world space.
+     * @param in_bbox_to_world_transform The Transform from this BoundingBox space to world space.
+     */
+    std::array<Location, 8> GetWorldVertices(const Transform &in_bbox_to_world_tr) const {
+        auto world_vertices = GetLocalVertices();
+        std::for_each(world_vertices.begin(), world_vertices.end(), [&in_bbox_to_world_tr](auto &world_vertex) {
+          in_bbox_to_world_tr.TransformPoint(world_vertex);
+        });
+        return world_vertices;
+    }
+
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
 
     bool operator==(const BoundingBox &rhs) const  {
       return (location == rhs.location) && (extent == rhs.extent);
@@ -40,6 +98,10 @@ namespace geom {
     bool operator!=(const BoundingBox &rhs) const  {
       return !(*this == rhs);
     }
+
+    // =========================================================================
+    // -- Conversions to UE4 types ---------------------------------------------
+    // =========================================================================
 
 #ifdef LIBCARLA_INCLUDED_FROM_UE4
 

--- a/LibCarla/source/carla/geom/Rotation.h
+++ b/LibCarla/source/carla/geom/Rotation.h
@@ -51,6 +51,60 @@ namespace geom {
       return Math::GetForwardVector(*this);
     }
 
+    void RotateVector(Vector3D &in_point) const {
+      // Rotates Rz(yaw) * Ry(pitch) * Rx(roll) = first x, then y, then z.
+      const float cy = std::cos(Math::ToRadians(yaw));
+      const float sy = std::sin(Math::ToRadians(yaw));
+      const float cr = std::cos(Math::ToRadians(roll));
+      const float sr = std::sin(Math::ToRadians(roll));
+      const float cp = std::cos(Math::ToRadians(pitch));
+      const float sp = std::sin(Math::ToRadians(pitch));
+
+      Vector3D out_point;
+      out_point.x =
+        in_point.x * (cp * cy) +
+        in_point.y * (cy * sp * sr - sy * cr) +
+        in_point.z * (-cy * sp * cr - sy * sr);
+
+      out_point.y =
+        in_point.x * (cp * sy) +
+        in_point.y * (sy * sp * sr + cy * cr) +
+        in_point.z * (-sy * sp * cr + cy * sr);
+
+      out_point.z =
+        in_point.x * (sp) +
+        in_point.y * (-cp * sr) +
+        in_point.z * (cp * cr);
+
+      in_point = out_point;
+    }
+
+    void InverseRotateVector(Vector3D &in_point) const {
+      // Applies the transposed of the matrix used in RotateVector function,
+      // which is the rotation inverse.
+      const float cy = std::cos(Math::ToRadians(yaw));
+      const float sy = std::sin(Math::ToRadians(yaw));
+      const float cr = std::cos(Math::ToRadians(roll));
+      const float sr = std::sin(Math::ToRadians(roll));
+      const float cp = std::cos(Math::ToRadians(pitch));
+      const float sp = std::sin(Math::ToRadians(pitch));
+
+      Vector3D out_point;
+      out_point.x =
+        in_point.x * (cp * cy) +
+        in_point.y * (cp * sy) +
+        in_point.z * (sp);
+
+      out_point.y = in_point.x * (cy * sp * sr - sy * cr) + in_point.y * (sy * sp * sr + cy * cr) + in_point.z * (-cp * sr);
+
+      out_point.z =
+        in_point.x * (-cy * sp * cr - sy * sr) +
+        in_point.y * (-sy * sp * cr + cy * sr) +
+        in_point.z * (cp * cr);
+
+      in_point = out_point;
+    }
+
     // =========================================================================
     // -- Comparison operators -------------------------------------------------
     // =========================================================================

--- a/LibCarla/source/carla/geom/Rotation.h
+++ b/LibCarla/source/carla/geom/Rotation.h
@@ -95,7 +95,10 @@ namespace geom {
         in_point.y * (cp * sy) +
         in_point.z * (sp);
 
-      out_point.y = in_point.x * (cy * sp * sr - sy * cr) + in_point.y * (sy * sp * sr + cy * cr) + in_point.z * (-cp * sr);
+      out_point.y =
+        in_point.x * (cy * sp * sr - sy * cr) +
+        in_point.y * (sy * sp * sr + cy * cr) +
+        in_point.z * (-cp * sr);
 
       out_point.z =
         in_point.x * (-cy * sp * cr - sy * sr) +

--- a/LibCarla/source/carla/geom/Transform.h
+++ b/LibCarla/source/carla/geom/Transform.h
@@ -53,30 +53,19 @@ namespace geom {
       return rotation.GetForwardVector();
     }
 
+    /// Applies this transformation to @a in_point (first translation then rotation).
     void TransformPoint(Vector3D &in_point) const {
-      // Rotate
-      const float cy = std::cos(Math::ToRadians(rotation.yaw));
-      const float sy = std::sin(Math::ToRadians(rotation.yaw));
-      const float cr = std::cos(Math::ToRadians(rotation.roll));
-      const float sr = std::sin(Math::ToRadians(rotation.roll));
-      const float cp = std::cos(Math::ToRadians(rotation.pitch));
-      const float sp = std::sin(Math::ToRadians(rotation.pitch));
+      auto out_point = in_point;
+      rotation.RotateVector(out_point); // First rotate
+      out_point += location;            // Then translate
+      in_point = out_point;
+    }
 
-      Vector3D out_point;
-      out_point.x = in_point.x * (cp * cy) +
-          in_point.y * (cy * sp * sr - sy * cr) +
-          in_point.z * (-cy * sp * cr - sy * sr);
-      out_point.y = in_point.x * (cp * sy) +
-          in_point.y * (sy * sp * sr + cy * cr) +
-          in_point.z * (-sy * sp * cr + cy * sr);
-
-      out_point.z = in_point.x *  (sp) +
-          in_point.y * -(cp * sr) +
-          in_point.z *  (cp * cr);
-
-      // Translate
-      out_point += location;
-
+    /// Applies the inverse of this transformation to @a in_point
+    void InverseTransformPoint(Vector3D &in_point) const {
+      auto out_point = in_point;
+      out_point -= location;                   // First translate inverse
+      rotation.InverseRotateVector(out_point); // Then rotate inverse
       in_point = out_point;
     }
 

--- a/PythonAPI/carla/source/libcarla/Geom.cpp
+++ b/PythonAPI/carla/source/libcarla/Geom.cpp
@@ -86,25 +86,6 @@ static void TransformList(const carla::geom::Transform &self, boost::python::lis
   }
 }
 
-template <typename TContainer>
-static boost::python::list CreatePythonList(const TContainer &container) {
-  boost::python::list py_list;
-  for (auto iter = container.begin(); iter != container.end(); ++iter) {
-      py_list.append(*iter);
-  }
-  return py_list;
-}
-
-static boost::python::list BBoxGetLocalVerticesPython(const carla::geom::BoundingBox &self) {
-  return CreatePythonList(self.GetLocalVertices());
-}
-
-static boost::python::list BBoxGetWorldVerticesPython(
-    const carla::geom::BoundingBox &self,
-    const carla::geom::Transform &bbox_transform) {
-  return CreatePythonList(self.GetWorldVertices(bbox_transform));
-}
-
 void export_geom() {
   using namespace boost::python;
   namespace cg = carla::geom;
@@ -201,8 +182,8 @@ void export_geom() {
     .def_readwrite("location", &cg::BoundingBox::location)
     .def_readwrite("extent", &cg::BoundingBox::extent)
     .def("contains", &cg::BoundingBox::Contains, arg("point"), arg("bbox_transform"))
-    .def("get_local_vertices", &BBoxGetLocalVerticesPython)
-    .def("get_world_vertices", &BBoxGetWorldVerticesPython, arg("bbox_transform"))
+    .def("get_local_vertices", CALL_RETURNING_LIST(cg::BoundingBox, GetLocalVertices))
+    .def("get_world_vertices", CALL_RETURNING_LIST_1(cg::BoundingBox, GetWorldVertices, const cg::Transform&), arg("bbox_transform"))
     .def("__eq__", &cg::BoundingBox::operator==)
     .def("__ne__", &cg::BoundingBox::operator!=)
     .def(self_ns::str(self_ns::self))

--- a/PythonAPI/carla/source/libcarla/Geom.cpp
+++ b/PythonAPI/carla/source/libcarla/Geom.cpp
@@ -86,6 +86,25 @@ static void TransformList(const carla::geom::Transform &self, boost::python::lis
   }
 }
 
+template <typename TContainer>
+static boost::python::list CreatePythonList(const TContainer &container) {
+  boost::python::list py_list;
+  for (auto iter = container.begin(); iter != container.end(); ++iter) {
+      py_list.append(*iter);
+  }
+  return py_list;
+}
+
+static boost::python::list BBoxGetLocalVerticesPython(const carla::geom::BoundingBox &self) {
+  return CreatePythonList(self.GetLocalVertices());
+}
+
+static boost::python::list BBoxGetWorldVerticesPython(
+    const carla::geom::BoundingBox &self,
+    const carla::geom::Transform &bbox_transform) {
+  return CreatePythonList(self.GetWorldVertices(bbox_transform));
+}
+
 void export_geom() {
   using namespace boost::python;
   namespace cg = carla::geom;
@@ -181,6 +200,9 @@ void export_geom() {
         (arg("location")=cg::Location(), arg("extent")=cg::Vector3D())))
     .def_readwrite("location", &cg::BoundingBox::location)
     .def_readwrite("extent", &cg::BoundingBox::extent)
+    .def("contains", &cg::BoundingBox::Contains, arg("point"), arg("bbox_transform"))
+    .def("get_local_vertices", &BBoxGetLocalVerticesPython)
+    .def("get_world_vertices", &BBoxGetWorldVerticesPython, arg("bbox_transform"))
     .def("__eq__", &cg::BoundingBox::operator==)
     .def("__ne__", &cg::BoundingBox::operator!=)
     .def(self_ns::str(self_ns::self))

--- a/PythonAPI/docs/geom.yml
+++ b/PythonAPI/docs/geom.yml
@@ -311,29 +311,28 @@
       - param_name: world_point
         type: carla.Location
         doc: >
-          The point in world space to be checked whether it is inside this carla.BoundingBox or.
+          The point in world space to be checked.
       - param_name: transform
         type: carla.Transform
         doc: >
-          The carla.Transform that transforms from this carla.BoundingBox space to world space.
+          Contains location and rotation needed to convert this object's local space to world space.
       doc: >
-        Returns whether a point in world space is inside this BoundingBox.
+        Returns **True** if a point passed in world space is inside this bounding box.
     # --------------------------------------
     - def_name: get_local_vertices
-      return: a list of carla.Location
-      params:
+      return: list(carla.Location)
       doc: >
-        Returns the vertices of this carla.BoundingBox in local space.
+        Returns a list containing the locations of this object's vertices in local space.
     # --------------------------------------
     - def_name: get_world_vertices
-      return: a list of carla.Location
+      return: list(carla.Location)
       params:
       - param_name: transform
         type: carla.Transform
         doc: >
-          The carla.Transform that transforms from this carla.BoundingBox space to world space.
+          Contains location and rotation needed to convert this object's local space to world space.
       doc: >
-        Returns the vertices of this carla.BoundingBox in world space.
+        Returns a list containing the locations of this object's vertices in world space.
     # --------------------------------------
     - def_name: __eq__
       params:

--- a/PythonAPI/docs/geom.yml
+++ b/PythonAPI/docs/geom.yml
@@ -16,10 +16,10 @@
     methods:
     - def_name: __init__
       params:
-      - param_name: x 
+      - param_name: x
         type: float
         default: 0.0
-      - param_name: y 
+      - param_name: y
         type: float
         default: 0.0
       doc: >
@@ -135,13 +135,13 @@
     methods:
     - def_name: __init__
       params:
-      - param_name: x 
+      - param_name: x
         type: float
         default: 0.0
       - param_name: 'y'
         type: float
         default: 0.0
-      - param_name: z 
+      - param_name: z
         type: float
         default: 0.0
       doc: >
@@ -176,7 +176,7 @@
       Class that represents a 3D rotation. All rotation angles are stored in degrees.
 
 
-      ![UE4_Rotation](https://d26ilriwvtzlb.cloudfront.net/8/83/BRMC_9.jpg)  
+      ![UE4_Rotation](https://d26ilriwvtzlb.cloudfront.net/8/83/BRMC_9.jpg)
       _Unreal Engine's standard (from [UE4 docs](https://wiki.unrealengine.com/Blueprint_Rotating_Movement_Component))_
     # - PROPERTIES -------------------------
     instance_variables:
@@ -292,7 +292,7 @@
     - var_name: extent
       type: carla.Vector3D
       doc: >
-        It contains the vector from the center of the bounding box to one of the vertex of the box.  
+        It contains the vector from the center of the bounding box to one of the vertex of the box.
 
         So, if you want to know the _X bounding box size_, you can just do `extent.x * 2`
     # - METHODS ----------------------------
@@ -304,6 +304,36 @@
       - param_name: extent
         type: carla.Vector3D
       doc: >
+    # --------------------------------------
+    - def_name: contains
+      return: bool
+      params:
+      - param_name: world_point
+        type: carla.Location
+        doc: >
+          The point in world space to be checked whether it is inside this carla.BoundingBox or.
+      - param_name: transform
+        type: carla.Transform
+        doc: >
+          The carla.Transform that transforms from this carla.BoundingBox space to world space.
+      doc: >
+        Returns whether a point in world space is inside this BoundingBox.
+    # --------------------------------------
+    - def_name: get_local_vertices
+      return: a list of carla.Location
+      params:
+      doc: >
+        Returns the vertices of this carla.BoundingBox in local space.
+    # --------------------------------------
+    - def_name: get_world_vertices
+      return: a list of carla.Location
+      params:
+      - param_name: transform
+        type: carla.Transform
+        doc: >
+          The carla.Transform that transforms from this carla.BoundingBox space to world space.
+      doc: >
+        Returns the vertices of this carla.BoundingBox in world space.
     # --------------------------------------
     - def_name: __eq__
       params:
@@ -324,7 +354,7 @@
   - class_name: GeoLocation
     # - DESCRIPTION ------------------------
     doc: >
-      Class that contains geolocation simulated data 
+      Class that contains geolocation simulated data
     # - PROPERTIES -------------------------
     instance_variables:
     - var_name: latitude


### PR DESCRIPTION
#### Description

Added new methods to BoundingBox:
- BoundingBox::Contains: whether a point in world space is contained by the bbox.
- BoundingBox::GetWorldVertices: returns a list of the 8 vertices of the bbox in world space.
- BoundingBox::GetLocalVertices: returns a list of the 8 vertices of the bbox in local space.

Exposed them to the Python API as:
- contains
- get_world_vertices
- get_local_vertices.

To implement this, I have also modified Transform and Rotation to be able to transform points back and forth:
- Transform::InverseTransformPoint
- Rotation::RotatePoint (moved from Transform::TransformPoint to its own function)
- Transform::InverseRotatePoint 

Also added a tests that make sure that transformation back and forth are coherent to one another (P after being transformed and untransformed should yield P again).

And another test for local and world vertices, making sure that they match when using the bbox Transform.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7.17
  * **Unreal Engine version(s):** 4.22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2392)
<!-- Reviewable:end -->
