### PR TITLE
Update UE4 version (from 4.22.2 to 4.24.3)

### DIFF
--- a/Util/Docker/README.md
+++ b/Util/Docker/README.md
@@ -50,10 +50,10 @@ ue4-docker setup
 ## Building the Docker images
 
 Navigate to `carla/Util/Docker` and use the following commands, each one will take a long time.  
-First, let's create a Docker image containing a compiled version of Unreal Engine 4 version `22.2`. Change the version if needed.
+First, let's create a Docker image containing a compiled version of Unreal Engine 4 version `24.3`. Change the version if needed.
 
 ```
-ue4-docker build 4.22.2 --no-engine --no-minimal
+ue4-docker build 4.24.3 --no-engine --no-minimal
 ```
 
 Next, this will build the image with all the necessary requisites to build Carla in a **Ubuntu 18.04**


### PR DESCRIPTION
#### Description

Updating version of UE4 to be use when building the docker. Some users got confused and used version 4.22.2 instead of the new 4.24.3 with last version of CARLA 0.9.9, and then got some errors.

Fixes # 3011

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** -
  * **Unreal Engine version(s):** UE 4.24.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3034)
<!-- Reviewable:end -->
