### PR TITLE
New API function to add angular impulse to an actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Latest
+
+  * Added API function **add_angular_impulse** to add angular impulse to any actor
+
 ## CARLA 0.9.9
 
   * Introduced hybrid mode for Traffic Manager

--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -82,7 +82,7 @@ export UE4_ROOT=~/UnrealEngine_4.24
 make launch
 make PythonAPI 
 
-# Run an example script to test CARLA. 
+# Press play in the Editor to initialize the server, and run an example script to test CARLA. 
 cd PythonAPI/examples
 python3 spawn_npc.py
 ```

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -48,7 +48,7 @@ git clone https://github.com/carla-simulator/carla
 make launch
 make PythonAPI
 
-# Run an example script to test CARLA. 
+# Press play in the Editor to initialize the server, and run an example script to test CARLA. 
 cd PythonAPI/Examples && python3 spawn_npc.py
 ```
 </details>

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -16,11 +16,11 @@ The identifier of the blueprint this actor was based on, e.g. "vehicle.ford.must
 
 <h3>Methods</h3>
 - <a name="carla.Actor.add_impulse"></a>**<font color="#7fb800">add_impulse</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**impulse**</font>)  
-Adds an impulse to the actor.  
+Adds an impulse to the actor. The parameter `impulse` determines magnitude and global axis where it is applied.  
     - **Parameters:**
         - `impulse` (_[carla.Vector3D](#carla.Vector3D)_)  
 - <a name="carla.Actor.add_angular_impulse"></a>**<font color="#7fb800">add_angular_impulse</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**impulse**</font>)  
-Adds an angular impulse to the actor (in degrees).  
+Adds an angular impulse to the actor. The parameter `impulse` determines magnitude and global axis where it is applied.  
     - **Parameters:**
         - `impulse` (_[carla.Vector3D](#carla.Vector3D)_)  
 - <a name="carla.Actor.destroy"></a>**<font color="#7fb800">destroy</font>**(<font color="#00a6ed">**self**</font>)  
@@ -2455,7 +2455,7 @@ Command adaptation of **<font color="#7fb800">add_angular_impulse()</font>** in 
 - <a name="command.ApplyAngularImpulse.actor_id"></a>**<font color="#f8805a">actor_id</font>** (_int_)  
 Actor affected by the command.  
 - <a name="command.ApplyAngularImpulse.impulse"></a>**<font color="#f8805a">impulse</font>** (_[carla.Vector3D](#carla.Vector3D)_)  
-Angular impulse applied to the actor.  
+Angular impulse applied to the actor. Determines magnitude and global axis where it is applied.  
 
 <h3>Methods</h3>
 - <a name="command.ApplyAngularImpulse.__init__"></a>**<font color="#7fb800">\__init__</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**actor**</font>, <font color="#00a6ed">**impulse**</font>)  

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -19,6 +19,10 @@ The identifier of the blueprint this actor was based on, e.g. "vehicle.ford.must
 Adds an impulse to the actor.  
     - **Parameters:**
         - `impulse` (_[carla.Vector3D](#carla.Vector3D)_)  
+- <a name="carla.Actor.add_angular_impulse"></a>**<font color="#7fb800">add_angular_impulse</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**impulse**</font>)  
+Adds an angular impulse to the actor (in degrees).  
+    - **Parameters:**
+        - `impulse` (_[carla.Vector3D](#carla.Vector3D)_)  
 - <a name="carla.Actor.destroy"></a>**<font color="#7fb800">destroy</font>**(<font color="#00a6ed">**self**</font>)  
 Tells the simulator to destroy this actor and returns <b>True</b> if it was successful. It has no effect if it was already destroyed.  
     - **Return:** _bool_  
@@ -2441,6 +2445,23 @@ Returns __True__ if both **<font color="#f8805a">timestamp</font>** are the same
 - <a name="carla.WorldSnapshot.__ne__"></a>**<font color="#7fb800">\__ne__</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**other**=[carla.WorldSnapshot](#carla.WorldSnapshot)</font>)  
 Returns <b>True</b> if both **<font color="#f8805a">timestamp</font>** are different.  
     - **Return:** _bool_  
+
+---
+
+## command.ApplyAngularImpulse<a name="command.ApplyAngularImpulse"></a>
+Command adaptation of **<font color="#7fb800">add_angular_impulse()</font>** in [carla.Actor](#carla.Actor). Adds angular impulse to an actor.  
+
+<h3>Instance Variables</h3>
+- <a name="command.ApplyAngularImpulse.actor_id"></a>**<font color="#f8805a">actor_id</font>** (_int_)  
+Actor affected by the command.  
+- <a name="command.ApplyAngularImpulse.impulse"></a>**<font color="#f8805a">impulse</font>** (_[carla.Vector3D](#carla.Vector3D)_)  
+Angular impulse applied to the actor.  
+
+<h3>Methods</h3>
+- <a name="command.ApplyAngularImpulse.__init__"></a>**<font color="#7fb800">\__init__</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**actor**</font>, <font color="#00a6ed">**impulse**</font>)  
+    - **Parameters:**
+        - `actor` (_[carla.Actor](#carla.Actor) or int_) – Actor or its ID to whom the command will be applied to.  
+        - `impulse` (_[carla.Vector3D](#carla.Vector3D)_)  
 
 ---
 

--- a/LibCarla/source/carla/client/Actor.cpp
+++ b/LibCarla/source/carla/client/Actor.cpp
@@ -28,10 +28,6 @@ namespace client {
     return GetEpisode().Lock()->GetActorAngularVelocity(*this);
   }
 
-  void Actor::SetAngularVelocity(const geom::Vector3D &vector) {
-    GetEpisode().Lock()->SetActorAngularVelocity(*this, vector);
-  }
-
   geom::Vector3D Actor::GetAcceleration() const {
     return GetEpisode().Lock()->GetActorAcceleration(*this);
   }
@@ -48,8 +44,16 @@ namespace client {
     GetEpisode().Lock()->SetActorVelocity(*this, vector);
   }
 
+  void Actor::SetAngularVelocity(const geom::Vector3D &vector) {
+    GetEpisode().Lock()->SetActorAngularVelocity(*this, vector);
+  }
+
   void Actor::AddImpulse(const geom::Vector3D &vector) {
     GetEpisode().Lock()->AddActorImpulse(*this, vector);
+  }
+
+  void Actor::AddAngularImpulse(const geom::Vector3D &vector) {
+    GetEpisode().Lock()->AddActorAngularImpulse(*this, vector);
   }
 
   void Actor::SetSimulatePhysics(const bool enabled) {

--- a/LibCarla/source/carla/client/Actor.h
+++ b/LibCarla/source/carla/client/Actor.h
@@ -67,14 +67,17 @@ namespace client {
     /// Set the actor velocity.
     void SetVelocity(const geom::Vector3D &vector);
 
+    /// Set the angular velocity of the actor
+    void SetAngularVelocity(const geom::Vector3D &vector);
+
     /// Add impulse to the actor.
     void AddImpulse(const geom::Vector3D &vector);
 
+    /// Add angular impulse to the actor.
+    void AddAngularImpulse(const geom::Vector3D &vector);
+
     /// Enable or disable physics simulation on this actor.
     void SetSimulatePhysics(bool enabled = true);
-
-    /// Set the angular velocity of the actor
-    void SetAngularVelocity(const geom::Vector3D &vector);
 
     /// @warning This method only checks whether this instance of Actor has
     /// called the Destroy() method, it does not check whether the actor is

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -269,6 +269,10 @@ namespace detail {
     _pimpl->AsyncCall("add_actor_impulse", actor, vector);
   }
 
+  void Client::AddActorAngularImpulse(rpc::ActorId actor, const geom::Vector3D &vector) {
+    _pimpl->AsyncCall("add_actor_angular_impulse", actor, vector);
+  }
+
   void Client::SetActorSimulatePhysics(rpc::ActorId actor, const bool enabled) {
     _pimpl->AsyncCall("set_actor_simulate_physics", actor, enabled);
   }

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -159,6 +159,10 @@ namespace detail {
         rpc::ActorId actor,
         const geom::Vector3D &vector);
 
+    void AddActorAngularImpulse(
+        rpc::ActorId actor,
+        const geom::Vector3D &vector);
+
     void SetActorSimulatePhysics(
         rpc::ActorId actor,
         bool enabled);

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -325,6 +325,10 @@ namespace detail {
       _client.AddActorImpulse(actor.GetId(), vector);
     }
 
+    void AddActorAngularImpulse(const Actor &actor, const geom::Vector3D &vector) {
+      _client.AddActorAngularImpulse(actor.GetId(), vector);
+    }
+
     geom::Vector3D GetActorAcceleration(const Actor &actor) const {
       return GetActorSnapshot(actor).acceleration;
     }

--- a/LibCarla/source/carla/rpc/Command.h
+++ b/LibCarla/source/carla/rpc/Command.h
@@ -131,6 +131,16 @@ namespace rpc {
       MSGPACK_DEFINE_ARRAY(actor, impulse);
     };
 
+    struct ApplyAngularImpulse : CommandBase<ApplyAngularImpulse> {
+      ApplyAngularImpulse() = default;
+      ApplyAngularImpulse(ActorId id, const geom::Vector3D &value)
+        : actor(id),
+          impulse(value) {}
+      ActorId actor;
+      geom::Vector3D impulse;
+      MSGPACK_DEFINE_ARRAY(actor, impulse);
+    };
+
     struct SetSimulatePhysics : CommandBase<SetSimulatePhysics> {
       SetSimulatePhysics() = default;
       SetSimulatePhysics(ActorId id, bool value)
@@ -168,6 +178,7 @@ namespace rpc {
         ApplyVelocity,
         ApplyAngularVelocity,
         ApplyImpulse,
+        ApplyAngularImpulse,
         SetSimulatePhysics,
         SetAutopilot>;
 

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -86,6 +86,7 @@ void export_actor() {
       .def("set_velocity", &cc::Actor::SetVelocity, (arg("vector")))
       .def("set_angular_velocity", &cc::Actor::SetAngularVelocity, (arg("vector")))
       .def("add_impulse", &cc::Actor::AddImpulse, (arg("vector")))
+      .def("add_angular_impulse", &cc::Actor::AddAngularImpulse, (arg("vector")))
       .def("set_simulate_physics", &cc::Actor::SetSimulatePhysics, (arg("enabled") = true))
       .def("destroy", CALL_WITHOUT_GIL(cc::Actor, Destroy))
       .def(self_ns::str(self_ns::self))

--- a/PythonAPI/carla/source/libcarla/Commands.cpp
+++ b/PythonAPI/carla/source/libcarla/Commands.cpp
@@ -144,6 +144,13 @@ void export_commands() {
     .def_readwrite("impulse", &cr::Command::ApplyImpulse::impulse)
   ;
 
+  class_<cr::Command::ApplyAngularImpulse>("ApplyAngularImpulse")
+    .def("__init__", &command_impl::CustomInit<ActorPtr, cg::Vector3D>, (arg("actor"), arg("impulse")))
+    .def(init<cr::ActorId, cg::Vector3D>((arg("actor_id"), arg("impulse"))))
+    .def_readwrite("actor_id", &cr::Command::ApplyAngularImpulse::actor)
+    .def_readwrite("impulse", &cr::Command::ApplyAngularImpulse::impulse)
+  ;
+
   class_<cr::Command::SetSimulatePhysics>("SetSimulatePhysics")
     .def("__init__", &command_impl::CustomInit<ActorPtr, bool>, (arg("actor"), arg("enabled")))
     .def(init<cr::ActorId, bool>((arg("actor_id"), arg("enabled"))))
@@ -168,6 +175,7 @@ void export_commands() {
   implicitly_convertible<cr::Command::ApplyVelocity, cr::Command>();
   implicitly_convertible<cr::Command::ApplyAngularVelocity, cr::Command>();
   implicitly_convertible<cr::Command::ApplyImpulse, cr::Command>();
+  implicitly_convertible<cr::Command::ApplyAngularImpulse, cr::Command>();
   implicitly_convertible<cr::Command::SetSimulatePhysics, cr::Command>();
   implicitly_convertible<cr::Command::SetAutopilot, cr::Command>();
 }

--- a/PythonAPI/docs/actor.yml
+++ b/PythonAPI/docs/actor.yml
@@ -38,6 +38,13 @@
       doc: >
         Adds an impulse to the actor.
     # --------------------------------------
+    - def_name: add_angular_impulse
+      params:
+      - param_name: impulse
+        type: carla.Vector3D
+      doc: >
+        Adds an angular impulse to the actor (in degrees).
+    # --------------------------------------
     - def_name: destroy
       return: bool
       doc: >

--- a/PythonAPI/docs/actor.yml
+++ b/PythonAPI/docs/actor.yml
@@ -36,14 +36,14 @@
       - param_name: impulse
         type: carla.Vector3D
       doc: >
-        Adds an impulse to the actor.
+        Adds an impulse to the actor. The parameter `impulse` determines magnitude and global axis where it is applied.  
     # --------------------------------------
     - def_name: add_angular_impulse
       params:
       - param_name: impulse
         type: carla.Vector3D
       doc: >
-        Adds an angular impulse to the actor (in degrees).
+        Adds an angular impulse to the actor. The parameter `impulse` determines magnitude and global axis where it is applied.  
     # --------------------------------------
     - def_name: destroy
       return: bool

--- a/PythonAPI/docs/commands.yml
+++ b/PythonAPI/docs/commands.yml
@@ -281,7 +281,7 @@
   - class_name: ApplyAngularImpulse
     # - DESCRIPTION ------------------------
     doc: >
-      Command adaptation of **<font color="#7fb800">add_angular_impulse()</font>** in carla.Actor. Adds angular impulse to an actor.
+      Command adaptation of **<font color="#7fb800">add_angular_impulse()</font>** in carla.Actor. Adds angular impulse to an actor.  
     # - PROPERTIES -------------------------
     instance_variables:
     - var_name: actor_id
@@ -291,7 +291,7 @@
     - var_name: impulse
       type: carla.Vector3D
       doc: >
-        Angular impulse applied to the actor. 
+        Angular impulse applied to the actor. Determines magnitude and global axis where it is applied.  
     # - METHODS ----------------------------
     methods:
     - def_name: __init__

--- a/PythonAPI/docs/commands.yml
+++ b/PythonAPI/docs/commands.yml
@@ -278,6 +278,32 @@
         type: carla.Vector3D
     # --------------------------------------
 
+  - class_name: ApplyAngularImpulse
+    # - DESCRIPTION ------------------------
+    doc: >
+      Command adaptation of **<font color="#7fb800">add_angular_impulse()</font>** in carla.Actor. Adds angular impulse to an actor.
+    # - PROPERTIES -------------------------
+    instance_variables:
+    - var_name: actor_id
+      type: int
+      doc: >
+        Actor affected by the command. 
+    - var_name: impulse
+      type: carla.Vector3D
+      doc: >
+        Angular impulse applied to the actor. 
+    # - METHODS ----------------------------
+    methods:
+    - def_name: __init__
+      params:
+      - param_name: actor
+        type: carla.Actor or int
+        doc: > 
+          Actor or its ID to whom the command will be applied to. 
+      - param_name: impulse
+        type: carla.Vector3D
+    # --------------------------------------
+
   - class_name: SetSimulatePhysics
     # - DESCRIPTION ------------------------
     doc: >

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -586,6 +586,28 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
+  BIND_SYNC(add_actor_angular_impulse) << [this](
+      cr::ActorId ActorId,
+      cr::Vector3D vector) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    auto ActorView = Episode->FindActor(ActorId);
+    if (!ActorView.IsValid())
+    {
+      RESPOND_ERROR("unable to add actor angular impulse: actor not found");
+    }
+    auto RootComponent = Cast<UPrimitiveComponent>(ActorView.GetActor()->GetRootComponent());
+    if (RootComponent == nullptr)
+    {
+      RESPOND_ERROR("unable to add actor angular impulse: not supported by actor");
+    }
+    RootComponent->AddAngularImpulseInDegrees(
+        vector.ToFVector(),
+        "None",
+        false);
+    return R<void>::Success();
+  };
+
   BIND_SYNC(get_physics_control) << [this](
       cr::ActorId ActorId) -> R<cr::VehiclePhysicsControl>
   {
@@ -1031,6 +1053,7 @@ void FCarlaServer::FPimpl::BindActions()
       [=](auto, const C::ApplyVelocity &c) {        MAKE_RESULT(set_actor_velocity(c.actor, c.velocity)); },
       [=](auto, const C::ApplyAngularVelocity &c) { MAKE_RESULT(set_actor_angular_velocity(c.actor, c.angular_velocity)); },
       [=](auto, const C::ApplyImpulse &c) {         MAKE_RESULT(add_actor_impulse(c.actor, c.impulse)); },
+      [=](auto, const C::ApplyAngularImpulse &c) {  MAKE_RESULT(add_actor_angular_impulse(c.actor, c.impulse)); },
       [=](auto, const C::SetSimulatePhysics &c) {   MAKE_RESULT(set_actor_simulate_physics(c.actor, c.enabled)); },
       // TODO: SetAutopilot should be removed. This is the old way to control the vehicles
       [=](auto, const C::SetAutopilot &c) {         MAKE_RESULT(set_actor_autopilot(c.actor, c.enabled)); },


### PR DESCRIPTION
#### Description

New API function **actor.add_angular_impulse(vector)**
It sends an angular impulse to the actor.

The **vector** has this characteristics:

* in **world** coordinates
* in **degree** units
* defines the **axis** of rotation
* the magnitude is the **strength** of the impulse

It takes into account the **mass** of the actor, so for massive actors you need bigger impulse (magnitude of the vector).

You can use it as a function like:

`actor.add_angular_impulse(carla.Vector3D(0, 100, 0))`

or as a command batch:

`batch = []`
`batch.append(carla.command.ApplyAngularImpulse(actor, carla.Vector3D(0, 100, 0)))`
`client.apply_batch(batch, True)`

Both will apply an angular impulse of 100 degrees on the world Y axis (pitch).

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** Python 3.7
  * **Unreal Engine version(s):** UE 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2813)
<!-- Reviewable:end -->
