### PR TITLE
Changing Jenkinsfile for Doxygen

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,7 @@ pipeline
                                 sh 'rm -rf ~/carla-simulator.github.io/Doxygen'
                                 sh '''
                                     cd ~/carla-simulator.github.io
+                                    git remote set-url origin git@github.com:carla-simulator/carla-simulator.github.io.git
                                     git fetch
                                     git checkout -B master origin/master
                                 '''


### PR DESCRIPTION
#### Description

This is just an addition to the Jenkinsfile to let the Jenkins machine to update the documentation from Doxygen to Github through SSH (private key) instead of using normal URL (user/password).

This stage only happens when building the **master** branch.

#### Where has this been tested?

  * **Platform(s):** -
  * **Python version(s):** -
  * **Unreal Engine version(s):** -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3258)
<!-- Reviewable:end -->
