### PR TITLE
Removing plugins as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Plugins"]
-	path = Plugins
-	url = https://github.com/carla-simulator/carla-plugins.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
   * OpenDRIVE ingestion bugfixes
   * Added Dynamic Vision Sensor (DVS) camera based on ESIM simulation http://rpg.ifi.uzh.ch/esim.html
   * Added support for additional TraCI clients in Sumo co-simulation
-  * CARLA repo now includes a folder for plugins from the community
   * Added API functions `get_right_vector` and `get_up_vector`
   * Added parameter to enable/disable pedestrian navigation in standalone mode
   * Improved mesh split in standalone mode


### PR DESCRIPTION

#### Description

Removing the Plugins folder as submodule, we will use Plugins in another way.
After removing, you may need to use the command:
`git rm Plugins`
to properly remove the references to the plugin in your CARLA repo.

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2948)
<!-- Reviewable:end -->
