### PR TITLE
Fixed trigger box generation for traffic signs

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
@@ -41,6 +41,9 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9*Map.GetLaneWidth(signal_waypoint)*0.5);
+        // Prevent a situation where the road width is 0
+        // This could happen in a lane that is just appearing
+        BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
@@ -103,6 +106,9 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
             auto NextWaypoint = CurrentWaypoint;
             float BoxSize = static_cast<float>(
                 0.9*Map.GetLaneWidth(NextWaypoint)*0.5);
+            // Prevent a situation where the road width is 0
+            // This could happen in a lane that is just appearing
+            BoxSize = std::max(0.01f, BoxSize);
             float UEBoxSize = 100*BoxSize;
             GenerateCheckBox(Map.ComputeTransform(NextWaypoint), UEBoxSize);
             while (true)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
@@ -41,8 +41,8 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9*Map.GetLaneWidth(signal_waypoint)*0.5);
-        // Prevent a situation where the road width is 0
-        // This could happen in a lane that is just appearing
+        // Prevent a situation where the road width is 0,
+        // this could happen in a lane that is just appearing
         BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -43,6 +43,9 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9f*Map.GetLaneWidth(signal_waypoint)*0.5);
+        // Prevent a situation where the road width is 0
+        // This could happen in a lane that is just appearing
+        BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -43,8 +43,8 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9f*Map.GetLaneWidth(signal_waypoint)*0.5);
-        // Prevent a situation where the road width is 0
-        // This could happen in a lane that is just appearing
+        // Prevent a situation where the road width is 0,
+        // this could happen in a lane that is just appearing
         BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -41,6 +41,9 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9*Map.GetLaneWidth(signal_waypoint)/2.0);
+        // Prevent a situation where the road width is 0
+        // This could happen in a lane that is just appearing
+        BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
@@ -104,6 +107,9 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
             auto NextWaypoint = CurrentWaypoint;
             float BoxSize = static_cast<float>(
                 0.9*Map.GetLaneWidth(NextWaypoint)/2.0);
+            // Prevent a situation where the road width is 0
+            // This could happen in a lane that is just appearing
+            BoxSize = std::max(0.01f, BoxSize);
             float UEBoxSize = 100*BoxSize;
             GenerateCheckBox(Map.ComputeTransform(NextWaypoint), UEBoxSize);
             while (true)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -41,8 +41,8 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
             0.9*Map.GetLaneWidth(signal_waypoint)/2.0);
-        // Prevent a situation where the road width is 0
-        // This could happen in a lane that is just appearing
+        // Prevent a situation where the road width is 0,
+        // this could happen in a lane that is just appearing
         BoxSize = std::max(0.01f, BoxSize);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
@@ -107,8 +107,8 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
             auto NextWaypoint = CurrentWaypoint;
             float BoxSize = static_cast<float>(
                 0.9*Map.GetLaneWidth(NextWaypoint)/2.0);
-            // Prevent a situation where the road width is 0
-            // This could happen in a lane that is just appearing
+            // Prevent a situation where the road width is 0,
+            // this could happen in a lane that is just appearing
             BoxSize = std::max(0.01f, BoxSize);
             float UEBoxSize = 100*BoxSize;
             GenerateCheckBox(Map.ComputeTransform(NextWaypoint), UEBoxSize);


### PR DESCRIPTION
#### Description

This fixes the generation of trigger boxes when signs are placed in lanes with 0 width (can happen when a lane is being created along the road).

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2,3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3203)
<!-- Reviewable:end -->
