### PR TITLE
Standalone Opendrive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
   * Introduced hybrid mode for Traffic Manager
   * Upgraded to Unreal Engine 4.24
   * Fixed autonomous agents' incorrect detection of red traffic lights affecting them
-  * Added walkable pedestrian crosswalks in OpenDRIVE standalone mode
   * Improved manual_control by adding realistic throttle and brake
+  * Added walkable pedestrian crosswalks in OpenDRIVE standalone mode
+  * Improved mesh generation with a chunk system for better performance and bigger maps in the future
   * Added security features to the standalone OpenDRIVE mode aiming to prevent cars from falling down from the road
   * Added new Behavior agent
   * Added automatic generation of traffic lights, stop signal and yield signal from OpenDRIVE file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Added walkable pedestrian crosswalks in OpenDRIVE standalone mode
   * Improved mesh generation with a chunk system for better performance and bigger maps in the future
   * Added security features to the standalone OpenDRIVE mode aiming to prevent cars from falling down from the road
+  * Added junction smoothing algorithm to prevent roads from blocking other roads with level differences
   * Added new Behavior agent
   * Added automatic generation of traffic lights, stop signal and yield signal from OpenDRIVE file
   * Upgraded to AD RSS v3.0.0 supporting complex road layouts and i.e. intersections

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -1464,7 +1464,7 @@ All possible states for traffic lights. These can either change at a specific ti
 ---
 
 ## carla.TrafficManager<a name="carla.TrafficManager"></a>
-The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a [carla.VehicleControl](#carla.VehicleControl) is applied to every vehicle registered in a traffic manager.
+The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a [carla.VehicleControl](#carla.VehicleControl) is applied to every vehicle registered in a traffic manager.  
 In order to learn more, visit the [documentation](adv_traffic_manager.md) regarding this module.  
 
 <h3>Methods</h3>
@@ -1494,7 +1494,7 @@ Sets the minimum distance in meters that vehicles have to keep with the rest. Th
     - **Parameters:**
         - `distance` (_float_) – Meters between vehicles.  
 - <a name="carla.TrafficManager.global_percentage_speed_difference"></a>**<font color="#7fb800">global_percentage_speed_difference</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**percentage**</font>)  
-Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
 Default is 30. Exceeding a speed limit can be done using negative percentages.  
     - **Parameters:**
         - `percentage` (_float_) – Percentage difference between intended speed and the current limit.  
@@ -1516,7 +1516,7 @@ During the collision detection stage, which runs every frame, this method sets a
 - <a name="carla.TrafficManager.reset_traffic_lights"></a>**<font color="#7fb800">reset_traffic_lights</font>**(<font color="#00a6ed">**self**</font>)  
 Resets every traffic light in the map to its initial state.  
 - <a name="carla.TrafficManager.vehicle_percentage_speed_difference"></a>**<font color="#7fb800">vehicle_percentage_speed_difference</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**actor**</font>, <font color="#00a6ed">**percentage**</font>)  
-Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
 Default is 30. Exceeding a speed limit can be done using negative percentages.  
     - **Parameters:**
         - `actor` (_[carla.Actor](#carla.Actor)_) – Vehicle whose speed behaviour is being changed.  

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -1075,6 +1075,25 @@ Distance between `actor` and `other`.
 
 ---
 
+## carla.OpendriveGenerationParameters<a name="carla.OpendriveGenerationParameters"></a>
+This class defines the parameters used when generating a world using an OpenDRIVE file.  
+
+<h3>Instance Variables</h3>
+- <a name="carla.OpendriveGenerationParameters.vertex_distance"></a>**<font color="#f8805a">vertex_distance</font>**  
+The distance between vertices when generating the world mesh from OpenDRIVE.  
+- <a name="carla.OpendriveGenerationParameters.max_road_length"></a>**<font color="#f8805a">max_road_length</font>**  
+Max road length for a single mesh portion.  
+- <a name="carla.OpendriveGenerationParameters.wall_height"></a>**<font color="#f8805a">wall_height</font>**  
+Defines the height of walls added to roads to prevent vehicles from falling.  
+- <a name="carla.OpendriveGenerationParameters.additional_width"></a>**<font color="#f8805a">additional_width</font>**  
+Additional with to junction lanes to prevent vehicles from falling.  
+- <a name="carla.OpendriveGenerationParameters.smooth_junctions"></a>**<font color="#f8805a">smooth_junctions</font>**  
+When this variable is `True` the generated junctions will be smoothed to prevent roads from blocking other roads.  
+- <a name="carla.OpendriveGenerationParameters.enable_mesh_visibility"></a>**<font color="#f8805a">enable_mesh_visibility</font>**  
+This variable indicates whether the mesh should be rendered to reduce the rendering overhead.  
+
+---
+
 ## carla.RadarDetection<a name="carla.RadarDetection"></a>
 Data contained inside a [carla.RadarMeasurement](#carla.RadarMeasurement). Each of these represents one of the points in the cloud that a <b>sensor.other.radar</b> registers and contains the distance, angle and velocity in relation to the radar.  
 
@@ -1445,7 +1464,7 @@ All possible states for traffic lights. These can either change at a specific ti
 ---
 
 ## carla.TrafficManager<a name="carla.TrafficManager"></a>
-The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a [carla.VehicleControl](#carla.VehicleControl) is applied to every vehicle registered in a traffic manager.  
+The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a [carla.VehicleControl](#carla.VehicleControl) is applied to every vehicle registered in a traffic manager.
 In order to learn more, visit the [documentation](adv_traffic_manager.md) regarding this module.  
 
 <h3>Methods</h3>
@@ -1475,7 +1494,7 @@ Sets the minimum distance in meters that vehicles have to keep with the rest. Th
     - **Parameters:**
         - `distance` (_float_) – Meters between vehicles.  
 - <a name="carla.TrafficManager.global_percentage_speed_difference"></a>**<font color="#7fb800">global_percentage_speed_difference</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**percentage**</font>)  
-Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
+Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
 Default is 30. Exceeding a speed limit can be done using negative percentages.  
     - **Parameters:**
         - `percentage` (_float_) – Percentage difference between intended speed and the current limit.  
@@ -1497,7 +1516,7 @@ During the collision detection stage, which runs every frame, this method sets a
 - <a name="carla.TrafficManager.reset_traffic_lights"></a>**<font color="#7fb800">reset_traffic_lights</font>**(<font color="#00a6ed">**self**</font>)  
 Resets every traffic light in the map to its initial state.  
 - <a name="carla.TrafficManager.vehicle_percentage_speed_difference"></a>**<font color="#7fb800">vehicle_percentage_speed_difference</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**actor**</font>, <font color="#00a6ed">**percentage**</font>)  
-Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
+Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
 Default is 30. Exceeding a speed limit can be done using negative percentages.  
     - **Parameters:**
         - `actor` (_[carla.Actor](#carla.Actor)_) – Vehicle whose speed behaviour is being changed.  

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -64,14 +64,9 @@ namespace client {
 
     World GenerateOpenDriveWorld(
         std::string opendrive,
-        double resolution=2.f,
-        double wall_height=1.f,
-        double additional_width=.6f) const {
+        const rpc::OpendriveGenerationParameters & params) const {
       return World{_simulator->LoadOpenDriveEpisode(
-          std::move(opendrive),
-          resolution,
-          wall_height,
-          additional_width)};
+          std::move(opendrive), params)};
     }
 
     /// Return an instance of the world currently active in the simulator.

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -145,9 +145,9 @@ namespace detail {
     _pimpl->CallAndWait<void>("load_new_episode", std::move(map_name));
   }
 
-  void Client::CopyOpenDriveToServer(std::string opendrive, double resolution, double wall_height, double additional_width) {
+  void Client::CopyOpenDriveToServer(std::string opendrive, const rpc::OpendriveGenerationParameters & params) {
     // Await response, we need to be sure in this one.
-    _pimpl->CallAndWait<void>("copy_opendrive_to_file", std::move(opendrive), resolution, wall_height, additional_width);
+    _pimpl->CallAndWait<void>("copy_opendrive_to_file", std::move(opendrive), params);
   }
 
   rpc::EpisodeInfo Client::GetEpisodeInfo() {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -22,6 +22,7 @@
 #include "carla/rpc/VehiclePhysicsControl.h"
 #include "carla/rpc/VehicleLightState.h"
 #include "carla/rpc/WeatherParameters.h"
+#include "carla/rpc/OpendriveGenerationParameters.h"
 
 #include <functional>
 #include <memory>
@@ -86,7 +87,8 @@ namespace detail {
 
     void LoadEpisode(std::string map_name);
 
-    void CopyOpenDriveToServer(std::string opendrive, double resolution, double wall_height, double additional_width);
+    void CopyOpenDriveToServer(
+        std::string opendrive, const rpc::OpendriveGenerationParameters & params);
 
     rpc::EpisodeInfo GetEpisodeInfo();
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -98,14 +98,12 @@ namespace detail {
 
   EpisodeProxy Simulator::LoadOpenDriveEpisode(
       std::string opendrive,
-      double resolution,
-      double wall_height,
-      double additional_width) {
+      const rpc::OpendriveGenerationParameters & params) {
     // The "OpenDriveMap" is an ".umap" located in:
     // "carla/Unreal/CarlaUE4/Content/Carla/Maps/"
     // It will load the last sended OpenDRIVE by client's "LoadOpenDriveEpisode()"
     constexpr auto custom_opendrive_map = "OpenDriveMap";
-    _client.CopyOpenDriveToServer(std::move(opendrive), resolution, wall_height, additional_width);
+    _client.CopyOpenDriveToServer(std::move(opendrive), params);
     return LoadEpisode(custom_opendrive_map);
   }
 

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -70,9 +70,7 @@ namespace detail {
 
     EpisodeProxy LoadOpenDriveEpisode(
         std::string opendrive,
-        double resolution,
-        double wall_height,
-        double additional_width);
+        const rpc::OpendriveGenerationParameters & params);
 
     /// @}
     // =========================================================================

--- a/LibCarla/source/carla/geom/Mesh.cpp
+++ b/LibCarla/source/carla/geom/Mesh.cpp
@@ -250,6 +250,10 @@ namespace geom {
     return _vertices;
   }
 
+  std::vector<Mesh::vertex_type> &Mesh::GetVertices() {
+    return _vertices;
+  }
+
   size_t Mesh::GetVerticesNum() const {
     return _vertices.size();
   }

--- a/LibCarla/source/carla/geom/Mesh.cpp
+++ b/LibCarla/source/carla/geom/Mesh.cpp
@@ -37,6 +37,7 @@ namespace geom {
     return true;
   }
 
+  // e.g:
   // 1   3   5   7
   // #---#---#---#
   // | / | / | / |
@@ -65,13 +66,12 @@ namespace geom {
     }
   }
 
-  //   6   5
-  //   #---#
-  //   | / |
-  // 1 #---# 4
-  //   | \ |
-  //   #---#
-  //   2   3
+  // e.g:
+  // 2   1   6
+  // #---#---#
+  // | / | \ |
+  // #---#---#
+  // 3   4   5
   void Mesh::AddTriangleFan(const std::vector<Mesh::vertex_type> &vertices) {
     DEBUG_ASSERT(vertices.size() >= 3);
     const size_t initial_index = GetVerticesNum() + 1;

--- a/LibCarla/source/carla/geom/Mesh.cpp
+++ b/LibCarla/source/carla/geom/Mesh.cpp
@@ -11,7 +11,6 @@
 #include <ios>
 
 #include <carla/geom/Math.h>
-#include <carla/geom/Location.h>
 
 namespace carla {
 namespace geom {

--- a/LibCarla/source/carla/geom/Mesh.h
+++ b/LibCarla/source/carla/geom/Mesh.h
@@ -123,6 +123,8 @@ namespace geom {
 
     const std::vector<vertex_type> &GetVertices() const;
 
+    std::vector<vertex_type> &GetVertices();
+
     size_t GetVerticesNum() const;
 
     const std::vector<normal_type> &GetNormals() const;

--- a/LibCarla/source/carla/geom/Mesh.h
+++ b/LibCarla/source/carla/geom/Mesh.h
@@ -11,6 +11,10 @@
 #include <carla/geom/Vector3D.h>
 #include <carla/geom/Vector2D.h>
 
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+#include "Util/ProceduralCustomMesh.h"
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+
 namespace carla {
 namespace geom {
 
@@ -138,6 +142,65 @@ namespace geom {
     Mesh &operator+=(const Mesh &rhs);
 
     friend Mesh operator+(const Mesh &lhs, const Mesh &rhs);
+
+    // =========================================================================
+    // -- Conversions to UE4 types ---------------------------------------------
+    // =========================================================================
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    operator FProceduralCustomMesh() const {
+      FProceduralCustomMesh Mesh;
+
+      // Build the mesh
+      for (const auto Vertex : GetVertices())
+      {
+        // From meters to centimeters
+        Mesh.Vertices.Add(FVector{1e2f * Vertex.x, 1e2f * Vertex.y, 1e2f * Vertex.z});
+      }
+
+      const auto Indexes = GetIndexes();
+      TArray<FTriIndices> TriIndices;
+      for (auto i = 0u; i < Indexes.size(); i += 3)
+      {
+        FTriIndices Triangle;
+        // "-1" since mesh indexes in Unreal starts from index 0.
+        Mesh.Triangles.Add(Indexes[i]     - 1);
+        // Since Unreal's coords are left handed, invert the last 2 indices.
+        Mesh.Triangles.Add(Indexes[i + 2] - 1);
+        Mesh.Triangles.Add(Indexes[i + 1] - 1);
+
+        Triangle.v0 = Indexes[i]     - 1;
+        Triangle.v1 = Indexes[i + 2] - 1;
+        Triangle.v2 = Indexes[i + 1] - 1;
+        TriIndices.Add(Triangle);
+      }
+
+      // Compute the normals
+      TArray<FVector> Normals;
+      Mesh.Normals.Init(FVector::UpVector, Mesh.Vertices.Num());
+
+      for (const auto &Triangle : TriIndices) {
+        FVector Normal;
+        const FVector U = Mesh.Vertices[Triangle.v1] - Mesh.Vertices[Triangle.v0];
+        const FVector V = Mesh.Vertices[Triangle.v2] - Mesh.Vertices[Triangle.v0];
+        Normal.X = (U.Y * V.Z) - (U.Z * V.Y);
+        Normal.Y = (U.Z * V.X) - (U.X * V.Z);
+        Normal.Z = (U.X * V.Y) - (U.Y * V.X);
+        Normal = -Normal;
+        Normal = Normal.GetSafeNormal(.0001f);
+        if (Normal != FVector::ZeroVector)
+        {
+          Mesh.Normals[Triangle.v0] = Normal;
+          Mesh.Normals[Triangle.v1] = Normal;
+          Mesh.Normals[Triangle.v2] = Normal;
+        }
+      }
+
+      return Mesh;
+    }
+
+#endif // LIBCARLA_INCLUDED_FROM_UE4
 
   private:
 

--- a/LibCarla/source/carla/geom/MeshFactory.cpp
+++ b/LibCarla/source/carla/geom/MeshFactory.cpp
@@ -57,7 +57,6 @@ namespace geom {
     if (lane.IsStraight()) {
       // Mesh optimization: If the lane is straight just add vertices at the
       // begining and at the end of it
-
       const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
       vertices.push_back(edges.first);
       vertices.push_back(edges.second);
@@ -86,6 +85,130 @@ namespace geom {
     out_mesh.AddMaterial(
         lane.GetType() == road::Lane::LaneType::Sidewalk ? "sidewalk" : "road");
     out_mesh.AddTriangleStrip(vertices);
+    out_mesh.EndMaterial();
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::GenerateWalls(const road::LaneSection &lane_section) const {
+    Mesh out_mesh;
+
+    const auto min_lane = lane_section.GetLanes().begin()->first == 0 ?
+        1 : lane_section.GetLanes().begin()->first;
+    const auto max_lane = lane_section.GetLanes().rbegin()->first == 0 ?
+        -1 : lane_section.GetLanes().rbegin()->first;
+
+    for (auto &&lane_pair : lane_section.GetLanes()) {
+      const auto &lane = lane_pair.second;
+      const double s_start = lane.GetDistance() + EPSILON;
+      const double s_end = lane.GetDistance() + lane.GetLength() - EPSILON;
+      if (lane.GetId() == max_lane) {
+        out_mesh += *GenerateLeftWall(lane, s_start, s_end);
+      }
+      if (lane.GetId() == min_lane) {
+        out_mesh += *GenerateRightWall(lane, s_start, s_end);
+      }
+    }
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::GenerateRightWall(
+      const road::Lane &lane, const double s_start, const double s_end) const {
+    RELEASE_ASSERT(road_param.resolution > 0.0);
+    DEBUG_ASSERT(s_start >= 0.0);
+    DEBUG_ASSERT(s_end <= lane.GetDistance() + lane.GetLength());
+    DEBUG_ASSERT(s_end >= EPSILON);
+    DEBUG_ASSERT(s_start < s_end);
+    // The lane with lane_id 0 have no physical representation in OpenDRIVE
+    Mesh out_mesh;
+    if (lane.GetId() == 0) {
+      return std::make_unique<Mesh>(out_mesh);
+    }
+    double s_current = s_start;
+    const geom::Vector3D height_vector = geom::Vector3D(0.f, 0.f, road_param.wall_height);
+
+    std::vector<geom::Vector3D> r_vertices;
+    if (lane.IsStraight()) {
+      // Mesh optimization: If the lane is straight just add vertices at the
+      // begining and at the end of it
+      const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+      r_vertices.push_back(edges.first + height_vector);
+      r_vertices.push_back(edges.first);
+    } else {
+      // Iterate over the lane's 's' and store the vertices based on it's width
+      do {
+        // Get the location of the edges of the current lane at the current waypoint
+        const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+        r_vertices.push_back(edges.first + height_vector);
+        r_vertices.push_back(edges.first);
+
+        // Update the current waypoint's "s"
+        s_current += road_param.resolution;
+      } while(s_current < s_end);
+    }
+
+    // This ensures the mesh is constant and have no gaps between roads,
+    // adding geometry at the very end of the lane
+    if (s_end - (s_current - road_param.resolution) > EPSILON) {
+      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
+      r_vertices.push_back(edges.first + height_vector);
+      r_vertices.push_back(edges.first);
+    }
+
+    // Add the adient material, create the strip and close the material
+    out_mesh.AddMaterial(
+        lane.GetType() == road::Lane::LaneType::Sidewalk ? "sidewalk" : "road");
+    out_mesh.AddTriangleStrip(r_vertices);
+    out_mesh.EndMaterial();
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::GenerateLeftWall(
+      const road::Lane &lane, const double s_start, const double s_end) const {
+    RELEASE_ASSERT(road_param.resolution > 0.0);
+    DEBUG_ASSERT(s_start >= 0.0);
+    DEBUG_ASSERT(s_end <= lane.GetDistance() + lane.GetLength());
+    DEBUG_ASSERT(s_end >= EPSILON);
+    DEBUG_ASSERT(s_start < s_end);
+    // The lane with lane_id 0 have no physical representation in OpenDRIVE
+    Mesh out_mesh;
+    if (lane.GetId() == 0) {
+      return std::make_unique<Mesh>(out_mesh);
+    }
+    double s_current = s_start;
+    const geom::Vector3D height_vector = geom::Vector3D(0.f, 0.f, road_param.wall_height);
+
+    std::vector<geom::Vector3D> l_vertices;
+    if (lane.IsStraight()) {
+      // Mesh optimization: If the lane is straight just add vertices at the
+      // begining and at the end of it
+      const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+      l_vertices.push_back(edges.second);
+      l_vertices.push_back(edges.second + height_vector);
+    } else {
+      // Iterate over the lane's 's' and store the vertices based on it's width
+      do {
+        // Get the location of the edges of the current lane at the current waypoint
+        const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+        l_vertices.push_back(edges.second);
+        l_vertices.push_back(edges.second + height_vector);
+
+        // Update the current waypoint's "s"
+        s_current += road_param.resolution;
+      } while(s_current < s_end);
+    }
+
+    // This ensures the mesh is constant and have no gaps between roads,
+    // adding geometry at the very end of the lane
+    if (s_end - (s_current - road_param.resolution) > EPSILON) {
+      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
+      l_vertices.push_back(edges.second);
+      l_vertices.push_back(edges.second + height_vector);
+    }
+
+    // Add the adient material, create the strip and close the material
+    out_mesh.AddMaterial(
+        lane.GetType() == road::Lane::LaneType::Sidewalk ? "sidewalk" : "road");
+    out_mesh.AddTriangleStrip(l_vertices);
     out_mesh.EndMaterial();
     return std::make_unique<Mesh>(out_mesh);
   }
@@ -121,11 +244,102 @@ namespace geom {
         s_current = s_until;
       }
       if (s_end - s_current > EPSILON) {
+        Mesh lane_section_mesh;
         for (auto &&lane_pair : lane_section.GetLanes()) {
-          mesh_uptr_list.emplace_back(Generate(lane_pair.second, s_current, s_end));
+          lane_section_mesh += *Generate(lane_pair.second, s_current, s_end);
         }
+        mesh_uptr_list.emplace_back(std::make_unique<Mesh>(lane_section_mesh));
       }
     }
+    return mesh_uptr_list;
+  }
+
+  std::vector<std::unique_ptr<Mesh>> MeshFactory::GenerateWallsWithMaxLen(
+      const road::Road &road, const double max_len) const {
+    std::vector<std::unique_ptr<Mesh>> mesh_uptr_list;
+    for (auto &&lane_section : road.GetLaneSections()) {
+      auto section_uptr_list = GenerateWallsWithMaxLen(lane_section, max_len);
+      mesh_uptr_list.insert(
+          mesh_uptr_list.end(),
+          std::make_move_iterator(section_uptr_list.begin()),
+          std::make_move_iterator(section_uptr_list.end()));
+    }
+    return mesh_uptr_list;
+  }
+
+  std::vector<std::unique_ptr<Mesh>> MeshFactory::GenerateWallsWithMaxLen(
+      const road::LaneSection &lane_section, const double max_len) const {
+    std::vector<std::unique_ptr<Mesh>> mesh_uptr_list;
+
+    const auto min_lane = lane_section.GetLanes().begin()->first == 0 ?
+        1 : lane_section.GetLanes().begin()->first;
+    const auto max_lane = lane_section.GetLanes().rbegin()->first == 0 ?
+        -1 : lane_section.GetLanes().rbegin()->first;
+
+    if (lane_section.GetLength() < max_len) {
+      mesh_uptr_list.emplace_back(GenerateWalls(lane_section));
+    } else {
+      double s_current = lane_section.GetDistance() + EPSILON;
+      const double s_end = lane_section.GetDistance() + lane_section.GetLength() - EPSILON;
+      while(s_current + max_len < s_end) {
+        const auto s_until = s_current + max_len;
+        Mesh lane_section_mesh;
+        for (auto &&lane_pair : lane_section.GetLanes()) {
+          const auto &lane = lane_pair.second;
+          if (lane.GetId() == max_lane) {
+            lane_section_mesh += *GenerateLeftWall(lane, s_current, s_until);
+          }
+          if (lane.GetId() == min_lane) {
+            lane_section_mesh += *GenerateRightWall(lane, s_current, s_until);
+          }
+        }
+        mesh_uptr_list.emplace_back(std::make_unique<Mesh>(lane_section_mesh));
+        s_current = s_until;
+      }
+      if (s_end - s_current > EPSILON) {
+        Mesh lane_section_mesh;
+        for (auto &&lane_pair : lane_section.GetLanes()) {
+          const auto &lane = lane_pair.second;
+          if (lane.GetId() == max_lane) {
+            lane_section_mesh += *GenerateLeftWall(lane, s_current, s_end);
+          }
+          if (lane.GetId() == min_lane) {
+            lane_section_mesh += *GenerateRightWall(lane, s_current, s_end);
+          }
+        }
+        mesh_uptr_list.emplace_back(std::make_unique<Mesh>(lane_section_mesh));
+      }
+    }
+    return mesh_uptr_list;
+  }
+
+  std::vector<std::unique_ptr<Mesh>> MeshFactory::GenerateAllWithMaxLen(
+      const road::Road &road, const double max_len) const {
+    std::vector<std::unique_ptr<Mesh>> mesh_uptr_list;
+
+    // Get road meshes
+    auto roads = GenerateWithMaxLen(road, max_len);
+    mesh_uptr_list.insert(
+        mesh_uptr_list.end(),
+        std::make_move_iterator(roads.begin()),
+        std::make_move_iterator(roads.end()));
+
+    // Get wall meshes only if is not a junction
+    if (!road.IsJunction()) {
+      auto walls = GenerateWallsWithMaxLen(road, max_len);
+
+      if (roads.size() == walls.size()) {
+        for (size_t i = 0; i < walls.size(); ++i) {
+          *mesh_uptr_list[i] += *walls[i];
+        }
+      } else {
+        mesh_uptr_list.insert(
+            mesh_uptr_list.end(),
+            std::make_move_iterator(walls.begin()),
+            std::make_move_iterator(walls.end()));
+      }
+    }
+
     return mesh_uptr_list;
   }
 

--- a/LibCarla/source/carla/geom/MeshFactory.cpp
+++ b/LibCarla/source/carla/geom/MeshFactory.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include <carla/geom/MeshFactory.h>
+
+#include <vector>
+
+#include <carla/geom/Vector3D.h>
+
+namespace carla {
+namespace geom {
+
+  /// We use this epsilon to shift the waypoints away from the edges of the lane
+  /// sections to avoid floating point precision errors.
+  static constexpr double EPSILON = 10.0 * std::numeric_limits<double>::epsilon();
+
+  std::unique_ptr<Mesh> MeshFactory::Generate(const road::Road &road) const {
+    geom::Mesh out_mesh;
+    for (auto &&lane_section : road.GetLaneSections()) {
+      out_mesh += *Generate(lane_section);
+    }
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::Generate(const road::LaneSection &lane_section) const {
+    geom::Mesh out_mesh;
+    for (auto &&lane_pair : lane_section.GetLanes()) {
+      out_mesh += *Generate(lane_pair.second);
+    }
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::Generate(const road::Lane &lane) const {
+    RELEASE_ASSERT(road_param.resolution > 0.0);
+    // The lane with lane_id 0 have no physical representation in OpenDRIVE
+    geom::Mesh out_mesh;
+    if (lane.GetId() == 0) {
+      return std::make_unique<Mesh>(out_mesh);
+    }
+    const auto end_distance = lane.GetDistance() + lane.GetLength() - EPSILON;
+    double current_s = lane.GetLaneSection()->GetDistance() + EPSILON;
+
+    std::vector<geom::Vector3D> vertices;
+    if (lane.IsStraight()) {
+      // Mesh optimization: If the lane is straight just add vertices at the
+      // begining and at the end of it
+      const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+      vertices.push_back(edges.first);
+      vertices.push_back(edges.second);
+    } else {
+      // Iterate over the lane's 's' and store the vertices based on it's width
+      do {
+        // Get the location of the edges of the current lane at the current waypoint
+        const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+        vertices.push_back(edges.first);
+        vertices.push_back(edges.second);
+
+        // Update the current waypoint's "s"
+        current_s += road_param.resolution;
+      } while(current_s < end_distance);
+    }
+
+    // This ensures the mesh is constant and have no gaps between roads,
+    // adding geometry at the very end of the lane
+    if (end_distance - (current_s - road_param.resolution) > EPSILON) {
+      current_s = end_distance;
+      const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+      vertices.push_back(edges.first);
+      vertices.push_back(edges.second);
+    }
+
+    // Add the adient material, create the strip and close the material
+    out_mesh.AddMaterial(
+        lane.GetType() == road::Lane::LaneType::Sidewalk ? "sidewalk" : "road");
+    out_mesh.AddTriangleStrip(vertices);
+    out_mesh.EndMaterial();
+    return std::make_unique<Mesh>(out_mesh);
+  }
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/MeshFactory.cpp
+++ b/LibCarla/source/carla/geom/MeshFactory.cpp
@@ -18,7 +18,7 @@ namespace geom {
   static constexpr double EPSILON = 10.0 * std::numeric_limits<double>::epsilon();
 
   std::unique_ptr<Mesh> MeshFactory::Generate(const road::Road &road) const {
-    geom::Mesh out_mesh;
+    Mesh out_mesh;
     for (auto &&lane_section : road.GetLaneSections()) {
       out_mesh += *Generate(lane_section);
     }
@@ -26,7 +26,7 @@ namespace geom {
   }
 
   std::unique_ptr<Mesh> MeshFactory::Generate(const road::LaneSection &lane_section) const {
-    geom::Mesh out_mesh;
+    Mesh out_mesh;
     for (auto &&lane_pair : lane_section.GetLanes()) {
       out_mesh += *Generate(lane_pair.second);
     }
@@ -34,40 +34,50 @@ namespace geom {
   }
 
   std::unique_ptr<Mesh> MeshFactory::Generate(const road::Lane &lane) const {
+    const double s_start = lane.GetDistance() + EPSILON;
+    const double s_end = lane.GetDistance() + lane.GetLength() - EPSILON;
+    return Generate(lane, s_start, s_end);
+  }
+
+  std::unique_ptr<Mesh> MeshFactory::Generate(
+      const road::Lane &lane, const double s_start, const double s_end) const {
     RELEASE_ASSERT(road_param.resolution > 0.0);
+    DEBUG_ASSERT(s_start >= 0.0);
+    DEBUG_ASSERT(s_end <= lane.GetDistance() + lane.GetLength());
+    DEBUG_ASSERT(s_end >= EPSILON);
+    DEBUG_ASSERT(s_start < s_end);
     // The lane with lane_id 0 have no physical representation in OpenDRIVE
-    geom::Mesh out_mesh;
+    Mesh out_mesh;
     if (lane.GetId() == 0) {
       return std::make_unique<Mesh>(out_mesh);
     }
-    const auto end_distance = lane.GetDistance() + lane.GetLength() - EPSILON;
-    double current_s = lane.GetLaneSection()->GetDistance() + EPSILON;
+    double s_current = s_start;
 
     std::vector<geom::Vector3D> vertices;
     if (lane.IsStraight()) {
       // Mesh optimization: If the lane is straight just add vertices at the
       // begining and at the end of it
-      const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+
+      const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
       vertices.push_back(edges.first);
       vertices.push_back(edges.second);
     } else {
       // Iterate over the lane's 's' and store the vertices based on it's width
       do {
         // Get the location of the edges of the current lane at the current waypoint
-        const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+        const auto edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
         vertices.push_back(edges.first);
         vertices.push_back(edges.second);
 
         // Update the current waypoint's "s"
-        current_s += road_param.resolution;
-      } while(current_s < end_distance);
+        s_current += road_param.resolution;
+      } while(s_current < s_end);
     }
 
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
-    if (end_distance - (current_s - road_param.resolution) > EPSILON) {
-      current_s = end_distance;
-      const auto edges = lane.GetCornerPositions(current_s, road_param.extra_lane_width);
+    if (s_end - (s_current - road_param.resolution) > EPSILON) {
+      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
       vertices.push_back(edges.first);
       vertices.push_back(edges.second);
     }
@@ -78,6 +88,45 @@ namespace geom {
     out_mesh.AddTriangleStrip(vertices);
     out_mesh.EndMaterial();
     return std::make_unique<Mesh>(out_mesh);
+  }
+
+  std::vector<std::unique_ptr<Mesh>> MeshFactory::GenerateWithMaxLen(
+      const road::Road &road, const double max_len) const {
+    std::vector<std::unique_ptr<Mesh>> mesh_uptr_list;
+    for (auto &&lane_section : road.GetLaneSections()) {
+      auto section_uptr_list = GenerateWithMaxLen(lane_section, max_len);
+      mesh_uptr_list.insert(
+          mesh_uptr_list.end(),
+          std::make_move_iterator(section_uptr_list.begin()),
+          std::make_move_iterator(section_uptr_list.end()));
+    }
+    return mesh_uptr_list;
+  }
+
+  std::vector<std::unique_ptr<Mesh>> MeshFactory::GenerateWithMaxLen(
+      const road::LaneSection &lane_section, const double max_len) const {
+    std::vector<std::unique_ptr<Mesh>> mesh_uptr_list;
+    if (lane_section.GetLength() < max_len) {
+      mesh_uptr_list.emplace_back(Generate(lane_section));
+    } else {
+      double s_current = lane_section.GetDistance() + EPSILON;
+      const double s_end = lane_section.GetDistance() + lane_section.GetLength() - EPSILON;
+      while(s_current + max_len < s_end) {
+        const auto s_until = s_current + max_len;
+        Mesh lane_section_mesh;
+        for (auto &&lane_pair : lane_section.GetLanes()) {
+          lane_section_mesh += *Generate(lane_pair.second, s_current, s_until);
+        }
+        mesh_uptr_list.emplace_back(std::make_unique<Mesh>(lane_section_mesh));
+        s_current = s_until;
+      }
+      if (s_end - s_current > EPSILON) {
+        for (auto &&lane_pair : lane_section.GetLanes()) {
+          mesh_uptr_list.emplace_back(Generate(lane_pair.second, s_current, s_end));
+        }
+      }
+    }
+    return mesh_uptr_list;
   }
 
 } // namespace geom

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <carla/geom/Mesh.h>
 #include <carla/road/Road.h>
@@ -32,8 +33,20 @@ namespace geom {
     /// Generates a mesh that defines a lane section
     std::unique_ptr<Mesh> Generate(const road::LaneSection &lane_section) const;
 
-    /// Generates a mesh that defines a lane
+    /// Generates a mesh that defines a lane from a given s start and end
+    std::unique_ptr<Mesh> Generate(
+        const road::Lane &lane, const double s_start, const double s_end) const;
+
+    /// Generates a mesh that defines the whole lane
     std::unique_ptr<Mesh> Generate(const road::Lane &lane) const;
+
+    /// Generates a mesh that defines a lane
+    std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
+        const road::Road &road, const double max_len) const;
+
+    /// Generates a mesh that defines a lane
+    std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
+        const road::LaneSection &lane_section, const double max_len) const;
 
     // =========================================================================
     // -- Generation parameters ------------------------------------------------

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -60,23 +60,23 @@ namespace geom {
 
     /// Generates list of meshes that defines a single road with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
-        const road::Road &road, const double max_len) const;
+        const road::Road &road) const;
 
     /// Generates list of meshes that defines a single lane_section with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
-        const road::LaneSection &lane_section, const double max_len) const;
+        const road::LaneSection &lane_section) const;
 
     std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
-        const road::Road &road, const double max_len) const;
+        const road::Road &road) const;
 
     std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
-        const road::LaneSection &lane_section, const double max_len) const;
+        const road::LaneSection &lane_section) const;
 
     // -- Util --
 
     /// Generates a chunked road with all the features needed for simulation
     std::vector<std::unique_ptr<Mesh>> GenerateAllWithMaxLen(
-        const road::Road &road, const double max_len) const;
+        const road::Road &road) const;
 
     // =========================================================================
     // -- Generation parameters ------------------------------------------------
@@ -85,6 +85,7 @@ namespace geom {
     /// Parameters for the road generation
     struct RoadParameters {
       float resolution       = 2.0f;
+      float max_road_len     = 50.0f;
       float extra_lane_width = 1.0f;
       float wall_height      = 0.6f;
     };

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -27,6 +27,8 @@ namespace geom {
     // -- Map Related ----------------------------------------------------------
     // =========================================================================
 
+    // -- Basic --
+
     /// Generates a mesh that defines a road
     std::unique_ptr<Mesh> Generate(const road::Road &road) const;
 
@@ -40,19 +42,47 @@ namespace geom {
     /// Generates a mesh that defines the whole lane
     std::unique_ptr<Mesh> Generate(const road::Lane &lane) const;
 
-    /// Generates a mesh that defines a lane
+    // -- Walls --
+
+    /// Genrates a mesh representing a wall on the road corners to avoid
+    /// cars falling down
+    std::unique_ptr<Mesh> GenerateWalls(const road::LaneSection &lane_section) const;
+
+    /// Generates a wall-like mesh at the right side of the lane
+    std::unique_ptr<Mesh> GenerateRightWall(
+        const road::Lane &lane, const double s_start, const double s_end) const;
+
+    /// Generates a wall-like mesh at the left side of the lane
+    std::unique_ptr<Mesh> GenerateLeftWall(
+        const road::Lane &lane, const double s_start, const double s_end) const;
+
+    // -- Chunked --
+
+    /// Generates list of meshes that defines a single road with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
         const road::Road &road, const double max_len) const;
 
-    /// Generates a mesh that defines a lane
+    /// Generates list of meshes that defines a single lane_section with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
         const road::LaneSection &lane_section, const double max_len) const;
+
+    std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
+        const road::Road &road, const double max_len) const;
+
+    std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
+        const road::LaneSection &lane_section, const double max_len) const;
+
+    // -- Util --
+
+    /// Generates a chunked road with all the features needed for simulation
+    std::vector<std::unique_ptr<Mesh>> GenerateAllWithMaxLen(
+        const road::Road &road, const double max_len) const;
 
     // =========================================================================
     // -- Generation parameters ------------------------------------------------
     // =========================================================================
 
-    /// Generates a mesh that defines a lane
+    /// Parameters for the road generation
     struct RoadParameters {
       float resolution       = 2.0f;
       float extra_lane_width = 1.0f;

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <memory>
+
+#include <carla/geom/Mesh.h>
+#include <carla/road/Road.h>
+#include <carla/road/LaneSection.h>
+#include <carla/road/Lane.h>
+
+namespace carla {
+namespace geom {
+
+  /// Mesh helper generator static
+  class MeshFactory {
+  public:
+
+    MeshFactory() = default;
+
+    // =========================================================================
+    // -- Map Related ----------------------------------------------------------
+    // =========================================================================
+
+    /// Generates a mesh that defines a road
+    std::unique_ptr<Mesh> Generate(const road::Road &road) const;
+
+    /// Generates a mesh that defines a lane section
+    std::unique_ptr<Mesh> Generate(const road::LaneSection &lane_section) const;
+
+    /// Generates a mesh that defines a lane
+    std::unique_ptr<Mesh> Generate(const road::Lane &lane) const;
+
+    // =========================================================================
+    // -- Generation parameters ------------------------------------------------
+    // =========================================================================
+
+    /// Generates a mesh that defines a lane
+    struct RoadParameters {
+      float resolution       = 2.0f;
+      float extra_lane_width = 1.0f;
+      float wall_height      = 0.6f;
+    };
+
+    RoadParameters road_param;
+
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -78,6 +78,8 @@ namespace geom {
     std::vector<std::unique_ptr<Mesh>> GenerateAllWithMaxLen(
         const road::Road &road) const;
 
+    std::unique_ptr<Mesh> MergeAndSmooth(std::vector<std::unique_ptr<Mesh>> &lane_meshes) const;
+
     // =========================================================================
     // -- Generation parameters ------------------------------------------------
     // =========================================================================

--- a/LibCarla/source/carla/geom/MeshFactory.h
+++ b/LibCarla/source/carla/geom/MeshFactory.h
@@ -17,7 +17,7 @@
 namespace carla {
 namespace geom {
 
-  /// Mesh helper generator static
+  /// Mesh helper generator
   class MeshFactory {
   public:
 
@@ -58,17 +58,19 @@ namespace geom {
 
     // -- Chunked --
 
-    /// Generates list of meshes that defines a single road with a maximum length
+    /// Generates a list of meshes that defines a road with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
         const road::Road &road) const;
 
-    /// Generates list of meshes that defines a single lane_section with a maximum length
+    /// Generates a list of meshes that defines a lane_section with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
         const road::LaneSection &lane_section) const;
 
+    /// Generates a list of meshes that defines a road safety wall with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
         const road::Road &road) const;
 
+    /// Generates a list of meshes that defines a lane_section safety wall with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWallsWithMaxLen(
         const road::LaneSection &lane_section) const;
 
@@ -86,10 +88,14 @@ namespace geom {
 
     /// Parameters for the road generation
     struct RoadParameters {
-      float resolution       = 2.0f;
-      float max_road_len     = 50.0f;
-      float extra_lane_width = 1.0f;
-      float wall_height      = 0.6f;
+      float resolution                  =  2.0f;
+      float max_road_len                = 50.0f;
+      float extra_lane_width            =  1.0f;
+      float wall_height                 =  0.6f;
+      // Road mesh smoothness:
+      float max_weight_distance         =  5.0f;
+      float same_lane_weight_multiplier =  2.0f;
+      float lane_ends_multiplier        =  2.0f;
     };
 
     RoadParameters road_param;

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -129,7 +129,7 @@ namespace road {
     const Road *road = GetRoad();
     DEBUG_ASSERT(road != nullptr);
 
-    // must s be smaller (or eq) than road lenght and bigger (or eq) than 0?
+    // must s be smaller (or eq) than road length and bigger (or eq) than 0?
     RELEASE_ASSERT(s <= road->GetLength());
     RELEASE_ASSERT(s >= 0.0);
 

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -1,15 +1,22 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#include "carla/Debug.h"
 #include "carla/road/Lane.h"
-#include "carla/road/LaneSection.h"
-#include "carla/road/Road.h"
 
 #include <limits>
+
+#include "carla/Debug.h"
+#include "carla/road/element/Geometry.h"
+#include "carla/road/element/RoadInfoElevation.h"
+#include "carla/road/element/RoadInfoGeometry.h"
+#include "carla/road/element/RoadInfoLaneOffset.h"
+#include "carla/road/element/RoadInfoLaneWidth.h"
+#include "carla/road/LaneSection.h"
+#include "carla/road/MapData.h"
+#include "carla/road/Road.h"
 
 namespace carla {
 namespace road {
@@ -45,6 +52,175 @@ namespace road {
     DEBUG_ASSERT(road != nullptr);
     const auto s = GetDistance();
     return road->UpperBound(s) - s;
+  }
+
+  double Lane::GetWidth(const double s) const {
+    RELEASE_ASSERT(s <= GetRoad()->GetLength());
+    const auto width_info = GetInfo<element::RoadInfoLaneWidth>(s);
+    RELEASE_ASSERT(width_info != nullptr);
+    return width_info->GetPolynomial().Evaluate(s);
+  }
+
+  bool Lane::IsStraight() const {
+    Road *road = GetRoad();
+    RELEASE_ASSERT(road != nullptr);
+    auto *geometry = road->GetInfo<element::RoadInfoGeometry>(GetDistance());
+    DEBUG_ASSERT(geometry != nullptr);
+    auto geometry_type = geometry->GetGeometry().GetType();
+    if (geometry_type != element::GeometryType::LINE) {
+      return false;
+    }
+    if(GetDistance() < geometry->GetDistance() ||
+        GetDistance() + GetLength() >
+        geometry->GetDistance() + geometry->GetGeometry().GetLength()) {
+      return false;
+    }
+    auto lane_offsets = GetInfos<element::RoadInfoLaneOffset>();
+    for (auto *lane_offset : lane_offsets) {
+      if (std::abs(lane_offset->GetPolynomial().GetC()) > 0 ||
+          std::abs(lane_offset->GetPolynomial().GetD()) > 0) {
+        return false;
+      }
+    }
+    auto elevations = road->GetInfos<element::RoadInfoElevation>();
+    for (auto *elevation : elevations) {
+      if (std::abs(elevation->GetPolynomial().GetC()) > 0 ||
+          std::abs(elevation->GetPolynomial().GetD()) > 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns a pair containing first = width, second = tangent,
+  /// for an specific Lane given an s and a iterator over lanes
+  template <typename T>
+  static std::pair<double, double> ComputeTotalLaneWidth(
+      const T container,
+      const double s,
+      const LaneId lane_id) {
+
+    // lane_id can't be 0
+    RELEASE_ASSERT(lane_id != 0);
+
+    const bool negative_lane_id = lane_id < 0;
+    double dist = 0.0;
+    double tangent = 0.0;
+    for (const auto &lane : container) {
+      auto info = lane.second.template GetInfo<element::RoadInfoLaneWidth>(s);
+      RELEASE_ASSERT(info != nullptr);
+      const auto current_polynomial = info->GetPolynomial();
+      auto current_dist = current_polynomial.Evaluate(s);
+      auto current_tang = current_polynomial.Tangent(s);
+      if (lane.first != lane_id) {
+        dist += negative_lane_id ? current_dist : -current_dist;
+        tangent += current_tang;
+      } else if (lane.first == lane_id) {
+        current_dist *= 0.5;
+        dist += negative_lane_id ? current_dist : -current_dist;
+        tangent += current_tang * 0.5;
+        break;
+      }
+    }
+    return std::make_pair(dist, tangent);
+  }
+
+  geom::Transform Lane::ComputeTransform(const double s) const {
+    const Road *road = GetRoad();
+    DEBUG_ASSERT(road != nullptr);
+
+    // must s be smaller (or eq) than road lenght and bigger (or eq) than 0?
+    RELEASE_ASSERT(s <= road->GetLength());
+    RELEASE_ASSERT(s >= 0.0);
+
+    const auto *lane_section = GetLaneSection();
+    DEBUG_ASSERT(lane_section != nullptr);
+    const std::map<LaneId, Lane> &lanes = lane_section->GetLanes();
+
+    // check that lane_id exists on the current s
+    RELEASE_ASSERT(!lanes.empty());
+    RELEASE_ASSERT(GetId() >= lanes.begin()->first);
+    RELEASE_ASSERT(GetId() <= lanes.rbegin()->first);
+
+    float lane_width = 0.0f;
+    float lane_tangent = 0.0f;
+
+    if (GetId() < 0) {
+      // right lane
+      const auto side_lanes = MakeListView(
+          std::make_reverse_iterator(lanes.lower_bound(0)), lanes.rend());
+      const auto computed_width =
+          ComputeTotalLaneWidth(side_lanes, s, GetId());
+      lane_width = static_cast<float>(computed_width.first);
+      lane_tangent = static_cast<float>(computed_width.second);
+    } else if (GetId() > 0) {
+      // left lane
+      const auto side_lanes = MakeListView(lanes.lower_bound(1), lanes.end());
+      const auto computed_width =
+          ComputeTotalLaneWidth(side_lanes, s, GetId());
+      lane_width = static_cast<float>(computed_width.first);
+      lane_tangent = static_cast<float>(computed_width.second);
+    }
+
+    // get a directed point in s and apply the computed lateral offet
+    element::DirectedPoint dp = road->GetDirectedPointIn(s);
+
+    // compute the tangent of the laneOffset
+    const auto lane_offset_info = road->GetInfo<element::RoadInfoLaneOffset>(s);
+    const auto lane_offset_tangent = static_cast<float>(lane_offset_info->GetPolynomial().Tangent(s));
+
+    lane_tangent -= lane_offset_tangent;
+
+    // Unreal's Y axis hack
+    lane_tangent *= -1;
+
+    geom::Rotation rot(
+        geom::Math::ToDegrees(static_cast<float>(dp.pitch)),
+        geom::Math::ToDegrees(-static_cast<float>(dp.tangent)), // Unreal's Y axis hack
+        0.0f);
+
+    dp.ApplyLateralOffset(lane_width);
+
+    if (GetId() > 0) {
+      rot.yaw += 180.0f + geom::Math::ToDegrees(lane_tangent);
+      rot.pitch = 360.0f - rot.pitch;
+    } else {
+      rot.yaw -= geom::Math::ToDegrees(lane_tangent);
+    }
+
+    // Unreal's Y axis hack
+    dp.location.y *= -1;
+
+    return geom::Transform(dp.location, rot);
+  }
+
+  std::pair<geom::Vector3D, geom::Vector3D> Lane::GetCornerPositions(
+      const double s, const float extra_width) const {
+    DEBUG_ASSERT(GetRoad() != nullptr);
+
+    float lane_width = static_cast<float>(GetWidth(s)) / 2.0f;
+    if (extra_width != 0.f && GetRoad()->IsJunction() && GetType() == Lane::LaneType::Driving) {
+      lane_width += extra_width;
+    }
+    lane_width = GetId() > 0 ? -lane_width : lane_width;
+
+    const geom::Transform wp_trnsf = ComputeTransform(s);
+
+    const auto wp_right_distance = wp_trnsf.GetRightVector() * lane_width;
+
+    auto loc_r = static_cast<geom::Vector3D>(wp_trnsf.location) + wp_right_distance;
+    auto loc_l = static_cast<geom::Vector3D>(wp_trnsf.location) - wp_right_distance;
+
+    // Apply an offset to the Sidewalks
+    if (GetType() == LaneType::Sidewalk) {
+      // RoadRunner doesn't export it right now and as a workarround where 15.24 cm
+      // is the exact height that match with most of the RoadRunner sidewalks
+      loc_r.z += 0.1524f;
+      loc_l.z += 0.1524f;
+      /// TODO: use the OpenDRIVE 5.3.7.2.1.1.9 Lane Height Record
+    }
+
+    return std::make_pair(loc_r, loc_l);
   }
 
 } // road

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include "carla/Debug.h"
+#include "carla/geom/Math.h"
 #include "carla/road/element/Geometry.h"
 #include "carla/road/element/RoadInfoElevation.h"
 #include "carla/road/element/RoadInfoGeometry.h"
@@ -114,11 +115,11 @@ namespace road {
       auto current_tang = current_polynomial.Tangent(s);
       if (lane.first != lane_id) {
         dist += negative_lane_id ? current_dist : -current_dist;
-        tangent += current_tang;
+        tangent += negative_lane_id ? current_tang : -current_tang;
       } else {
         current_dist *= 0.5;
         dist += negative_lane_id ? current_dist : -current_dist;
-        tangent += current_tang * 0.5;
+        tangent += (negative_lane_id ? current_tang : -current_tang) * 0.5;
         break;
       }
     }
@@ -183,7 +184,7 @@ namespace road {
     dp.ApplyLateralOffset(lane_width);
 
     if (GetId() > 0) {
-      rot.yaw += 180.0f;
+      rot.yaw += 180.0f - geom::Math::ToDegrees(lane_tangent);
       rot.pitch = 360.0f - rot.pitch;
     } else {
       rot.yaw -= geom::Math::ToDegrees(lane_tangent);

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -167,7 +167,8 @@ namespace road {
 
     // compute the tangent of the laneOffset
     const auto lane_offset_info = road->GetInfo<element::RoadInfoLaneOffset>(s);
-    const auto lane_offset_tangent = static_cast<float>(lane_offset_info->GetPolynomial().Tangent(s));
+    const auto lane_offset_tangent =
+        static_cast<float>(lane_offset_info->GetPolynomial().Tangent(s));
 
     lane_tangent -= lane_offset_tangent;
 
@@ -182,7 +183,7 @@ namespace road {
     dp.ApplyLateralOffset(lane_width);
 
     if (GetId() > 0) {
-      rot.yaw += 180.0f + geom::Math::ToDegrees(lane_tangent);
+      rot.yaw += 180.0f;
       rot.pitch = 360.0f - rot.pitch;
     } else {
       rot.yaw -= geom::Math::ToDegrees(lane_tangent);

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -143,7 +143,10 @@ namespace road {
     RELEASE_ASSERT(GetId() >= lanes.begin()->first);
     RELEASE_ASSERT(GetId() <= lanes.rbegin()->first);
 
-    float lane_width = 0.0f;
+    // These will accumulate the lateral offset (t) and lane heading of all
+    // the lanes in between the current lane and lane 0, where the main road
+    // geometry is described
+    float lane_t_offset = 0.0f;
     float lane_tangent = 0.0f;
 
     if (GetId() < 0) {
@@ -152,77 +155,110 @@ namespace road {
           std::make_reverse_iterator(lanes.lower_bound(0)), lanes.rend());
       const auto computed_width =
           ComputeTotalLaneWidth(side_lanes, s, GetId());
-      lane_width = static_cast<float>(computed_width.first);
+      lane_t_offset = static_cast<float>(computed_width.first);
       lane_tangent = static_cast<float>(computed_width.second);
     } else if (GetId() > 0) {
       // left lane
       const auto side_lanes = MakeListView(lanes.lower_bound(1), lanes.end());
       const auto computed_width =
           ComputeTotalLaneWidth(side_lanes, s, GetId());
-      lane_width = static_cast<float>(computed_width.first);
+      lane_t_offset = static_cast<float>(computed_width.first);
       lane_tangent = static_cast<float>(computed_width.second);
     }
 
-    // get a directed point in s and apply the computed lateral offet
-    element::DirectedPoint dp = road->GetDirectedPointIn(s);
-
-    // compute the tangent of the laneOffset
+    // Compute the tangent of the road's (lane 0) "laneOffset" on the current s
     const auto lane_offset_info = road->GetInfo<element::RoadInfoLaneOffset>(s);
     const auto lane_offset_tangent =
         static_cast<float>(lane_offset_info->GetPolynomial().Tangent(s));
 
+    // Update the road tangent with the "laneOffset" information at current s
     lane_tangent -= lane_offset_tangent;
 
-    // Unreal's Y axis hack
-    lane_tangent *= -1;
+    // Get a directed point on the center of the current lane given an s
+    element::DirectedPoint dp = road->GetDirectedPointIn(s);
 
-    geom::Rotation rot(
-        geom::Math::ToDegrees(static_cast<float>(dp.pitch)),
-        geom::Math::ToDegrees(-static_cast<float>(dp.tangent)), // Unreal's Y axis hack
-        0.0f);
+    // Transform from the center of the road to the center of the lane
+    dp.ApplyLateralOffset(lane_t_offset);
 
-    dp.ApplyLateralOffset(lane_width);
-
-    if (GetId() > 0) {
-      rot.yaw += 180.0f - geom::Math::ToDegrees(lane_tangent);
-      rot.pitch = 360.0f - rot.pitch;
-    } else {
-      rot.yaw -= geom::Math::ToDegrees(lane_tangent);
-    }
+    // Update the lane tangent with the road "laneOffset" at current s
+    dp.tangent -= lane_tangent;
 
     // Unreal's Y axis hack
     dp.location.y *= -1;
+    dp.tangent    *= -1;
+
+    geom::Rotation rot(
+        geom::Math::ToDegrees(static_cast<float>(dp.pitch)),
+        geom::Math::ToDegrees(static_cast<float>(dp.tangent)),
+        0.0f);
+
+    // Fix the direction of the possitive lanes
+    if (GetId() > 0) {
+      rot.yaw += 180.0f;
+      rot.pitch = 360.0f - rot.pitch;
+    }
 
     return geom::Transform(dp.location, rot);
   }
 
   std::pair<geom::Vector3D, geom::Vector3D> Lane::GetCornerPositions(
       const double s, const float extra_width) const {
-    DEBUG_ASSERT(GetRoad() != nullptr);
+    const Road *road = GetRoad();
+    DEBUG_ASSERT(road != nullptr);
+
+    const auto *lane_section = GetLaneSection();
+    DEBUG_ASSERT(lane_section != nullptr);
+    const std::map<LaneId, Lane> &lanes = lane_section->GetLanes();
+
+    // check that lane_id exists on the current s
+    RELEASE_ASSERT(!lanes.empty());
+    RELEASE_ASSERT(GetId() >= lanes.begin()->first);
+    RELEASE_ASSERT(GetId() <= lanes.rbegin()->first);
+
+    float lane_t_offset = 0.0f;
+
+    if (GetId() < 0) {
+      // right lane
+      const auto side_lanes = MakeListView(
+          std::make_reverse_iterator(lanes.lower_bound(0)), lanes.rend());
+      const auto computed_width =
+          ComputeTotalLaneWidth(side_lanes, s, GetId());
+      lane_t_offset = static_cast<float>(computed_width.first);
+    } else if (GetId() > 0) {
+      // left lane
+      const auto side_lanes = MakeListView(lanes.lower_bound(1), lanes.end());
+      const auto computed_width =
+          ComputeTotalLaneWidth(side_lanes, s, GetId());
+      lane_t_offset = static_cast<float>(computed_width.first);
+    }
 
     float lane_width = static_cast<float>(GetWidth(s)) / 2.0f;
-    if (extra_width != 0.f && GetRoad()->IsJunction() && GetType() == Lane::LaneType::Driving) {
+    if (extra_width != 0.f && road->IsJunction() && GetType() == Lane::LaneType::Driving) {
       lane_width += extra_width;
     }
-    lane_width = GetId() > 0 ? -lane_width : lane_width;
 
-    const geom::Transform wp_trnsf = ComputeTransform(s);
+    // Get two points on the center of the road on given s
+    element::DirectedPoint dp_r, dp_l;
+    dp_r = dp_l = road->GetDirectedPointIn(s);
 
-    const auto wp_right_distance = wp_trnsf.GetRightVector() * lane_width;
+    // Transform from the center of the road to each of lane corners
+    dp_r.ApplyLateralOffset(lane_t_offset + lane_width);
+    dp_l.ApplyLateralOffset(lane_t_offset - lane_width);
 
-    auto loc_r = static_cast<geom::Vector3D>(wp_trnsf.location) + wp_right_distance;
-    auto loc_l = static_cast<geom::Vector3D>(wp_trnsf.location) - wp_right_distance;
+    // Unreal's Y axis hack
+    dp_r.location.y *= -1;
+    dp_l.location.y *= -1;
 
     // Apply an offset to the Sidewalks
     if (GetType() == LaneType::Sidewalk) {
       // RoadRunner doesn't export it right now and as a workarround where 15.24 cm
       // is the exact height that match with most of the RoadRunner sidewalks
-      loc_r.z += 0.1524f;
-      loc_l.z += 0.1524f;
+      dp_r.location.z += 0.1524f;
+      dp_l.location.z += 0.1524f;
       /// TODO: use the OpenDRIVE 5.3.7.2.1.1.9 Lane Height Record
     }
 
-    return std::make_pair(loc_r, loc_l);
+    return std::make_pair(dp_r.location, dp_l.location);
   }
 
 } // road

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -115,7 +115,7 @@ namespace road {
       if (lane.first != lane_id) {
         dist += negative_lane_id ? current_dist : -current_dist;
         tangent += current_tang;
-      } else if (lane.first == lane_id) {
+      } else {
         current_dist *= 0.5;
         dist += negative_lane_id ? current_dist : -current_dist;
         tangent += current_tang * 0.5;

--- a/LibCarla/source/carla/road/Lane.h
+++ b/LibCarla/source/carla/road/Lane.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "carla/geom/Mesh.h"
+#include "carla/geom/Transform.h"
 #include "carla/road/InformationSet.h"
 #include "carla/road/RoadTypes.h"
 
@@ -104,6 +106,18 @@ namespace road {
     double GetDistance() const;
 
     double GetLength() const;
+
+    /// Returns the total lane width given a s
+    double GetWidth(const double s) const;
+
+    /// Checks whether the geometry is straight or not
+    bool IsStraight() const;
+
+    geom::Transform ComputeTransform(const double s) const;
+
+    /// Computes the location of the edges given a s
+    std::pair<geom::Vector3D, geom::Vector3D> GetCornerPositions(
+      const double s, const float extra_width = 0.f) const;
 
   private:
 

--- a/LibCarla/source/carla/road/LaneSection.cpp
+++ b/LibCarla/source/carla/road/LaneSection.cpp
@@ -5,6 +5,7 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "carla/road/LaneSection.h"
+#include "carla/road/Road.h"
 
 namespace carla {
 namespace road {
@@ -13,7 +14,13 @@ namespace road {
     return _s;
   }
 
-  Road *LaneSection::GetRoad() {
+  double LaneSection::GetLength() const {
+    const auto *road = GetRoad();
+    DEBUG_ASSERT(road != nullptr);
+    return road->UpperBound(_s) - _s;
+  }
+
+  Road *LaneSection::GetRoad() const {
     return _road;
   }
 

--- a/LibCarla/source/carla/road/LaneSection.h
+++ b/LibCarla/source/carla/road/LaneSection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include "carla/geom/CubicPolynomial.h"
 #include "carla/NonCopyable.h"
 #include "carla/road/Lane.h"
 #include "carla/road/RoadElementSet.h"
 #include "carla/road/RoadTypes.h"
-#include "carla/geom/CubicPolynomial.h"
 
 #include <map>
 #include <vector>

--- a/LibCarla/source/carla/road/LaneSection.h
+++ b/LibCarla/source/carla/road/LaneSection.h
@@ -28,7 +28,9 @@ namespace road {
 
     double GetDistance() const;
 
-    Road *GetRoad();
+    double GetLength() const;
+
+    Road *GetRoad() const;
 
     Lane *GetLane(const LaneId id);
 

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -955,7 +955,6 @@ namespace road {
       std::vector<std::unique_ptr<geom::Mesh>> lane_meshes;
       for(const auto &connection_pair : junction.GetConnections()) {
         const auto &connection = connection_pair.second;
-        DEBUG_ASSERT(_data.GetRoads().contains(connection.connecting_road));
         const auto &road = _data.GetRoads().at(connection.connecting_road);
         for (auto &&lane_section : road.GetLaneSections()) {
           for (auto &&lane_pair : lane_section.GetLanes()) {

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -955,6 +955,7 @@ namespace road {
     RELEASE_ASSERT(max_road_len > 0.0);
     geom::MeshFactory mesh_factory;
     mesh_factory.road_param.resolution = static_cast<float>(distance);
+    mesh_factory.road_param.max_road_len = max_road_len;
     mesh_factory.road_param.extra_lane_width = extra_width;
     std::vector<std::unique_ptr<geom::Mesh>> out_mesh_list;
 
@@ -962,7 +963,7 @@ namespace road {
     for (auto &&pair : _data.GetRoads()) {
       const auto &road = pair.second;
       std::vector<std::unique_ptr<geom::Mesh>> road_mesh_list =
-          mesh_factory.GenerateAllWithMaxLen(road, max_road_len);
+          mesh_factory.GenerateAllWithMaxLen(road);
 
       // If the road in in a junction, add the road to the junction mesh instead of
       // doing it separately, this is needed for the road mesh smooth algorithm

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -932,38 +932,6 @@ namespace road {
     return _data.GetJunction(id);
   }
 
-  /// Computes the location of the edges of the current lane at the current waypoint
-  static std::pair<geom::Vector3D, geom::Vector3D> GetWaypointCornerPositions(
-      const Map &map, const Waypoint &waypoint, const Lane &lane, const float extra_width=0.f) {
-    float lane_width = static_cast<float>(map.GetLaneWidth(waypoint)) / 2.0f;
-
-    DEBUG_ASSERT(lane.GetRoad() != nullptr);
-    if (extra_width != 0.f && lane.GetRoad()->IsJunction() && lane.GetType() == Lane::LaneType::Driving) {
-      lane_width += extra_width;
-    }
-    lane_width = waypoint.lane_id > 0 ? -lane_width : lane_width;
-
-    const geom::Transform wp_trnasf = map.ComputeTransform(waypoint);
-    auto loc_r = static_cast<geom::Vector3D>(wp_trnasf.location) +
-        (wp_trnasf.GetRightVector() *  lane_width);
-    auto loc_l = static_cast<geom::Vector3D>(wp_trnasf.location) +
-        (wp_trnasf.GetRightVector() * -lane_width);
-
-    if (lane.GetType() == Lane::LaneType::Driving) {
-
-    }
-    // Apply an offset to the Sidewalks
-    else if (lane.GetType() == Lane::LaneType::Sidewalk) {
-      // RoadRunner doesn't export it right now and as a workarround where 15.24 cm
-      // is the exact height that match with most of the RoadRunner sidewalks
-      loc_r.z += 0.1524f;
-      loc_l.z += 0.1524f;
-      /// TODO: use the OpenDRIVE 5.3.7.2.1.1.9 Lane Height Record
-    }
-
-    return std::make_pair(loc_r, loc_l);
-  }
-
   geom::Mesh Map::GenerateMesh(const double distance, const float extra_width) const {
     RELEASE_ASSERT(distance > 0.0);
     geom::MeshFactory mesh_factory;
@@ -994,7 +962,7 @@ namespace road {
     for (auto &&pair : _data.GetRoads()) {
       const auto &road = pair.second;
       std::vector<std::unique_ptr<geom::Mesh>> road_mesh_list =
-          mesh_factory.GenerateWithMaxLen(road, max_road_len);
+          mesh_factory.GenerateAllWithMaxLen(road, max_road_len);
 
       // If the road in in a junction, add the road to the junction mesh instead of
       // doing it separately, this is needed for the road mesh smooth algorithm
@@ -1060,104 +1028,6 @@ namespace road {
     } while (i < crosswalk_vertex.size());
 
     out_mesh.EndMaterial();
-    return out_mesh;
-  }
-
-  geom::Mesh Map::GenerateWalls(
-      const double distance, const float wall_height) const {
-    RELEASE_ASSERT(distance > 0.0);
-    geom::Mesh out_mesh;
-    if (wall_height == 0.0f) {
-      return out_mesh;
-    }
-    // Iterate each lane in each lane_section in each road
-    for (const auto &pair : _data.GetRoads()) {
-      const auto &road = pair.second;
-      if (road.IsJunction()) {
-        continue;
-      }
-      for (const auto &lane_section : road.GetLaneSections()) {
-        const auto min_lane = lane_section.GetLanes().begin()->first == 0 ?
-            1 : lane_section.GetLanes().begin()->first;
-        const auto max_lane = lane_section.GetLanes().rbegin()->first == 0 ?
-            -1 : lane_section.GetLanes().rbegin()->first;
-        for (const auto &lane_pair : lane_section.GetLanes()) {
-          // Get the lane reference
-          const auto &lane = lane_pair.second;
-          // The lane with lane_id 0 have no physical representation in OpenDRIVE
-          if (lane.GetId() == 0) {
-            continue;
-          }
-
-          const auto end_distance = lane.GetDistance() + lane.GetLength() - EPSILON;
-          Waypoint current_wp {
-              road.GetId(),
-              lane_section.GetId(),
-              lane.GetId(),
-              lane_section.GetDistance() + EPSILON };
-
-          std::vector<geom::Vector3D> r_vertices;
-          std::vector<geom::Vector3D> l_vertices;
-          if (lane.IsStraight()) {
-            // Mesh optimization: If the lane is straight just add vertices at the
-            // begining and at the end of it
-            const auto edges = GetWaypointCornerPositions(*this, current_wp, lane);
-            // vertices.push_back(edges.first);
-            // vertices.push_back(edges.second);
-            if (lane.GetId() == min_lane) {
-              r_vertices.push_back(edges.first + geom::Vector3D(0.f, 0.f, wall_height));
-              r_vertices.push_back(edges.first);
-            }
-            if (lane.GetId() == max_lane) {
-              l_vertices.push_back(edges.second);
-              l_vertices.push_back(edges.second + geom::Vector3D(0.f, 0.f, wall_height));
-            }
-          } else {
-            // Iterate over the lane's 's' and store the vertices based on it's width
-            do {
-              // Get the location of the edges of the current lane at the current waypoint
-              const auto edges = GetWaypointCornerPositions(*this, current_wp, lane);
-              // vertices.push_back(edges.first);
-              // vertices.push_back(edges.second);
-              if (lane.GetId() == min_lane) {
-                r_vertices.push_back(edges.first + geom::Vector3D(0.f, 0.f, wall_height));
-                r_vertices.push_back(edges.first);
-              }
-              if (lane.GetId() == max_lane) {
-                l_vertices.push_back(edges.second);
-                l_vertices.push_back(edges.second + geom::Vector3D(0.f, 0.f, wall_height));
-              }
-              // Update the current waypoint's "s"
-              current_wp.s += distance;
-            } while(current_wp.s < end_distance);
-          }
-
-          // This ensures the mesh is constant and have no gaps between roads,
-          // adding geometry at the very end of the lane
-          if (end_distance - (current_wp.s - distance) > EPSILON) {
-            current_wp.s = end_distance;
-            const auto edges = GetWaypointCornerPositions(*this, current_wp, lane);
-            // vertices.push_back(edges.first);
-            // vertices.push_back(edges.second);
-            if (lane.GetId() == min_lane) {
-              r_vertices.push_back(edges.first + geom::Vector3D(0.f, 0.f, wall_height));
-              r_vertices.push_back(edges.first);
-            }
-            if (lane.GetId() == max_lane) {
-              l_vertices.push_back(edges.second);
-              l_vertices.push_back(edges.second + geom::Vector3D(0.f, 0.f, wall_height));
-            }
-          }
-          // Add the adient material, create the strip and close the material
-          out_mesh.AddMaterial(
-              lane.GetType() == Lane::LaneType::Sidewalk ? "sidewalk" : "road");
-          out_mesh.AddTriangleStrip(r_vertices);
-          out_mesh.AddTriangleStrip(l_vertices);
-          out_mesh.EndMaterial();
-        }
-      }
-    }
-
     return out_mesh;
   }
 

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -6,15 +6,15 @@
 
 #pragma once
 
-#include "carla/NonCopyable.h"
-#include "carla/geom/Transform.h"
-#include "carla/road/MapData.h"
 #include "carla/geom/Mesh.h"
-#include "carla/road/RoadTypes.h"
+#include "carla/geom/Rtree.h"
+#include "carla/geom/Transform.h"
+#include "carla/NonCopyable.h"
 #include "carla/road/element/LaneMarking.h"
 #include "carla/road/element/RoadInfoMarkRecord.h"
 #include "carla/road/element/Waypoint.h"
-#include "carla/geom/Rtree.h"
+#include "carla/road/MapData.h"
+#include "carla/road/RoadTypes.h"
 
 #include <boost/optional.hpp>
 

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -150,10 +150,16 @@ namespace road {
         ComputeJunctionConflicts(JuncId id) const;
 
     /// Buids a mesh based on the OpenDRIVE
-    geom::Mesh GenerateMesh(const double distance, const float extra_width = 0.6f) const;
+    geom::Mesh GenerateMesh(
+        const double distance,
+        const float extra_width = 0.6f,
+        const  bool smooth_junctions = true) const;
 
     std::vector<std::unique_ptr<geom::Mesh>> GenerateChunkedMesh(
-      const double distance, const float max_road_len = 50.0f, const float extra_width = 0.6f) const;
+        const double distance,
+        const float max_road_len = 50.0f,
+        const float extra_width = 0.6f,
+        const  bool smooth_junctions = true) const;
 
     /// Buids a mesh of all crosswalks based on the OpenDRIVE
     geom::Mesh GetAllCrosswalkMesh() const;

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -150,10 +150,10 @@ namespace road {
         ComputeJunctionConflicts(JuncId id) const;
 
     /// Buids a mesh based on the OpenDRIVE
-    geom::Mesh GenerateMesh(const double distance, const float extra_width = 0.f) const;
+    geom::Mesh GenerateMesh(const double distance, const float extra_width = 0.6f) const;
 
     std::vector<std::unique_ptr<geom::Mesh>> GenerateChunkedMesh(
-      const double distance, const float max_road_len, const float extra_width = 0.f) const;
+      const double distance, const float max_road_len = 50.0f, const float extra_width = 0.6f) const;
 
     /// Buids a mesh of all crosswalks based on the OpenDRIVE
     geom::Mesh GetAllCrosswalkMesh() const;

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -152,6 +152,9 @@ namespace road {
     /// Buids a mesh based on the OpenDRIVE
     geom::Mesh GenerateMesh(const double distance, const float extra_width = 0.f) const;
 
+    std::vector<std::unique_ptr<geom::Mesh>> GenerateChunkedMesh(
+      const double distance, const float max_road_len, const float extra_width = 0.f) const;
+
     /// Buids a mesh of all crosswalks based on the OpenDRIVE
     geom::Mesh GetAllCrosswalkMesh() const;
 

--- a/LibCarla/source/carla/road/MapData.h
+++ b/LibCarla/source/carla/road/MapData.h
@@ -41,6 +41,10 @@ namespace road {
 
     std::unordered_map<JuncId, Junction> &GetJunctions();
 
+    const std::unordered_map<JuncId, Junction> &GetJunctions() const {
+      return _junctions;
+    }
+
     bool ContainsRoad(RoadId id) const {
       return (_roads.find(id) != _roads.end());
     }

--- a/LibCarla/source/carla/road/Road.cpp
+++ b/LibCarla/source/carla/road/Road.cpp
@@ -1,22 +1,22 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "carla/Exception.h"
-#include "carla/ListView.h"
-#include "carla/Logging.h"
 #include "carla/geom/CubicPolynomial.h"
 #include "carla/geom/Location.h"
 #include "carla/geom/Math.h"
-#include "carla/road/Lane.h"
-#include "carla/road/MapData.h"
-#include "carla/road/Road.h"
+#include "carla/ListView.h"
+#include "carla/Logging.h"
 #include "carla/road/element/RoadInfoElevation.h"
 #include "carla/road/element/RoadInfoGeometry.h"
 #include "carla/road/element/RoadInfoLaneOffset.h"
 #include "carla/road/element/RoadInfoLaneWidth.h"
+#include "carla/road/Lane.h"
+#include "carla/road/MapData.h"
+#include "carla/road/Road.h"
 
 #include <stdexcept>
 

--- a/LibCarla/source/carla/road/Road.h
+++ b/LibCarla/source/carla/road/Road.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -6,17 +6,18 @@
 
 #pragma once
 
+#include "carla/geom/Mesh.h"
 #include "carla/Iterator.h"
 #include "carla/ListView.h"
 #include "carla/NonCopyable.h"
+#include "carla/road/element/Geometry.h"
+#include "carla/road/element/RoadInfo.h"
 #include "carla/road/InformationSet.h"
 #include "carla/road/Junction.h"
 #include "carla/road/LaneSection.h"
 #include "carla/road/LaneSectionMap.h"
 #include "carla/road/RoadElementSet.h"
 #include "carla/road/RoadTypes.h"
-#include "carla/road/element/Geometry.h"
-#include "carla/road/element/RoadInfo.h"
 
 #include <unordered_map>
 #include <vector>
@@ -161,8 +162,6 @@ namespace road {
     const LaneSection &GetLaneSectionById(SectionId id) const {
       return _lane_sections.GetById(id);
     }
-
-
 
     /// Return the upper bound "s", i.e., the end distance of the lane section
     /// at @a s (clamped at road's length).

--- a/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
+++ b/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.

--- a/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
+++ b/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "carla/MsgPack.h"
+
+namespace carla {
+namespace rpc {
+
+  /// Seting for map generation from opendrive without additional geometry
+  struct OpendriveGenerationParameters {
+    OpendriveGenerationParameters(){}
+    OpendriveGenerationParameters(
+        double v_distance,
+        double w_height,
+        double a_width,
+        bool e_visibility)
+      : vertex_distance(v_distance),
+        wall_height(w_height),
+        additional_width(a_width),
+        enable_mesh_visibility(e_visibility)
+        {}
+
+    double vertex_distance = 2.f;
+    double wall_height = 1.f;
+    double additional_width = 0.6f;
+    bool enable_mesh_visibility = true;
+
+    MSGPACK_DEFINE_ARRAY(vertex_distance, wall_height, additional_width, enable_mesh_visibility);
+  };
+
+}
+}

--- a/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
+++ b/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
@@ -14,21 +14,29 @@ namespace rpc {
     OpendriveGenerationParameters(){}
     OpendriveGenerationParameters(
         double v_distance,
+        double max_road_len,
         double w_height,
         double a_width,
         bool e_visibility)
       : vertex_distance(v_distance),
+        max_road_length(max_road_len),
         wall_height(w_height),
         additional_width(a_width),
         enable_mesh_visibility(e_visibility)
         {}
 
-    double vertex_distance = 2.f;
-    double wall_height = 1.f;
-    double additional_width = 0.6f;
+    double vertex_distance = 2.0;
+    double max_road_length = 50.0;
+    double wall_height = 1.0;
+    double additional_width = 0.6;
     bool enable_mesh_visibility = true;
 
-    MSGPACK_DEFINE_ARRAY(vertex_distance, wall_height, additional_width, enable_mesh_visibility);
+    MSGPACK_DEFINE_ARRAY(
+        vertex_distance,
+        max_road_length,
+        wall_height,
+        additional_width,
+        enable_mesh_visibility);
   };
 
 }

--- a/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
+++ b/LibCarla/source/carla/rpc/OpendriveGenerationParameters.h
@@ -17,11 +17,13 @@ namespace rpc {
         double max_road_len,
         double w_height,
         double a_width,
+        bool smooth_junc,
         bool e_visibility)
       : vertex_distance(v_distance),
         max_road_length(max_road_len),
         wall_height(w_height),
         additional_width(a_width),
+        smooth_junctions(smooth_junc),
         enable_mesh_visibility(e_visibility)
         {}
 
@@ -29,6 +31,7 @@ namespace rpc {
     double max_road_length = 50.0;
     double wall_height = 1.0;
     double additional_width = 0.6;
+    bool smooth_junctions = true;
     bool enable_mesh_visibility = true;
 
     MSGPACK_DEFINE_ARRAY(
@@ -36,6 +39,7 @@ namespace rpc {
         max_road_length,
         wall_height,
         additional_width,
+        smooth_junctions,
         enable_mesh_visibility);
   };
 

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -163,6 +163,15 @@ static auto ApplyBatchCommandsSync(
 void export_client() {
   using namespace boost::python;
   namespace cc = carla::client;
+  namespace rpc = carla::rpc;
+
+  class_<rpc::OpendriveGenerationParameters>("OpendriveGenerationParameters",
+      init<double, double, double, bool>((arg("vertex_distance")=2.0, arg("wall_height")=1.0, arg("additional_width")=0.6, arg("enable_mesh_visibility")=true)))
+    .def_readwrite("vertex_distance", &rpc::OpendriveGenerationParameters::vertex_distance)
+    .def_readwrite("wall_height", &rpc::OpendriveGenerationParameters::wall_height)
+    .def_readwrite("additional_width", &rpc::OpendriveGenerationParameters::additional_width)
+    .def_readwrite("enable_mesh_visibility", &rpc::OpendriveGenerationParameters::enable_mesh_visibility)
+  ;
 
   class_<cc::Client>("Client",
       init<std::string, uint16_t, size_t>((arg("host"), arg("port"), arg("worker_threads")=0u)))
@@ -173,7 +182,8 @@ void export_client() {
     .def("get_available_maps", &GetAvailableMaps)
     .def("reload_world", CONST_CALL_WITHOUT_GIL(cc::Client, ReloadWorld))
     .def("load_world", CONST_CALL_WITHOUT_GIL_1(cc::Client, LoadWorld, std::string), (arg("map_name")))
-    .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_4(cc::Client, GenerateOpenDriveWorld, std::string, double, double, double), (arg("opendrive"), arg("resolution")=2.0, arg("wall_height")=1.0, arg("additional_width")=0.6))
+    .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_2(cc::Client, GenerateOpenDriveWorld, std::string,
+        rpc::OpendriveGenerationParameters), (arg("opendrive"), arg("parameters")=rpc::OpendriveGenerationParameters()))
     .def("start_recorder", CALL_WITHOUT_GIL_1(cc::Client, StartRecorder, std::string), (arg("name")))
     .def("stop_recorder", &cc::Client::StopRecorder)
     .def("show_recorder_file_info", CALL_WITHOUT_GIL_2(cc::Client, ShowRecorderFileInfo, std::string, bool), (arg("name"), arg("show_all")))

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -166,11 +166,12 @@ void export_client() {
   namespace rpc = carla::rpc;
 
   class_<rpc::OpendriveGenerationParameters>("OpendriveGenerationParameters",
-      init<double, double, double, double, bool>((arg("vertex_distance")=2.0, arg("max_road_length")=50.0, arg("wall_height")=1.0, arg("additional_width")=0.6, arg("enable_mesh_visibility")=true)))
+      init<double, double, double, double, bool, bool>((arg("vertex_distance")=2.0, arg("max_road_length")=50.0, arg("wall_height")=1.0, arg("additional_width")=0.6, arg("smooth_junctions")=true, arg("enable_mesh_visibility")=true)))
     .def_readwrite("vertex_distance", &rpc::OpendriveGenerationParameters::vertex_distance)
     .def_readwrite("max_road_length", &rpc::OpendriveGenerationParameters::max_road_length)
     .def_readwrite("wall_height", &rpc::OpendriveGenerationParameters::wall_height)
     .def_readwrite("additional_width", &rpc::OpendriveGenerationParameters::additional_width)
+    .def_readwrite("smooth_junctions", &rpc::OpendriveGenerationParameters::smooth_junctions)
     .def_readwrite("enable_mesh_visibility", &rpc::OpendriveGenerationParameters::enable_mesh_visibility)
   ;
 

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -166,8 +166,9 @@ void export_client() {
   namespace rpc = carla::rpc;
 
   class_<rpc::OpendriveGenerationParameters>("OpendriveGenerationParameters",
-      init<double, double, double, bool>((arg("vertex_distance")=2.0, arg("wall_height")=1.0, arg("additional_width")=0.6, arg("enable_mesh_visibility")=true)))
+      init<double, double, double, double, bool>((arg("vertex_distance")=2.0, arg("max_road_length")=50.0, arg("wall_height")=1.0, arg("additional_width")=0.6, arg("enable_mesh_visibility")=true)))
     .def_readwrite("vertex_distance", &rpc::OpendriveGenerationParameters::vertex_distance)
+    .def_readwrite("max_road_length", &rpc::OpendriveGenerationParameters::max_road_length)
     .def_readwrite("wall_height", &rpc::OpendriveGenerationParameters::wall_height)
     .def_readwrite("additional_width", &rpc::OpendriveGenerationParameters::additional_width)
     .def_readwrite("enable_mesh_visibility", &rpc::OpendriveGenerationParameters::enable_mesh_visibility)

--- a/PythonAPI/carla/source/libcarla/libcarla.cpp
+++ b/PythonAPI/carla/source/libcarla/libcarla.cpp
@@ -50,6 +50,7 @@ static boost::python::object OptionalToPythonObject(OptionalT &optional) {
 // Convenient for const requests without arguments.
 #define CONST_CALL_WITHOUT_GIL(cls, fn) CALL_WITHOUT_GIL(const cls, fn)
 #define CONST_CALL_WITHOUT_GIL_1(cls, fn, T1_) CALL_WITHOUT_GIL_1(const cls, fn, T1_)
+#define CONST_CALL_WITHOUT_GIL_2(cls, fn, T1_, T2_) CALL_WITHOUT_GIL_2(const cls, fn, T1_, T2_)
 #define CONST_CALL_WITHOUT_GIL_4(cls, fn, T1_, T2_, T3_, T4_) CALL_WITHOUT_GIL_4(const cls, fn, T1_, T2_, T3_, T4_)
 
 // Convenient for const requests that need to make a copy of the returned value.

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -40,7 +40,7 @@
       - param_name: commands
         type: list
         doc: >
-          A list of commands to execute in batch. Each command is different and has its own parameters. They appear listed at the bottom of this page. 
+          A list of commands to execute in batch. Each command is different and has its own parameters. They appear listed at the bottom of this page.
       doc: >
         Executes a list of commands on a single simulation step and retrieves no information. If you need information about the response of each command, use the **<font color="#7fb800">apply_batch_sync()</font>** function right below this one.
         [Here](https://github.com/carla-simulator/carla/blob/10c5f6a482a21abfd00220c68c7f12b4110b7f63/PythonAPI/examples/spawn_npc.py#L126) is an example on how to delete the actors that appear in carla.ActorList all at once.
@@ -55,7 +55,7 @@
         type: bool
         default: false
         doc: >
-          A boolean parameter to specify whether or not to perform a carla.World.tick after applying the batch in _synchronous mode_. It is __False__ by default. 
+          A boolean parameter to specify whether or not to perform a carla.World.tick after applying the batch in _synchronous mode_. It is __False__ by default.
       return: list(command.Response)
       doc: >
         Executes a list of commands on a single simulation step, blocks until the commands are linked, and returns a list of <b>command.Response</b> that can be used to determine whether a single command succeeded or not. [Here](https://github.com/carla-simulator/carla/blob/10c5f6a482a21abfd00220c68c7f12b4110b7f63/PythonAPI/examples/spawn_npc.py#L112-L116) is an example of it being used to spawn actors.
@@ -233,10 +233,10 @@
         type: int
         default: 8000
         doc: >
-          Port that will be used by the traffic manager. Default is `8000`. 
+          Port that will be used by the traffic manager. Default is `8000`.
       return: carla.TrafficManager
       doc: >
-        Returns an instance of the traffic manager related to the specified port. If it does not exist, this will be created. 
+        Returns an instance of the traffic manager related to the specified port. If it does not exist, this will be created.
     # --------------------------------------
     - def_name: get_world
       params:
@@ -267,8 +267,8 @@
   - class_name: TrafficManager
     # - DESCRIPTION ------------------------
     doc: >
-      The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a carla.VehicleControl is applied to every vehicle registered in a traffic manager.  
-      
+      The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a carla.VehicleControl is applied to every vehicle registered in a traffic manager.
+
       In order to learn more, visit the [documentation](adv_traffic_manager.md) regarding this module.
     # - PROPERTIES -------------------------
     instance_variables:
@@ -283,16 +283,16 @@
       - param_name: enable
         type: bool
         doc: >
-          __True__ is default and enables lane changes. __False__ will disable them. 
+          __True__ is default and enables lane changes. __False__ will disable them.
       doc: >
-        Turns on or off lane changing behaviour for a vehicle. 
+        Turns on or off lane changing behaviour for a vehicle.
     # --------------------------------------
     - def_name: collision_detection
       params:
       - param_name: reference_actor
         type: carla.Actor
         doc: >
-          Vehicle that is going to ignore collisions. 
+          Vehicle that is going to ignore collisions.
       - param_name: other_actor
         type: carla.Actor
         doc: >
@@ -300,7 +300,7 @@
       - param_name: detect_collision
         type: bool
         doc: >
-          __True__ is default and enables collisions. __False will disable them. 
+          __True__ is default and enables collisions. __False will disable them.
       doc: >
         Tunes on/off collisions between a vehicle and another specific actor. In order to ignore all other vehicles, traffic lights or walkers, use the specific __ignore__ methods described in this same section.
     # --------------------------------------
@@ -309,11 +309,11 @@
       - param_name: actor
         type: carla.Actor
         doc: >
-          Vehicle whose minimum distance is being changed. 
+          Vehicle whose minimum distance is being changed.
       - param_name: distance
         type: float
         doc: >
-          Meters between both vehicles. 
+          Meters between both vehicles.
       doc: >
         Sets the minimum distance in meters that a vehicle has to keep with the others. The distance is in meters and will affect the minimum moving distance. It is computed from front to back of the vehicle objects.
     # --------------------------------------
@@ -322,20 +322,20 @@
       - param_name: actor
         type: carla.Actor
         doc: >
-          Vehicle being forced to change lanes. 
+          Vehicle being forced to change lanes.
       - param_name: direction
         type: bool
-        doc: > 
-          Destination lane. __True__ is the one on the left and __False__ is the right one. 
+        doc: >
+          Destination lane. __True__ is the one on the left and __False__ is the right one.
       doc: >
-        Forces a vehicle to change either to the lane on its left or right, if existing, as indicated in `direction`. This method applies the lane change no matter what, disregarding possible collisions. 
+        Forces a vehicle to change either to the lane on its left or right, if existing, as indicated in `direction`. This method applies the lane change no matter what, disregarding possible collisions.
     # --------------------------------------
     - def_name: global_distance_to_leading_vehicle
       params:
       - param_name: distance
         type: float
         doc: >
-          Meters between vehicles. 
+          Meters between vehicles.
       doc: >
         Sets the minimum distance in meters that vehicles have to keep with the rest. The distance is in meters and will affect the minimum moving distance. It is computed from center to center of the vehicle objects.
     # --------------------------------------
@@ -346,9 +346,9 @@
         doc: >
           Percentage difference between intended speed and the current limit.
       doc: >
-        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
-        
-        Default is 30. Exceeding a speed limit can be done using negative percentages. 
+        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+
+        Default is 30. Exceeding a speed limit can be done using negative percentages.
     # --------------------------------------
     - def_name: ignore_lights_percentage
       params:
@@ -361,7 +361,7 @@
         doc: >
           Between 0 and 100. Amount of times traffic lights will be ignored.
       doc: >
-        During the traffic light stage, which runs every frame, this method sets the percent chance that traffic lights will be ignored for a vehicle. 
+        During the traffic light stage, which runs every frame, this method sets the percent chance that traffic lights will be ignored for a vehicle.
     # --------------------------------------
     - def_name: ignore_vehicles_percentage
       params:
@@ -372,7 +372,7 @@
       - param_name: perc
         type: float
         doc: >
-          Between 0 and 100. Amount of times collisions will be ignored. 
+          Between 0 and 100. Amount of times collisions will be ignored.
       doc: >
         During the collision detection stage, which runs every frame, this method sets a percent chance that collisions with another vehicle will be ignored for a vehicle.
     # --------------------------------------
@@ -385,28 +385,28 @@
       - param_name: perc
         type: float
         doc: >
-          Between 0 and 100. Amount of times collisions will be ignored. 
+          Between 0 and 100. Amount of times collisions will be ignored.
       doc: >
         During the collision detection stage, which runs every frame, this method sets a percent chance that collisions with walkers will be ignored for a vehicle.
     # --------------------------------------
     - def_name: reset_traffic_lights
       doc: >
-        Resets every traffic light in the map to its initial state. 
+        Resets every traffic light in the map to its initial state.
     # --------------------------------------
     - def_name: vehicle_percentage_speed_difference
       params:
       - param_name: actor
         type: carla.Actor
         doc: >
-          Vehicle whose speed behaviour is being changed. 
+          Vehicle whose speed behaviour is being changed.
       - param_name: percentage
         type: float
         doc: >
-          Percentage difference between intended speed and the current limit.  
+          Percentage difference between intended speed and the current limit.
       doc: >
-        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
-        
-        Default is 30. Exceeding a speed limit can be done using negative percentages. 
+        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+
+        Default is 30. Exceeding a speed limit can be done using negative percentages.
     # --------------------------------------
     - def_name: set_hybrid_physics_mode
       params:
@@ -428,3 +428,28 @@
       doc: >
         With hybrid physics on, changes the radius of the area of influence where physics are enabled. 
     # --------------------------------------
+
+  - class_name: OpendriveGenerationParameters
+    # - DESCRIPTION ------------------------
+    doc: >
+      This class defines the parameters used when generating a world using an OpenDRIVE file.
+    # - PROPERTIES -------------------------
+    instance_variables:
+    - var_name: vertex_distance
+      doc: >
+        The distance between vertices when generating the world mesh from OpenDRIVE.
+    - var_name: max_road_length
+      doc: >
+        Max road length for a single mesh portion.
+    - var_name: wall_height
+      doc: >
+        Defines the height of walls added to roads to prevent vehicles from falling.
+    - var_name: additional_width
+      doc: >
+        Additional with to junction lanes to prevent vehicles from falling.
+    - var_name: smooth_junctions
+      doc: >
+        When this variable is `True` the generated junctions will be smoothed to prevent roads from blocking other roads.
+    - var_name: enable_mesh_visibility
+      doc: >
+        This variable indicates whether the mesh should be rendered to reduce the rendering overhead.

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -267,7 +267,7 @@
   - class_name: TrafficManager
     # - DESCRIPTION ------------------------
     doc: >
-      The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a carla.VehicleControl is applied to every vehicle registered in a traffic manager.
+      The traffic manager is a module built on top of the CARLA API in C++. It handles any group of vehicles set to autopilot mode to populate the simulation with realistic urban traffic conditions and give the chance to user to customize some behaviours. The architecture of the traffic manager is divided in five different goal-oriented stages and a PID controller where the information flows until eventually, a carla.VehicleControl is applied to every vehicle registered in a traffic manager.  
 
       In order to learn more, visit the [documentation](adv_traffic_manager.md) regarding this module.
     # - PROPERTIES -------------------------
@@ -346,7 +346,7 @@
         doc: >
           Percentage difference between intended speed and the current limit.
       doc: >
-        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
 
         Default is 30. Exceeding a speed limit can be done using negative percentages.
     # --------------------------------------
@@ -404,7 +404,7 @@
         doc: >
           Percentage difference between intended speed and the current limit.
       doc: >
-        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
+        Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.  
 
         Default is 30. Exceeding a speed limit can be done using negative percentages.
     # --------------------------------------

--- a/PythonAPI/util/config.py
+++ b/PythonAPI/util/config.py
@@ -210,10 +210,15 @@ def main():
                     print('file could not be readed.')
                     sys.exit()
             print('load opendrive map %r.' % os.path.basename(args.xodr_path))
-            resolution = 2.0 # in meters
+            vertex_distance = 2.0 # in meters
             wall_height = 1.0 # in meters
             extra_width = 0.6 # in meters
-            world = client.generate_opendrive_world(data, resolution, wall_height, extra_width)
+            world = client.generate_opendrive_world(
+                data, carla.OpendriveGenerationParameters(
+                    vertex_distance,
+                    wall_height,
+                    extra_width,
+                    True))
         else:
             print('file not found.')
 

--- a/PythonAPI/util/config.py
+++ b/PythonAPI/util/config.py
@@ -210,15 +210,17 @@ def main():
                     print('file could not be readed.')
                     sys.exit()
             print('load opendrive map %r.' % os.path.basename(args.xodr_path))
-            vertex_distance = 2.0 # in meters
-            wall_height = 1.0 # in meters
-            extra_width = 0.6 # in meters
+            vertex_distance = 2.0  # in meters
+            max_road_length = 50.0 # in meters
+            wall_height = 1.0      # in meters
+            extra_width = 0.6      # in meters
             world = client.generate_opendrive_world(
                 data, carla.OpendriveGenerationParameters(
-                    vertex_distance,
-                    wall_height,
-                    extra_width,
-                    True))
+                    vertex_distance=vertex_distance,
+                    max_road_length=max_road_length,
+                    wall_height=wall_height,
+                    additional_width=extra_width,
+                    enable_mesh_visibility=True))
         else:
             print('file not found.')
 

--- a/PythonAPI/util/config.py
+++ b/PythonAPI/util/config.py
@@ -220,6 +220,7 @@ def main():
                     max_road_length=max_road_length,
                     wall_height=wall_height,
                     additional_width=extra_width,
+                    smooth_junctions=True,
                     enable_mesh_visibility=True))
         else:
             print('file not found.')

--- a/PythonAPI/util/lane_explorer.py
+++ b/PythonAPI/util/lane_explorer.py
@@ -21,7 +21,6 @@ except IndexError:
 import carla
 
 import argparse
-import math
 import random
 import time
 
@@ -38,13 +37,9 @@ waypoint_separation = 4
 
 
 def draw_transform(debug, trans, col=carla.Color(255, 0, 0), lt=-1):
-    yaw_in_rad = math.radians(trans.rotation.yaw)
-    pitch_in_rad = math.radians(trans.rotation.pitch)
-    p1 = carla.Location(
-        x=trans.location.x + math.cos(pitch_in_rad) * math.cos(yaw_in_rad),
-        y=trans.location.y + math.cos(pitch_in_rad) * math.sin(yaw_in_rad),
-        z=trans.location.z + math.sin(pitch_in_rad))
-    debug.draw_arrow(trans.location, p1, thickness=0.05, arrow_size=0.1, color=col, life_time=lt)
+    debug.draw_arrow(
+        trans.location, trans.location + trans.get_forward_vector(),
+        thickness=0.05, arrow_size=0.1, color=col, life_time=lt)
 
 
 def draw_waypoint_union(debug, w0, w1, color=carla.Color(255, 0, 0), lt=5):

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -130,16 +130,6 @@ static FString BuildRecastBuilderFile()
 
 bool UCarlaEpisode::LoadNewOpendriveEpisode(
     const FString &OpenDriveString,
-    float VertexDistance,
-    float WallHeight,
-    float AdditionalWidth)
-{
-  return LoadNewOpendriveEpisode(OpenDriveString,
-      carla::rpc::OpendriveGenerationParameters(VertexDistance, WallHeight, AdditionalWidth, true));
-}
-
-bool UCarlaEpisode::LoadNewOpendriveEpisode(
-    const FString &OpenDriveString,
     const carla::rpc::OpendriveGenerationParameters &Params)
 {
   if (OpenDriveString.IsEmpty())
@@ -204,8 +194,9 @@ bool UCarlaEpisode::LoadNewOpendriveEpisode(
   }
   // Build the mesh generation config file
   const FString ConfigData = FString::Printf(
-      TEXT("resolution=%s\nwall_height=%s\nadditional_width=%s\nmesh_visibility=%s"),
+      TEXT("resolution=%s\nmax_road_length=%s\nwall_height=%s\nadditional_width=%s\nmesh_visibility=%s\n"),
       *FString::SanitizeFloat(Params.vertex_distance),
+      *FString::SanitizeFloat(Params.max_road_length),
       *FString::SanitizeFloat(Params.wall_height),
       *FString::SanitizeFloat(Params.additional_width),
       *MeshVisibilityStr);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -16,6 +16,7 @@
 #include "Carla/Util/BoundingBoxCalculator.h"
 #include "Carla/Util/RandomEngine.h"
 #include "Carla/Vehicle/VehicleSpawnPoint.h"
+#include "Carla/Game/CarlaStatics.h"
 
 #include "Engine/StaticMeshActor.h"
 #include "EngineUtils.h"
@@ -180,33 +181,15 @@ bool UCarlaEpisode::LoadNewOpendriveEpisode(
     return false;
   }
 
-  const FString AbsoluteCONFPath = FPaths::ConvertRelativePathToFull(
-      FPaths::ProjectContentDir() + "Carla/Maps/OpenDrive/OpenDriveMap.conf");
-
-  FString MeshVisibilityStr = "true";
-  if(Params.enable_mesh_visibility)
+  UCarlaGameInstance * GameInstance = UCarlaStatics::GetGameInstance(GetWorld());
+  if(GameInstance)
   {
-    MeshVisibilityStr = "true";
+    GameInstance->SetOpendriveGenerationParameters(Params);
   }
   else
   {
-    MeshVisibilityStr = "false";
+    carla::log_warning("Missing game instance");
   }
-  // Build the mesh generation config file
-  const FString ConfigData = FString::Printf(
-      TEXT("resolution=%s\nmax_road_length=%s\nwall_height=%s\nadditional_width=%s\nmesh_visibility=%s\n"),
-      *FString::SanitizeFloat(Params.vertex_distance),
-      *FString::SanitizeFloat(Params.max_road_length),
-      *FString::SanitizeFloat(Params.wall_height),
-      *FString::SanitizeFloat(Params.additional_width),
-      *MeshVisibilityStr);
-
-  // Save the config file
-  FFileHelper::SaveStringToFile(
-      ConfigData,
-      *AbsoluteCONFPath,
-      FFileHelper::EEncodingOptions::ForceUTF8,
-      &IFileManager::Get());
 
   const FString AbsoluteRecastBuilderPath = BuildRecastBuilderFile();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -21,6 +21,7 @@
 #include <carla/geom/GeoLocation.h>
 #include <carla/rpc/Actor.h>
 #include <carla/rpc/ActorDescription.h>
+#include <carla/rpc/OpendriveGenerationParameters.h>
 #include <carla/streaming/Server.h>
 #include <compiler/enable-ue4-macros.h>
 
@@ -61,9 +62,17 @@ public:
   UFUNCTION(BlueprintCallable)
   bool LoadNewOpendriveEpisode(
       const FString &OpenDriveString,
-      float Resolution,
+      float VertexDistance,
       float WallHeight,
       float AdditionalWidth);
+
+  /// Load a new map generating the mesh from OpenDRIVE data and
+  /// start a new episode.
+  ///
+  /// If @a MapString is empty, it fails.
+  bool LoadNewOpendriveEpisode(
+      const FString &OpenDriveString,
+      const carla::rpc::OpendriveGenerationParameters &Params);
 
   // ===========================================================================
   // -- Episode settings -------------------------------------------------------

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -59,17 +59,6 @@ public:
   /// start a new episode.
   ///
   /// If @a MapString is empty, it fails.
-  UFUNCTION(BlueprintCallable)
-  bool LoadNewOpendriveEpisode(
-      const FString &OpenDriveString,
-      float VertexDistance,
-      float WallHeight,
-      float AdditionalWidth);
-
-  /// Load a new map generating the mesh from OpenDRIVE data and
-  /// start a new episode.
-  ///
-  /// If @a MapString is empty, it fails.
   bool LoadNewOpendriveEpisode(
       const FString &OpenDriveString,
       const carla::rpc::OpendriveGenerationParameters &Params);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
@@ -73,10 +73,22 @@ public:
     return CarlaEngine.GetServer();
   }
 
+  void SetOpendriveGenerationParameters(
+      const carla::rpc::OpendriveGenerationParameters & Parameters) {
+    GenerationParameters = Parameters;
+  }
+
+  const carla::rpc::OpendriveGenerationParameters&
+      GetOpendriveGenerationParameters() const {
+    return GenerationParameters;
+  }
+
 private:
 
   UPROPERTY(Category = "CARLA Settings", EditAnywhere)
   UCarlaSettings *CarlaSettings = nullptr;
 
   FCarlaEngine CarlaEngine;
+
+  carla::rpc::OpendriveGenerationParameters GenerationParameters;
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
@@ -67,9 +67,10 @@ void AOpenDriveGenerator::GenerateRoadMesh()
 
   static const FString ConfigFilePath =
       FPaths::ProjectContentDir() + "Carla/Maps/OpenDrive/OpenDriveMap.conf";
-  float Resolution      = 2.0f;
-  float WallHeight      = 1.0f;
-  float AdditionalWidth = 0.6f;
+  float Resolution = 2.f;
+  float WallHeight = 1.f;
+  float AdditionalWidth = .6f;
+  bool MeshVisibility = true;
   if (FPaths::FileExists(ConfigFilePath)) {
     FString ConfigData;
     TArray<FString> Lines;
@@ -89,6 +90,10 @@ void AOpenDriveGenerator::GenerateRoadMesh()
       else if (Key == "additional_width")
       {
         AdditionalWidth = FCString::Atof(*Value);
+      }
+      else if (Key == "mesh_visibility")
+      {
+        MeshVisibility = Value.ToBool();
       }
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
@@ -68,6 +68,7 @@ void AOpenDriveGenerator::GenerateRoadMesh()
   static const FString ConfigFilePath =
       FPaths::ProjectContentDir() + "Carla/Maps/OpenDrive/OpenDriveMap.conf";
   float Resolution = 2.f;
+  float MaxRoadLength = 50.0f;
   float WallHeight = 1.f;
   float AdditionalWidth = .6f;
   bool MeshVisibility = true;
@@ -87,6 +88,10 @@ void AOpenDriveGenerator::GenerateRoadMesh()
       {
         WallHeight = FCString::Atof(*Value);
       }
+      else if (Key == "max_road_length")
+      {
+        MaxRoadLength = FCString::Atof(*Value);
+      }
       else if (Key == "additional_width")
       {
         AdditionalWidth = FCString::Atof(*Value);
@@ -98,11 +103,8 @@ void AOpenDriveGenerator::GenerateRoadMesh()
     }
   }
 
-  // const FProceduralCustomMesh MeshData =
-  //     CarlaMap->GenerateMesh(Resolution, AdditionalWidth) +
-  //     CarlaMap->GenerateWalls(Resolution, WallHeight);
-
-  const auto Meshes = CarlaMap->GenerateChunkedMesh(Resolution, 50.0f, AdditionalWidth);
+  const auto Meshes = CarlaMap->GenerateChunkedMesh(
+      Resolution, MaxRoadLength, AdditionalWidth);
   for (const auto &Mesh : Meshes) {
     AActor *TempActor = GetWorld()->SpawnActor<AActor>();
     UProceduralMeshComponent *TempPMC = NewObject<UProceduralMeshComponent>(TempActor);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.h
@@ -64,7 +64,7 @@ protected:
   FString OpenDriveData;
 
   UPROPERTY(EditAnywhere)
-  UProceduralMeshComponent *RoadMesh;
+  TArray<AActor *> ActorMeshList;
 
   boost::optional<carla::road::Map> CarlaMap;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -234,10 +234,11 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
-  BIND_SYNC(copy_opendrive_to_file) << [this](const std::string &opendrive, double resolution, double wall_height, double additional_width) -> R<void>
+  BIND_SYNC(copy_opendrive_to_file) << [this](const std::string &opendrive, carla::rpc::OpendriveGenerationParameters Params) -> R<void>
   {
+    carla::log_warning("Hello", Params.vertex_distance);
     REQUIRE_CARLA_EPISODE();
-    if (!Episode->LoadNewOpendriveEpisode(cr::ToFString(opendrive), resolution, wall_height, additional_width))
+    if (!Episode->LoadNewOpendriveEpisode(cr::ToFString(opendrive), Params))
     {
       RESPOND_ERROR("opendrive could not be correctly parsed");
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -236,7 +236,6 @@ void FCarlaServer::FPimpl::BindActions()
 
   BIND_SYNC(copy_opendrive_to_file) << [this](const std::string &opendrive, carla::rpc::OpendriveGenerationParameters Params) -> R<void>
   {
-    carla::log_warning("Hello", Params.vertex_distance);
     REQUIRE_CARLA_EPISODE();
     if (!Episode->LoadNewOpendriveEpisode(cr::ToFString(opendrive), Params))
     {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ProceduralCustomMesh.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ProceduralCustomMesh.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "ProceduralCustomMesh.generated.h"
+
+/// A definition of a Carla Mesh.
+USTRUCT()
+struct CARLA_API FProceduralCustomMesh
+{
+  GENERATED_BODY()
+
+  UPROPERTY()
+  TArray<FVector> Vertices;
+
+  UPROPERTY()
+  TArray<int32> Triangles;
+
+  UPROPERTY()
+  TArray<FVector> Normals;
+
+  UPROPERTY()
+  TArray<FVector2D> UV0;
+
+  UPROPERTY()
+  TArray<FLinearColor> VertexColor;
+
+  // This is commented due to an strange bug including ProceduralMeshComponent.h
+  // UPROPERTY()
+  // TArray<FProcMeshTangent> Tangents;
+};


### PR DESCRIPTION
#### Description

Added standalone OpenDRIVE mode.

The mesh generation in the OpenDRIVE standalone mode has been greatly improved. Junctions have been polished to avoid inaccuracies, especially where uneven lanes joined. Instead of creating the whole map as a unique mesh, different fragments are created. Working smaller prevents unexpected issues. Also, by dividing the mesh, not all of it has to be rendered at a time. This is a step towards a larger goal, where the feature will be able to generate huge maps.

Added junction smoothing algorithm to prevent roads blocking other roads within junctions.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04 
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** UE4.24

#### Possible Drawbacks
The junction smoothing is not perfect and may produce bumbs in some situation. Regardless, it should allow the vehicles to move through the intersections in the vast majority of situations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2713)
<!-- Reviewable:end -->
