### PR TITLE
Added a warning when the SpringArm transformation can fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
   * Added PythonAPI command to set multiple car light states at once
   * Added PythonAPI `carla.world.get_vehicles_light_states` to get all the car light states at once
   * OpenDRIVE ingestion bugfixes
+  * Added a warning if the user tries to use the SpringArm exactly in the 'z' axis of the attached actor
   * Improved the LiDAR and Radar sensors with a parallel implentation of the raycasting
-  * Added an approximation of the intensity of each point of the cloud in the LiDAR sensor.
+  * Added an approximation of the intensity of each point of the cloud in the LiDAR sensor
   * Added Dynamic Vision Sensor (DVS) camera based on ESIM simulation http://rpg.ifi.uzh.ch/esim.html
   * Improved LiDAR and radar to better match the shape of the vehicles
   * Added support for additional TraCI clients in Sumo co-simulation
@@ -27,7 +28,7 @@
   * Fixed large RAM usage when loading polinomial geometry from OpenDRIVE
   * Fixed collision issues when debug draw(debug.draw_line) is called
   * Fixed Gyroscope sensor to properly give angular velocity readings in local frame
-  * Added Renderdoc plugin to the Unreal project.
+  * Added Renderdoc plugin to the Unreal project
   * Replace deprectated `platform.dist()` with recommended `distro.linux_distribution()`
 
 ## CARLA 0.9.9

--- a/Docs/tuto_G_retrieve_data.md
+++ b/Docs/tuto_G_retrieve_data.md
@@ -532,7 +532,7 @@ lidar_bp.set_attribute('range',str(20))
 lidar_location = carla.Location(0,0,2)
 lidar_rotation = carla.Rotation(0,0,0)
 lidar_transform = carla.Transform(lidar_location,lidar_rotation)
-lidar_sen = world.spawn_actor(lidar_bp,lidar_transform,attach_to=ego_vehicle,attachment_type=carla.AttachmentType.SpringArm)
+lidar_sen = world.spawn_actor(lidar_bp,lidar_transform,attach_to=ego_vehicle)
 lidar_sen.listen(lambda point_cloud: point_cloud.save_to_disk('tutorial/new_lidar_output/%.6d.ply' % point_cloud.frame))
 ```
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -229,6 +229,17 @@ namespace detail {
       const geom::Transform &transform,
       rpc::ActorId parent,
       rpc::AttachmentType attachment_type) {
+
+      if(attachment_type == rpc::AttachmentType::SpringArm) {
+        const auto a = transform.location.MakeSafeUnitVector(std::numeric_limits<float>::epsilon());
+        const auto z = geom::Vector3D(0.0f, 0.f, 1.0f);
+        constexpr float OneEps = 1.0f - std::numeric_limits<float>::epsilon();
+        if (geom::Math::Dot(a, z) > OneEps) {
+          std::cout << "WARNING: Transformations with translation only in the 'z' axis are ill-formed when \
+            using SprintArm attachment. Please, be careful with that." << std::endl;
+        }
+      }
+
     return _pimpl->CallAndWait<rpc::Actor>("spawn_actor_with_parent",
         description,
         transform,


### PR DESCRIPTION
#### Description

If an actor is attached to another one with z transformation with a translation only in the z axis with the SpringArm,
its transformation will be ill formed. A warning has been added when the actor is spawn to alert the user of this issue.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->
#2842 


#### Where has this been tested?

  * **Platform(s):** Ubuntu 28.04
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3036)
<!-- Reviewable:end -->
