### PR TITLE
Replaced use of reserved keyword None in PythonAPI

### DIFF
--- a/PythonAPI/carla/source/libcarla/LightManager.cpp
+++ b/PythonAPI/carla/source/libcarla/LightManager.cpp
@@ -294,7 +294,7 @@ void export_lightmanager() {
     using namespace boost::python;
 
     enum_<cr::LightState::LightGroup>("LightGroup")
-      .value("None", cr::LightState::LightGroup::None)
+      .value("NONE", cr::LightState::LightGroup::None)
       .value("Vehicle", cr::LightState::LightGroup::Vehicle)
       .value("Street", cr::LightState::LightGroup::Street)
       .value("Building", cr::LightState::LightGroup::Building)


### PR DESCRIPTION
#### Description

Quick fix on LightGroup names. The python binding was using None which is a reserved keyword on Python. It was replaced by NONE

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2839)
<!-- Reviewable:end -->
