### PR TITLE
extends local_planner setting method

### DIFF
--- a/PythonAPI/carla/agents/navigation/controller.py
+++ b/PythonAPI/carla/agents/navigation/controller.py
@@ -194,9 +194,14 @@ class PIDLateralController():
                                          y=math.sin(math.radians(vehicle_transform.rotation.yaw)))
 
         v_vec = np.array([v_end.x - v_begin.x, v_end.y - v_begin.y, 0.0])
-        w_vec = np.array([waypoint.transform.location.x -
-                          v_begin.x, waypoint.transform.location.y -
-                          v_begin.y, 0.0])
+        if isinstance(waypoint, carla.Waypoint):
+            w_vec = np.array([waypoint.transform.location.x -
+                            v_begin.x, waypoint.transform.location.y -
+                            v_begin.y, 0.0])
+        else:
+            w_vec = np.array([waypoint.location.x -
+                            v_begin.x, waypoint.location.y -
+                            v_begin.y, 0.0])
         _dot = math.acos(np.clip(np.dot(w_vec, v_vec) /
                                  (np.linalg.norm(w_vec) * np.linalg.norm(v_vec)), -1.0, 1.0))
 

--- a/PythonAPI/carla/agents/navigation/local_planner.py
+++ b/PythonAPI/carla/agents/navigation/local_planner.py
@@ -241,8 +241,12 @@ class LocalPlanner(object):
         max_index = -1
 
         for i, (waypoint, _) in enumerate(self._waypoint_buffer):
-            if waypoint.transform.location.distance(vehicle_transform.location) < self._min_distance:
-                max_index = i
+            if isinstance(waypoint, carla.Waypoint):
+                if waypoint.transform.location.distance(vehicle_transform.location) < self._min_distance:
+                    max_index = i
+            else:
+                if waypoint.location.distance(vehicle_transform.location) < self._min_distance:
+                    max_index = i
         if max_index >= 0:
             for i in range(max_index + 1):
                 self._waypoint_buffer.popleft()


### PR DESCRIPTION

In set_global_plan method, current_plan consists of carla.Waypoint.  But we can't customize Waypoint,  and we can't set current_plan in there have no waypoint,  like parking lots.  
 So, I extend  local_planner setting method. in addition to Waypoint,  current_plan can also be composed of Transform.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check`
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3190)
<!-- Reviewable:end -->
