### PR TITLE
Fix the mistake in GetLeftLaneMarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Upgraded to AD RSS v3.0.0 supporting complex road layouts and i.e. intersections
   * Added examples of sumo co-simulation for Town01, Town04 and Town05
   * Added ptv vissim and carla co-simulation
+  * Fixed `GetLeftLaneMarking()` from a possible runtime error
   * API extensions:
     - Added new methods to `Map`: `get_all_landmarks`, `get_all_landmarks_from_id` and `get_all_landmarks_of_type`
   * Added synchronization of traffic lights in sumo co-simulation

--- a/LibCarla/source/carla/client/Waypoint.cpp
+++ b/LibCarla/source/carla/client/Waypoint.cpp
@@ -145,7 +145,7 @@ namespace client {
   }
 
   boost::optional<road::element::LaneMarking> Waypoint::GetLeftLaneMarking() const {
-    if (_mark_record.first != nullptr) {
+    if (_mark_record.second != nullptr) {
       return road::element::LaneMarking(*_mark_record.second);
     }
     return boost::optional<road::element::LaneMarking>{};


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

`GetLeftLaneMarking` is supposed to look at the second element of `_mark_record`, not the first one, in terms of context as well as according to the comment. 
* It may cause the runtime error by trying to dereference the null pointer. 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** Python 3.6 and Python 2.7 
  * **Unreal Engine version(s):** 4.22

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2771)
<!-- Reviewable:end -->
