### PR TITLE
TrafficLight and TrafficSigns can spawn on sublevels

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -229,10 +229,13 @@ ATrafficLightManager* ACarlaGameModeBase::GetTrafficLightManager()
 {
   if (!TrafficLightManager)
   {
-    AActor* TrafficLightManagerActor = UGameplayStatics::GetActorOfClass(GetWorld(), ATrafficLightManager::StaticClass());
+    UWorld* World = GetWorld();
+    AActor* TrafficLightManagerActor = UGameplayStatics::GetActorOfClass(World, ATrafficLightManager::StaticClass());
     if(TrafficLightManagerActor == nullptr)
     {
-      TrafficLightManager = GetWorld()->SpawnActor<ATrafficLightManager>();
+      FActorSpawnParameters SpawnParams;
+      SpawnParams.OverrideLevel = GetLevelToSpanInto("TrafficLights");
+      TrafficLightManager = World->SpawnActor<ATrafficLightManager>(SpawnParams);
     }
     else
     {
@@ -485,4 +488,27 @@ void ACarlaGameModeBase::ConvertMapLayerMaskToMapNames(int32 MapLayer, TArray<FN
     }
   }
 
+}
+
+ULevel* ACarlaGameModeBase::GetLevelToSpanInto(FString LevelName)
+{
+  ULevel* OutLevel = nullptr;
+  UWorld* World = GetWorld();
+  const TArray <ULevelStreaming*> Levels = World->GetStreamingLevels();
+
+  for(ULevelStreaming* Level : Levels)
+  {
+    FString FullSubMapName = Level->PackageNameToLoad.ToString();
+    if(FullSubMapName.Contains(LevelName))
+    {
+      OutLevel = Level->GetLoadedLevel();
+      if(!OutLevel)
+      {
+        UE_LOG(LogCarla, Warning, TEXT("%s has not been loaded"), *LevelName);
+      }
+      break;
+    }
+  }
+
+  return OutLevel;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -234,7 +234,7 @@ ATrafficLightManager* ACarlaGameModeBase::GetTrafficLightManager()
     if(TrafficLightManagerActor == nullptr)
     {
       FActorSpawnParameters SpawnParams;
-      SpawnParams.OverrideLevel = GetLevelToSpanInto("TrafficLights");
+      SpawnParams.OverrideLevel = GetULevelFromName("TrafficLights");
       TrafficLightManager = World->SpawnActor<ATrafficLightManager>(SpawnParams);
     }
     else
@@ -490,7 +490,7 @@ void ACarlaGameModeBase::ConvertMapLayerMaskToMapNames(int32 MapLayer, TArray<FN
 
 }
 
-ULevel* ACarlaGameModeBase::GetLevelToSpanInto(FString LevelName)
+ULevel* ACarlaGameModeBase::GetULevelFromName(FString LevelName)
 {
   ULevel* OutLevel = nullptr;
   UWorld* World = GetWorld();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -70,6 +70,9 @@ public:
   UFUNCTION(Category = "Carla Game Mode", BlueprintCallable, CallInEditor, Exec)
   void UnLoadMapLayer(int32 MapLayers);
 
+  UFUNCTION(Category = "Carla Game Mode")
+  ULevel* GetLevelToSpanInto(FString LevelName);
+
 protected:
 
   void InitGame(const FString &MapName, const FString &Options, FString &ErrorMessage) override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -71,7 +71,7 @@ public:
   void UnLoadMapLayer(int32 MapLayers);
 
   UFUNCTION(Category = "Carla Game Mode")
-  ULevel* GetLevelToSpanInto(FString LevelName);
+  ULevel* GetULevelFromName(FString LevelName);
 
 protected:
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -53,6 +53,9 @@ ATrafficLightManager::ATrafficLightManager()
 
 void ATrafficLightManager::RegisterLightComponentFromOpenDRIVE(UTrafficLightComponent * TrafficLightComponent)
 {
+  ACarlaGameModeBase *GM = UCarlaStatics::GetGameMode(GetWorld());
+  check(GM);
+
   // Cast to std::string
   carla::road::SignId SignId(TCHAR_TO_UTF8(*(TrafficLightComponent->GetSignId())));
 
@@ -78,8 +81,10 @@ void ATrafficLightManager::RegisterLightComponentFromOpenDRIVE(UTrafficLightComp
     // Search/create TrafficGroup (junction traffic light manager)
     if(!TrafficGroups.Contains(JunctionId))
     {
+      FActorSpawnParameters SpawnParams;
+      SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
       auto * NewTrafficLightGroup =
-          GetWorld()->SpawnActor<ATrafficLightGroup>();
+          GetWorld()->SpawnActor<ATrafficLightGroup>(SpawnParams);
       NewTrafficLightGroup->JunctionId = JunctionId;
       TrafficGroups.Add(JunctionId, NewTrafficLightGroup);
     }
@@ -97,8 +102,10 @@ void ATrafficLightManager::RegisterLightComponentFromOpenDRIVE(UTrafficLightComp
   }
   else
   {
+    FActorSpawnParameters SpawnParams;
+    SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
     auto * NewTrafficLightGroup =
-          GetWorld()->SpawnActor<ATrafficLightGroup>();
+          GetWorld()->SpawnActor<ATrafficLightGroup>(SpawnParams);
     NewTrafficLightGroup->JunctionId = TrafficLightGroupMissingId;
     TrafficGroups.Add(NewTrafficLightGroup->JunctionId, NewTrafficLightGroup);
     TrafficLightGroup = NewTrafficLightGroup;
@@ -439,6 +446,9 @@ void ATrafficLightManager::SpawnTrafficLights()
       }
     }
   }
+
+  ACarlaGameModeBase *GM = UCarlaStatics::GetGameMode(GetWorld());
+  check(GM);
   for(auto &SignalId : SignalsToSpawn)
   {
     // TODO: should this be an assert?
@@ -468,6 +478,7 @@ void ATrafficLightManager::SpawnTrafficLights()
     SpawnParams.Owner = this;
     SpawnParams.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
     ATrafficLightBase * TrafficLight = GetWorld()->SpawnActor<ATrafficLightBase>(
         TrafficLightModel,
         SpawnLocation,
@@ -509,6 +520,9 @@ void ATrafficLightManager::SpawnTrafficLights()
 
 void ATrafficLightManager::SpawnSignals()
 {
+  ACarlaGameModeBase *GM = UCarlaStatics::GetGameMode(GetWorld());
+  check(GM);
+
   const auto &Signals = GetMap()->GetSignals();
   for (auto& SignalPair : Signals)
   {
@@ -559,6 +573,7 @@ void ATrafficLightManager::SpawnSignals()
       SpawnParams.Owner = this;
       SpawnParams.SpawnCollisionHandlingOverride =
           ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+      SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficSigns");
       ATrafficSignBase * TrafficSign = GetWorld()->SpawnActor<ATrafficSignBase>(
           TrafficSignsModels[SignalType],
           SpawnLocation,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -82,7 +82,7 @@ void ATrafficLightManager::RegisterLightComponentFromOpenDRIVE(UTrafficLightComp
     if(!TrafficGroups.Contains(JunctionId))
     {
       FActorSpawnParameters SpawnParams;
-      SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
+      SpawnParams.OverrideLevel = GM->GetULevelFromName("TrafficLights");
       auto * NewTrafficLightGroup =
           GetWorld()->SpawnActor<ATrafficLightGroup>(SpawnParams);
       NewTrafficLightGroup->JunctionId = JunctionId;
@@ -103,7 +103,7 @@ void ATrafficLightManager::RegisterLightComponentFromOpenDRIVE(UTrafficLightComp
   else
   {
     FActorSpawnParameters SpawnParams;
-    SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
+    SpawnParams.OverrideLevel = GM->GetULevelFromName("TrafficLights");
     auto * NewTrafficLightGroup =
           GetWorld()->SpawnActor<ATrafficLightGroup>(SpawnParams);
     NewTrafficLightGroup->JunctionId = TrafficLightGroupMissingId;
@@ -478,7 +478,7 @@ void ATrafficLightManager::SpawnTrafficLights()
     SpawnParams.Owner = this;
     SpawnParams.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-    SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficLights");
+    SpawnParams.OverrideLevel = GM->GetULevelFromName("TrafficLights");
     ATrafficLightBase * TrafficLight = GetWorld()->SpawnActor<ATrafficLightBase>(
         TrafficLightModel,
         SpawnLocation,
@@ -573,7 +573,7 @@ void ATrafficLightManager::SpawnSignals()
       SpawnParams.Owner = this;
       SpawnParams.SpawnCollisionHandlingOverride =
           ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-      SpawnParams.OverrideLevel = GM->GetLevelToSpanInto("TrafficSigns");
+      SpawnParams.OverrideLevel = GM->GetULevelFromName("TrafficSigns");
       ATrafficSignBase * TrafficSign = GetWorld()->SpawnActor<ATrafficSignBase>(
           TrafficSignsModels[SignalType],
           SpawnLocation,


### PR DESCRIPTION
#### Description

The TL (TrafficLight) and TS (TrafficSigns) were spawned from code always to the persistent level.
Now, before spawning them it is detected if the level support sub-levelling and if the right sublevel exists, so they can be spawned in the right level.

If there are no sublevels or the specific sublevel is not included in the hierarchy, they will be added to the persistent level as before.


#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3532)
<!-- Reviewable:end -->
