### PR TITLE
Added off state to traffic lights.

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -97,9 +97,16 @@ void UTrafficLightComponent::SetLightState(ETrafficLightState NewState)
       {
         Controller->SetTrafficLight(nullptr);
       }
+      // workarround for tm not supporting off state
+      if (LightState == ETrafficLightState::Off)
+      {
+        Controller->SetTrafficLightState(ETrafficLightState::Green);
+        Controller->SetTrafficLight(nullptr);
+      }
     }
   }
-  if (LightState == ETrafficLightState::Green)
+  if (LightState == ETrafficLightState::Green ||
+      LightState == ETrafficLightState::Off)
   {
     Vehicles.Empty();
   }
@@ -153,11 +160,17 @@ void UTrafficLightComponent::OnOverlapTriggerBox(UPrimitiveComponent *Overlapped
     if (VehicleController)
     {
       VehicleController->SetTrafficLightState(LightState);
-      if (LightState != ETrafficLightState::Green)
+      if (LightState != ETrafficLightState::Green &&
+          LightState != ETrafficLightState::Off)
       {
         Vehicles.Add(VehicleController);
         VehicleController->SetTrafficLight(
             Cast<ATrafficLightBase>(GetOwner()));
+      }
+      // workarround for tm not supporting off state
+      if (LightState == ETrafficLightState::Off)
+      {
+        VehicleController->SetTrafficLightState(ETrafficLightState::Green);
       }
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightState.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightState.h
@@ -6,11 +6,17 @@
 
 #pragma once
 
+#include <compiler/disable-ue4-macros.h>
+#include <carla/rpc/TrafficLightState.h>
+#include <compiler/enable-ue4-macros.h>
+
 #include "TrafficLightState.generated.h"
+
 
 UENUM(BlueprintType)
 enum class ETrafficLightState : uint8 {
   Red       UMETA(DisplayName = "Red"),
   Yellow    UMETA(DisplayName = "Yellow"),
-  Green     UMETA(DisplayName = "Green")
+  Green     UMETA(DisplayName = "Green"),
+  Off       UMETA(DisplayName = "Off")
 };


### PR DESCRIPTION
#### Description

Added off state to traffic lights so that all lights are off. The related content branch is `axel/traffic-lights-off`.

The UE4 enum for traffic light state was lacking the off state. It has been added and the blueprints in the content branch have been updated to shut the lights off when this state is triggered.

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

Traffic manager stops vehicles when the state is off in the same way when it is red. As a workaround, traffic lights report green state to the vehicles when they are off. This should be fixed once the traffic manager is capable of detecting off state properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3302)
<!-- Reviewable:end -->
