### PR TITLE
Fix sign creation on imported maps

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -12,6 +12,28 @@
 #include "HAL/PlatformFilemanager.h"
 #include "UObject/ConstructorHelpers.h"
 
+static bool ValidateStaticMesh(UStaticMesh* Mesh) {
+  FString AssetName = Mesh->GetName();
+
+  if (  AssetName.Contains(TEXT("light"), ESearchCase::IgnoreCase) ||
+        AssetName.Contains(TEXT("sign"),  ESearchCase::IgnoreCase) ) {
+    return false;
+  }
+
+  for(int i = 0; i < Mesh->StaticMaterials.Num(); i++) {
+      UMaterialInterface* Material = Mesh->GetMaterial(i);
+      FString MaterialName = Material->GetName();
+
+      if (  MaterialName.Contains(TEXT("light"), ESearchCase::IgnoreCase) ||
+            MaterialName.Contains(TEXT("sign"),  ESearchCase::IgnoreCase) ) {
+        return false;
+      }
+  }
+
+  return true;
+}
+
+
 UPrepareAssetsForCookingCommandlet::UPrepareAssetsForCookingCommandlet()
 {
   // Set necessary flags to run commandlet
@@ -24,11 +46,11 @@ UPrepareAssetsForCookingCommandlet::UPrepareAssetsForCookingCommandlet()
   // Get Carla Default materials, these will be used for maps that need to use
   // Carla materials
   static ConstructorHelpers::FObjectFinder<UMaterial> MarkingNode(TEXT(
-      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_W.M_MarkingLane_W'"));
+      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_Y.M_MarkingLane_Y'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> RoadNode(TEXT(
       "Material'/Game/Carla/Static/GenericMaterials/Masters/LowComplexity/M_Road1.M_Road1'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> RoadNodeAux(TEXT(
-      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_Y.M_MarkingLane_Y'"));
+      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_W.M_MarkingLane_W'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> TerrainNodeMaterial(TEXT(
       "Material'/Game/Carla/Static/GenericMaterials/Grass/M_Grass01.M_Grass01'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> SidewalkNode(TEXT(
@@ -105,7 +127,7 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
   {
     // Spawn Static Mesh
     MeshAsset = Cast<UStaticMesh>(MapAsset.GetAsset());
-    if (MeshAsset)
+    if (MeshAsset && ValidateStaticMesh(MeshAsset) )
     {
       MeshActor = World->SpawnActor<AStaticMeshActor>(AStaticMeshActor::StaticClass(), zeroTransform);
       UStaticMeshComponent *MeshComponent = MeshActor->GetStaticMeshComponent();
@@ -128,6 +150,10 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
         BodySetup->CollisionTraceFlag = CTF_UseComplexAsSimple;
         MeshAsset->MarkPackageDirty();
       }
+
+      // rotate all meshes 180 degrees to fit with OpenDRIVE info
+      // (seems that new version of RoadRunner is doing this)
+      // MeshActor->SetActorRotation(FRotator(0.0f, 180.0f, 0.0f));
 
       SpawnedMeshes.Add(MeshActor);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -46,11 +46,11 @@ UPrepareAssetsForCookingCommandlet::UPrepareAssetsForCookingCommandlet()
   // Get Carla Default materials, these will be used for maps that need to use
   // Carla materials
   static ConstructorHelpers::FObjectFinder<UMaterial> MarkingNode(TEXT(
-      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_Y.M_MarkingLane_Y'"));
+      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_W.M_MarkingLane_W'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> RoadNode(TEXT(
       "Material'/Game/Carla/Static/GenericMaterials/Masters/LowComplexity/M_Road1.M_Road1'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> RoadNodeAux(TEXT(
-      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_W.M_MarkingLane_W'"));
+      "Material'/Game/Carla/Static/GenericMaterials/LaneMarking/M_MarkingLane_Y.M_MarkingLane_Y'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> TerrainNodeMaterial(TEXT(
       "Material'/Game/Carla/Static/GenericMaterials/Grass/M_Grass01.M_Grass01'"));
   static ConstructorHelpers::FObjectFinder<UMaterial> SidewalkNode(TEXT(
@@ -150,10 +150,6 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
         BodySetup->CollisionTraceFlag = CTF_UseComplexAsSimple;
         MeshAsset->MarkPackageDirty();
       }
-
-      // rotate all meshes 180 degrees to fit with OpenDRIVE info
-      // (seems that new version of RoadRunner is doing this)
-      // MeshActor->SetActorRotation(FRotator(0.0f, 180.0f, 0.0f));
 
       SpawnedMeshes.Add(MeshActor);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -17,6 +17,8 @@
 #include "DrawDebugHelpers.h"
 #include "Kismet/KismetSystemLibrary.h"
 
+#include "Carla/Traffic/TrafficLightManager.h"
+
 ACarlaGameModeBase::ACarlaGameModeBase(const FObjectInitializer& ObjectInitializer)
   : Super(ObjectInitializer)
 {
@@ -62,6 +64,12 @@ void ACarlaGameModeBase::InitGame(
 
   auto World = GetWorld();
   check(World != nullptr);
+
+  AActor* TrafficLightManagerActor =  UGameplayStatics::GetActorOfClass(World, ATrafficLightManager::StaticClass());
+  if(TrafficLightManagerActor == nullptr) {
+    World->SpawnActor<ATrafficLightManager>();
+  }
+
 
   GameInstance = Cast<UCarlaGameInstance>(GetGameInstance());
   checkf(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
@@ -176,6 +176,12 @@ void AOpenDriveGenerator::BeginPlay()
 
   GenerateAll();
 
+  auto World = GetWorld();
+  check(World != nullptr);
+
   // Autogenerate signals
-  GetWorld()->SpawnActor<ATrafficLightManager>();
+  AActor* TrafficLightManagerActor =  UGameplayStatics::GetActorOfClass(World, ATrafficLightManager::StaticClass());
+  if(TrafficLightManagerActor == nullptr) {
+    World->SpawnActor<ATrafficLightManager>();
+  }
 }


### PR DESCRIPTION
#### Description

The signs where not created properly on imported maps.

Also sign prop duplication was fixed.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2, 3
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

Props with names that contains "light" or "sign" or if their materials contains "light" or "sign" on their name, will not be imported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2852)
<!-- Reviewable:end -->
