### PR TITLE
Added methods to get trafficlights and trafficsigns from landmarks

### DIFF
--- a/LibCarla/source/carla/client/Landmark.h
+++ b/LibCarla/source/carla/client/Landmark.h
@@ -19,7 +19,7 @@ namespace carla {
 namespace client {
 
   /// Class containing a reference to RoadInfoSignal
-  class Landmark : private MovableNonCopyable {
+  class Landmark {
   public:
 
     SharedPtr<Waypoint> GetWaypoint() const {

--- a/LibCarla/source/carla/client/TrafficSign.cpp
+++ b/LibCarla/source/carla/client/TrafficSign.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/client/TrafficSign.h"
+#include "carla/client/detail/Simulator.h"
+#include "carla/client/ActorList.h"
+
+namespace carla {
+namespace client {
+
+  carla::road::SignId TrafficSign::GetSignId() const {
+    return std::string(GetEpisode().Lock()->GetActorSnapshot(*this).state.traffic_light_data.sign_id);
+  }
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/TrafficSign.h
+++ b/LibCarla/source/carla/client/TrafficSign.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "carla/client/Actor.h"
+#include "carla/road/RoadTypes.h"
 
 namespace carla {
 namespace client {
@@ -19,6 +20,9 @@ namespace client {
     const geom::BoundingBox &GetTriggerVolume() const {
       return ActorState::GetBoundingBox();
     }
+
+    carla::road::SignId GetSignId() const;
+
   };
 
 } // namespace client

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -11,6 +11,7 @@
 #include "carla/client/ActorBlueprint.h"
 #include "carla/client/ActorList.h"
 #include "carla/client/detail/Simulator.h"
+#include "carla/StringUtil.h"
 
 #include <exception>
 
@@ -111,6 +112,38 @@ namespace client {
 
   void World::SetPedestriansCrossFactor(float percentage) {
     _episode.Lock()->SetPedestriansCrossFactor(percentage);
+  }
+
+  SharedPtr<Actor> World::GetTrafficSign(const Landmark& landmark) const {
+    SharedPtr<ActorList> actors = GetActors();
+    SharedPtr<TrafficSign> result;
+    std::string landmark_id = landmark.GetId();
+    for (size_t i = 0; i < actors->size(); i++) {
+      SharedPtr<Actor> actor = actors->at(i);
+      if (StringUtil::Match(actor->GetTypeId(), "*traffic.*")) {
+        TrafficSign* sign = static_cast<TrafficSign*>(actor.get());
+        if(sign && (sign->GetSignId() == landmark_id)) {
+          return actor;
+        }
+      }
+    }
+    return nullptr;
+  }
+
+  SharedPtr<Actor> World::GetTrafficLight(const Landmark& landmark) const {
+    SharedPtr<ActorList> actors = GetActors();
+    SharedPtr<TrafficLight> result;
+    std::string landmark_id = landmark.GetId();
+    for (size_t i = 0; i < actors->size(); i++) {
+      SharedPtr<Actor> actor = actors->at(i);
+      if (StringUtil::Match(actor->GetTypeId(), "*traffic_light*")) {
+        TrafficLight* tl = static_cast<TrafficLight*>(actor.get());
+        if(tl && (tl->GetSignId() == landmark_id)) {
+          return actor;
+        }
+      }
+    }
+    return nullptr;
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -9,6 +9,7 @@
 #include "carla/Memory.h"
 #include "carla/Time.h"
 #include "carla/client/DebugHelper.h"
+#include "carla/client/Landmark.h"
 #include "carla/client/Timestamp.h"
 #include "carla/client/WorldSnapshot.h"
 #include "carla/client/detail/EpisodeProxy.h"
@@ -29,6 +30,8 @@ namespace client {
   class ActorList;
   class BlueprintLibrary;
   class Map;
+  class TrafficLight;
+  class TrafficSign;
 
   class World {
   public:
@@ -124,6 +127,10 @@ namespace client {
     /// percentage of 0.5f means 50% of all pedestrians can cross roads
     /// percentage of 1.0f means all pedestrians can cross roads if needed
     void SetPedestriansCrossFactor(float percentage);
+
+    SharedPtr<Actor> GetTrafficSign(const Landmark& landmark) const;
+
+    SharedPtr<Actor> GetTrafficLight(const Landmark& landmark) const;
 
     DebugHelper MakeDebugHelper() const {
       return DebugHelper{_episode};

--- a/LibCarla/source/carla/sensor/data/ActorDynamicState.h
+++ b/LibCarla/source/carla/sensor/data/ActorDynamicState.h
@@ -90,16 +90,27 @@ namespace detail {
 #pragma pack(pop)
 
 #pragma pack(push, 1)
+
   struct TrafficLightData {
     TrafficLightData() = default;
 
-    rpc::TrafficLightState state;
+    char sign_id[32u];
     float green_time;
     float yellow_time;
     float red_time;
     float elapsed_time;
-    bool time_is_frozen;
     uint32_t pole_index;
+    bool time_is_frozen;
+    rpc::TrafficLightState state;
+  };
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+
+  struct TrafficSignData {
+    TrafficSignData() = default;
+
+    char sign_id[32u];
   };
 #pragma pack(pop)
 } // namespace detail
@@ -121,6 +132,7 @@ namespace detail {
 
     union TypeDependentState {
       detail::TrafficLightData traffic_light_data;
+      detail::TrafficSignData traffic_sign_data;
       detail::VehicleData vehicle_data;
       detail::PackedWalkerControl walker_control;
     } state;
@@ -128,27 +140,12 @@ namespace detail {
 
 #pragma pack(pop)
 
-static_assert(
-    sizeof(ActorDynamicState) == 93u,
+ static_assert(
+    sizeof(ActorDynamicState) == 118u,
     "Invalid ActorDynamicState size! "
     "If you modified this class please update the size here, else you may "
     "comment this assert, but your platform may have compatibility issues "
     "connecting to other platforms.");
-
-#pragma pack(push, 1)
-
-/// Dynamic state of a component of an actor at a certain frame.
-struct ComponentDynamicState {
-
-  // World transform
-  geom::Transform transform;
-
-  union TypeDependentState {
-    detail::TrafficLightData traffic_light_data;
-  } state;
-
-};
-#pragma pack(pop)
 
 } // namespace data
 } // namespace sensor

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -162,6 +162,8 @@ void export_world() {
     .def("remove_on_tick", &cc::World::RemoveOnTick, (arg("callback_id")))
     .def("tick", &Tick, (arg("seconds")=10.0))
     .def("set_pedestrians_cross_factor", CALL_WITHOUT_GIL_1(cc::World, SetPedestriansCrossFactor, float), (arg("percentage")))
+    .def("get_traffic_sign", CONST_CALL_WITHOUT_GIL_1(cc::World, GetTrafficSign, cc::Landmark), arg("landmark"))
+    .def("get_traffic_light", CONST_CALL_WITHOUT_GIL_1(cc::World, GetTrafficLight, cc::Landmark), arg("landmark"))
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
@@ -31,6 +31,10 @@ static FActorView::ActorType FActorRegistry_GetActorType(const FActorView &View)
   {
     return FActorView::ActorType::TrafficLight;
   }
+  else if (nullptr != Cast<ATrafficSignBase>(View.GetActor()))
+  {
+    return FActorView::ActorType::TrafficSign;
+  }
   else
   {
     return FActorView::ActorType::Other;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorView.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorView.h
@@ -23,6 +23,7 @@ public:
     Vehicle,
     Walker,
     TrafficLight,
+    TrafficSign,
     INVALID
   };
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
@@ -111,7 +111,8 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
             UE_LOG(LogCarla, Warning, TEXT("The max size of a signal id is 32. %s (%d)"), *fstring_sign_id, sign_id.length());
             sign_id_length = max_size;
           }
-          std::strncpy(state.traffic_light_data.sign_id, sign_id.c_str(), sign_id_length);
+          std::memset(state.traffic_light_data.sign_id, '\0', max_size);
+          std::memcpy(state.traffic_light_data.sign_id, sign_id.c_str(), sign_id_length);
           state.traffic_light_data.state = static_cast<TLS>(TrafficLightComponent->GetLightState());
           state.traffic_light_data.green_time = Controller->GetGreenTime();
           state.traffic_light_data.yellow_time = Controller->GetYellowTime();
@@ -142,7 +143,8 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
           UE_LOG(LogCarla, Warning, TEXT("The max size of a signal id is 32. %s (%d)"), *fstring_sign_id, sign_id.length());
           sign_id_length = max_size;
         }
-        std::strncpy(state.traffic_sign_data.sign_id, sign_id.c_str(), sign_id_length);
+        std::memset(state.traffic_light_data.sign_id, '\0', max_size);
+        std::memcpy(state.traffic_sign_data.sign_id, sign_id.c_str(), sign_id_length);
       }
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
@@ -11,11 +11,14 @@
 #include "Carla/Traffic/TrafficLightComponent.h"
 #include "Carla/Traffic/TrafficLightController.h"
 #include "Carla/Traffic/TrafficLightGroup.h"
+#include "Carla/Traffic/TrafficSignBase.h"
+#include "Carla/Traffic/SignComponent.h"
 #include "Carla/Walker/WalkerController.h"
 
 #include "CoreGlobals.h"
 
 #include <compiler/disable-ue4-macros.h>
+#include <carla/rpc/String.h>
 #include <carla/sensor/SensorRegistry.h>
 #include <carla/sensor/data/ActorDynamicState.h>
 #include <compiler/enable-ue4-macros.h>
@@ -67,14 +70,15 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
     auto TrafficLight = Cast<ATrafficLightBase>(View.GetActor());
     if (TrafficLight != nullptr)
     {
-
       UTrafficLightComponent* TrafficLightComponent =
-      Cast<UTrafficLightComponent>(TrafficLight->FindComponentByClass<UTrafficLightComponent>());
+        Cast<UTrafficLightComponent>(TrafficLight->FindComponentByClass<UTrafficLightComponent>());
 
       using TLS = carla::rpc::TrafficLightState;
 
-      if(TrafficLightComponent == nullptr) {
+      if(TrafficLightComponent == nullptr)
+      {
         // Old way: traffic lights are actors
+        state.traffic_light_data.sign_id[0] = '\0';
         state.traffic_light_data.state = static_cast<TLS>(TrafficLight->GetTrafficLightState());
         state.traffic_light_data.green_time = TrafficLight->GetGreenTime();
         state.traffic_light_data.yellow_time = TrafficLight->GetYellowTime();
@@ -82,7 +86,9 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
         state.traffic_light_data.elapsed_time = TrafficLight->GetElapsedTime();
         state.traffic_light_data.time_is_frozen = TrafficLight->GetTimeIsFrozen();
         state.traffic_light_data.pole_index = TrafficLight->GetPoleIndex();
-      } else {
+      }
+      else
+      {
         UTrafficLightController* Controller =  TrafficLightComponent->GetController();
         ATrafficLightGroup* Group = TrafficLightComponent->GetGroup();
 
@@ -96,6 +102,16 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
         }
         else
         {
+          const FString fstring_sign_id = TrafficLightComponent->GetSignId();
+          const std::string sign_id = carla::rpc::FromFString(fstring_sign_id);
+          constexpr size_t max_size = sizeof(state.traffic_light_data.sign_id);
+          size_t sign_id_length = sign_id.length();
+          if(max_size < sign_id_length)
+          {
+            UE_LOG(LogCarla, Warning, TEXT("The max size of a signal id is 32. %s (%d)"), *fstring_sign_id, sign_id.length());
+            sign_id_length = max_size;
+          }
+          std::strncpy(state.traffic_light_data.sign_id, sign_id.c_str(), sign_id_length);
           state.traffic_light_data.state = static_cast<TLS>(TrafficLightComponent->GetLightState());
           state.traffic_light_data.green_time = Controller->GetGreenTime();
           state.traffic_light_data.yellow_time = Controller->GetYellowTime();
@@ -107,49 +123,30 @@ static auto FWorldObserver_GetActorState(const FActorView &View, const FActorReg
       }
     }
   }
-
-  return state;
-}
-
-static void FWorldObserver_GetActorComponentsState(
-  const FActorView &View,
-  const FActorRegistry &Registry,
-  TArray<carla::sensor::data::ComponentDynamicState>& Out)
-{
-  using AType = FActorView::ActorType;
-
-  if (AType::TrafficLight == View.GetActorType())
+  else if (AType::TrafficSign == View.GetActorType())
   {
-    auto TrafficLightActor = Cast<ATrafficLightBase>(View.GetActor());
-    if (TrafficLightActor == nullptr)
+    auto TrafficSign = Cast<ATrafficSignBase>(View.GetActor());
+    if (TrafficSign != nullptr)
     {
-      return;
-    }
+      USignComponent* TrafficSignComponent =
+        Cast<USignComponent>(TrafficSign->FindComponentByClass<USignComponent>());
 
-    TArray<UTrafficLightComponent*> TrafficLights;
-    TrafficLightActor->GetComponents<UTrafficLightComponent>(TrafficLights);
-
-    for(auto& TrafficLight : TrafficLights)
-    {
-      using TLS = carla::rpc::TrafficLightState;
-
-      UTrafficLightController* Controller =  TrafficLight->GetController();
-      ATrafficLightGroup* Group = TrafficLight->GetGroup();
-
-      carla::sensor::data::ComponentDynamicState CompState;
-      CompState.transform = TrafficLight->GetComponentTransform();
-      CompState.state.traffic_light_data.state = static_cast<TLS>(TrafficLight->GetLightState());
-      CompState.state.traffic_light_data.green_time = Controller->GetGreenTime();
-      CompState.state.traffic_light_data.yellow_time = Controller->GetYellowTime();
-      CompState.state.traffic_light_data.red_time = Controller->GetRedTime();
-      CompState.state.traffic_light_data.elapsed_time = Group->GetElapsedTime();
-      CompState.state.traffic_light_data.time_is_frozen = Group->IsFrozen();
-      // Nobody is using this right now, perhaps we should remove it?
-      CompState.state.traffic_light_data.pole_index = 0;
-
-      Out.Push(CompState);
+      if(TrafficSignComponent)
+      {
+        const FString fstring_sign_id = TrafficSignComponent->GetSignId();
+        const std::string sign_id = carla::rpc::FromFString(fstring_sign_id);
+        constexpr size_t max_size = sizeof(state.traffic_sign_data.sign_id);
+        size_t sign_id_length = sign_id.length();
+        if(max_size < sign_id_length)
+        {
+          UE_LOG(LogCarla, Warning, TEXT("The max size of a signal id is 32. %s (%d)"), *fstring_sign_id, sign_id.length());
+          sign_id_length = max_size;
+        }
+        std::strncpy(state.traffic_sign_data.sign_id, sign_id.c_str(), sign_id_length);
+      }
     }
   }
+  return state;
 }
 
 static carla::geom::Vector3D FWorldObserver_GetAngularVelocity(const AActor &Actor)
@@ -181,7 +178,6 @@ static carla::Buffer FWorldObserver_Serialize(
 
   using Serializer = carla::sensor::s11n::EpisodeStateSerializer;
   using ActorDynamicState = carla::sensor::data::ActorDynamicState;
-  using ComponentDynamicState = carla::sensor::data::ComponentDynamicState;
 
   const auto &Registry = Episode.GetActorRegistry();
 


### PR DESCRIPTION
#### Description

The PythonAPI has been updated to be able to get a TrafficLight or TrafficSign actor from a Landmark.

Example:
```python
traffic_lights = waypoint.get_landmarks_of_type(100, "1000001")
if len(traffic_lights) > 0:
    traffic_light = self.world.get_traffic_light(traffic_lights[0])
    print( traffic_light.state )
    print( traffic_light.get_state() )
    print( traffic_light.get_green_time() )
    print( traffic_light.get_yellow_time() )
    print( traffic_light.get_red_time() )
    print( traffic_light.get_elapsed_time() )
    print( traffic_light.is_frozen() )
    print( traffic_light.get_pole_index() )
    print( traffic_light.get_group_traffic_lights() )
    print( traffic_light.trigger_volume.location )
    print( traffic_light.trigger_volume.extent )
```

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2672)
<!-- Reviewable:end -->
