### PR TITLE
Fixed get_all_landmarks functions returning corrupted landmarks

### DIFF
--- a/LibCarla/source/carla/client/Landmark.h
+++ b/LibCarla/source/carla/client/Landmark.h
@@ -121,14 +121,18 @@ namespace client {
 
     Landmark(
         SharedPtr<Waypoint> waypoint,
+        SharedPtr<const Map> parent,
         const road::element::RoadInfoSignal* signal,
         double distance_from_search = 0)
       : _waypoint(waypoint),
+        _parent(parent),
         _signal(signal),
         _distance_from_search(distance_from_search) {}
 
     /// waypoint where the signal is affecting
     SharedPtr<Waypoint> _waypoint;
+
+    SharedPtr<const Map> _parent;
 
     const road::element::RoadInfoSignal* _signal;
 

--- a/LibCarla/source/carla/client/Map.cpp
+++ b/LibCarla/source/carla/client/Map.cpp
@@ -137,7 +137,7 @@ namespace client {
     auto signal_references = _map.GetAllSignalReferences();
     for(auto* signal_reference : signal_references) {
       result.emplace_back(
-          new Landmark(nullptr, signal_reference, 0));
+          new Landmark(nullptr, shared_from_this(), signal_reference, 0));
     }
     return result;
   }
@@ -148,7 +148,7 @@ namespace client {
     for(auto* signal_reference : signal_references) {
       if(signal_reference->GetSignalId() == id) {
         result.emplace_back(
-            new Landmark(nullptr, signal_reference, 0));
+            new Landmark(nullptr, shared_from_this(), signal_reference, 0));
       }
     }
     return result;
@@ -160,7 +160,7 @@ namespace client {
     for(auto* signal_reference : signal_references) {
       if(signal_reference->GetSignal()->GetType() == type) {
         result.emplace_back(
-            new Landmark(nullptr, signal_reference, 0));
+            new Landmark(nullptr, shared_from_this(), signal_reference, 0));
       }
     }
     return result;

--- a/LibCarla/source/carla/client/Waypoint.cpp
+++ b/LibCarla/source/carla/client/Waypoint.cpp
@@ -220,7 +220,7 @@ namespace client {
       added_signals.insert(signal_data.signal);
       auto waypoint = SharedPtr<Waypoint>(new Waypoint(_parent, signal_data.waypoint));
       result.emplace_back(
-          new Landmark(waypoint, signal_data.signal, signal_data.accumulated_s));
+          new Landmark(waypoint, _parent, signal_data.signal, signal_data.accumulated_s));
     }
     return result;
   }
@@ -238,7 +238,7 @@ namespace client {
         }
         auto waypoint = SharedPtr<Waypoint>(new Waypoint(_parent, signal_data.waypoint));
         result.emplace_back(
-            new Landmark(waypoint, signal_data.signal, signal_data.accumulated_s));
+            new Landmark(waypoint, _parent, signal_data.signal, signal_data.accumulated_s));
       }
     }
     return result;


### PR DESCRIPTION
#### Description

This is a quick fix for the functions `get_all_landmarks`, `get_all_landmarks_from_id` and `get_all_landmarks_of_type` returning corrupted landmarks.

The issue happened when calling these functions in the following way:
```
for landmark in world.get_map().get_all_landmarks():
    # do stuff with landmark
```
The call `world.get_map()` calls the simulator to retrieve the OpenDRIVE file and parses the map. Then the call `get_all_landmarks()` retrieves a list of landmarks with contents that points towards the map. After this last call, python deletes the map from `world.get_map()` rendering the contents of the landmark list corrupted.

This fix adds the necessary shared pointers to the Landmark class to prevent this deletion from happening before the loop is completed.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** UE4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2710)
<!-- Reviewable:end -->
