### PR TITLE
Reinforce collisions in SetSimulatePhysics(true)

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -852,6 +852,11 @@ void FCarlaServer::FPimpl::BindActions()
         RESPOND_ERROR("unable to set actor simulate physics: not supported by actor");
       }
       RootComponent->SetSimulatePhysics(bEnabled);
+      RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+
+      auto Vehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
+      if(Vehicle)
+        Vehicle->SetActorEnableCollision(true);
     }
 
     return R<void>::Success();


### PR DESCRIPTION
#### Description

In some special cases, when the physics are re-enabled, the collisions seem to not work.
This fix reinforces them to be enabled to be sure.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04 
  * **Python version(s):**3.6.9
  * **Unreal Engine version(s):**4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3380)
<!-- Reviewable:end -->
