### PR TITLE
Fix for missing elevation profile and lane offset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@
   * Enabled Mesh distance fields
   * API extensions:
     - Added new methods to `BoundingBox`: `contains()`, `get_local_vertices()` and `get_world_vertices(transform)`
-    - Added new function to get a waypoint specifying parameters from the openDRIVE: `map.get_waypoint_xodr(road_id, lane_id, s)`
+    - Added new function to get a waypoint specifying parameters from the OpenDRIVE: `map.get_waypoint_xodr(road_id, lane_id, s)`
     - Added 3 new parameters for the `carla.Weather`: `fog_density`, `fog_distance`, and (ground) `wetness`
   * New python clients:
     - `weather.py`: allows weather changes using the new weather parameters
   * Fixed docker build of .BIN for pedestrian navigation
+  * Fixed crash when missing elevation profile and lane offset in OpenDRIVE
   * Fixed typos
   * Fixed agent failures due to API changes in `is_within_distance_ahead()`
   * Fixed incorrect doppler velocity for RADAR sensor

--- a/LibCarla/source/carla/opendrive/parser/ProfilesParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/ProfilesParser.cpp
@@ -54,6 +54,7 @@ namespace parser {
 
       // parse elevation profile
       pugi::xml_node node_profile = node_road.child("elevationProfile");
+      uint number_profiles = 0;
       if (node_profile) {
         // all geometry
         for (pugi::xml_node node_elevation : node_profile.children("elevation")) {
@@ -72,7 +73,24 @@ namespace parser {
 
           // add it
           elevation_profile.emplace_back(elev);
+          number_profiles++;
         }
+      }
+      // add a default profile if none is found
+      if(number_profiles == 0){
+        ElevationProfile elev;
+        road::RoadId road_id = node_road.attribute("id").as_uint();
+        elev.road = map_builder.GetRoad(road_id);
+
+        // get common properties
+        elev.s = 0;
+        elev.a = 0;
+        elev.b = 0;
+        elev.c = 0;
+        elev.d = 0;
+
+        // add it
+        elevation_profile.emplace_back(elev);
       }
 
       // parse lateral profile

--- a/LibCarla/source/carla/opendrive/parser/RoadParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/RoadParser.cpp
@@ -164,6 +164,11 @@ namespace parser {
         offset.d = node_offset.attribute("d").as_double();
         road.section_offsets.emplace_back(offset);
       }
+      // Add default lane offset if none is found
+      if(road.section_offsets.size() == 0) {
+        LaneOffset offset { 0.0, 0.0, 0.0, 0.0, 0.0 };
+        road.section_offsets.emplace_back(offset);
+      }
 
       // lane sections
       for (pugi::xml_node node_section : node_road.child("lanes").children("laneSection")) {


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Fixed crash when reading OpenDRIVE file with missing elevation profile or lane offset.
All roads will have a default neutral elevation profile and lane offset if none is specified.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2 and 3
  * **Unreal Engine version(s):** 4.22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2484)
<!-- Reviewable:end -->
