### PR TITLE
New feature: remote sumo instance in spawn_npc_sumo.py

### DIFF
--- a/Co-Simulation/Sumo/run_synchronization.py
+++ b/Co-Simulation/Sumo/run_synchronization.py
@@ -276,7 +276,7 @@ if __name__ == '__main__':
                            metavar='P',
                            default=None,
                            type=int,
-                           help='TCP port to liston to (default: 8813)')
+                           help='TCP port to listen to (default: 8813)')
     argparser.add_argument('--sumo-gui', action='store_true', help='run the gui version of sumo')
     argparser.add_argument('--step-length',
                            default=0.05,

--- a/Co-Simulation/Sumo/spawn_npc_sumo.py
+++ b/Co-Simulation/Sumo/spawn_npc_sumo.py
@@ -116,8 +116,8 @@ def main(args):
     sumo_net = sumolib.net.readNet(net_file)
     sumo_simulation = SumoSimulation(cfg_file,
                                      args.step_length,
-                                     host=None,
-                                     port=None,
+                                     host=args.sumo_host,
+                                     port=args.sumo_port,
                                      sumo_gui=args.sumo_gui,
                                      client_order=args.client_order)
 
@@ -218,6 +218,13 @@ if __name__ == '__main__':
                            default=2000,
                            type=int,
                            help='TCP port to listen to (default: 2000)')
+    argparser.add_argument('--sumo-host',
+                           default=None,
+                           help='IP of the sumo host server (default: None)')
+    argparser.add_argument('--sumo-port',
+                           default=None,
+                           type=int,
+                           help='TCP port to listen to (default: None)')
     argparser.add_argument('-n',
                            '--number-of-vehicles',
                            metavar='N',


### PR DESCRIPTION
#### Description

This pull requests adds two new arguments to `spawn_npc_sumo.py`: `--sumo-host` and `--sumo-port`. This way, the script can be used to connect to a remote sumo instance.
It also fixes a typo in `run_synchronization.py`.

#### Where has this been tested?

  * **Platform(s): Ubuntu 20.04, Debian Bullseye**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3263)
<!-- Reviewable:end -->
