### PR TITLE
Replace deprecated function call in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ matrix:
       install:
         - pip2 install -q --user setuptools
         - pip2 install -q --user -r PythonAPI/test/requirements.txt
+        - pip2 install -q --user -r PythonAPI/carla/requirements.txt
         - pip3 install -q --user setuptools
         - pip3 install -q --user -r PythonAPI/test/requirements.txt
+        - pip3 install -q --user -r PythonAPI/carla/requirements.txt
       script:
         - while sleep 2m; do echo "still building..."; done &
         - make setup >> build.log 2>&1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   * Fixed collision issues when debug draw(debug.draw_line) is called
   * Fixed Gyroscope sensor to properly give angular velocity readings in local frame
   * Added Renderdoc plugin to the Unreal project.
+  * Replace deprectated `platform.dist()` with recommended `distro.linux_distribution()`
 
 ## CARLA 0.9.9
 

--- a/PythonAPI/carla/requirements.txt
+++ b/PythonAPI/carla/requirements.txt
@@ -1,3 +1,4 @@
 networkx
 numpy; python_version < '3.0'
 numpy==1.18.4; python_version >= '3.0'
+distro

--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -10,7 +10,6 @@ from setuptools import setup, Extension
 
 import fnmatch
 import os
-import platform
 import sys
 
 def is_rss_variant_enabled():
@@ -33,8 +32,9 @@ def get_libcarla_extensions():
                 yield os.path.join(root, filename)
 
     if os.name == "posix":
-        # @todo Replace deprecated method.
-        linux_distro = platform.dist()[0]  # pylint: disable=W1505
+        import distro
+
+        linux_distro = distro.linux_distribution()[0]
         if linux_distro.lower() in ["ubuntu", "debian", "deepin"]:
             pwd = os.path.dirname(os.path.realpath(__file__))
             pylib = "libboost_python%d%d.a" % (sys.version_info.major,

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -369,17 +369,6 @@ fi
 unset RECAST_BASENAME
 
 # ==============================================================================
-# -- Install python requirements -----------------------------------------------
-# ==============================================================================
-
-log "Installing python requirements"
-
-pip2 install --ignore-installed --user setuptools==44.1.1
-pip2 install --user distro
-pip3 install --ignore-installed --user setuptools
-pip3 install --user distro
-
-# ==============================================================================
 # -- Generate Version.h --------------------------------------------------------
 # ==============================================================================
 

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -369,6 +369,17 @@ fi
 unset RECAST_BASENAME
 
 # ==============================================================================
+# -- Install python requirements -----------------------------------------------
+# ==============================================================================
+
+log "Installing python requirements"
+
+pip2 install --ignore-installed --user setuptools==44.1.1
+pip2 install --user distro
+pip3 install --ignore-installed --user setuptools
+pip3 install --user distro
+
+# ==============================================================================
 # -- Generate Version.h --------------------------------------------------------
 # ==============================================================================
 


### PR DESCRIPTION
#### Description

Replaced the deprecated function call `platform.dist()` with recommended `distro.linux_distribution()` in `setup.py`. Recommendation is from the python docs of the platform module: https://docs.python.org/3.7/library/platform.html#unix-platforms

The deprecated call is removed in Python 3.8 which is default Python version of Ubuntu 20.04.

#### Where has this been tested?

  * **Platform(s):** 18.04
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

No drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2857)
<!-- Reviewable:end -->
