### PR TITLE
Add horizontal fov parameter to lidar sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   * Fixed dependency of library **Xerces-c** on package
   * Fixed minor typo in the simulation data section of the documentation
   * Fixed the `config.py` to read the `.osm ` files in proper `utf-8` encoding
+  * Added `horizontal_fov` parameter to lidar sensor to allow for restriction of its field of view
 
 ## CARLA 0.9.10
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -900,8 +900,7 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       DropOffIntensityLimit,
       DropOffAtZeroIntensity,
       StdDevLidar,
-      HorizontalFOV
-    });
+      HorizontalFOV});
   }
   else if (Id == "ray_cast_semantic") {
     Definition.Variations.Append({

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -849,6 +849,11 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
   LowerFOV.Id = TEXT("lower_fov");
   LowerFOV.Type = EActorAttributeType::Float;
   LowerFOV.RecommendedValues = { TEXT("-30.0") };
+  // Horizontal FOV.
+  FActorVariation HorizontalFOV;
+  HorizontalFOV.Id = TEXT("horizontal_fov");
+  HorizontalFOV.Type = EActorAttributeType::Float;
+  HorizontalFOV.RecommendedValues = { TEXT("360.0") };
   // Atmospheric Attenuation Rate.
   FActorVariation AtmospAttenRate;
   AtmospAttenRate.Id = TEXT("atmosphere_attenuation_rate");
@@ -894,7 +899,9 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       DropOffGenRate,
       DropOffIntensityLimit,
       DropOffAtZeroIntensity,
-      StdDevLidar});
+      StdDevLidar,
+      HorizontalFOV
+    });
   }
   else if (Id == "ray_cast_semantic") {
     Definition.Variations.Append({
@@ -903,7 +910,8 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       PointsPerSecond,
       Frequency,
       UpperFOV,
-      LowerFOV});
+      LowerFOV,
+      HorizontalFOV});
   }
   else {
     DEBUG_ASSERT(false);
@@ -1516,6 +1524,8 @@ void UActorBlueprintFunctionLibrary::SetLidar(
       RetrieveActorAttributeToFloat("upper_fov", Description.Variations, Lidar.UpperFovLimit);
   Lidar.LowerFovLimit =
       RetrieveActorAttributeToFloat("lower_fov", Description.Variations, Lidar.LowerFovLimit);
+  Lidar.HorizontalFov =
+      RetrieveActorAttributeToFloat("horizontal_fov", Description.Variations, Lidar.HorizontalFov);
   Lidar.AtmospAttenRate =
       RetrieveActorAttributeToFloat("atmosphere_attenuation_rate", Description.Variations, Lidar.AtmospAttenRate);
   Lidar.RandomSeed =

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarDescription.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarDescription.h
@@ -38,6 +38,10 @@ struct CARLA_API FLidarDescription
   /// horizontal line.
   UPROPERTY(EditAnywhere)
   float LowerFovLimit = -30.0f;
+  
+  /// Horizontal field of view
+  UPROPERTY(EditAnywhere)
+  float HorizontalFov = 360.0f;
 
   /// Attenuation Rate in the atmosphere in m^-1.
   UPROPERTY(EditAnywhere)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -95,7 +95,8 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
 
   const float CurrentHorizontalAngle = carla::geom::Math::ToDegrees(
       SemanticLidarData.GetHorizontalAngle());
-  const float AngleDistanceOfTick = Description.RotationFrequency * 360.0f * DeltaTime;
+  const float AngleDistanceOfTick = Description.RotationFrequency * Description.HorizontalFov 
+      * DeltaTime;
   const float AngleDistanceOfLaserMeasure = AngleDistanceOfTick / PointsToScanWithOneLaser;
 
   ResetRecordedHits(ChannelCount, PointsToScanWithOneLaser);
@@ -106,7 +107,9 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
     for (auto idxPtsOneLaser = 0u; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
       FHitResult HitResult;
       const float VertAngle = LaserAngles[idxChannel];
-      const float HorizAngle = CurrentHorizontalAngle + AngleDistanceOfLaserMeasure * idxPtsOneLaser;
+      const float HorizAngle = std::fmod(std::fmod(CurrentHorizontalAngle 
+          + AngleDistanceOfLaserMeasure * idxPtsOneLaser, Description.HorizontalFov) 
+          - Description.HorizontalFov / 2, 360.0f);
       const bool PreprocessResult = RayPreprocessCondition[idxChannel][idxPtsOneLaser];
 
       if (PreprocessResult && ShootLaser(VertAngle, HorizAngle, HitResult)) {
@@ -120,7 +123,7 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
   ComputeAndSaveDetections(ActorTransf);
 
   const float HorizontalAngle = carla::geom::Math::ToRadians(
-      std::fmod(CurrentHorizontalAngle + AngleDistanceOfTick, 360.0f));
+      std::fmod(CurrentHorizontalAngle + AngleDistanceOfTick, Description.HorizontalFov));
   SemanticLidarData.SetHorizontalAngle(HorizontalAngle);
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -107,9 +107,8 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
     for (auto idxPtsOneLaser = 0u; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
       FHitResult HitResult;
       const float VertAngle = LaserAngles[idxChannel];
-      const float HorizAngle = std::fmod(std::fmod(CurrentHorizontalAngle 
-          + AngleDistanceOfLaserMeasure * idxPtsOneLaser, Description.HorizontalFov) 
-          - Description.HorizontalFov / 2, 360.0f);
+      const float HorizAngle = std::fmod(CurrentHorizontalAngle + AngleDistanceOfLaserMeasure
+          * idxPtsOneLaser, Description.HorizontalFov) - Description.HorizontalFov / 2;
       const bool PreprocessResult = RayPreprocessCondition[idxChannel][idxPtsOneLaser];
 
       if (PreprocessResult && ShootLaser(VertAngle, HorizAngle, HitResult)) {


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Added a "horizontal_fov" parameter to (semantic) lidar to allow for a restricted field of view of the sensor. The field of view is centered around the axis in which the sensor is directed. The rotation frequency parameter is scaled towards the total fov of the sensor, meaning it describes the frequency for one full scan of the fov.

Fixes #1440 #1544

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04.5
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.24.3

#### Possible Drawbacks

With a default 360° horizontal FOV the lidar scan will start at -180° and finish at 180° when performing a full revolution, assuming the sensor itself is at a 0° orientation. Previously the scan would in this case start at 0° and finish at 360°.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3525)
<!-- Reviewable:end -->
