### PR TITLE
Bernat/fix sync deadlock

### DIFF
--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -77,14 +77,8 @@ namespace tcp {
       if (!_socket.is_open()) {
         return;
       }
-      if (_is_writing) {
-        log_debug("session", _session_id, ": connection too slow: message discarded");
-        return;
-      }
-      _is_writing = true;
 
       auto handle_sent = [this, self, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
-        _is_writing = false;
         if (ec) {
           log_info("session", _session_id, ": error sending data :", ec.message());
           CloseNow();

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
@@ -95,8 +95,6 @@ namespace tcp {
     boost::asio::io_context::strand _strand;
 
     callback_function_type _on_closed;
-
-    bool _is_writing = false;
   };
 
 } // namespace tcp

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -175,7 +175,7 @@ unset BOOST_BASENAME
 # -- Get rpclib and compile it with libc++ and libstdc++ -----------------------
 # ==============================================================================
 
-RPCLIB_PATCH=v2.2.1_c2
+RPCLIB_PATCH=v2.2.1_c3
 RPCLIB_BASENAME=rpclib-${RPCLIB_PATCH}-${CXX_TAG}
 
 RPCLIB_LIBCXX_INCLUDE=${PWD}/${RPCLIB_BASENAME}-libcxx-install/include

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -36,7 +36,7 @@ rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
 
-set RPC_VERSION=v2.2.1_c2
+set RPC_VERSION=v2.2.1_c3
 set RPC_SRC=rpclib-src
 set RPC_SRC_DIR=%BUILD_DIR%%RPC_SRC%\
 set RPC_INSTALL=rpclib-install


### PR DESCRIPTION
#### Description

Removed some **is_writing** bool variable that could drop all future stream packets if a problem happens like time out in one of them. A better solution is pending.

Also fix a crash when closing sessions in the RPClib. We use a new version **2.2.1.c3** of the RPClib fork.

Related to issue: #2809

#### Where has this been tested?

  * **Platform(s):** Windows, Ubuntu
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3144)
<!-- Reviewable:end -->
