### PR TITLE
Fix bug PTV Vissim relative path

### DIFF
--- a/Co-Simulation/PTV-Vissim/vissim_integration/carla_simulation.py
+++ b/Co-Simulation/PTV-Vissim/vissim_integration/carla_simulation.py
@@ -37,12 +37,6 @@ class CarlaSimulation(object):
         self.world = self.client.get_world()
         self.blueprint_library = self.world.get_blueprint_library()
 
-        # Configuring carla simulation in sync mode.
-        settings = self.world.get_settings()
-        settings.synchronous_mode = True
-        settings.fixed_delta_seconds = args.step_length
-        self.world.apply_settings(settings)
-
         # The following sets contain updated information for the current frame.
         self._active_actors = set()
         self.spawned_actors = set()

--- a/Co-Simulation/PTV-Vissim/vissim_integration/vissim_simulation.py
+++ b/Co-Simulation/PTV-Vissim/vissim_integration/vissim_simulation.py
@@ -14,6 +14,7 @@
 import enum
 import logging
 import math
+import os
 
 import carla  # pylint: disable=import-error
 from ctypes import *
@@ -143,15 +144,19 @@ class PTVVissimSimulation(object):
 
         # Connection to vissim simulator.
         logging.info('Establishing a connection with a GUI version of PTV-Vissim')
-        self.ds_proxy.VISSIM_Connect(args.vissim_version, args.vissim_network,
-                                     int(1. / args.step_length),
-                                     c_double(constants.VISSIM_VISIBILITY_RADIUS),
-                                     c_ushort(constants.VISSIM_MAX_SIMULATOR_VEH),
-                                     c_ushort(constants.VISSIM_MAX_SIMULATOR_PED),
-                                     c_ushort(constants.VISSIM_MAX_SIMULATOR_DET),
-                                     c_ushort(constants.VISSIM_MAX_VISSIM_VEH),
-                                     c_ushort(constants.VISSIM_MAX_VISSIM_PED),
-                                     c_ushort(constants.VISSIM_MAX_VISSIM_SIGGRP))
+        result = self.ds_proxy.VISSIM_Connect(args.vissim_version,
+                                              os.path.abspath(args.vissim_network),
+                                              int(1. / args.step_length),
+                                              c_double(constants.VISSIM_VISIBILITY_RADIUS),
+                                              c_ushort(constants.VISSIM_MAX_SIMULATOR_VEH),
+                                              c_ushort(constants.VISSIM_MAX_SIMULATOR_PED),
+                                              c_ushort(constants.VISSIM_MAX_SIMULATOR_DET),
+                                              c_ushort(constants.VISSIM_MAX_VISSIM_VEH),
+                                              c_ushort(constants.VISSIM_MAX_VISSIM_PED),
+                                              c_ushort(constants.VISSIM_MAX_VISSIM_SIGGRP))
+
+        if not result:
+            raise RuntimeError('There was an error when establishing a connection with PTV-Vissim')
 
         # Structures to keep track of the simulation state at each time step.
         self._vissim_vehicles = {}  # vissim_actor_id: VissimVehicle (only vissim traffic)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
This PR fixes a bug that was freezing carla when calling the synchronization script with a relative path for the vissim network. Now it is possible to call the synchronization script in the following way:

```sh
python run_synchronization examples/Town01/Town01.inpx
```

<!-- Please explain the changes you made here as detailed as possible. -->


#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.7.7
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2740)
<!-- Reviewable:end -->
