### PR TITLE
Update CarlaRecorder.cpp

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -101,6 +101,7 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
           if (bAdditionalData)
           {
             AddActorKinematics(View);
+			AddActorBoundingBox(View);
           }
           break;
 
@@ -117,6 +118,8 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
         // save the state of each traffic light
         case FActorView::ActorType::TrafficLight:
           AddTrafficLightState(View);
+		  ATrafficSignBase* TrafficSign = Cast<ATrafficSignBase>(View.GetActor());	
+		  AddTriggerVolume(*TrafficSign);
           break;
       }
     }


### PR DESCRIPTION
Fixed bug in Recorder: vehicle bounding-boxes and trigger-volumes of traffic signs were not saved to recorder-file.

  - [V] up-to-date with the `dev` branch 
  - [X] tested with latest changes
  - [V] Code compiles correctly
  - [X] All tests passing with `make check` (only Linux)

Description:
------------
Bounding-boxes and trigger-volumes were not added to the boxes arrays in the Ticking loop of the recorder but only once on start. Due to this, no bounding/trigger boxes were not actually saved to recorder-file. 

Tested on:
   Platform(s): Windows...
   Python version(s): 3.6
   Unreal Engine version(s): 4.24.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3548)
<!-- Reviewable:end -->
