### PR TITLE
Fix dead-lock in synchronous mode at high frame rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Latest
+
+  * Fixed random dead-lock on synchronous mode at high frame rate
+  
 ## CARLA 0.9.10
 
   * Added retrieval of bounding boxes for all the elements of the level

--- a/LibCarla/source/carla/streaming/Server.h
+++ b/LibCarla/source/carla/streaming/Server.h
@@ -60,6 +60,10 @@ namespace streaming {
       _pool.AsyncRun(worker_threads);
     }
 
+    void SetSynchronousMode(bool is_synchro) {
+      _server.SetSynchronousMode(is_synchro);
+    }
+
   private:
 
     // The order of these two arguments is very important.

--- a/LibCarla/source/carla/streaming/detail/tcp/Server.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/Server.cpp
@@ -20,7 +20,8 @@ namespace tcp {
   Server::Server(boost::asio::io_context &io_context, endpoint ep)
     : _io_context(io_context),
       _acceptor(_io_context, std::move(ep)),
-      _timeout(time_duration::seconds(10u)) {}
+      _timeout(time_duration::seconds(10u)),
+      _synchronous(false) {}
 
   void Server::OpenSession(
       time_duration timeout,
@@ -28,7 +29,7 @@ namespace tcp {
       ServerSession::callback_function_type on_closed) {
     using boost::system::error_code;
 
-    auto session = std::make_shared<ServerSession>(_io_context, timeout);
+    auto session = std::make_shared<ServerSession>(_io_context, timeout, *this);
 
     auto handle_query = [on_opened, on_closed, session](const error_code &ec) {
       if (!ec) {

--- a/LibCarla/source/carla/streaming/detail/tcp/Server.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/Server.h
@@ -58,7 +58,7 @@ namespace tcp {
       _synchronous = is_synchro;
     }
 
-    bool IsSynchronousMode(void) {
+    bool IsSynchronousMode() const {
       return _synchronous;
     }
 

--- a/LibCarla/source/carla/streaming/detail/tcp/Server.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/Server.h
@@ -54,6 +54,14 @@ namespace tcp {
       });
     }
 
+    void SetSynchronousMode(bool is_synchro) {
+      _synchronous = is_synchro;
+    }
+
+    bool IsSynchronousMode(void) {
+      return _synchronous;
+    }
+
   private:
 
     void OpenSession(
@@ -66,6 +74,8 @@ namespace tcp {
     boost::asio::ip::tcp::acceptor _acceptor;
 
     std::atomic<time_duration> _timeout;
+
+    bool _synchronous;
   };
 
 } // namespace tcp

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -5,6 +5,7 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "carla/streaming/detail/tcp/ServerSession.h"
+#include "carla/streaming/detail/tcp/Server.h"
 
 #include "carla/Debug.h"
 #include "carla/Logging.h"
@@ -15,6 +16,7 @@
 #include <boost/asio/post.hpp>
 
 #include <atomic>
+#include <thread>
 
 namespace carla {
 namespace streaming {
@@ -25,9 +27,11 @@ namespace tcp {
 
   ServerSession::ServerSession(
       boost::asio::io_context &io_context,
-      const time_duration timeout)
+      const time_duration timeout,
+      Server &server)
     : LIBCARLA_INITIALIZE_LIFETIME_PROFILER(
           std::string("tcp server session ") + std::to_string(SESSION_COUNTER)),
+      _server(server),
       _session_id(SESSION_COUNTER++),
       _socket(io_context),
       _timeout(timeout),
@@ -79,8 +83,17 @@ namespace tcp {
       if (!_socket.is_open()) {
         return;
       }
-      while (_is_writing) {
-        std::this_thread::yield();
+      if (_is_writing) {
+        if (_server.IsSynchronousMode()) {
+          // wait until previous message has been sent
+          while (_is_writing) {
+            std::this_thread::yield();
+          }
+        } else {
+          // ignore this message
+          log_debug("session", _session_id, ": connection too slow: message discarded");
+          return;
+        }      
       }
       _is_writing = true;
 

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
@@ -26,6 +26,8 @@ namespace streaming {
 namespace detail {
 namespace tcp {
 
+  class Server;
+
   /// A TCP server session. When a session opens, it reads from the socket a
   /// stream id object and passes itself to the callback functor. The session
   /// closes itself after @a timeout of inactivity is met.
@@ -40,7 +42,8 @@ namespace tcp {
 
     explicit ServerSession(
         boost::asio::io_context &io_context,
-        time_duration timeout);
+        time_duration timeout,
+        Server &server);
 
     /// Starts the session and calls @a on_opened after successfully reading the
     /// stream id, and @a on_closed once the session is closed.
@@ -81,6 +84,8 @@ namespace tcp {
     void CloseNow();
 
     friend class Server;
+
+    Server &_server;
 
     const size_t _session_id;
 

--- a/LibCarla/source/carla/streaming/low_level/Server.h
+++ b/LibCarla/source/carla/streaming/low_level/Server.h
@@ -64,6 +64,10 @@ namespace low_level {
       return _dispatcher.MakeStream();
     }
 
+    void SetSynchronousMode(bool is_synchro) {
+      _server.SetSynchronousMode(is_synchro);
+    }
+
   private:
 
     void StartServer() {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -287,6 +287,7 @@ void FCarlaServer::FPimpl::BindActions()
   {
     REQUIRE_CARLA_EPISODE();
     Episode->ApplySettings(settings);
+    StreamingServer.SetSynchronousMode(settings.synchronous_mode);
     return GFrameCounter;
   };
 


### PR DESCRIPTION
#### Description

Fixed a dead lock in synchronous mode happening randomly at high frame rate. 

It was caused by a race condition between messages to be sent through the network (the message causing the dead-lock was the one who has the episode data). The messages are added in a queue and processed in order. While one is being sending a flag is marked, and then the flag is unmarked once the message has been sent. But the unmarking of the flag was coded in a handler that was added to the queue when the message has been sent, instead of processing it at the instant. That was producing the race condition when another message was added to the queue before this handler, because if the flag is not unmarked the next message will be discarded. 

In the case of a message with the episode data, if it is skipped in synchronous mode then the client will never receive that episode, and will wait forever, while the server will never receive another tick, so both will be in dead-lock.

The fixes just do two things:

* communicate to the stream server in which mode the server is running (synchronous or asynchronous)
* process the handler of a message sent at the instant, instead of adding to the queue. 
* in synchronous mode the server will wait until he can send a message (wait for the flag unmarked)
* in asynchronous mode we will skip sending a message while flag is marked (for slow networks)

Fixes # 2809

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3394)
<!-- Reviewable:end -->
