### PR TITLE
Remove superfluous flag in docker documentation

### DIFF
--- a/Docs/build_docker.md
+++ b/Docs/build_docker.md
@@ -51,7 +51,7 @@ docker pull carlasim/carla:0.8.2
 Running CARLA under docker.
 
 ```sh
-docker run -p 2000-2002:2000-2002 --runtime=nvidia -e --gpus all carlasim/carla:0.8.4
+docker run -p 2000-2002:2000-2002 --runtime=nvidia --gpus all carlasim/carla:0.8.4
 ```
 
 The `-p 2000-2002:2000-2002` argument is to redirect host ports for the docker container.


### PR DESCRIPTION
The `-e` flag is used to define an environment variable. It requires a parameter. `-e --gpus all` means "Define environment variable `--gpus` to be empty, execute image `all:latest`. I have a suspicion that whoever wrote this intended to define an environment variable but forgot it (e.g. `NVIDIA_VISIBLE_DEVICES=0` used below).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2625)
<!-- Reviewable:end -->
