### PR TITLE
Fixed noise on manual_control

### DIFF
--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -1081,6 +1081,8 @@ def game_loop(args):
         display = pygame.display.set_mode(
             (args.width, args.height),
             pygame.HWSURFACE | pygame.DOUBLEBUF)
+        display.fill((0,0,0))
+        pygame.display.flip()
 
         hud = HUD(args.width, args.height)
         world = World(client.get_world(), hud, args)


### PR DESCRIPTION
#### Description

In packages executed with python2 and Pygame 2.0 the initial image is all noise. This issue hasn't been detected with other versions of Pygame nor python 3.
The initial surface of the window has been set to black to avoid this.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3608)
<!-- Reviewable:end -->
