### PR TITLE
RayCastSemanticLidar: Fix actor's id bug

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -165,11 +165,9 @@ void ARayCastSemanticLidar::ComputeRawDetection(const FHitResult& HitInfo, const
     Detection.object_tag = static_cast<uint32_t>(HitInfo.Component->CustomDepthStencilValue);
     if (actor != nullptr) {
       
-      Detection.object_tag = static_cast<uint32_t>(crp::CityObjectLabel::None);
-
       FActorView view = Registry.Find(actor);
       if(view.IsValid())
-        const FActorInfo* ActorInfo = view.GetActorInfo();
+        Detection.object_idx = view.GetActorId();
     }
     else {
       UE_LOG(LogCarla, Warning, TEXT("Actor not valid %p!!!!"), actor);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -162,20 +162,14 @@ void ARayCastSemanticLidar::ComputeRawDetection(const FHitResult& HitInfo, const
 
     AActor* actor = HitInfo.Actor.Get();
     Detection.object_idx = 0;
-    Detection.object_tag = static_cast<uint32_t>(crp::CityObjectLabel::None);
+    Detection.object_tag = static_cast<uint32_t>(HitInfo.Component->CustomDepthStencilValue);
     if (actor != nullptr) {
+      
+      Detection.object_tag = static_cast<uint32_t>(crp::CityObjectLabel::None);
 
       FActorView view = Registry.Find(actor);
-
-      if(view.IsValid()) {
+      if(view.IsValid())
         const FActorInfo* ActorInfo = view.GetActorInfo();
-        Detection.object_idx = ActorInfo->Description.UId;
-
-        Detection.object_tag = static_cast<uint32_t>(HitInfo.Component->CustomDepthStencilValue);
-      }
-      else {
-        Detection.object_tag = static_cast<uint32_t>(HitInfo.Component->CustomDepthStencilValue);
-      }
     }
     else {
       UE_LOG(LogCarla, Warning, TEXT("Actor not valid %p!!!!"), actor);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -160,14 +160,16 @@ void ARayCastSemanticLidar::ComputeRawDetection(const FHitResult& HitInfo, const
 
     const FActorRegistry &Registry = GetEpisode().GetActorRegistry();
 
-    AActor* actor = HitInfo.Actor.Get();
+    const AActor* actor = HitInfo.Actor.Get();
     Detection.object_idx = 0;
     Detection.object_tag = static_cast<uint32_t>(HitInfo.Component->CustomDepthStencilValue);
+
     if (actor != nullptr) {
-      
-      FActorView view = Registry.Find(actor);
+
+      const FActorView view = Registry.Find(actor);
       if(view.IsValid())
         Detection.object_idx = view.GetActorId();
+
     }
     else {
       UE_LOG(LogCarla, Warning, TEXT("Actor not valid %p!!!!"), actor);


### PR DESCRIPTION
#### Description

We were getting the id from ActorInfo and this one is not the same as the client's actor id.
Now, we take it from FActorView that correspond to the one we need.



#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** Python 3.6.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3396)
<!-- Reviewable:end -->
