### PR TITLE
Running Carla when choosing a) deb Carla install

### DIFF
--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -139,7 +139,7 @@ Open a terminal in the main CARLA folder. Run the following command to execute t
 > CarlaUE4.exe
 ```
 !!! Important
-    In the __deb installation__, `CarlaUE4.sh` will be in `/opt/carla/bin/`, instead of the main `carla/` folder where it normally is. 
+    In the __deb installation__, `CarlaUE4.sh` will be in `/opt/carla-simulator/bin/`, instead of the main `carla/` folder where it normally is. 
 
 A window containing a view over the city will pop up. This is the _spectator view_. To fly around the city use the mouse and `WASD` keys (while clicking). The server simulator is now running and waiting for a client to connect and interact with the world.  
 Now it is time to start running scripts. The following example will spawn some life into the city: 


### PR DESCRIPTION
This fixes a minor error in the documentation regarding running carla, if the deb installation was choosen.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3178)
<!-- Reviewable:end -->
