### PR TITLE
Update install_boost.bat

### DIFF
--- a/Util/InstallersWin/install_boost.bat
+++ b/Util/InstallersWin/install_boost.bat
@@ -104,7 +104,7 @@ if not exist "%BOOST_SRC_DIR%" (
 cd "%BOOST_SRC_DIR%"
 if not exist "b2.exe" (
     echo %FILE_N% Generating build...
-    call bootstrap.bat
+    call bootstrap.bat vc141
 )
 
 if %errorlevel% neq 0 goto error_bootstrap


### PR DESCRIPTION
Specify toolset while bootstraping boost 
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
The VS2017 Build Tools are not easily available anymore.  Therefor changes have to be made if one wants to compile Carla on a machine using the VS2019 Build Tools and target the VS2017 toolchain/compilers.
<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows 10 1903 + VS2019 BuildTools [Win SDK 10.0.017763 MSVC v141 (v14.16)]
  * **Python version(s):** 3.7.7
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks
It's not using the TOOLSET enviroment variable as b2.exe and bootstrap uses a different syntax for this variable.
"msvc-14.1" vs "msvc : 141"
This is a minimal fix for bootstraping boost only. 

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/2982)
<!-- Reviewable:end -->
