### PR TITLE
Fixed spdlog version to v1.7.0 for RSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Latest
 
-  * Upgraded to AD RSS v4.0.1 supporting unstructured scenes and pedestrians
+  * Upgraded to AD RSS v4.0.1 supporting unstructured scenes and pedestrians, and fixed spdlog to v1.7.0
   * Fixed a bug where `get_traffic_light` would always return `None`
   * Changed frozen behavior for traffic lights. It now affects to all traffic lights at the same time
   * Added API function `freeze_all_traffic_lights` and `reset_group`

--- a/Util/BuildTools/Ad-rss.sh
+++ b/Util/BuildTools/Ad-rss.sh
@@ -28,7 +28,7 @@ else
     log "Retrieving ${ADRSS_BASENAME}."
 
     pushd "${CARLA_BUILD_FOLDER}/${ADRSS_BASENAME}/src" >/dev/null
-    git clone --depth=1 -b v1.x https://github.com/gabime/spdlog.git
+    git clone --depth=1 -b v1.7.0 https://github.com/gabime/spdlog.git
     git clone --depth=1 -b 4.9.3 https://github.com/OSGeo/PROJ.git
     git clone --depth=1 -b v2.1.0 https://github.com/carla-simulator/map.git
     git clone --depth=1 -b v4.0.1 https://github.com/intel/ad-rss-lib.git


### PR DESCRIPTION
Just using the v1.x branch is now longer working, as it
requires a cmake newer than 3.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3128)
<!-- Reviewable:end -->
