### PR TITLE
Fixes to some issues found running with sanitizers

### DIFF
--- a/LibCarla/source/carla/nav/Navigation.cpp
+++ b/LibCarla/source/carla/nav/Navigation.cpp
@@ -193,7 +193,7 @@ namespace nav {
       return;
     }
 
-    DEBUG_ASSERT(_crowd != nullptr);
+    DEBUG_ASSERT(_crowd == nullptr);
 
     // create and init
     _crowd = dtAllocCrowd();

--- a/LibCarla/source/carla/profiler/Profiler.h
+++ b/LibCarla/source/carla/profiler/Profiler.h
@@ -57,7 +57,7 @@ namespace detail {
     }
 
     static inline float fps(float milliseconds) {
-      return 1e3f / milliseconds;
+      return milliseconds > 0.0f ? (1e3f / milliseconds) : std::numeric_limits<float>::max();
     }
 
     const std::string _name;

--- a/LibCarla/source/carla/rpc/Response.h
+++ b/LibCarla/source/carla/rpc/Response.h
@@ -33,7 +33,10 @@ namespace rpc {
 
   private:
 
-    std::string _what;
+    /// @todo Needs initialization, empty strings end up calling memcpy on a
+    /// nullptr. Possibly a bug in MsgPack but could also be our specialization
+    /// for variants
+    std::string _what{"unknown error"};
   };
 
   template <typename T>

--- a/LibCarla/source/carla/sensor/data/Array.h
+++ b/LibCarla/source/carla/sensor/data/Array.h
@@ -35,51 +35,51 @@ namespace data {
     using const_reference = typename std::add_const<value_type>::type &;
 
     iterator begin() {
-     return reinterpret_cast<iterator>(_data.begin() + _offset);
+      return reinterpret_cast<iterator>(_data.begin() + _offset);
     }
 
     const_iterator cbegin() const {
-     return reinterpret_cast<const_iterator>(_data.begin() + _offset);
+      return reinterpret_cast<const_iterator>(_data.begin() + _offset);
     }
 
     const_iterator begin() const {
-     return cbegin();
+      return cbegin();
     }
 
     iterator end() {
-     return reinterpret_cast<iterator>(_data.end());
+      return reinterpret_cast<iterator>(_data.end());
     }
 
     const_iterator cend() const {
-     return reinterpret_cast<const_iterator>(_data.end());
+      return reinterpret_cast<const_iterator>(_data.end());
     }
 
     const_iterator end() const {
-     return cend();
+      return cend();
     }
 
     reverse_iterator rbegin() {
-     return reverse_iterator(begin());
+      return reverse_iterator(begin());
     }
 
     const_reverse_iterator crbegin() const {
-     return const_reverse_iterator(cbegin());
+      return const_reverse_iterator(cbegin());
     }
 
     const_reverse_iterator rbegin() const {
-     return crbegin();
+      return crbegin();
     }
 
     reverse_iterator rend() {
-     return reverse_iterator(end());
+      return reverse_iterator(end());
     }
 
     const_reverse_iterator crend() const {
-     return const_reverse_iterator(cend());
+      return const_reverse_iterator(cend());
     }
 
     const_reverse_iterator rend() const {
-     return crend();
+      return crend();
     }
 
     bool empty() const {
@@ -123,21 +123,18 @@ namespace data {
 
   protected:
 
-    explicit Array(size_t offset, RawData data)
+    template <typename FuncT>
+    explicit Array(RawData &&data, FuncT get_offset)
       : SensorData(data),
-        _data(std::move(data)) {
-      SetOffset(offset);
-    }
-
-    explicit Array(RawData data)
-      : Array(0u, std::move(data)) {}
-
-    void SetOffset(size_t offset) {
-      _offset = offset;
+        _data(std::move(data)),
+        _offset(get_offset(_data)) {
       DEBUG_ASSERT(_data.size() >= _offset);
       DEBUG_ASSERT((_data.size() - _offset) % sizeof(T) == 0u);
       DEBUG_ASSERT(begin() <= end());
     }
+
+    explicit Array(size_t offset, RawData &&data)
+      : Array(std::move(data), [offset](const RawData &) { return offset; }) {}
 
     const RawData &GetRawData() const {
       return _data;
@@ -145,9 +142,9 @@ namespace data {
 
   private:
 
-    size_t _offset;
-
     RawData _data;
+
+    const size_t _offset;
   };
 
 } // namespace data

--- a/LibCarla/source/carla/sensor/data/DVSEventArray.h
+++ b/LibCarla/source/carla/sensor/data/DVSEventArray.h
@@ -25,7 +25,7 @@ namespace data {
 
     friend Serializer;
 
-    explicit DVSEventArray(RawData data)
+    explicit DVSEventArray(RawData &&data)
       : Super(Serializer::header_offset, std::move(data)) {
     }
 

--- a/LibCarla/source/carla/sensor/data/ImageTmpl.h
+++ b/LibCarla/source/carla/sensor/data/ImageTmpl.h
@@ -24,7 +24,7 @@ namespace data {
 
     friend Serializer;
 
-    explicit ImageTmpl(RawData data)
+    explicit ImageTmpl(RawData &&data)
       : Super(Serializer::header_offset, std::move(data)) {
       DEBUG_ASSERT(GetWidth() * GetHeight() == Super::size());
     }

--- a/LibCarla/source/carla/sensor/data/LidarMeasurement.h
+++ b/LibCarla/source/carla/sensor/data/LidarMeasurement.h
@@ -20,16 +20,17 @@ namespace data {
   class LidarMeasurement : public Array<rpc::Location>  {
     static_assert(sizeof(rpc::Location) == 3u * sizeof(float), "Location size missmatch");
     using Super = Array<rpc::Location>;
+
   protected:
 
     using Serializer = s11n::LidarSerializer;
 
     friend Serializer;
 
-    explicit LidarMeasurement(RawData data)
-      : Super(std::move(data)) {
-      Super::SetOffset(Serializer::GetHeaderOffset(Super::GetRawData()));
-    }
+    explicit LidarMeasurement(RawData &&data)
+      : Super(std::move(data), [](const RawData &d) {
+      return Serializer::GetHeaderOffset(d);
+    }) {}
 
   private:
 

--- a/LibCarla/source/carla/sensor/data/RadarMeasurement.h
+++ b/LibCarla/source/carla/sensor/data/RadarMeasurement.h
@@ -25,8 +25,8 @@ namespace data {
 
     friend Serializer;
 
-    explicit RadarMeasurement(RawData data)
-      : Super(std::move(data)) {}
+    explicit RadarMeasurement(RawData &&data)
+      : Super(0u, std::move(data)) {}
 
   public:
 

--- a/LibCarla/source/carla/sensor/data/RawEpisodeState.h
+++ b/LibCarla/source/carla/sensor/data/RawEpisodeState.h
@@ -24,7 +24,7 @@ namespace data {
 
     friend Serializer;
 
-    explicit RawEpisodeState(RawData data)
+    explicit RawEpisodeState(RawData &&data)
       : Super(Serializer::header_offset, std::move(data)) {}
 
   private:

--- a/LibCarla/source/test/common/test_streaming.cpp
+++ b/LibCarla/source/test/common/test_streaming.cpp
@@ -75,6 +75,8 @@ TEST(streaming, low_level_sending_strings) {
 
   std::this_thread::sleep_for(2ms);
   ASSERT_GE(message_count, number_of_messages - 3u);
+
+  io.service.stop();
 }
 
 TEST(streaming, low_level_unsubscribing) {
@@ -118,6 +120,8 @@ TEST(streaming, low_level_unsubscribing) {
 
     ASSERT_GE(message_count, number_of_messages - 3u);
   }
+
+  io.service.stop();
 }
 
 TEST(streaming, low_level_tcp_small_message) {


### PR DESCRIPTION
Found running the build from #2693.

- Division by zero in Profiler.h
- Calling memcpy with a nullptr on MsgPack
- Accessing the address of a destroyed object in the benchmarking tests
- Two wrongly placed asserts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2901)
<!-- Reviewable:end -->
