### PR TITLE
Remove unnecessary resource locking by reducing the level of parallel…

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -100,20 +100,16 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
 
   GetWorld()->GetPhysicsScene()->GetPxScene()->lockRead();
   ParallelFor(ChannelCount, [&](int32 idxChannel) {
-
-    FCriticalSection Mutex;
-    ParallelFor(PointsToScanWithOneLaser, [&](int32 idxPtsOneLaser) {
+    for (int idxPtsOneLaser = 0; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
       FHitResult HitResult;
       const float VertAngle = LaserAngles[idxChannel];
       const float HorizAngle = CurrentHorizontalAngle + AngleDistanceOfLaserMeasure * idxPtsOneLaser;
       const bool PreprocessResult = PreprocessRay();
 
       if (PreprocessResult && ShootLaser(VertAngle, HorizAngle, HitResult)) {
-        Mutex.Lock();
         WritePointAsync(idxChannel, HitResult);
-        Mutex.Unlock();
       }
-    });
+    };
   });
   GetWorld()->GetPhysicsScene()->GetPxScene()->unlockRead();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -100,7 +100,7 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
 
   GetWorld()->GetPhysicsScene()->GetPxScene()->lockRead();
   ParallelFor(ChannelCount, [&](int32 idxChannel) {
-    for (int idxPtsOneLaser = 0; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
+    for (auto idxPtsOneLaser = 0u; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
       FHitResult HitResult;
       const float VertAngle = LaserAngles[idxChannel];
       const float HorizAngle = CurrentHorizontalAngle + AngleDistanceOfLaserMeasure * idxPtsOneLaser;


### PR DESCRIPTION
…ism in the inner loop.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check`:

```
[  FAILED  ] 1 test, listed below:
[  FAILED  ] benchmark_streaming.image_1920x1080_mt
```
(not sure if this is caused by this change, as it also fails on master branch on my machine)

  - [x] If relevant, update CHANGELOG.md with your changes

#### Description

This PR makes the parallelization more coarse (switching from task-per-point to task-per-channel) allowing me to remove the mutex for the critical section that deals with emplacement of elements, as each task now emplaces the elements into it's own vector separate vector.

Result of running `python raycast_sensor_testing.py -ln 1 -ln 0 --profiling`
Before the change: https://pastebin.com/RSxhKx90
After the change: https://pastebin.com/Y5R8v6iy

Result of running `python raycast_sensor_testing.py -sln 1 -ln 0 --profiling`
Before the change: https://pastebin.com/Hk7av3F1
After the change: https://pastebin.com/dziSeVd4

We can observe a noticeable difference in performance for the non-semantic lidar, and on-par or better performance on the semantic lidar, likely due to the fact that the hit registration is a more expensive computation for the semantic lidar (as per discussion with Daniel Santos), therefore making it so that the threads spend less time contending for the mutex since they have more work to the before getting to it.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** Python 3.6
  * **Unreal Engine version(s):** Unreal 4.24

#### Possible Drawbacks

Not only does this improve the performance, but it also simplifies the source code. Therefore, I do not see any obvious drawbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3169)
<!-- Reviewable:end -->
