### PR TITLE
Spawn lone traffic lights

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
@@ -44,6 +44,8 @@ public:
   UFUNCTION(Category = "Traffic Light", BlueprintPure)
   UTrafficLightController* GetController();
 
+  virtual void InitializeSign(const carla::road::Map &Map) override;
+
 protected:
 
   UFUNCTION(BlueprintCallable)
@@ -57,6 +59,11 @@ protected:
 private:
 
   friend ATrafficLightManager;
+
+  void GenerateTrafficLightBox(
+      const FTransform BoxTransform,
+      float BoxSize);
+
   UPROPERTY(Category = "Traffic Light", EditAnywhere)
   ETrafficLightState LightState;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -230,13 +230,13 @@ void ATrafficLightManager::ResetTrafficLightObjects()
 
 void ATrafficLightManager::SpawnTrafficLights()
 {
-  TArray<std::string> SignalsToSpawn;
+  std::unordered_set<std::string> SignalsToSpawn;
   for(const auto& ControllerPair : GetMap()->GetControllers())
   {
     const auto& Controller = ControllerPair.second;
     for(const auto& SignalId : Controller->GetSignals())
     {
-      SignalsToSpawn.Add(SignalId);
+      SignalsToSpawn.insert(SignalId);
     }
   }
   const auto& Signals = GetMap()->GetSignals();
@@ -246,9 +246,10 @@ void ATrafficLightManager::SpawnTrafficLights()
     const auto& Signal = SignalPair.second;
     if(!Signal->GetControllers().size() &&
        !GetMap()->IsJunction(Signal->GetRoadId()) &&
-       carla::road::SignalType::IsTrafficLight(Signal->GetType()))
+       carla::road::SignalType::IsTrafficLight(Signal->GetType()) &&
+       !SignalsToSpawn.count(SignalId))
     {
-      SignalsToSpawn.Add(SignalId);
+      SignalsToSpawn.insert(SignalId);
     }
   }
   for(auto &SignalId : SignalsToSpawn)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
@@ -56,12 +56,6 @@ private:
 
   void SpawnSignals();
 
-  void GenerateTriggerBoxesForTrafficLights();
-
-  void GenerateTriggerBox(const carla::road::element::Waypoint &waypoint,
-    UTrafficLightComponent* TrafficLightComponent,
-    float BoxSize);
-
   void RemoveRoadrunnerProps() const;
 
   void RemoveAttachedProps(TArray<AActor*> Actors) const;
@@ -102,5 +96,8 @@ private:
 
   UPROPERTY()
   bool TrafficLightsGenerated = false;
+
+  UPROPERTY()
+  int LoneTrafficLightsGroupControllerId = -1;
 
 };


### PR DESCRIPTION
#### Description

Moved trigger box generation for traffic lights from `ATrafficLightManager` to `UTrafficLightComponent'.

Added spawn of traffic lights without controllers when defined outside junctions. The signal needs to fullfill the following conditions for this to happen:
- Has no controllers
- Is defined outside any junction (standard roads)
- It's type corresponds to a traffic light as defined in the OpenDRIVE specification.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** UE4.24

#### Possible Drawbacks
A traffic light may be defined outside a junction but may take effect inside one. The traffic light will spawn and behave independently of the other lights in the junction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2705)
<!-- Reviewable:end -->
