### PR TITLE
Add plugins repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Plugins"]
+	path = Plugins
+	url = https://github.com/carla-simulator/carla-plugins.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * OpenDRIVE ingestion bugfixes
   * Added Dynamic Vision Sensor (DVS) camera based on ESIM simulation http://rpg.ifi.uzh.ch/esim.html
   * Added support for additional TraCI clients in Sumo co-simulation
+  * CARLA repo now includes a folder for plugins from the community
   * Added API functions `get_right_vector` and `get_up_vector`
   * Added parameter to enable/disable pedestrian navigation in standalone mode
   * Improved mesh split in standalone mode


### PR DESCRIPTION
#### Description

We add a submodule to the CARLA repo to publish all plugins available for CARLA
To get those plugins you need to use these commands:

- when cloning CARLA repo add the command --recursive, like

`git clone https://github.com/carla-simulator/carla --recursive`

- or if you already have cloned the repo

`git submodule update --init`

#### Where has this been tested?

  * **Platform(s):** -
  * **Python version(s):** -
  * **Unreal Engine version(s):** -

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2921)
<!-- Reviewable:end -->
