### PR TITLE
Fixed weather out in PythonAPI

### DIFF
--- a/PythonAPI/carla/source/libcarla/Weather.cpp
+++ b/PythonAPI/carla/source/libcarla/Weather.cpp
@@ -13,11 +13,16 @@ namespace rpc {
 
   std::ostream &operator<<(std::ostream &out, const WeatherParameters &weather) {
     out << "WeatherParameters(cloudiness=" << std::to_string(weather.cloudiness)
+        << ", cloudiness=" << std::to_string(weather.cloudiness)
         << ", precipitation=" << std::to_string(weather.precipitation)
         << ", precipitation_deposits=" << std::to_string(weather.precipitation_deposits)
         << ", wind_intensity=" << std::to_string(weather.wind_intensity)
         << ", sun_azimuth_angle=" << std::to_string(weather.sun_azimuth_angle)
-        << ", sun_altitude_angle=" << std::to_string(weather.sun_altitude_angle) << ')';
+        << ", sun_altitude_angle=" << std::to_string(weather.sun_altitude_angle)
+        << ", fog_density=" << std::to_string(weather.fog_density)
+        << ", fog_distance=" << std::to_string(weather.fog_distance)
+        << ", fog_falloff=" << std::to_string(weather.fog_falloff)
+        << ", wetness=" << std::to_string(weather.wetness) << ')';
     return out;
   }
 


### PR DESCRIPTION
#### Description
Quick fix where all the elements of the weather parameters are now exposed when printing an instance in Python.

#### Where has this been tested?
  * **Platform(s):** Ubuntu 18
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2957)
<!-- Reviewable:end -->
