### PR TITLE
Compile and link Xerces-c in setup

### DIFF
--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -33,12 +33,12 @@ sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -c --short)/ llvm
 sudo apt-get update
 
 # Additional dependencies for Ubuntu 18.04
-sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev libxerces-c-dev &&
+sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev &&
 pip2 install --user setuptools &&
 pip3 install --user -Iv setuptools==47.3.1
 
 # Additional dependencies for previous Ubuntu versions
-sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng16-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev libxerces-c-dev &&
+sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng16-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev &&
 pip2 install --user setuptools &&
 pip3 install --user -Iv setuptools==47.3.1 &&
 pip2 install --user distro &&
@@ -124,7 +124,7 @@ sudo apt-get update
 
 __Ubuntu 18.04__.
 ```sh
-sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev libxerces-c-dev &&
+sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev &&
 pip2 install --user setuptools &&
 pip3 install --user -Iv setuptools==47.3.1 &&
 pip2 install --user distro &&
@@ -132,7 +132,7 @@ pip3 install --user distro
 ```
 __Previous Ubuntu__ versions.
 ```sh
-sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng16-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev libxerces-c-dev &&
+sudo apt-get install build-essential clang-8 lld-8 g++-7 cmake ninja-build libvulkan1 python python-pip python-dev python3-dev python3-pip libpng16-dev libtiff5-dev libjpeg-dev tzdata sed curl unzip autoconf libtool rsync libxml2-dev &&
 pip2 install --user setuptools &&
 pip3 install --user -Iv setuptools==47.3.1 &&
 pip2 install --user distro &&

--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -51,8 +51,8 @@ def get_libcarla_extensions():
                 os.path.join(pwd, 'dependencies/lib/libRecast.a'),
                 os.path.join(pwd, 'dependencies/lib/libDetour.a'),
                 os.path.join(pwd, 'dependencies/lib/libDetourCrowd.a'),
-                os.path.join(pwd, 'dependencies/lib/libosm2odr.a')]
-            extra_link_args += [os.path.join(pwd, 'dependencies/lib/libxerces-c.a')]
+                os.path.join(pwd, 'dependencies/lib/libosm2odr.a'),
+                os.path.join(pwd, 'dependencies/lib/libxerces-c.a')]
             extra_link_args += ['-lz']
             extra_compile_args = [
                 '-isystem', 'dependencies/include/system', '-fPIC', '-std=c++14',

--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -52,7 +52,7 @@ def get_libcarla_extensions():
                 os.path.join(pwd, 'dependencies/lib/libDetour.a'),
                 os.path.join(pwd, 'dependencies/lib/libDetourCrowd.a'),
                 os.path.join(pwd, 'dependencies/lib/libosm2odr.a')]
-            extra_link_args += ['-lxerces-c']
+            extra_link_args += [os.path.join(pwd, 'dependencies/lib/libxerces-c.a')]
             extra_link_args += ['-lz']
             extra_compile_args = [
                 '-isystem', 'dependencies/include/system', '-fPIC', '-std=c++14',

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -413,6 +413,51 @@ else
   rm -Rf ${LIBPNG_BASENAME}-source
 fi
 
+# ==============================================================================
+# -- Get and compile libxerces 3.2.3 ------------------------------
+# ==============================================================================
+
+XERCESC_VERSION=3.2.3
+XERCESC_BASENAME=xerces-c-${XERCESC_VERSION}
+
+XERCESC_TEMP_FOLDER=${XERCESC_BASENAME}
+XERCESC_REPO=https://ftp.cixug.es/apache//xerces/c/3/sources/xerces-c-${XERCESC_VERSION}.tar.gz
+
+XERCESC_SRC_DIR=${XERCESC_BASENAME}-source
+XERCESC_INSTALL_DIR=${XERCESC_BASENAME}-install
+
+if [[ -d ${XERCESC_INSTALL_DIR} ]] ; then
+  log "Xerces-c already installed."
+else
+  log "Retrieving xerces-c."
+  wget ${XERCESC_REPO}
+
+  log "Extracting xerces-c."
+  tar -xzf ${XERCESC_BASENAME}.tar.gz
+  mv ${XERCESC_BASENAME} ${XERCESC_SRC_DIR}
+  mkdir -p ${XERCESC_INSTALL_DIR}
+  mkdir -p ${XERCESC_SRC_DIR}/build
+
+  pushd ${XERCESC_SRC_DIR}/build >/dev/null
+
+  # define clang compiler
+  # export CC=/usr/bin/clang-8
+  # export CXX=/usr/bin/clang++-8
+  cmake -G "Ninja" \
+      -DCMAKE_CXX_FLAGS="-std=c++14 -fPIC -w" \
+      -DCMAKE_INSTALL_PREFIX="../../${XERCESC_INSTALL_DIR}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -Dnetwork=OFF \
+      ..
+  ninja
+  ninja install
+
+  popd >/dev/null
+
+  rm -Rf ${XERCESC_BASENAME}.tar.gz
+  rm -Rf ${XERCESC_SRC_DIR}
+fi
 
 # ==============================================================================
 # -- Generate Version.h --------------------------------------------------------

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -440,14 +440,12 @@ else
 
   pushd ${XERCESC_SRC_DIR}/build >/dev/null
 
-  # define clang compiler
-  # export CC=/usr/bin/clang-8
-  # export CXX=/usr/bin/clang++-8
   cmake -G "Ninja" \
       -DCMAKE_CXX_FLAGS="-std=c++14 -fPIC -w" \
       -DCMAKE_INSTALL_PREFIX="../../${XERCESC_INSTALL_DIR}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=OFF \
+      -Dtranscoder=gnuiconv \
       -Dnetwork=OFF \
       ..
   ninja

--- a/Util/Docker/Prerequisites.Dockerfile
+++ b/Util/Docker/Prerequisites.Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update ; \
     libtool \
     rsync \
     libxml2-dev \
-    aria2 \
-    libxerces-c-dev && \
+    aria2 && \
   pip3 install -Iv setuptools==47.3.1 && \
   pip3 install distro && \
   update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-8/bin/clang++ 180 && \

--- a/Util/OSM2ODR/CMakeLists.txt
+++ b/Util/OSM2ODR/CMakeLists.txt
@@ -77,14 +77,12 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import setuptools" RESULT_VARIA
     #set(ENABLED_FEATURES "${ENABLED_FEATURES} Proj")
 #endif (PROJ_FOUND)
 
-if (WIN32)
-    set(XERCES_PATH "../../Build/xerces-c-3.2.3-install")
-    set(XercesC_INCLUDE_DIR "${XERCES_PATH}/include")
-    set(XercesC_LIBRARY "${XERCES_PATH}/lib")
-    # Install xercesc
-    file(GLOB XERCES_LIBS "${XercesC_LIBRARY}/*.*")
-    install(FILES ${XERCES_LIBS} DESTINATION lib)
-endif ()
+set(XERCES_PATH "../../Build/xerces-c-3.2.3-install")
+set(XercesC_INCLUDE_DIR "${XERCES_PATH}/include")
+set(XercesC_LIBRARY "${XERCES_PATH}/lib")
+# Install xercesc
+file(GLOB XERCES_LIBS "${XercesC_LIBRARY}/*.*")
+install(FILES ${XERCES_LIBS} DESTINATION lib)
 find_package(XercesC REQUIRED)
 if (XercesC_FOUND)
     include_directories(SYSTEM ${XercesC_INCLUDE_DIRS})

--- a/Util/OSM2ODR/src/CMakeLists.txt
+++ b/Util/OSM2ODR/src/CMakeLists.txt
@@ -59,8 +59,8 @@ set(osm2odr_sources "${osm2odr_sources};${utils_traction_wire_sources}")
 
 add_library(osm2odr STATIC ${osm2odr_sources})
 target_link_libraries(osm2odr ${XercesC_LIBRARIES} ${ZLIB_LIBRARIES} ${PROJ_LIBRARY})
-if (WIN32)
-    target_compile_definitions(osm2odr PUBLIC "XERCES_STATIC_LIBRARY")
-endif ()
+
+target_compile_definitions(osm2odr PUBLIC "XERCES_STATIC_LIBRARY")
+
 install(TARGETS osm2odr ARCHIVE DESTINATION lib)
 install(FILES OSM2ODR.h DESTINATION include)


### PR DESCRIPTION
#### Description

Added Xerces-c library to automatic compilation in setup.sh instead of being a required library installed in your system though `apt-get`. 
Removed the library from requirements and documentation as it is compiled during setup.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3379)
<!-- Reviewable:end -->
