### PR TITLE
Remove TM's Traffic Light reset, and use the new one from World instead

### DIFF
--- a/LibCarla/source/carla/trafficmanager/TrafficManager.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManager.h
@@ -181,14 +181,6 @@ public:
     }
   }
 
-  /// Method to reset all traffic lights.
-  void ResetAllTrafficLights() {
-    TrafficManagerBase* tm_ptr = GetTM(_port);
-    if(tm_ptr != nullptr){
-      tm_ptr->ResetAllTrafficLights();
-    }
-  }
-
   /// Method to switch traffic manager into synchronous execution.
   void SetSynchronousMode(bool mode) {
     TrafficManagerBase* tm_ptr = GetTM(_port);

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerBase.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerBase.h
@@ -86,9 +86,6 @@ public:
   /// Method to provide synchronous tick
   virtual bool SynchronousTick() = 0;
 
-  /// Method to reset all traffic lights.
-  virtual void ResetAllTrafficLights() = 0;
-
   /// Get carla episode information
   virtual  carla::client::detail::EpisodeProxy& GetEpisodeProxy() = 0;
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerClient.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerClient.h
@@ -156,12 +156,6 @@ public:
     return _client->call("synchronous_tick").as<bool>();
   }
 
-  /// Method to reset all traffic light groups to the initial stage.
-  void ResetAllTrafficLights() {
-    DEBUG_ASSERT(_client != nullptr);
-    _client->call("reset_all_traffic_lights");
-  }
-
   /// Check if remote traffic manager is alive
   void HealthCheckRemoteTM() {
     DEBUG_ASSERT(_client != nullptr);

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -361,26 +361,6 @@ bool TrafficManagerLocal::CheckAllFrozen(TLGroup tl_to_freeze) {
   return true;
 }
 
-void TrafficManagerLocal::ResetAllTrafficLights() {
-  // Filter based on wildcard pattern.
-  const auto world_traffic_lights = world.GetActors()->Filter("*traffic_light*");
-
-  std::vector<TLGroup> list_of_all_groups;
-  std::vector<carla::ActorId> list_of_ids;
-
-  for (auto iter = world_traffic_lights->begin(); iter != world_traffic_lights->end(); iter++) {
-    auto tl = *iter;
-    if (!(std::find(list_of_ids.begin(), list_of_ids.end(), tl->GetId()) != list_of_ids.end())) {
-      const TLGroup tl_group = boost::static_pointer_cast<cc::TrafficLight>(tl)->GetGroupTrafficLights();
-      list_of_all_groups.push_back(tl_group);
-    }
-  }
-
-  for (TLGroup &tl_group : list_of_all_groups) {
-    tl_group.front()->ResetGroup();
-  }
-}
-
 void TrafficManagerLocal::SetSynchronousMode(bool mode) {
   const bool previous_mode = parameters.GetSynchronousMode();
   parameters.SetSynchronousMode(mode);
@@ -404,7 +384,7 @@ std::vector<ActorId> TrafficManagerLocal::GetRegisteredVehiclesIDs() {
 
 void TrafficManagerLocal::SetRandomDeviceSeed(const uint64_t _seed) {
   seed = _seed;
-  ResetAllTrafficLights();
+  world.ResetAllTrafficLights();
 }
 
 } // namespace traffic_manager

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
@@ -199,12 +199,6 @@ public:
   /// Method to provide synchronous tick.
   bool SynchronousTick();
 
-  /// Method to reset all traffic light groups to the initial stage.
-  void ResetAllTrafficLights();
-
-  /// Method to start all traffic light groups to the initial stage.
-  void StartAllTrafficLights();
-
   /// Get CARLA episode information.
   carla::client::detail::EpisodeProxy &GetEpisodeProxy();
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerRemote.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerRemote.cpp
@@ -185,10 +185,6 @@ void TrafficManagerRemote::SetOSMMode(const bool mode_switch) {
   client.SetOSMMode(mode_switch);
 }
 
-void TrafficManagerRemote::ResetAllTrafficLights() {
-  client.ResetAllTrafficLights();
-}
-
 void TrafficManagerRemote::SetSynchronousMode(bool mode) {
   client.SetSynchronousMode(mode);
 }

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerRemote.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerRemote.h
@@ -108,9 +108,6 @@ public:
   /// Method to provide synchronous tick
   bool SynchronousTick();
 
-  /// Method to reset all traffic lights.
-  void ResetAllTrafficLights();
-
   /// Get CARLA episode information.
   carla::client::detail::EpisodeProxy& GetEpisodeProxy();
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerServer.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerServer.h
@@ -188,11 +188,6 @@ public:
         return tm->SynchronousTick();
       });
 
-      /// Method to reset all traffic lights.
-      server->bind("reset_all_traffic_lights", [=]() {
-        tm->ResetAllTrafficLights();
-      });
-
       /// Method to check server is alive or not.
       server->bind("health_check_remote_TM", [=](){});
 

--- a/PythonAPI/carla/source/libcarla/TrafficManager.cpp
+++ b/PythonAPI/carla/source/libcarla/TrafficManager.cpp
@@ -25,7 +25,6 @@ void export_trafficmanager() {
     .def("force_lane_change", &ctm::TrafficManager::SetForceLaneChange)
     .def("auto_lane_change", &ctm::TrafficManager::SetAutoLaneChange)
     .def("distance_to_leading_vehicle", &ctm::TrafficManager::SetDistanceToLeadingVehicle)
-    .def("reset_traffic_lights", &ctm::TrafficManager::ResetAllTrafficLights)
     .def("ignore_walkers_percentage", &ctm::TrafficManager::SetPercentageIgnoreWalkers)
     .def("ignore_vehicles_percentage", &ctm::TrafficManager::SetPercentageIgnoreVehicles)
     .def("ignore_lights_percentage", &ctm::TrafficManager::SetPercentageRunningLight)


### PR DESCRIPTION
#### Description

This PR removes the Traffic Light reset method from TM, and changes its usages from TM's one to the new one in World.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18
  * **Python version(s):** Python 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

Documentation must be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3498)
<!-- Reviewable:end -->
