### PR TITLE
OpenDRIVE ingestion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fixed Update.sh from failing when the root folder contains a space on it
   * Fixed missing include directive in file **WheelPhysicsControl.h**
   * Fixed gravity measurement bug from IMU sensor
+  * OpenDRIVE ingestion bugfixes
 
 ## CARLA 0.9.9
 

--- a/LibCarla/source/carla/client/Waypoint.cpp
+++ b/LibCarla/source/carla/client/Waypoint.cpp
@@ -87,7 +87,11 @@ namespace client {
       remaining_length = current_s;
     }
     remaining_length -= std::numeric_limits<double>::epsilon();
-    result.emplace_back(result.back()->GetNext(remaining_length).front());
+    if(result.size()) {
+      result.emplace_back(result.back()->GetNext(remaining_length).front());
+    } else {
+      result.emplace_back(GetNext(remaining_length).front());
+    }
 
     return result;
   }
@@ -114,7 +118,11 @@ namespace client {
       remaining_length = current_s;
     }
     remaining_length -= std::numeric_limits<double>::epsilon();
-    result.emplace_back(result.back()->GetPrevious(remaining_length).front());
+    if(result.size()) {
+      result.emplace_back(result.back()->GetPrevious(remaining_length).front());
+    } else {
+      result.emplace_back(GetPrevious(remaining_length).front());
+    }
 
     return result;
   }

--- a/LibCarla/source/carla/geom/MeshFactory.cpp
+++ b/LibCarla/source/carla/geom/MeshFactory.cpp
@@ -17,6 +17,7 @@ namespace geom {
   /// We use this epsilon to shift the waypoints away from the edges of the lane
   /// sections to avoid floating point precision errors.
   static constexpr double EPSILON = 10.0 * std::numeric_limits<double>::epsilon();
+  static constexpr double MESH_EPSILON = 50.0 * std::numeric_limits<double>::epsilon();
 
   std::unique_ptr<Mesh> MeshFactory::Generate(const road::Road &road) const {
     Mesh out_mesh;
@@ -77,7 +78,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
       vertices.push_back(edges.first);
       vertices.push_back(edges.second);
     }
@@ -150,7 +151,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
       r_vertices.push_back(edges.first + height_vector);
       r_vertices.push_back(edges.first);
     }
@@ -201,7 +202,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
       l_vertices.push_back(edges.second);
       l_vertices.push_back(edges.second + height_vector);
     }

--- a/LibCarla/source/carla/geom/MeshFactory.cpp
+++ b/LibCarla/source/carla/geom/MeshFactory.cpp
@@ -78,7 +78,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end - MESH_EPSILON, road_param.extra_lane_width);
       vertices.push_back(edges.first);
       vertices.push_back(edges.second);
     }
@@ -151,7 +151,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end - MESH_EPSILON, road_param.extra_lane_width);
       r_vertices.push_back(edges.first + height_vector);
       r_vertices.push_back(edges.first);
     }
@@ -202,7 +202,7 @@ namespace geom {
     // This ensures the mesh is constant and have no gaps between roads,
     // adding geometry at the very end of the lane
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
-      const auto edges = lane.GetCornerPositions(s_end * MESH_EPSILON, road_param.extra_lane_width);
+      const auto edges = lane.GetCornerPositions(s_end - MESH_EPSILON, road_param.extra_lane_width);
       l_vertices.push_back(edges.second);
       l_vertices.push_back(edges.second + height_vector);
     }

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -185,7 +185,7 @@ namespace road {
       } else if (delta_s <= 0) {
         return result_start;
       } else {
-        return GetNext(result_start, distance_to_segment.first).front();
+        return GetNext(result_start, delta_s).front();
       }
     } else {
       double delta_s = distance_to_segment.first;
@@ -195,7 +195,7 @@ namespace road {
       } else if (delta_s <= 0) {
         return result_start;
       } else {
-        return GetNext(result_start, distance_to_segment.first).front();
+        return GetNext(result_start, delta_s).front();
       }
     }
   }

--- a/LibCarla/source/carla/road/MapBuilder.cpp
+++ b/LibCarla/source/carla/road/MapBuilder.cpp
@@ -840,7 +840,10 @@ namespace road {
         for (int i = 0; i < number_intervals; ++i) {
           if (interval < std::numeric_limits<double>::epsilon())
             break;
-          next_wp = map.GetNext(next_wp, interval).back();
+          auto next = map.GetNext(next_wp, interval);
+          if(next.size()){
+            next_wp = next.back();
+          }
 
           location = map.ComputeTransform(next_wp).location;
           get_min_max(location);

--- a/LibCarla/source/carla/road/element/Geometry.cpp
+++ b/LibCarla/source/carla/road/element/Geometry.cpp
@@ -136,10 +136,11 @@ namespace element {
     double current_s = 0;
     double current_u = 0;
     double last_u = 0;
-    double last_v = 0;
+    double last_v = _poly.Evaluate(current_u);
     double last_s = 0;
-    RtreeValue last_val;
+    RtreeValue last_val{last_u, last_v, last_s, _poly.Tangent(current_u)};
     while (current_s < _length + delta_u) {
+      current_u += delta_u;
       double current_v = _poly.Evaluate(current_u);
       double du = current_u - last_u;
       double dv = current_v - last_v;
@@ -157,7 +158,6 @@ namespace element {
       last_s = current_s;
       last_val = current_val;
 
-      current_u += delta_u;
     }
   }
 
@@ -167,7 +167,6 @@ namespace element {
 
     auto &val1 = result.second.first;
     auto &val2 = result.second.second;
-
     double rate = (val2.s - dist) / (val2.s - val1.s);
     double u = rate * val1.u + (1.0 - rate) * val2.u;
     double v = rate * val1.v + (1.0 - rate) * val2.v;
@@ -195,11 +194,17 @@ namespace element {
     }
     double param_p = 0;
     double current_s = 0;
-    double last_u = 0;
-    double last_v = 0;
+    double last_u = _polyU.Evaluate(param_p);
+    double last_v = _polyV.Evaluate(param_p);
     double last_s = 0;
-    RtreeValue last_val;
+    RtreeValue last_val{
+        last_u,
+        last_v,
+        last_s,
+        _polyU.Tangent(param_p),
+        _polyV.Tangent(param_p) };
     for(size_t i = 0; i < number_intervals; ++i) {
+      param_p += delta_p;
       double current_u = _polyU.Evaluate(param_p);
       double current_v = _polyV.Evaluate(param_p);
       double du = current_u - last_u;
@@ -224,7 +229,6 @@ namespace element {
       last_s = current_s;
       last_val = current_val;
 
-      param_p += delta_p;
       if(current_s > _length){
         break;
       }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -11,6 +11,7 @@
 #include "Components/BoxComponent.h"
 
 #include <compiler/disable-ue4-macros.h>
+#include <carla/rpc/String.h>
 #include <carla/road/SignalType.h>
 #include <compiler/enable-ue4-macros.h>
 
@@ -254,6 +255,17 @@ void ATrafficLightManager::SpawnTrafficLights()
   }
   for(auto &SignalId : SignalsToSpawn)
   {
+    // TODO: should this be an assert?
+    // RELEASE_ASSERT(
+    //     Signals.count(SignalId) > 0,
+    //     "Reference to inexistent signal. Possible OpenDRIVE error.");
+    if (Signals.count(SignalId) == 0)
+    {
+      UE_LOG(LogCarla, Warning,
+          TEXT("Possible OpenDRIVE error, reference to nonexistent signal id: %s"),
+          *carla::rpc::ToFString(SignalId));
+      continue;
+    }
     const auto& Signal = Signals.at(SignalId);
     auto CarlaTransform = Signal->GetTransform();
     FTransform SpawnTransform(CarlaTransform);


### PR DESCRIPTION
#### Description

* Fixed poly geometries problems at `s = 0`, crash when computing the junction's bounding box
* Fixed crash in `GetNextUntilLaneEnd`, and `GetPreviousUntilLaneStart` for very short roads.
* Fixed a particular case of a floating-point error in mesh generation
* Fixed traffic light ingestion from wrongly defined OpenDRIVE that crashes the simulation when using the OpenDRIVE standalone mode

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2828)
<!-- Reviewable:end -->
