### PR TITLE
Fix windows script to find UE4 directory

### DIFF
--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -14,7 +14,7 @@
 * [__CARLA build__](#carla-build)  
 	* Clone repository  
 	* Get assets  
-	* Set the environment variable 
+	* Set the environment variable  
 	* make CARLA  
 
 The build process can be quite long and tedious. The **[F.A.Q.](build_faq.md)** section contains the most common issues and solutions that appear during the installation. However, the CARLA forum is open for anybody to post unexpected issues, doubts or suggestions. There is a specific section for installation issues on Linux. Feel free to login and become part of the community. 
@@ -93,7 +93,7 @@ python3 spawn_npc.py
 
 ### System specifics
 
-* __Ubuntu 16.04 or later.__ Currently migrating to Ubuntu 18.  
+* __Ubuntu 18.04.__ Since release 0.9.9, CARLA cannot run in Ubuntu 16.04 using default compilers.  
 * __30GB disk space.__ Installing all the software needed and CARLA itself will require quite a lot of space, especially Unreal Engine. Make sure to have around 30/50GB of free disk space.  
 * __An adequate GPU.__ CARLA aims for realistic simulations, so the server needs at least a 4GB GPU. A dedicated GPU is highly recommended for machine learning.  
 * __Two TCP ports and good internet connection.__ 2000 and 2001 by default. Be sure neither the firewall nor any other application block these.  
@@ -168,7 +168,7 @@ Unreal Engine should be installed in the system. Run `Engine/Binaries/Linux/UE4E
 cd ~/UnrealEngine_4.24/Engine/Binaries/Linux && ./UE4Editor
 ```
 
-In case something went wrong, it is related with Unreal Engine There is not much CARLA can do about it. However, the [build documentation](https://wiki.unrealengine.com/Building_On_Linux) provided by Unreal Engine may be helpful.
+In case something went wrong, it is related with Unreal Engine There is not much CARLA can do about it. However, the [build documentation](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Build/BatchFiles/Linux/README.md) provided by Unreal Engine may be helpful.
 
 ---
 ## CARLA build

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -10,6 +10,7 @@
 * [__CARLA build__](#carla-build)  
 	* Clone repository  
 	* Get assets  
+	* Set the environment variable  
 	* make CARLA  
 
 The build process can be quite long and tedious. The **[F.A.Q.](build_faq.md)** section contains the most common issues and solutions that appear during the installation. However, the CARLA forum is open for anybody to post unexpected issues, doubts or suggestions. There is a specific section for installation issues on Linux. Feel free to login and become part of the community. 

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -124,6 +124,15 @@ Only the assets package is yet to be downloaded. `\Util\ContentVersions.txt` con
 
 Download the __latest__ assets to work with the current version of CARLA.
 
+### Set the environment variable
+
+This is necessary for CARLA to find the Unreal Engine installation folder. By doing so, users can choose which specific version of Unreal Engine is to be used. If no environment variable is specified, the CARLA will look up in the directories and use the last version in search order.  
+
+__1.   Open the Windows Control Panel__ and go to `Advanced System Settings`.  
+__2.   On the `Advanced` panel__ open `Environment Variables...`.  
+__3.   Click `New...`__ to create the variable.  
+__4.   Name the variable as `UE4_ROOT`__ and choose the path to the installation folder of the desire UE4 installation.  
+
 ### make CARLA
 
 The last step is to finally build CARLA. There are different `make` commands to build the different modules. All of them run in the root CARLA folder.  

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -63,7 +63,7 @@ The requirements are simpler than those for the build installation.
 
 * __Server side.__ A 4GB minimum GPU will be needed to run a highly realistic environment. A dedicated GPU is highly advised for machine learning.  
 * __Client side.__ [Python](https://www.python.org/downloads/) is necessary to access the API via command line. Also, a good internet connection and two TCP ports (2000 and 2001 by default).  
-* __System requirements.__ Any 64-bits OS should run CARLA.  
+* __System requirements.__ Any 64-bits OS should run CARLA. However, since release 0.9.9, __CARLA cannot run in 16.04 Linux systems with default compilers__. These should be upgraded to work with CARLA.  
 * __Other requirements.__  Two Python modules: [Pygame](https://pypi.org/project/pygame/) to create graphics directly with Python, and [Numpy](https://pypi.org/project/numpy/) for great calculus.  
 
 To install both modules using [pip](https://pip.pypa.io/en/stable/installing/), run the following commands. 

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -14,7 +14,6 @@ rem ============================================================================
 rem -- Parse arguments ---------------------------------------------------------
 rem ============================================================================
 
-set UE_VERSION=4.24
 set BUILD_UE4_EDITOR=false
 set LAUNCH_UE4_EDITOR=false
 set REMOVE_INTERMEDIATE=false
@@ -51,11 +50,15 @@ if %REMOVE_INTERMEDIATE% == false (
     )
 )
 
-rem Extract Unreal Engine root path
+rem Get Unreal Engine root path
 if not defined UE4_ROOT (
-    set KEY_NAME="HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine\%UE_VERSION%"
+    set KEY_NAME="HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine"
     set VALUE_NAME=InstalledDirectory
-    for /f "usebackq tokens=2*" %%A in (`reg query !KEY_NAME! /v !VALUE_NAME! /reg:64`) do set UE4_ROOT=%%B
+    for /f "usebackq tokens=1,2,*" %%A in (`reg query !KEY_NAME! /s /reg:64`) do (
+        if "%%A" == "!VALUE_NAME!" (
+            set UE4_ROOT=%%C
+        )
+    )
     if not defined UE4_ROOT goto error_unreal_no_found
 )
 
@@ -157,5 +160,5 @@ rem ============================================================================
 
 :error_unreal_no_found
     echo.
-    echo %FILE_N% [ERROR] Unreal Engine %UE_VERSION% not detected
+    echo %FILE_N% [ERROR] Unreal Engine not detected
     goto bad_exit

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 rem BAT script that creates the binaries for Carla (carla.org).
 rem Run it through a cmd with the x64 Visual C++ Toolset enabled.
@@ -14,6 +14,7 @@ rem ============================================================================
 rem -- Parse arguments ---------------------------------------------------------
 rem ============================================================================
 
+set UE_VERSION=4.24
 set BUILD_UE4_EDITOR=false
 set LAUNCH_UE4_EDITOR=false
 set REMOVE_INTERMEDIATE=false
@@ -48,6 +49,14 @@ if %REMOVE_INTERMEDIATE% == false (
             goto eof
         )
     )
+)
+
+rem Extract Unreal Engine root path
+if not defined UE4_ROOT (
+    set KEY_NAME="HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine\%UE_VERSION%"
+    set VALUE_NAME=InstalledDirectory
+    for /f "usebackq tokens=2*" %%A in (`reg query !KEY_NAME! /v !VALUE_NAME! /reg:64`) do set UE4_ROOT=%%B
+    if not defined UE4_ROOT goto error_unreal_no_found
 )
 
 rem Set the visual studio solution directory
@@ -145,3 +154,8 @@ rem ============================================================================
 :bad_exit
     endlocal
     exit /b %errorlevel%
+
+:error_unreal_no_found
+    echo.
+    echo %FILE_N% [ERROR] Unreal Engine %UE_VERSION% not detected
+    goto bad_exit

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -22,8 +22,6 @@ set DO_PACKAGE=true
 set DO_COPY_FILES=true
 set DO_TARBALL=true
 set DO_CLEAN=false
-
-set UE_VERSION=4.24
 set PACKAGES=Carla
 
 
@@ -43,10 +41,6 @@ if not "%1"=="" (
 
     if "%1"=="--no-packaging" (
         set DO_PACKAGE=false
-    )
-
-    if "%1"=="--ue-version" (
-        set UE_VERSION=%~2
     )
 
     if "%1"=="--packages" (
@@ -71,13 +65,17 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-rem Extract Unreal Engine root path
-rem
-set KEY_NAME="HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine\%UE_VERSION%"
-set VALUE_NAME=InstalledDirectory
-
-for /f "usebackq tokens=2*" %%A in (`reg query %KEY_NAME% /v %VALUE_NAME% /reg:64`) do set UE4_ROOT=%%B
-if not defined UE4_ROOT goto error_unreal_no_found
+rem Get Unreal Engine root path
+if not defined UE4_ROOT (
+    set KEY_NAME="HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine"
+    set VALUE_NAME=InstalledDirectory
+    for /f "usebackq tokens=1,2,*" %%A in (`reg query !KEY_NAME! /s /reg:64`) do (
+        if "%%A" == "!VALUE_NAME!" (
+            set UE4_ROOT=%%C
+        )
+    )
+    if not defined UE4_ROOT goto error_unreal_no_found
+)
 
 rem Set packaging paths
 rem
@@ -354,7 +352,7 @@ rem ============================================================================
 
 :error_unreal_no_found
     echo.
-    echo %FILE_N% [ERROR] Unreal Engine %UE_VERSION% not detected
+    echo %FILE_N% [ERROR] Unreal Engine not detected
     goto bad_exit
 
 :error_build_editor


### PR DESCRIPTION
#### Description

In Windows build there was a discrepancy on how to get the Unreal Engine directory, so we now use two methods together:

- First it tries to use the environment variable **UE4_ROOT**. If that variable is defined, then we use it.

- If the UE4_ROOT is not defined, then we search on the windows registry for all keys inside:

        HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine\

  the result could be:

        4.21
        4.22
        4.23
        4.24

  then we use always the last one, following the order on the registry, so probably the last installed version of UE will be the one to use.

We get the **InstalledDirectory** of that version and we can continue.

If all these methods fail, the we can not make the windows build.


Fixes #  2776

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** -
  * **Unreal Engine version(s):** UE 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2784)
<!-- Reviewable:end -->
