### PR TITLE
Remove unecessary line from launcher script to avoid sudo

### DIFF
--- a/Util/CreateDebian.sh
+++ b/Util/CreateDebian.sh
@@ -71,7 +71,6 @@ rm CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping.sym
 rm CarlaUE4.sh
 cat >> CarlaUE4.sh <<EOF
 #!/bin/sh
-sudo chmod +x "/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping"
 "/opt/carla-simulator/CarlaUE4/Binaries/Linux/CarlaUE4-Linux-Shipping" CarlaUE4 \$@
 EOF
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

The launcher script CarlaUE4.sh shouldn't require sudo. In fact the line that
requires sudo is not necessary at all since the executable flag is already
set.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2945)
<!-- Reviewable:end -->
