### PR TITLE
Demonstration of left-handed hack for LibCarla

### DIFF
--- a/LibCarla/source/carla/road/MapBuilder.cpp
+++ b/LibCarla/source/carla/road/MapBuilder.cpp
@@ -555,7 +555,10 @@ namespace road {
     // successor and predecessor (road and lane)
     LaneId next;
     RoadId next_road;
-    if (lane_id <= 0) {
+
+    // Forward lane (left) leads into successors
+    // Backward lane (right) leads into predecessors
+    if (lane_id >= 0) {
       next_road = road.GetSuccessor();
       next = lane->GetSuccessor();
     } else {
@@ -568,12 +571,13 @@ namespace road {
     double s = section.GetDistance();
 
     // check if we are in a lane section in the middle
-    if ((lane_id > 0 && s > 0) ||
-        (lane_id <= 0 && road._lane_sections.upper_bound(s) != road._lane_sections.end())) {
+    if ((lane_id < 0 && s > 0) ||
+        (lane_id >= 0 && road._lane_sections.upper_bound(s) != road._lane_sections.end())) {
       // check if lane has a next link (if not, it deads in the middle section)
       if (next != 0 || (lane_id == 0 && next == 0)) {
         // change to next / prev section
-        if (lane_id <= 0) {
+        // Next or Prev depends on road direction
+        if (lane_id >= 0) {
           result.push_back(road.GetNextLane(s, next));
         } else {
           result.push_back(road.GetPrevLane(s, next));
@@ -593,7 +597,7 @@ namespace road {
       auto next_road_as_junction = static_cast<JuncId>(next_road);
       auto options = GetJunctionLanes(next_road_as_junction, road_id, lane_id);
       for (auto opt : options) {
-        result.push_back(GetEdgeLanePointer(opt.first, (opt.second <= 0), opt.second));
+        result.push_back(GetEdgeLanePointer(opt.first, (opt.second >= 0), opt.second));
       }
     }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
Hacked in some left-handed traffic assumptions into LibCarla. This changes the assumptions from right-handed traffic (default) to left-handed. As this is not a good change, it is in a draft PR for reference purposes and should never be merged. 

This doesn't resolve any issues but users who want to ONLY work on left-handed traffic can use this fix. <!-- If fixes an issue, please add here the issue number. -->

#### Procedure

First, use RoadRunner and make a map with left-handed traffic (left-hand lanes should have "forward" travel direction, "backward" for right handed lanes), export with the left-hand setting.

1. Get this change
2. `make clean`
3. `make LibCarla` (builds this change. copying into CarlaUE4 and PythonAPI dependencies folder)
4. `make pythonAPI` (builds PythonAPI with this change)
5. `make launch` (starts CarlaUE4 with this change)
6. Import the xodr/fbx you generated (Don't use `make import` because it's broken on master, I rely on [this change that fixes that](https://github.com/carla-simulator/carla/pull/2390))
7. run example

#### Proposal

I created this to show that it's fairly simple to handle left-handed traffic, it's just blocked by some assumptions carla makes. I have some ideas for real support:
- Determine first what kind of left-handed support we want to give. I think it's a requirement to support RHT and LHT in the same build, but is it necessary to support RHT and LHT in the same MAP?
- Ask RoadRunner to update their OpenDrive spec. They are using Opendrive 1.4, but if RoadRunner updated to OpenDrive 1.5 spec from 1.4 and use the updated Road Header Record (http://opendrive.org/docs/OpenDRIVEFormatSpecRev1.5M.pdf, section 5.3.1, rule), it could get rid of the current `<UserData><VectorRoad travelDir=forward/backward>` setup. Then Carla would also be able to support the OpenDrive 1.5 format (instead of needing to specifically support the custom tag in the OpenDrive file produced by RoadRunner). 
- Carla needs to parse either the RoadRunner tag or the OpenDrive 1.5 RHR to determine the handedness of roads. If we don't expect to find LHT and RHT together in a map, as soon as we see a lane of positive lane ID + backward/forward, we can assume the traffic direction for the whole file. If not, then it gets a bit more complicated but still doable.
- When parsing the lanes, since we already check the contents of <left> <center> and <right> headers in OpenDrive, why don't we give Carla Roads more descriptive arrays of left/center/right lanes? 
- If we don't want to do that, can we at least make a helper function for checking the ID? I didn't do it this time, but it is weird to keep doing comparisons against the lane ID. Would be much better to be on a higher level of abstraction and have a clear function that does it instead of a lane ID comparison and a comment every time saying what it's all about.

#### Where has this been tested?

  * **Platform(s):** ... Windows 10 x64, Ubuntu 18.04
  * **Python version(s):** ... 3.6.9
  * **Unreal Engine version(s):** ... 4.22.3

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

It literally breaks all right-handed traffic maps on import and driving on left-handed maps, so it has a huge drawback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2442)
<!-- Reviewable:end -->
