### PR TITLE
Existing actors in replayer are positioned to the initial position

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -54,6 +54,10 @@ std::pair<int, FActorView>CarlaReplayerHelper::TryToCreateReplayerActor(
       if (desc->Id == ActorDesc.Id)
       {
         // we don't need to create, actor of same type already exist
+        // relocate
+        FRotator Rot = FRotator::MakeFromEuler(Rotation);
+        FTransform Trans2(Rot, Location, FVector(1, 1, 1));
+        view.GetActor()->SetActorTransform(Trans2, false, nullptr, ETeleportType::TeleportPhysics);
         return std::pair<int, FActorView>(2, view);
       }
     }


### PR DESCRIPTION
#### Description

Actors that are already present in the scene when replaying were not moved to the initial position in the first frame. This PR fixes this as it produces problems during a frame if it overlaps objects.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3328)
<!-- Reviewable:end -->
