### PR TITLE
Signal displacement and traffic signs crash fix

### DIFF
--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -5,7 +5,6 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "carla/road/Map.h"
-
 #include "carla/Exception.h"
 #include "carla/geom/Math.h"
 #include "carla/geom/MeshFactory.h"
@@ -506,7 +505,7 @@ namespace road {
     const auto &lane = GetLane(waypoint);
     const bool forward = (waypoint.lane_id <= 0);
     const double signed_distance = forward ? distance : -distance;
-    const double relative_s = waypoint.s - lane.GetDistance() + EPSILON;
+    const double relative_s = waypoint.s - lane.GetDistance();
     const double remaining_lane_length = forward ? lane.GetLength() - relative_s : relative_s;
     DEBUG_ASSERT(remaining_lane_length >= 0.0);
 
@@ -539,7 +538,7 @@ namespace road {
     const auto &lane = GetLane(waypoint);
     const bool forward = !(waypoint.lane_id <= 0);
     const double signed_distance = forward ? distance : -distance;
-    const double relative_s = waypoint.s - lane.GetDistance() + EPSILON;
+    const double relative_s = waypoint.s - lane.GetDistance();
     const double remaining_lane_length = forward ? lane.GetLength() - relative_s : relative_s;
     DEBUG_ASSERT(remaining_lane_length >= 0.0);
 

--- a/LibCarla/source/carla/road/MapBuilder.cpp
+++ b/LibCarla/source/carla/road/MapBuilder.cpp
@@ -746,6 +746,18 @@ namespace road {
     }
   }
 
+  geom::Transform MapBuilder::ComputeSignalTransform(std::unique_ptr<Signal> &signal, MapData &data) {
+    DirectedPoint point = data.GetRoad(signal->_road_id).GetDirectedPointIn(signal->_s);
+    point.ApplyLateralOffset(static_cast<float>(-signal->_t));
+    point.location.y *= -1; // Unreal Y axis hack
+    point.location.z += static_cast<float>(signal->_zOffset);
+    geom::Transform transform(point.location, geom::Rotation(
+        geom::Math::ToDegrees(static_cast<float>(signal->_pitch)),
+        geom::Math::ToDegrees(static_cast<float>(-(point.tangent + signal->_hOffset))),
+        geom::Math::ToDegrees(static_cast<float>(signal->_roll))));
+    return transform;
+  }
+
   void MapBuilder::SolveSignalReferencesAndTransforms() {
     for(auto signal_reference : _temp_signal_reference_container){
       signal_reference->_signal =
@@ -754,15 +766,7 @@ namespace road {
 
     for(auto& signal_pair : _temp_signal_container){
       auto& signal = signal_pair.second;
-      DirectedPoint point = GetRoad(signal->_road_id)->GetDirectedPointIn(signal->_s);
-      point.ApplyLateralOffset(static_cast<float>(-signal->_t));
-      point.location.y *= -1; // Unreal Y axis hack
-      point.location.z += static_cast<float>(signal->_zOffset);
-      geom::Transform transform(point.location, geom::Rotation(
-          geom::Math::ToDegrees(static_cast<float>(signal->_pitch)),
-          geom::Math::ToDegrees(static_cast<float>(-(point.tangent + signal->_hOffset))),
-          geom::Math::ToDegrees(static_cast<float>(signal->_roll))));
-      signal->_transform = transform;
+      signal->_transform = ComputeSignalTransform(signal, _map_data);
     }
 
     _map_data._signals = std::move(_temp_signal_container);
@@ -952,19 +956,41 @@ void MapBuilder::CreateController(
   }
 
   void MapBuilder::CheckSignalsOnRoads(Map &map) {
-    for (auto& signal_pair : map._data.GetSignals()) {
+    for (auto& signal_pair : map._data._signals) {
       auto& signal = signal_pair.second;
+      auto signal_position = signal->GetTransform().location;
       auto closest_waypoint_to_signal =
-          map.GetClosestWaypointOnRoad(signal->GetTransform().location);
+          map.GetClosestWaypointOnRoad(signal_position);
       if(closest_waypoint_to_signal) {
         auto distance_to_road =
             (map.ComputeTransform(closest_waypoint_to_signal.get()).location -
-            signal->GetTransform().location).Length();
+            signal_position).Length();
         double lane_width = map.GetLaneWidth(closest_waypoint_to_signal.get());
-        if(distance_to_road < lane_width * 0.5) {
-          carla::log_warning("Traffic sign",
-              signal->GetSignalId(),
-              "overlaps a driving lane.");
+        int iter = 0;
+        int MaxIter = 10;
+        // Displaces signal until it finds a suitable spot
+        while(distance_to_road < lane_width * 0.5 && iter < MaxIter) {
+          if(iter == 0) {
+            log_warning("Traffic sign",
+                signal->GetSignalId(),
+                "overlaps a driving lane. Moving out of the road...");
+          }
+          geom::Vector3D displacement = 1.f*(signal->GetTransform().GetRightVector()) *
+              static_cast<float>(abs(lane_width))*0.5f;
+          signal_position += displacement;
+          closest_waypoint_to_signal =
+              map.GetClosestWaypointOnRoad(signal_position);
+          distance_to_road =
+              (map.ComputeTransform(closest_waypoint_to_signal.get()).location -
+              signal_position).Length();
+          lane_width = map.GetLaneWidth(closest_waypoint_to_signal.get());
+          iter++;
+        }
+        if(iter == MaxIter) {
+          log_warning("Failed to find suitable place for signal.");
+        } else {
+          // Only perform the displacement if a good location has been found
+          signal->_transform.location = signal_position;
         }
       }
     }

--- a/LibCarla/source/carla/road/MapBuilder.h
+++ b/LibCarla/source/carla/road/MapBuilder.h
@@ -353,6 +353,8 @@ namespace road {
     /// Create the bounding boxes of each junction
     void CreateJunctionBoundingBoxes(Map &map);
 
+    geom::Transform ComputeSignalTransform(std::unique_ptr<Signal> &signal,  MapData &data);
+
     /// Solves the signal references in the road
     void SolveSignalReferencesAndTransforms();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
@@ -196,12 +196,17 @@ void UStopSignComponent::GiveWayIfPossible()
           Cast<AWheeledVehicleAIController>(Vehicle->GetController());
         VehicleController->SetTrafficLightState(ETrafficLightState::Red);
       }
-
-      FTimerHandle TimerHandler;
       // 1 second delay
-      GetWorld()->GetTimerManager().SetTimer(TimerHandler, this, &UStopSignComponent::GiveWayIfPossible, 1.0f);
+      DelayedGiveWay(1.0f);
     }
   }
+}
+
+void UStopSignComponent::DelayedGiveWay(float Delay)
+{
+  FTimerHandle TimerHandler;
+  GetWorld()->GetTimerManager().
+      SetTimer(TimerHandler, this, &UStopSignComponent::GiveWayIfPossible, Delay);
 }
 
 void UStopSignComponent::OnOverlapBeginStopEffectBox(UPrimitiveComponent *OverlappedComp,
@@ -221,9 +226,8 @@ void UStopSignComponent::OnOverlapBeginStopEffectBox(UPrimitiveComponent *Overla
       VehicleController->SetTrafficLightState(ETrafficLightState::Red);
       VehiclesInStop.Add(Vehicle);
 
-      FTimerHandle TimerHandler;
       // 2 second delay for stop
-      GetWorld()->GetTimerManager().SetTimer(TimerHandler, this, &UStopSignComponent::GiveWayIfPossible, 2.0f);
+      DelayedGiveWay(2.0f);
     }
   }
   RemoveSameVehicleInBothLists();
@@ -279,7 +283,8 @@ void UStopSignComponent::OnOverlapEndStopCheckBox(UPrimitiveComponent *Overlappe
         VehiclesToCheck.Remove(Vehicle);
       }
     }
-    GiveWayIfPossible();
+    // 0.5s delay
+    DelayedGiveWay(0.5f);
   }
 }
 void UStopSignComponent::RemoveSameVehicleInBothLists()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.h
@@ -33,6 +33,8 @@ private:
   UFUNCTION(BlueprintCallable)
   void GiveWayIfPossible();
 
+  void DelayedGiveWay(float Delay);
+
   UFUNCTION(BlueprintCallable)
   void OnOverlapBeginStopEffectBox(UPrimitiveComponent *OverlappedComp,
       AActor *OtherActor,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -197,12 +197,17 @@ void UYieldSignComponent::GiveWayIfPossible()
           Cast<AWheeledVehicleAIController>(Vehicle->GetController());
         VehicleController->SetTrafficLightState(ETrafficLightState::Red);
       }
-
-      FTimerHandle TimerHandler;
       // 0.5 second delay
-      GetWorld()->GetTimerManager().SetTimer(TimerHandler, this, &UYieldSignComponent::GiveWayIfPossible, 0.5f);
+      DelayedGiveWay(0.5f);
     }
   }
+}
+
+void UYieldSignComponent::DelayedGiveWay(float Delay)
+{
+  FTimerHandle TimerHandler;
+  GetWorld()->GetTimerManager().
+      SetTimer(TimerHandler, this, &UYieldSignComponent::GiveWayIfPossible, Delay);
 }
 
 void UYieldSignComponent::OnOverlapBeginYieldEffectBox(UPrimitiveComponent *OverlappedComp,
@@ -276,7 +281,8 @@ void UYieldSignComponent::OnOverlapEndYieldCheckBox(UPrimitiveComponent *Overlap
         VehiclesToCheck.Remove(Vehicle);
       }
     }
-    GiveWayIfPossible();
+    // 0.5 second delay
+    DelayedGiveWay(0.5);
   }
 }
 void UYieldSignComponent::RemoveSameVehicleInBothLists()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.h
@@ -33,6 +33,8 @@ private:
   UFUNCTION(BlueprintCallable)
   void GiveWayIfPossible();
 
+  void DelayedGiveWay(float Delay);
+
   UFUNCTION(BlueprintCallable)
   void OnOverlapBeginYieldEffectBox(UPrimitiveComponent *OverlappedComp,
       AActor *OtherActor,


### PR DESCRIPTION
#### Description

Added small preprocess in `MapBuilder.cpp` to move the signals out of driving lanes. The signal is always moved to it's right until it finds a suitable spot. If it cannot find a suitable position (due to complex road layout) the signal will remain in it's original position.

Added a small fix to `UYieldSignComponent` and `UStopSignComponent` that would cause the simulation to crash when de-spawning vehicles affected by the signals.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** UE4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2736)
<!-- Reviewable:end -->
