### PR TITLE
Delete wrongly referenced .value attribute

### DIFF
--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -268,8 +268,8 @@ class GlobalRoutePlanner(object):
             else:
                 self._intersection_end_node = -1
                 current_edge = self._graph.edges[previous_node, current_node]
-                calculate_turn = current_edge['type'].value == RoadOption.LANEFOLLOW.value and not current_edge[
-                    'intersection'] and next_edge['type'].value == RoadOption.LANEFOLLOW.value and next_edge['intersection']
+                calculate_turn = current_edge['type'] == RoadOption.LANEFOLLOW and not current_edge[
+                    'intersection'] and next_edge['type'] == RoadOption.LANEFOLLOW and next_edge['intersection']
                 if calculate_turn:
                     last_node, tail_edge = self._successive_last_intersection_edge(index, route)
                     self._intersection_end_node = last_node
@@ -279,7 +279,7 @@ class GlobalRoutePlanner(object):
                     cross_list = []
                     for neighbor in self._graph.successors(current_node):
                         select_edge = self._graph.edges[current_node, neighbor]
-                        if select_edge['type'].value == RoadOption.LANEFOLLOW.value:
+                        if select_edge['type'] == RoadOption.LANEFOLLOW:
                             if neighbor != route[index+1]:
                                 sv = select_edge['net_vector']
                                 cross_list.append(np.cross(cv, sv)[2])
@@ -356,7 +356,7 @@ class GlobalRoutePlanner(object):
             edge = self._graph.edges[route[i], route[i+1]]
             path = []
 
-            if edge['type'].value != RoadOption.LANEFOLLOW.value and edge['type'].value != RoadOption.VOID.value:
+            if edge['type'] != RoadOption.LANEFOLLOW and edge['type'] != RoadOption.VOID:
                 route_trace.append((current_waypoint, road_option))
                 exit_wp = edge['exit_waypoint']
                 n1, n2 = self._road_id_to_edge[exit_wp.road_id][exit_wp.section_id][exit_wp.lane_id]


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Fixes #2719 

#### Where has this been tested?

  * **Platform(s):** ... Ubuntu 16
  * **Python version(s):** ... python 2.7.13
  * **Unreal Engine version(s):** ... 4.24

To be honest I don't know what is expected behavior for `automatic_control.py` script. So I was not able to test it on my environment.
But my guess is this is right correction because `agents.navigation.local_planner.RoadOption` is enum and its attributes are all int. After this modification, at least the error showed in #2719 disappeared.

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2742)
<!-- Reviewable:end -->
