### PR TITLE
Fix compilation issue with BullseyeCoverage

### DIFF
--- a/LibCarla/source/carla/geom/Rtree.h
+++ b/LibCarla/source/carla/geom/Rtree.h
@@ -46,9 +46,11 @@ namespace geom {
     std::vector<TreeElement> GetNearestNeighboursWithFilter(const BPoint &point, Filter filter,
         size_t number_neighbours = 1) const {
       std::vector<TreeElement> query_result;
-      _rtree.query(boost::geometry::index::nearest(point,
-          static_cast<unsigned int>(number_neighbours)) && boost::geometry::index::satisfies(filter),
-      std::back_inserter(query_result));
+      auto nearest = boost::geometry::index::nearest(point, static_cast<unsigned int>(number_neighbours));
+      auto satisfies = boost::geometry::index::satisfies(filter);
+      // Using explicit operator&& to workaround Bullseye coverage issue
+      // https://www.bullseye.com/help/trouble-logicalOverload.html.
+      _rtree.query(operator&&(nearest, satisfies), std::back_inserter(query_result));
       return query_result;
     }
 


### PR DESCRIPTION
Currently CARLA fails to build under Bullseye coverage due to the usage of an overloaded operator&& from Boost.Geometry. This is a limitation of the coverage tool and not Carla's fault, however since it can be worked around simply by changing how the operator&& is called it might be a good idea to do this small change in CARLA to avoid someone else stumbling upon this issue again.

This PR does not change behaviour, simply replaces `a && b` by `operator&&(a, b)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2691)
<!-- Reviewable:end -->
