### PR TITLE
Extended local planner with a lateral offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   * Fixed minor typo in the simulation data section of the documentation
   * Fixed the `config.py` to read the `.osm ` files in proper `utf-8` encoding
   * Added `horizontal_fov` parameter to lidar sensor to allow for restriction of its field of view
+  * Extended the local planner with a lateral `offset`.
 
 ## CARLA 0.9.10
 

--- a/PythonAPI/carla/agents/navigation/local_planner.py
+++ b/PythonAPI/carla/agents/navigation/local_planner.py
@@ -112,6 +112,7 @@ class LocalPlanner(object):
             'K_D': 0,
             'K_I': 0.05,
             'dt': self._dt}
+        self._offset = 0
 
         # parameters overload
         if opt_dict:
@@ -132,14 +133,17 @@ class LocalPlanner(object):
                 self._max_brake = opt_dict['max_brake']
             if 'max_steering' in opt_dict:
                 self._max_steer = opt_dict['max_steering']
+            if 'offset' in opt_dict:
+                self._offset = opt_dict['offset']
 
         self._current_waypoint = self._map.get_waypoint(self._vehicle.get_location())
         self._vehicle_controller = VehiclePIDController(self._vehicle,
                                                         args_lateral=args_lateral_dict,
                                                         args_longitudinal=args_longitudinal_dict,
+                                                        offset=self._offset,
                                                         max_throttle=self._max_throt,
                                                         max_brake=self._max_brake,
-                                                        max_steering=self._max_steer,)
+                                                        max_steering=self._max_steer)
 
         self._global_plan = False
 


### PR DESCRIPTION
### Description

Added an offset input to the VehiclePIDController, allowing the controlled vehicles to move displaced from the lane center.  The LocalPlanner has been extended to accomodate these changes.

It is important to note that due to the current state of the controllers, they are subject to break if the offset is high enough to make the vehicle drive through an adjacent lane. This is mainly due to the use of functions such as *get_waypoint()* or *is_at_traffic_light()*.


### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

### Possible Drawbacks

There should be no possible drawbacks as this is purely an extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3678)
<!-- Reviewable:end -->
