### PR TITLE
[Debian Package] Add support for new carla releases

### DIFF
--- a/Util/CreateDebian.sh
+++ b/Util/CreateDebian.sh
@@ -1,92 +1,113 @@
-#!/bin/sh
+#!/bin/bash
 
-#This script builds debian package for CARLA
-#Tested with Ubuntu 14.04, 16.04, 18.04 and 19.10
+# Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
 
-sudo apt-get install build-essential dh-make
+# This script builds a debian package for CARLA.
+#
+# Usage:
+#     $ ./CreateDebian.sh <CARLA-VERSION>
+#
+# Tested with Ubuntu 14.04, 16.04, 18.04 and 19.10.
+#
+# IMPORTANT: Add/remove the appropriate folders in Makefile at line 81.
 
-#Adding maintainer name
+# ==================================================================================================
+# -- Variables -------------------------------------------------------------------------------------
+# ==================================================================================================
+
+if [[ -z $1 ]];
+then
+  echo `date`" - Missing mandatory arguments: CARLA version. "
+  echo `date`" - Usage: ./CreateDebian.sh [version]. "
+  exit 1
+fi
+
+CARLA_VERSION=$1
+CARLA_DIR=carla-simulator-${CARLA_VERSION}
+CARLA_RELEASE_URL=https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_${CARLA_VERSION}.tar.gz
+ADDITIONAL_MAPS_URL=https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/AdditionalMaps_${CARLA_VERSION}.tar.gz
+
+# Adding maintainer name.
 DEBFULLNAME=Carla\ Simulator\ Team
 export DEBFULLNAME
 
-#replace CARLA_VERSION with your required carla-<version>
-CARLA_VERSION=0.9.9
-CARLA_DIR=carla-${CARLA_VERSION}
+# ==================================================================================================
+# -- Dependencies ----------------------------------------------------------------------------------
+# ==================================================================================================
+# Installing required dependencies.
+sudo apt-get install build-essential dh-make
 
-#replace the url with your carla release url
-CARLA_RELEASE_REPO=http://carla-assets-internal.s3.amazonaws.com/Releases/Linux/CARLA_${CARLA_VERSION}.tar.gz
-
-#replace the url with your required additional maps url
-#if you do not have additional map then comment line 21, 22, 40, 41
-ADDITIONALMAPS=http://carla-assets-internal.s3.amazonaws.com/Releases/Linux/AdditionalMaps_${CARLA_VERSION}.tar.gz
-ADDITIONALMAPS_TAR=AdditionalMaps_${CARLA_VERSION}.tar.gz
-
+# ==================================================================================================
+# -- Download --------------------------------------------------------------------------------------
+# ==================================================================================================
 mkdir -p carla-debian/${CARLA_DIR}
 cd carla-debian/${CARLA_DIR}
 
-#Check if Carla-<version> release is already downloaded
 FILE=$(pwd)/ImportAssets.sh
 if [ -f "$FILE" ]; then
-	ImportAssetscheck=1
+  echo "Package already downloaded!"
 else
-	ImportAssetscheck=0
+  curl ${CARLA_RELEASE_URL} | tar xz
+
+  wget ${ADDITIONAL_MAPS_URL}
+  mv AdditionalMaps_${CARLA_VERSION}.tar.gz Import/
 fi
 
-#If carla release is not already downloaded then it will download
-if [ ${ImportAssetscheck} == 0 ]
-then
-	curl ${CARLA_RELEASE_REPO} | tar xz
+# Importing new maps.
+./ImportAssets.sh
 
-	wget ${ADDITIONALMAPS}
-	mv ${ADDITIONALMAPS_TAR} Import/
-
-fi
-
-./ImportAssets.sh #importing new maps
-
-#removing unnecessary files
+# Removing unnecessary files
 rm CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping.debug
 rm CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping.sym
 
+# ==================================================================================================
+# -- Debian package --------------------------------------------------------------------------------
+# ==================================================================================================
+# Updating CarlaUE4.sh script
 rm CarlaUE4.sh
 cat >> CarlaUE4.sh <<EOF
 #!/bin/sh
-
-chmod +x "/opt/carla/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping"
-"/opt/carla/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping" CarlaUE4 $@
+sudo chmod +x "/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping"
+"/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping" CarlaUE4 $@
 EOF
 
-
+# Making debian package to install Carla in /opt folder
 rm Makefile
 
-#Making debian package to install Carla in /opt folder
 cat >> Makefile <<EOF
 binary:
 	# we are not going to build anything
 
 install:
-	mkdir -p \$(DESTDIR)/opt/carla/bin
-	cp  CarlaUE4.sh \$(DESTDIR)/opt/carla/bin
-	cp ImportAssets.sh \$(DESTDIR)/opt/carla
-	cp -r CarlaUE4 \$(DESTDIR)/opt/carla
-	cp -r Engine \$(DESTDIR)/opt/carla
-	cp -r Import \$(DESTDIR)/opt/carla
-	cp -r PythonAPI \$(DESTDIR)/opt/carla
+	mkdir -p \$(DESTDIR)/opt/carla-simulator/bin
+	cp CarlaUE4.sh \$(DESTDIR)/opt/carla-simulator/bin
+	cp ImportAssets.sh \$(DESTDIR)/opt/carla-simulator
+	cp -r CarlaUE4 \$(DESTDIR)/opt/carla-simulator
+	cp -r Engine \$(DESTDIR)/opt/carla-simulator
+	cp -r Import \$(DESTDIR)/opt/carla-simulator
+	cp -r PythonAPI \$(DESTDIR)/opt/carla-simulator
+	cp -r Co-Simulation \$(DESTDIR)/opt/carla-simulator
+	cp -r Tools \$(DESTDIR)/opt/carla-simulator
 EOF
 
-dh_make -e carla.simulator@gmail.com --indep --createorig -y  #to create necessary file structure for debian packaging
+# Create necessary file structure for debian packaging
+timeout --signal=SIGINT 10 dh_make -e carla.simulator@gmail.com --indep --createorig -y
 
 cd debian/
 
-#removing unnecessary files
+# Removing unnecessary files
 rm ./*.ex
 rm ./*.EX
 
+# Adding package dependencies(Package will install them itself) and description
 rm control
 
-#Adding package dependencies(Package will install them itself) and description
 cat >> control <<EOF
-Source: carla
+Source: carla-simulator
 Section: simulator
 Priority: optional
 Maintainer: Carla Simulator Team <carla.simulator@gmail.com>
@@ -94,14 +115,14 @@ Build-Depends: debhelper (>= 9)
 Standards-Version: ${CARLA_VERSION}
 Homepage: http://carla.org/
 
-Package: carla
+Package: carla-simulator
 Architecture: any
 Depends: python,
-	 python-numpy,
-	 python-pygame,
-	 libpng16-16,
-	 libjpeg8,
-	 libtiff5
+  python-numpy,
+  python-pygame,
+  libpng16-16,
+  libjpeg8,
+  libtiff5
 Description: Open-source simulator for autonomous driving research
  CARLA has been developed from the ground up to support development, training, and validation
  of autonomous driving systems. In addition to open-source code and protocols, CARLA provides
@@ -110,22 +131,23 @@ Description: Open-source simulator for autonomous driving research
  environmental conditions, full control of all static and dynamic actors, maps generation and much more.
 EOF
 
-
+# Adding Carla library path (carla.pth) to site-packages, during post installation.
 rm postinst
 
-#Adding Carla library path (carla.pth) to site-packages, during post installation.
 cat>> postinst << EOF
 #!/bin/sh
 
 SITEDIR=\$(python3 -c 'import site; site._script()' --user-site)
 mkdir -p "\$SITEDIR"
-echo "/opt/carla/PythonAPI/carla/dist/${CARLA_DIR}-py3.5-linux-x86_64.egg\n/opt/carla/PythonAPI/carla/" > "\$SITEDIR/carla.pth"
+PYTHON3_EGG=\$(ls /opt/carla-simulator/PythonAPI/carla/dist | grep py3.)
+echo "/opt/carla-simulator/PythonAPI/carla/dist/\$PYTHON3_EGG\n/opt/carla-simulator/PythonAPI/carla/" > "\$SITEDIR/carla.pth"
 
 SITEDIR=\$(python2 -c 'import site; site._script()' --user-site)
 mkdir -p "\$SITEDIR"
-echo "/opt/carla/PythonAPI/carla/dist/${CARLA_DIR}-py2.7-linux-x86_64.egg\n/opt/carla/PythonAPI/carla/" > "\$SITEDIR/carla.pth"
+PYTHON2_EGG=\$(ls /opt/carla-simulator/PythonAPI/carla/dist | grep py2.)
+echo "/opt/carla-simulator/PythonAPI/carla/dist/\$PYTHON2_EGG\n/opt/carla-simulator/PythonAPI/carla/" > "\$SITEDIR/carla.pth"
 
-chmod +x /opt/carla/bin/CarlaUE4.sh
+chmod +x /opt/carla-simulator/bin/CarlaUE4.sh
 
 set -e
 
@@ -143,12 +165,10 @@ case "\$1" in
 esac
 
 exit 0
-
 EOF
 
+# Removing Carla library from site-packages
 rm prerm
-
-#Removing Carla library from site-packages
 cat>> prerm << EOF
 #!/bin/sh
 
@@ -157,7 +177,6 @@ rm "\$SITEDIR/carla.pth"
 
 SITEDIR=\$(python2 -c 'import site; site._script()' --user-site)
 rm "\$SITEDIR/carla.pth"
-
 
 set -e
 
@@ -175,17 +194,17 @@ case "\$1" in
 esac
 
 exit 0
-
 EOF
 
+# Updating copyright.
 rm copyright
 cp ../LICENSE ./copyright
 
-#Updating debian/Changelog
+# Updating debian/Changelog
 awk '{sub(/UNRELEASED/,"stable")}1' changelog > tmp && mv tmp changelog
 awk '{sub(/unstable/,"stable")}1' changelog > tmp && mv tmp changelog
 cd ..
 
-dpkg-buildpackage -uc -us -b #building debian package
+# Building debian package.
+dpkg-buildpackage -uc -us -b
 
-#install debian package using "sudo dpkg -i ../carla_<version>_amd64.deb"

--- a/Util/CreateDebian.sh
+++ b/Util/CreateDebian.sh
@@ -72,7 +72,7 @@ rm CarlaUE4.sh
 cat >> CarlaUE4.sh <<EOF
 #!/bin/sh
 sudo chmod +x "/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping"
-"/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping" CarlaUE4 $@
+"/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping" CarlaUE4 \$@
 EOF
 
 # Making debian package to install Carla in /opt folder

--- a/Util/CreateDebian.sh
+++ b/Util/CreateDebian.sh
@@ -21,8 +21,8 @@
 
 if [[ -z $1 ]];
 then
-  echo `date`" - Missing mandatory arguments: CARLA version. "
-  echo `date`" - Usage: ./CreateDebian.sh [version]. "
+  echo "$(date) - Missing mandatory arguments: CARLA version. "
+  echo "$(date) - Usage: ./CreateDebian.sh [version]. "
   exit 1
 fi
 
@@ -44,17 +44,17 @@ sudo apt-get install build-essential dh-make
 # ==================================================================================================
 # -- Download --------------------------------------------------------------------------------------
 # ==================================================================================================
-mkdir -p carla-debian/${CARLA_DIR}
-cd carla-debian/${CARLA_DIR}
+mkdir -p carla-debian/"${CARLA_DIR}"
+cd carla-debian/"${CARLA_DIR}"
 
 FILE=$(pwd)/ImportAssets.sh
 if [ -f "$FILE" ]; then
   echo "Package already downloaded!"
 else
-  curl ${CARLA_RELEASE_URL} | tar xz
+  curl "${CARLA_RELEASE_URL}" | tar xz
 
-  wget ${ADDITIONAL_MAPS_URL}
-  mv AdditionalMaps_${CARLA_VERSION}.tar.gz Import/
+  wget "${ADDITIONAL_MAPS_URL}"
+  mv AdditionalMaps_"${CARLA_VERSION}".tar.gz Import/
 fi
 
 # Importing new maps.


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
This PR updates `Util/CreateDebian.sh` script to support new CARLA releases (trying to make it version independent).

This PR is based on the modifications introduced in the PR #2791 

Functionality added:
* Allow choosing carla release through a parameter when calling the script.
* Package name updated to `carla-simulator`.
* Package URL updated.
* Automatic detection of python3 and python2 egg files.
* Adds Co-Simulation folder to the debian package.

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #2770   <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7, 3.6.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2887)
<!-- Reviewable:end -->
