### PR TITLE
Stop vehicles at end of the recorded simulation, instead of using autopilot

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -353,17 +353,30 @@ bool CarlaReplayerHelper::ProcessReplayerFinish(bool bApplyAutopilot, bool bIgno
         // check for hero
         if (!(bIgnoreHero && IsHero[ActorView.GetActorId()]))
         {
+            // stop all vehicles
             SetActorSimulatePhysics(ActorView, true);
-            // autopilot
-            if (bApplyAutopilot)
-              SetActorAutopilot(ActorView, true, true);
+            SetActorVelocity(ActorView, FVector(0, 0, 0));
+            // reset any control assigned
+            auto Veh = Cast<ACarlaWheeledVehicle>(const_cast<AActor *>(ActorView.GetActor()));
+            if (Veh != nullptr)
+            {
+              FVehicleControl Control;
+              Control.Throttle = 0.0f;
+              Control.Steer = 0.0f;
+              Control.Brake = 0.0f;
+              Control.bHandBrake = false;
+              Control.bReverse = false;
+              Control.Gear = 1;
+              Control.bManualGearShift = false;
+              Veh->ApplyVehicleControl(Control, EVehicleInputPriority::User);
+            }
+
         }
         break;
 
       // walkers
       case FActorView::ActorType::Walker:
         // stop walker
-        SetActorVelocity(ActorView, FVector(0, 0, 0));
         SetWalkerSpeed(ActorView.GetActorId(), 0.0f);
         break;
     }


### PR DESCRIPTION
#### Description

Now that Traffic manager runs on client, we can not use the autopilot feature from server, so we can not enable autopilot at the end of a recorded simulation. Instead, I will stop all vehicles to avoid them go crazy.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 2.7, 3.7
  * **Unreal Engine version(s):** UE 4.24

#### Possible Drawbacks

Probably we will re-enable this feature in the future, with a better communication client-server

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2754)
<!-- Reviewable:end -->
