### PR TITLE
Toggle ragdoll physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Fixed bug in `waypoint.get_landmarks()` causing some landmarks to be missed when s = 0
   * Fixed the `actor.set_simulate_physics()` for pedestrians and vehicles
   * Fixed bug causing camera-based sensors to stop sending data
+  * Added `WorldSettings.deterministic_ragdolls` to enable deterministic or physically based ragdolls
   * Fixed the lack of determinism on the output of raycast sensors
   * Fixed bug in the actor's id returned by the semantic lidar
   * Fixed dependency of library **Xerces-c** on package

--- a/LibCarla/source/carla/rpc/EpisodeSettings.h
+++ b/LibCarla/source/carla/rpc/EpisodeSettings.h
@@ -37,8 +37,10 @@ namespace rpc {
 
     int max_substeps = 10;
 
+    bool deterministic_ragdolls = true;
+
     MSGPACK_DEFINE_ARRAY(synchronous_mode, no_rendering_mode, fixed_delta_seconds, substepping,
-        max_substep_delta_time, max_substeps);
+        max_substep_delta_time, max_substeps, deterministic_ragdolls);
 
     // =========================================================================
     // -- Constructors ---------------------------------------------------------
@@ -52,13 +54,15 @@ namespace rpc {
         double fixed_delta_seconds = 0.0,
         bool substepping = true,
         double max_substep_delta_time = 0.01,
-        int max_substeps = 10)
+        int max_substeps = 10,
+        bool deterministic_ragdolls = true)
       : synchronous_mode(synchronous_mode),
         no_rendering_mode(no_rendering_mode),
         fixed_delta_seconds(
             fixed_delta_seconds > 0.0 ? fixed_delta_seconds : boost::optional<double>{}),
         substepping(substepping),
-        max_substep_delta_time(max_substep_delta_time), max_substeps(max_substeps) {}
+        max_substep_delta_time(max_substep_delta_time), max_substeps(max_substeps),
+        deterministic_ragdolls(deterministic_ragdolls) {}
 
     // =========================================================================
     // -- Comparison operators -------------------------------------------------
@@ -71,7 +75,8 @@ namespace rpc {
           (substepping == rhs.substepping) &&
           (fixed_delta_seconds == rhs.fixed_delta_seconds) &&
           (max_substep_delta_time == rhs.max_substep_delta_time) &&
-          (max_substeps == rhs.max_substeps);
+          (max_substeps == rhs.max_substeps) &&
+          (deterministic_ragdolls == rhs.deterministic_ragdolls);
     }
 
     bool operator!=(const EpisodeSettings &rhs) const {
@@ -91,7 +96,8 @@ namespace rpc {
             Settings.FixedDeltaSeconds.Get(0.0),
             Settings.bSubstepping,
             Settings.MaxSubstepDeltaTime,
-            Settings.MaxSubsteps) {}
+            Settings.MaxSubsteps,
+            Settings.bDeterministicRagdolls) {}
 
     operator FEpisodeSettings() const {
       FEpisodeSettings Settings;
@@ -103,6 +109,7 @@ namespace rpc {
       Settings.bSubstepping = substepping;
       Settings.MaxSubstepDeltaTime = max_substep_delta_time;
       Settings.MaxSubsteps = max_substeps;
+      Settings.bDeterministicRagdolls = deterministic_ragdolls;
 
       return Settings;
     }

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -147,12 +147,14 @@ void export_world() {
          arg("fixed_delta_seconds")=0.0,
          arg("substepping")=true,
          arg("max_substep_delta_time")=0.01,
-         arg("max_substeps")=10)))
+         arg("max_substeps")=10,
+         arg("deterministic_ragdolls")=false)))
     .def_readwrite("synchronous_mode", &cr::EpisodeSettings::synchronous_mode)
     .def_readwrite("no_rendering_mode", &cr::EpisodeSettings::no_rendering_mode)
     .def_readwrite("substepping", &cr::EpisodeSettings::substepping)
     .def_readwrite("max_substep_delta_time", &cr::EpisodeSettings::max_substep_delta_time)
     .def_readwrite("max_substeps", &cr::EpisodeSettings::max_substeps)
+    .def_readwrite("deterministic_ragdolls", &cr::EpisodeSettings::deterministic_ragdolls)
     .add_property("fixed_delta_seconds",
         +[](const cr::EpisodeSettings &self) {
           return OptionalToPythonObject(self.fixed_delta_seconds);
@@ -277,6 +279,7 @@ void export_world() {
     .def("cast_ray", CALL_RETURNING_LIST_2(cc::World, CastRay, cg::Location, cg::Location), (arg("initial_location"), arg("final_location")))
     .def("project_point", CALL_RETURNING_OPTIONAL_3(cc::World, ProjectPoint, cg::Location, cg::Vector3D, float), (arg("location"), arg("direction"), arg("search_distance")=10000.f))
     .def("ground_projection", CALL_RETURNING_OPTIONAL_2(cc::World, GroundProjection, cg::Location, float), (arg("location"), arg("search_distance")=10000.f))
+
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -141,7 +141,7 @@ void export_world() {
   ;
 
   class_<cr::EpisodeSettings>("WorldSettings")
-    .def(init<bool, bool, double, bool, double, int>(
+    .def(init<bool, bool, double, bool, double, int, bool>(
         (arg("synchronous_mode")=false,
          arg("no_rendering_mode")=false,
          arg("fixed_delta_seconds")=0.0,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/EpisodeSettings.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/EpisodeSettings.h
@@ -27,4 +27,8 @@ struct CARLA_API FEpisodeSettings
   double MaxSubstepDeltaTime = 0.01;
 
   int MaxSubsteps = 10;
+
+  UPROPERTY(EditAnywhere, BlueprintReadWrite)
+  bool bDeterministicRagdolls = true;
+
 };


### PR DESCRIPTION
#### Description

Added `WorldSettings.deterministic_ragdolls` to enable or disable ragdoll physics and death animations.
For now this only has an effect with content branch `axel/ragdoll_animations`.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3631)
<!-- Reviewable:end -->
