### PR TITLE
Fix for slow TrafficManager setup on large XODR only maps.

### DIFF
--- a/LibCarla/source/carla/trafficmanager/InMemoryMap.cpp
+++ b/LibCarla/source/carla/trafficmanager/InMemoryMap.cpp
@@ -10,7 +10,6 @@
 namespace carla {
 namespace traffic_manager {
 
-
   namespace cg = carla::geom;
   using namespace constants::Map;
 
@@ -189,13 +188,13 @@ namespace traffic_manager {
     for (auto &simple_waypoint: dense_topology) {
       if (simple_waypoint != nullptr) {
         const cg::Location loc = simple_waypoint->GetLocation();
-        const int64_t grid_key = MakeGridKey(MakeGridId(loc.x, loc.y, true));
+        const std::string grid_key = MakeGridKey(MakeGridId(loc.x, loc.y, true));
         if (waypoint_grid.find(grid_key) == waypoint_grid.end()) {
           waypoint_grid.insert({grid_key, {simple_waypoint}});
         } else {
           waypoint_grid.at(grid_key).insert(simple_waypoint);
         }
-        const int64_t ped_grid_key = MakeGridKey(MakeGridId(loc.x, loc.y, false));
+        const std::string ped_grid_key = MakeGridKey(MakeGridId(loc.x, loc.y, false));
         if (ped_waypoint_grid.find(ped_grid_key) == ped_waypoint_grid.end()) {
           ped_waypoint_grid.insert({ped_grid_key, {simple_waypoint}});
         } else {
@@ -250,14 +249,8 @@ namespace traffic_manager {
     }
   }
 
-  int64_t InMemoryMap::MakeGridKey(std::pair<int, int> grid_id) {
-
-    int64_t grid_key = 0;
-    grid_key |= grid_id.first;
-    grid_key <<= 32;
-    grid_key |= grid_id.second;
-
-    return grid_key;
+  std::string InMemoryMap::MakeGridKey(std::pair<int, int> grid_key) {
+    return std::to_string(grid_key.first) + "#" + std::to_string(grid_key.second);
   }
 
   SimpleWaypointPtr InMemoryMap::GetWaypointInVicinity(cg::Location location) {
@@ -270,7 +263,7 @@ namespace traffic_manager {
     for (int i = -1; i <= 1; ++i) {
       for (int j = -1; j <= 1; ++j) {
 
-        const int64_t grid_key = MakeGridKey({grid_ids.first + i, grid_ids.second + j});
+        const std::string grid_key = MakeGridKey({grid_ids.first + i, grid_ids.second + j});
         if (waypoint_grid.find(grid_key) != waypoint_grid.end()) {
 
           const auto &waypoint_set = waypoint_grid.at(grid_key);
@@ -308,7 +301,7 @@ namespace traffic_manager {
     for (int i = -1; i <= 1; ++i) {
       for (int j = -1; j <= 1; ++j) {
 
-        const int64_t grid_key = MakeGridKey({grid_ids.first + i, grid_ids.second + j});
+        const std::string grid_key = MakeGridKey({grid_ids.first + i, grid_ids.second + j});
         if (ped_waypoint_grid.find(grid_key) != ped_waypoint_grid.end()) {
 
           const auto &waypoint_set = ped_waypoint_grid.at(grid_key);

--- a/LibCarla/source/carla/trafficmanager/InMemoryMap.h
+++ b/LibCarla/source/carla/trafficmanager/InMemoryMap.h
@@ -77,7 +77,7 @@ namespace crd = carla::road;
     /// local cache.
     NodeList GetDenseTopology() const;
 
-     std::string GetMapName();
+    std::string GetMapName();
 
   private:
 

--- a/LibCarla/source/carla/trafficmanager/InMemoryMap.h
+++ b/LibCarla/source/carla/trafficmanager/InMemoryMap.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <string>
 
 #include "carla/client/Map.h"
 #include "carla/client/Waypoint.h"
@@ -31,7 +32,7 @@ namespace crd = carla::road;
   using NodeList = std::vector<SimpleWaypointPtr>;
   using GeoGridId = crd::JuncId;
   using WorldMap = carla::SharedPtr<cc::Map>;
-  using WaypointGrid = std::unordered_map<int64_t, std::unordered_set<SimpleWaypointPtr>>;
+  using WaypointGrid = std::unordered_map<std::string, std::unordered_set<SimpleWaypointPtr>>;
 
   using SegmentId = std::tuple<crd::RoadId, crd::LaneId, crd::SectionId>;
   using SegmentTopology = std::map<SegmentId, std::pair<std::vector<SegmentId>, std::vector<SegmentId>>>;
@@ -76,7 +77,7 @@ namespace crd = carla::road;
     /// local cache.
     NodeList GetDenseTopology() const;
 
-    std::string GetMapName();
+     std::string GetMapName();
 
   private:
 
@@ -84,7 +85,7 @@ namespace crd = carla::road;
     std::pair<int, int> MakeGridId(float x, float y, bool vehicle_or_pedestrian);
 
     /// Method to generate map key for waypoint_grid.
-    int64_t MakeGridKey(std::pair<int, int> gird_id);
+    std::string MakeGridKey(std::pair<int, int> gird_id);
 
     /// This method is used to find and place lane change links.
     void FindAndLinkLaneChange(SimpleWaypointPtr reference_waypoint);


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Reverting back to using string keys to identify spatial grids as we found it empirically faster
and solves the problem of TrafficManager setup taking too long in case of large .xodr only maps.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.24

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2929)
<!-- Reviewable:end -->
