### PR TITLE
Allow waypoint creation from OpenDRIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Fixed Low/Epic quality settings transition
   * Enabled Mesh distance fields
   * API extensions:
+    - Added new function to get a waypoint specifying parameters from the openDRIVE: `map.get_waypoint_xodr(road_id, lane_id, s)`
     - Added 3 new parameters for the `carla.Weather`: `fog_density`, `fog_distance`, and (ground) `wetness`
   * New python clients:
     - `weather.py`: allows weather changes using the new weather parameters

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -692,6 +692,13 @@ Returns a list of transformations corresponding to the recommended spawn points 
 If **False**, the waypoint will be at the given location. Also, in this second case, the result may be `None` if the waypoint is not found.  
         - `lane_type` (_[carla.LaneType](#carla.LaneType)_) – This parameter is used to limit the search on a certain lane type. This can be used like a flag: `LaneType.Driving & LaneType.Shoulder`.  
     - **Return:** _[carla.Waypoint](#carla.Waypoint)_  
+- <a name="carla.Map.get_waypoint_xodr"></a>**<font color="#7fb800">get_waypoint_xodr</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**road_id**</font>, <font color="#00a6ed">**lane_id**</font>, <font color="#00a6ed">**s**</font>)  
+Get a waypoint if all the parameters passed are correct, otherwise return None.  
+    - **Parameters:**
+        - `road_id` (_int_) – Id of the road from where getting the waypoint.  
+        - `lane_id` (_int_) – Id of the lane to get the waypoint.  
+        - `s` (_float_) – Specify the length from the road start.  
+    - **Return:** _[carla.Waypoint](#carla.Waypoint)_  
 - <a name="carla.Map.get_topology"></a>**<font color="#7fb800">get_topology</font>**(<font color="#00a6ed">**self**</font>)  
 It provides a minimal graph of the topology of the current OpenDRIVE file. It is constituted by a list of pairs of waypoints, where the first waypoint is the origin and the second one is the destination. It can be loaded into [NetworkX](https://networkx.github.io/). A valid output could be: `[ (w0, w1), (w0, w2), (w1, w3), (w2, w3), (w0, w4) ]`.  
     - **Return:** _list(tuple([carla.Waypoint](#carla.Waypoint), [carla.Waypoint](#carla.Waypoint)))_  

--- a/LibCarla/source/carla/client/Map.cpp
+++ b/LibCarla/source/carla/client/Map.cpp
@@ -52,6 +52,17 @@ namespace client {
         nullptr;
   }
 
+  SharedPtr<Waypoint> Map::GetWaypointXODR(
+      carla::road::RoadId road_id,
+      carla::road::LaneId lane_id,
+      float s) const {
+    boost::optional<road::element::Waypoint> waypoint;
+    waypoint = _map.GetWaypoint(road_id, lane_id, s);
+    return waypoint.has_value() ?
+        SharedPtr<Waypoint>(new Waypoint{shared_from_this(), *waypoint}) :
+        nullptr;
+  }
+
   Map::TopologyList Map::GetTopology() const {
     namespace re = carla::road::element;
     std::unordered_map<re::Waypoint, SharedPtr<Waypoint>> waypoints;

--- a/LibCarla/source/carla/client/Map.h
+++ b/LibCarla/source/carla/client/Map.h
@@ -54,7 +54,7 @@ namespace client {
         bool project_to_road = true,
         uint32_t lane_type = static_cast<uint32_t>(road::Lane::LaneType::Driving)) const;
 
-    SharedPtr<Waypoint> Map::GetWaypointXODR(
+    SharedPtr<Waypoint> GetWaypointXODR(
       carla::road::RoadId road_id,
       carla::road::LaneId lane_id,
       float s) const;

--- a/LibCarla/source/carla/client/Map.h
+++ b/LibCarla/source/carla/client/Map.h
@@ -8,10 +8,11 @@
 
 #include "carla/Memory.h"
 #include "carla/NonCopyable.h"
-#include "carla/road/Map.h"
 #include "carla/road/element/LaneMarking.h"
-#include "carla/rpc/MapInfo.h"
 #include "carla/road/Lane.h"
+#include "carla/road/Map.h"
+#include "carla/road/RoadTypes.h"
+#include "carla/rpc/MapInfo.h"
 
 #include <string>
 
@@ -52,6 +53,11 @@ namespace client {
         const geom::Location &location,
         bool project_to_road = true,
         uint32_t lane_type = static_cast<uint32_t>(road::Lane::LaneType::Driving)) const;
+
+    SharedPtr<Waypoint> Map::GetWaypointXODR(
+      carla::road::RoadId road_id,
+      carla::road::LaneId lane_id,
+      float s) const;
 
     using TopologyList = std::vector<std::pair<SharedPtr<Waypoint>, SharedPtr<Waypoint>>>;
 

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -244,6 +244,47 @@ namespace road {
     return boost::optional<Waypoint>{};
   }
 
+  boost::optional<Waypoint> Map::GetWaypoint(
+      RoadId road_id,
+      LaneId lane_id,
+      float s) const {
+
+    // define the waypoint with the known parameters
+    Waypoint waypoint;
+    waypoint.road_id = road_id;
+    waypoint.lane_id = lane_id;
+    waypoint.s = s;
+
+    // check the road
+    if (!_data.ContainsRoad(waypoint.road_id)) {
+      return boost::optional<Waypoint>{};
+    }
+    const Road &road = _data.GetRoad(waypoint.road_id);
+
+    // check the 's' distance
+    if (s > road.GetLength())
+    {
+      return boost::optional<Waypoint>{};
+    }
+
+    // check the section
+    bool lane_found = false;
+    for (auto &section : road.GetLaneSectionsAt(s)) {
+      if (section.ContainsLane(lane_id)) {
+        waypoint.section_id = section.GetId();
+        lane_found = true;
+        break;
+      }
+    }
+
+    // check the lane id
+    if (!lane_found) {
+      return boost::optional<Waypoint>{};
+    }
+
+    return waypoint;
+  }
+
   geom::Transform Map::ComputeTransform(Waypoint waypoint) const {
     const auto &road = _data.GetRoad(waypoint.road_id);
 
@@ -342,6 +383,10 @@ namespace road {
 
   std::pair<const RoadInfoMarkRecord *, const RoadInfoMarkRecord *>
   Map::GetMarkRecord(const Waypoint waypoint) const {
+    // if lane Id is 0, just return a pair of nulls
+    if (waypoint.lane_id == 0)
+      return std::make_pair(nullptr, nullptr);
+
     const auto s = waypoint.s;
 
     const auto &current_lane = GetLane(waypoint);

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -262,7 +262,7 @@ namespace road {
     const Road &road = _data.GetRoad(waypoint.road_id);
 
     // check the 's' distance
-    if (s > road.GetLength())
+    if (s < 0.0f || s >= road.GetLength())
     {
       return boost::optional<Waypoint>{};
     }

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -52,6 +52,11 @@ namespace road {
         const geom::Location &location,
         uint32_t lane_type = static_cast<uint32_t>(Lane::LaneType::Driving)) const;
 
+    boost::optional<element::Waypoint> GetWaypoint(
+        RoadId road_id,
+        LaneId lane_id,
+        float s) const;
+
     geom::Transform ComputeTransform(Waypoint waypoint) const;
 
     /// ========================================================================

--- a/PythonAPI/carla/source/libcarla/Map.cpp
+++ b/PythonAPI/carla/source/libcarla/Map.cpp
@@ -130,6 +130,7 @@ void export_map() {
     .add_property("name", CALL_RETURNING_COPY(cc::Map, GetName))
     .def("get_spawn_points", CALL_RETURNING_LIST(cc::Map, GetRecommendedSpawnPoints))
     .def("get_waypoint", &cc::Map::GetWaypoint, (arg("location"), arg("project_to_road")=true, arg("lane_type")=cr::Lane::LaneType::Driving))
+    .def("get_waypoint_xodr", &cc::Map::GetWaypointXODR, (arg("road_id"), arg("lane_id"), arg("s")))
     .def("get_topology", &GetTopology)
     .def("generate_waypoints", CALL_RETURNING_LIST_1(cc::Map, GenerateWaypoints, double), (args("distance")))
     .def("transform_to_geolocation", &ToGeolocation, (arg("location")))

--- a/PythonAPI/docs/map.yml
+++ b/PythonAPI/docs/map.yml
@@ -184,6 +184,24 @@
           This can be used like a flag: `LaneType.Driving & LaneType.Shoulder`
       return: carla.Waypoint
     # --------------------------------------
+    - def_name: get_waypoint_xodr
+      doc: >
+        Get a waypoint if all the parameters passed are correct, otherwise return None
+      params:
+      - param_name: road_id
+        type: int
+        doc: > 
+          Id of the road from where getting the waypoint
+      - param_name: lane_id
+        type: int
+        doc: > 
+          Id of the lane to get the waypoint.
+      - param_name: s
+        type: float
+        doc: > 
+          Specify the length from the road start
+      return: carla.Waypoint
+    # --------------------------------------
     - def_name: get_topology
       doc: >
         It provides a minimal graph of the topology of the current OpenDRIVE file.


### PR DESCRIPTION
#### Description

We added a new function for the Python API where you can request a new waypoint giving a set of parameters from the openDRIVE file. The parameters are the road id, the lane id and the distance from the road start.

An example is:
```py
m = world.get_map()
w = m.get_waypoint_xodr(10, 2, 1)
```

It requests a waypoint placed a 1m of the lane id 2, from the road id 10.

For this waypoint, we can request a lane id of 0, which means that the waypoint will be placed at the centerline of the road.

If any of the parameters are wrong, then the result is None instead of a waypoint.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2426)
<!-- Reviewable:end -->
