### PR TITLE
Recast navigation generation from server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Added support to parse OpenDRIVE signals.
   * Added junction class as queryable object from waypoint
   * Added simple physical map generation from standalone OpenDRIVE data
+  * Added support for generating walker navigation on server-side
   * Added support for new geometry: `spiral`, `poly3`, and `paramPoly3`
   * Improved `get_waypoint(location)` performance
   * New weather system: night time, fog, rain ripples, and now wind affects vegetation and rain (not car physics)

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -970,7 +970,7 @@ namespace road {
   }
 
   /// Computes the location of the edges of the current lane at the current waypoint
-  static std::pair<geom::Vector3D, geom::Vector3D> GetWaypointCornerPosition(
+  static std::pair<geom::Vector3D, geom::Vector3D> GetWaypointCornerPositions(
       const Map &map, const Waypoint &waypoint, const Lane &lane) {
     float lane_width = static_cast<float>(map.GetLaneWidth(waypoint)) / 2.0f;
     lane_width = waypoint.lane_id > 0 ? -lane_width : lane_width;
@@ -998,22 +998,23 @@ namespace road {
   geom::Mesh Map::GenerateGeometry(double distance) const {
     RELEASE_ASSERT(distance > 0.0);
     geom::Mesh out_mesh;
+    // Iterate each lane in each lane_section in each road
     for (const auto &pair : _data.GetRoads()) {
       const auto &road = pair.second;
       for (const auto &lane_section : road.GetLaneSections()) {
         for (const auto &lane_pair : lane_section.GetLanes()) {
+          // Get the lane reference
           const auto &lane = lane_pair.second;
           // The lane with lane_id 0 have no physical representation in OpenDRIVE
           if (lane.GetId() == 0) {
             continue;
           }
           const auto end_distance = lane.GetDistance() + lane.GetLength() - EPSILON;
-          const Waypoint initial_waypoint {
+          Waypoint current_wp {
               road.GetId(),
               lane_section.GetId(),
               lane.GetId(),
               lane_section.GetDistance() + EPSILON };
-          Waypoint current_wp = initial_waypoint;
           bool first_waypoint = true;
 
           if (lane.GetType() == Lane::LaneType::Sidewalk) {
@@ -1024,7 +1025,7 @@ namespace road {
 
           do {
             // Get the location of the edges of the current lane at the current waypoint
-            const auto edges = GetWaypointCornerPosition(*this, current_wp, lane);
+            const auto edges = GetWaypointCornerPositions(*this, current_wp, lane);
             // This condition avoids adding indexes in the initial first waypoint
             if(first_waypoint) {
               // Add vertices only
@@ -1044,9 +1045,9 @@ namespace road {
           } while(current_wp.s < end_distance);
           // This ensures the mesh is constant and have no gaps between
           // segments and roads
-          if (current_wp.s - end_distance > EPSILON) {
-            current_wp.s = end_distance - EPSILON;
-            const auto edges = GetWaypointCornerPosition(*this, current_wp, lane);
+          if (end_distance - (current_wp.s - distance) > EPSILON) {
+            current_wp.s = end_distance;
+            const auto edges = GetWaypointCornerPositions(*this, current_wp, lane);
             const size_t last_index = out_mesh.GetLastVertexIndex();
             ExtrudeMeshEdge(
                 out_mesh, edges.first, edges.second, last_index - 1, last_index);

--- a/LibCarla/source/carla/sensor/SensorRegistry.h
+++ b/LibCarla/source/carla/sensor/SensorRegistry.h
@@ -57,6 +57,7 @@ namespace sensor {
     std::pair<AObstacleDetectionSensor *, s11n::ObstacleDetectionEventSerializer>,
     std::pair<ARadar *, s11n::RadarSerializer>,
     std::pair<ARayCastLidar *, s11n::LidarSerializer>,
+    std::pair<ARssSensor *, s11n::NoopSerializer>,
     std::pair<ASceneCaptureCamera *, s11n::ImageSerializer>,
     std::pair<ASemanticSegmentationCamera *, s11n::ImageSerializer>,
     std::pair<FWorldObserver *, s11n::EpisodeStateSerializer>
@@ -78,6 +79,7 @@ namespace sensor {
 #include "Carla/Sensor/ObstacleDetectionSensor.h"
 #include "Carla/Sensor/Radar.h"
 #include "Carla/Sensor/RayCastLidar.h"
+#include "Carla/Sensor/RssSensor.h"
 #include "Carla/Sensor/SceneCaptureCamera.h"
 #include "Carla/Sensor/SemanticSegmentationCamera.h"
 #include "Carla/Sensor/WorldObserver.h"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -120,7 +120,7 @@ static FString BuildRecastBuilderFile()
   // Define path depending on the UE4 build type (Package or Editor)
 #if UE_BUILD_SHIPPING
   const FString AbsoluteRecastBuilderPath = FPaths::ConvertRelativePathToFull(
-      FPaths::ProjectDir() + "Tools/" + RecastToolName);
+      FPaths::RootDir() + "Tools/" + RecastToolName);
 #else
   const FString AbsoluteRecastBuilderPath = FPaths::ConvertRelativePathToFull(
       FPaths::ProjectDir() + "../../Util/DockerUtils/dist/" + RecastToolName);
@@ -180,9 +180,11 @@ bool UCarlaEpisode::LoadNewOpendriveEpisode(const FString &OpenDriveString)
 
   if (FPaths::FileExists(AbsoluteRecastBuilderPath))
   {
+    /// @todo this can take too long to finish, clients need a method
+    /// to know if the navigation is available or not.
     FPlatformProcess::CreateProc(
         *AbsoluteRecastBuilderPath, *AbsoluteOBJPath,
-        true, false, false, nullptr, 0, nullptr, nullptr);
+        true, true, true, nullptr, 0, nullptr, nullptr);
   }
   else
   {

--- a/Util/BuildTools/BuildUtilsDocker.sh
+++ b/Util/BuildTools/BuildUtilsDocker.sh
@@ -33,9 +33,18 @@ rm "${CARLA_DOCKER_UTILS_FOLDER}/${LIB_NAME}"
 
 echo "Compiling FBX2OBJ..."
 mkdir -p "${FBX2OBJ_DIST}"
+mkdir -p "${FBX2OBJ_BUILD_FOLDER}"
 
-cmake -S "${FBX2OBJ_FOLDER}" -B "${FBX2OBJ_BUILD_FOLDER}"
+pushd "${FBX2OBJ_BUILD_FOLDER}" >/dev/null
 
-make -C "${FBX2OBJ_BUILD_FOLDER}" install
+cmake -G "Ninja" \
+    -DCMAKE_CXX_FLAGS="-fPIC -std=c++14" \
+    ..
+
+ninja
+
+ninja install
+
+popd >/dev/null
 
 log "Success!"

--- a/Util/BuildTools/Linux.mk
+++ b/Util/BuildTools/Linux.mk
@@ -12,7 +12,7 @@ launch-only:
 import: CarlaUE4Editor PythonAPI build.utils
 	@${CARLA_BUILD_TOOLS_FOLDER}/Import.py $(ARGS)
 
-package: CarlaUE4Editor PythonAPI
+package: CarlaUE4Editor PythonAPI build.utils
 	@${CARLA_BUILD_TOOLS_FOLDER}/Package.sh $(ARGS)
 
 docs:


### PR DESCRIPTION
#### Description
Now, `carla.client.generate_opendrive_world(opendrive)` will also automatically generate the Recast information allowing the walkers to move around the sidewalks.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2554)
<!-- Reviewable:end -->
