### PR TITLE
Fixed global planner's RoadOptions

### DIFF
--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -185,7 +185,7 @@ class GlobalRoutePlanner(object):
                             if next_segment is not None:
                                 self._graph.add_edge(
                                     self._id_map[segment['entryxyz']], next_segment[0], entry_waypoint=waypoint,
-                                    exit_waypoint=next_waypoint,
+                                    exit_waypoint=next_waypoint, intersection=False, exit_vector=None,
                                     path=[], length=0, type=next_road_option, change_waypoint=next_waypoint)
                                 right_found = True
                     if waypoint.left_lane_marking.lane_change & carla.LaneChange.Left and not left_found:
@@ -196,7 +196,7 @@ class GlobalRoutePlanner(object):
                             if next_segment is not None:
                                 self._graph.add_edge(
                                     self._id_map[segment['entryxyz']], next_segment[0], entry_waypoint=waypoint,
-                                    exit_waypoint=next_waypoint,
+                                    exit_waypoint=next_waypoint, intersection=False, exit_vector=None,
                                     path=[], length=0, type=next_road_option, change_waypoint=next_waypoint)
                                 left_found = True
                 if left_found and right_found:
@@ -275,7 +275,9 @@ class GlobalRoutePlanner(object):
                     self._intersection_end_node = last_node
                     if tail_edge is not None:
                         next_edge = tail_edge
-                    cv, nv = current_edge['exit_vector'], next_edge['net_vector']
+                    cv, nv = current_edge['exit_vector'], next_edge['exit_vector']
+                    if cv is None or nv is None:
+                        return next_edge['type']
                     cross_list = []
                     for neighbor in self._graph.successors(current_node):
                         select_edge = self._graph.edges[current_node, neighbor]

--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -567,7 +567,7 @@ class HUD(object):
             self._info_text += ['Nearby vehicles:']
             distance = lambda l: math.sqrt((l.x - t.location.x)**2 + (l.y - t.location.y)**2 + (l.z - t.location.z)**2)
             vehicles = [(distance(x.get_location()), x) for x in vehicles if x.id != world.player.id]
-            for d, vehicle in sorted(vehicles):
+            for d, vehicle in sorted(vehicles, key=lambda vehicles: vehicles[0]):
                 if d > 200.0:
                     break
                 vehicle_type = get_actor_display_name(vehicle, truncate=22)


### PR DESCRIPTION
### Description

**Before** RoadOptions were calculated from the angle between the direction of the entering road and the "net vector" (vector between the start of the intersection and the end).

**Now**, the "net vector" has been substituted by the angle of the existing road.

This helps deal with irregular intersection where some roads are very wide and other are very narrow (due to the difference in the amount of lanes).

Here are some HD images showing the idea.

Before (1st one was accepted as LEFT, but the second wasn't):
![image](https://user-images.githubusercontent.com/58212725/88901224-d28e9e00-d250-11ea-9c8c-9743472db5f8.png)

![image](https://user-images.githubusercontent.com/58212725/88902145-1635d780-d252-11ea-9454-5db714dbde8c.png)


After:

![image](https://user-images.githubusercontent.com/58212725/88901014-88a5b800-d250-11ea-84f1-2053605c54d9.png)


**Bonus change:** The manual control has a left panel with the closest vehicles. Added a clause that forces the comparison to only use the distances, not the vehicle itself (as they can't be compared, resulting in an error).


#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3137)
<!-- Reviewable:end -->
