### PR TITLE
Fixed conversion of std::string to FString.

### DIFF
--- a/LibCarla/source/carla/rpc/String.h
+++ b/LibCarla/source/carla/rpc/String.h
@@ -48,16 +48,10 @@ namespace rpc {
   // Slower conversion to fstring for long text
   static inline FString ToLongFString(const std::string &str) {
     FString result = "";
-    size_t i = 0;
-    while(i + MaxStringLength < str.size()) {
-      auto substr = str.substr(i, MaxStringLength);
-      FString temp_string(substr.size(), UTF8_TO_TCHAR(substr.c_str()));
-      result += temp_string;
-      i += MaxStringLength;
+    for (size_t i = 0; i < str.size(); i++)
+    {
+      result += str[i];
     }
-    auto substr = str.substr(i);
-    FString temp_string(substr.size(), UTF8_TO_TCHAR(substr.c_str()));
-    result += temp_string;
     return result;
   }
 


### PR DESCRIPTION
#### Description

Fix a bug regarding string format conversions.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks
The conversion becomes a bit slower but this is used typically for loading a map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3619)
<!-- Reviewable:end -->
