### PR TITLE
Fixed IMU gravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Fixed rain drop spawn issues when spawning camera sensors
   * Fixed Update.sh from failing when the root folder contains a space on it
   * Fixed missing include directive in file **WheelPhysicsControl.h**
+  * Fixed gravity measurement bug from IMU sensor
 
 ## CARLA 0.9.9
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -122,12 +122,12 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(
   PrevLocation[1] = CurrentLocation;
   PrevDeltaTime = DeltaTime;
 
+  // Add gravitational acceleration
+  FVectorAccelerometer.Z += GRAVITY;
+
   FQuat ImuRotation =
       GetRootComponent()->GetComponentTransform().GetRotation();
   FVectorAccelerometer = ImuRotation.UnrotateVector(FVectorAccelerometer);
-
-  // Add gravitational acceleration
-  FVectorAccelerometer.Z += GRAVITY;
 
   // Cast from FVector to our Vector3D to correctly send the data in m/s^2
   // and apply the desired noise function, in this case a normal distribution


### PR DESCRIPTION
#### Description

On the IMU sensor, there was an issue where acceleration due to gravity was added after rotating the actor acceleration vector to the orientation of the IMU. This meant that there was a constant 9.8 m/s^2 added to the Z axis of the accelerometer readings regardless of the orientation of the accelerometer. This PR changes this so that gravity is added to the Z axis before rotation.

Fixes #2790 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7, 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

If any code has been written to explicitly account for this error, it could break. However, anyone using an IMU in a Z-up orientation (the default) will see almost no changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2795)
<!-- Reviewable:end -->
