### PR TITLE
Fixed map.get_waypoint function crashing with LaneType.Any

### DIFF
--- a/PythonAPI/carla/source/libcarla/Map.cpp
+++ b/PythonAPI/carla/source/libcarla/Map.cpp
@@ -78,6 +78,14 @@ static carla::geom::GeoLocation ToGeolocation(
   return self.GetGeoReference().Transform(location);
 }
 
+static carla::SharedPtr<carla::client::Waypoint> GetWaypoint(
+    const carla::client::Map &self,
+    const carla::geom::Location &location,
+    bool project_to_road,
+    int32_t lane_type) {
+  return self.GetWaypoint(location, project_to_road, static_cast<uint32_t>(lane_type));
+}
+
 void export_map() {
   using namespace boost::python;
   namespace cc = carla::client;
@@ -158,7 +166,7 @@ void export_map() {
     .def(init<std::string, std::string>((arg("name"), arg("xodr_content"))))
     .add_property("name", CALL_RETURNING_COPY(cc::Map, GetName))
     .def("get_spawn_points", CALL_RETURNING_LIST(cc::Map, GetRecommendedSpawnPoints))
-    .def("get_waypoint", &cc::Map::GetWaypoint, (arg("location"), arg("project_to_road")=true, arg("lane_type")=cr::Lane::LaneType::Driving))
+    .def("get_waypoint", &GetWaypoint, (arg("location"), arg("project_to_road")=true, arg("lane_type")=static_cast<int32_t>(cr::Lane::LaneType::Driving)))
     .def("get_waypoint_xodr", &cc::Map::GetWaypointXODR, (arg("road_id"), arg("lane_id"), arg("s")))
     .def("get_topology", &GetTopology)
     .def("generate_waypoints", CALL_RETURNING_LIST_1(cc::Map, GenerateWaypoints, double), (args("distance")))

--- a/PythonAPI/carla/source/libcarla/Map.cpp
+++ b/PythonAPI/carla/source/libcarla/Map.cpp
@@ -78,6 +78,9 @@ static carla::geom::GeoLocation ToGeolocation(
   return self.GetGeoReference().Transform(location);
 }
 
+// interface with carla::client::Map::GetWaypoint
+// windows compiler requires the explicit conversion from int32_t to uint32_t
+// which is not possible in python side
 static carla::SharedPtr<carla::client::Waypoint> GetWaypoint(
     const carla::client::Map &self,
     const carla::geom::Location &location,


### PR DESCRIPTION

#### Description

Fixed windows signed - unsingned conversions of `LaneType` parameter in `map.get_waypoint()` function. An intermediate function accepts a signed version of the variable and then performs the explicit cast.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3458)
<!-- Reviewable:end -->
