### PR TITLE
Added initial support for CarSim

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,8 +90,8 @@ pipeline
                         {
                             steps
                             {
-                                sh 'make package ARGS="--python-version=3.7,2 --carsim'
-                                sh 'make package ARGS="--packages=AdditionalMaps --clean-intermediate --python-version=3.7,2 --carsim'
+                                sh 'make package ARGS="--python-version=3.7,2 --carsim"'
+                                sh 'make package ARGS="--packages=AdditionalMaps --clean-intermediate --python-version=3.7,2 --carsim"'
                                 sh 'make examples ARGS="localhost 3654"'
                             }
                             post
@@ -250,7 +250,7 @@ pipeline
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make CarlaUE4Editor
+                                    make CarlaUE4Editor ARGS="--carsim"
                                 """
                             }
                             post
@@ -278,11 +278,11 @@ pipeline
                             {
                                 bat """
                                     call ../setEnv64.bat
-                                    make package
+                                    make package ARGS="--carsim"
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make package ARGS="--packages=AdditionalMaps --clean-intermediate"
+                                    make package ARGS="--packages=AdditionalMaps --clean-intermediate --carsim"
                                 """
                             }
                             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline
                             {
                                 sh 'make LibCarla'
                                 sh 'make PythonAPI ARGS="--python-version=3.7,2"'
-                                sh 'make CarlaUE4Editor'
+                                sh 'make CarlaUE4Editor ARGS="--carsim"'
                                 sh 'make examples'
                             }
                             post
@@ -90,8 +90,8 @@ pipeline
                         {
                             steps
                             {
-                                sh 'make package ARGS="--python-version=3.7,2"'
-                                sh 'make package ARGS="--packages=AdditionalMaps --clean-intermediate --python-version=3.7,2"'
+                                sh 'make package ARGS="--python-version=3.7,2 --carsim'
+                                sh 'make package ARGS="--packages=AdditionalMaps --clean-intermediate --python-version=3.7,2 --carsim'
                                 sh 'make examples ARGS="localhost 3654"'
                             }
                             post

--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -88,8 +88,8 @@ namespace client {
     return boost::static_pointer_cast<TrafficLight>(GetWorld().GetActor(id));
   }
 
-  void Vehicle::SetCarSimEnabled(bool enabled, std::string simfile_path) {
-    GetEpisode().Lock()->SetCarSimEnabled(*this, enabled, simfile_path);
+  void Vehicle::EnableCarSim(std::string simfile_path) {
+    GetEpisode().Lock()->EnableCarSim(*this, simfile_path);
   }
 
   void Vehicle::UseCarSimRoad(bool enabled) {

--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -88,5 +88,9 @@ namespace client {
     return boost::static_pointer_cast<TrafficLight>(GetWorld().GetActor(id));
   }
 
+  void Vehicle::SetCarSimEnabled(bool enabled) {
+    GetEpisode().Lock()->SetCarSimEnabled(*this, enabled);
+  }
+
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -88,8 +88,12 @@ namespace client {
     return boost::static_pointer_cast<TrafficLight>(GetWorld().GetActor(id));
   }
 
-  void Vehicle::SetCarSimEnabled(bool enabled) {
-    GetEpisode().Lock()->SetCarSimEnabled(*this, enabled);
+  void Vehicle::SetCarSimEnabled(bool enabled, std::string simfile_path) {
+    GetEpisode().Lock()->SetCarSimEnabled(*this, enabled, simfile_path);
+  }
+
+  void Vehicle::UseCarSimRoad(bool enabled) {
+    GetEpisode().Lock()->UseCarSimRoad(*this, enabled);
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/Vehicle.h
+++ b/LibCarla/source/carla/client/Vehicle.h
@@ -87,6 +87,9 @@ namespace client {
     /// Retrieve the traffic light actor currently affecting this vehicle.
     SharedPtr<TrafficLight> GetTrafficLight() const;
 
+    /// Enables CarSim simulation if it is availiable
+    void SetCarSimEnabled(bool enabled);
+
   private:
 
     const bool _is_control_sticky;

--- a/LibCarla/source/carla/client/Vehicle.h
+++ b/LibCarla/source/carla/client/Vehicle.h
@@ -88,7 +88,7 @@ namespace client {
     SharedPtr<TrafficLight> GetTrafficLight() const;
 
     /// Enables CarSim simulation if it is availiable
-    void SetCarSimEnabled(bool enabled, std::string simfile_path);
+    void EnableCarSim(std::string simfile_path);
 
     /// Enables the use of CarSim internal road definition instead of unreal's
     void UseCarSimRoad(bool enabled);

--- a/LibCarla/source/carla/client/Vehicle.h
+++ b/LibCarla/source/carla/client/Vehicle.h
@@ -88,7 +88,10 @@ namespace client {
     SharedPtr<TrafficLight> GetTrafficLight() const;
 
     /// Enables CarSim simulation if it is availiable
-    void SetCarSimEnabled(bool enabled);
+    void SetCarSimEnabled(bool enabled, std::string simfile_path);
+
+    /// Enables the use of CarSim internal road definition instead of unreal's
+    void UseCarSimRoad(bool enabled);
 
   private:
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -330,6 +330,10 @@ namespace detail {
     _pimpl->AsyncCall("apply_control_to_vehicle", vehicle, control);
   }
 
+  void Client::SetCarSimEnabled(rpc::ActorId vehicle, bool enabled) {
+    _pimpl->AsyncCall("set_carsim_enabled", vehicle, enabled);
+  }
+
   void Client::ApplyControlToWalker(rpc::ActorId walker, const rpc::WalkerControl &control) {
     _pimpl->AsyncCall("apply_control_to_walker", walker, control);
   }

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -330,8 +330,12 @@ namespace detail {
     _pimpl->AsyncCall("apply_control_to_vehicle", vehicle, control);
   }
 
-  void Client::SetCarSimEnabled(rpc::ActorId vehicle, bool enabled) {
-    _pimpl->AsyncCall("set_carsim_enabled", vehicle, enabled);
+  void Client::SetCarSimEnabled(rpc::ActorId vehicle, bool enabled, std::string simfile_path) {
+    _pimpl->AsyncCall("set_carsim_enabled", vehicle, enabled, simfile_path);
+  }
+
+  void Client::UseCarSimRoad(rpc::ActorId vehicle, bool enabled) {
+    _pimpl->AsyncCall("use_carsim_road", vehicle, enabled);
   }
 
   void Client::ApplyControlToWalker(rpc::ActorId walker, const rpc::WalkerControl &control) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -330,8 +330,8 @@ namespace detail {
     _pimpl->AsyncCall("apply_control_to_vehicle", vehicle, control);
   }
 
-  void Client::SetCarSimEnabled(rpc::ActorId vehicle, bool enabled, std::string simfile_path) {
-    _pimpl->AsyncCall("set_carsim_enabled", vehicle, enabled, simfile_path);
+  void Client::EnableCarSim(rpc::ActorId vehicle, std::string simfile_path) {
+    _pimpl->AsyncCall("enable_carsim", vehicle, simfile_path);
   }
 
   void Client::UseCarSimRoad(rpc::ActorId vehicle, bool enabled) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -211,6 +211,10 @@ namespace detail {
         rpc::ActorId vehicle,
         const rpc::VehicleControl &control);
 
+    void SetCarSimEnabled(
+        rpc::ActorId vehicle,
+        bool enabled);
+
     void ApplyControlToWalker(
         rpc::ActorId walker,
         const rpc::WalkerControl &control);

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -211,9 +211,8 @@ namespace detail {
         rpc::ActorId vehicle,
         const rpc::VehicleControl &control);
 
-    void SetCarSimEnabled(
+    void EnableCarSim(
         rpc::ActorId vehicle,
-        bool enabled,
         std::string simfile_path);
 
     void UseCarSimRoad(

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -213,6 +213,11 @@ namespace detail {
 
     void SetCarSimEnabled(
         rpc::ActorId vehicle,
+        bool enabled,
+        std::string simfile_path);
+
+    void UseCarSimRoad(
+        rpc::ActorId vehicle,
         bool enabled);
 
     void ApplyControlToWalker(

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -445,8 +445,12 @@ namespace detail {
       _client.SetLightStateToVehicle(vehicle.GetId(), light_state);
     }
 
-    void SetCarSimEnabled(Vehicle &vehicle, bool enabled) {
-      _client.SetCarSimEnabled(vehicle.GetId(), enabled);
+    void SetCarSimEnabled(Vehicle &vehicle, bool enabled, std::string simfile_path) {
+      _client.SetCarSimEnabled(vehicle.GetId(), enabled, simfile_path);
+    }
+
+    void UseCarSimRoad(Vehicle &vehicle, bool enabled) {
+      _client.UseCarSimRoad(vehicle.GetId(), enabled);
     }
 
     /// @}

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -445,8 +445,8 @@ namespace detail {
       _client.SetLightStateToVehicle(vehicle.GetId(), light_state);
     }
 
-    void SetCarSimEnabled(Vehicle &vehicle, bool enabled, std::string simfile_path) {
-      _client.SetCarSimEnabled(vehicle.GetId(), enabled, simfile_path);
+    void EnableCarSim(Vehicle &vehicle, std::string simfile_path) {
+      _client.EnableCarSim(vehicle.GetId(), simfile_path);
     }
 
     void UseCarSimRoad(Vehicle &vehicle, bool enabled) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -445,6 +445,10 @@ namespace detail {
       _client.SetLightStateToVehicle(vehicle.GetId(), light_state);
     }
 
+    void SetCarSimEnabled(Vehicle &vehicle, bool enabled) {
+      _client.SetCarSimEnabled(vehicle.GetId(), enabled);
+    }
+
     /// @}
     // =========================================================================
     /// @name Operations with the recorder

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -141,6 +141,7 @@ void export_actor() {
       .def("get_traffic_light_state", &cc::Vehicle::GetTrafficLightState)
       .def("is_at_traffic_light", &cc::Vehicle::IsAtTrafficLight)
       .def("get_traffic_light", &cc::Vehicle::GetTrafficLight)
+      .def("set_carsim_enabled", &cc::Vehicle::SetCarSimEnabled)
       .def(self_ns::str(self_ns::self))
   ;
 

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -141,7 +141,8 @@ void export_actor() {
       .def("get_traffic_light_state", &cc::Vehicle::GetTrafficLightState)
       .def("is_at_traffic_light", &cc::Vehicle::IsAtTrafficLight)
       .def("get_traffic_light", &cc::Vehicle::GetTrafficLight)
-      .def("set_carsim_enabled", &cc::Vehicle::SetCarSimEnabled)
+      .def("set_carsim_enabled", &cc::Vehicle::SetCarSimEnabled, (arg("enabled"), arg("simfile_path") = ""))
+      .def("use_carsim_road", &cc::Vehicle::UseCarSimRoad, (arg("enabled")))
       .def(self_ns::str(self_ns::self))
   ;
 

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -141,7 +141,7 @@ void export_actor() {
       .def("get_traffic_light_state", &cc::Vehicle::GetTrafficLightState)
       .def("is_at_traffic_light", &cc::Vehicle::IsAtTrafficLight)
       .def("get_traffic_light", &cc::Vehicle::GetTrafficLight)
-      .def("set_carsim_enabled", &cc::Vehicle::SetCarSimEnabled, (arg("enabled"), arg("simfile_path") = ""))
+      .def("enable_carsim", &cc::Vehicle::EnableCarSim, (arg("simfile_path") = ""))
       .def("use_carsim_road", &cc::Vehicle::UseCarSimRoad, (arg("enabled")))
       .def(self_ns::str(self_ns::self))
   ;

--- a/Unreal/CarlaUE4/CarlaUE4.uproject
+++ b/Unreal/CarlaUE4/CarlaUE4.uproject
@@ -99,6 +99,11 @@
 		{
 			"Name": "RenderDocPlugin",
 			"Enabled": true
+		},
+		{
+			"Name": "CarSim",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/2d712649ca864c80812da7b5252f5608"
 		}
 	]
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -42,6 +42,13 @@ public class Carla : ModuleRules
         // ... add other public dependencies that you statically link with here ...
       }
       );
+    PublicDependencyModuleNames.AddRange(
+      new string[]
+      {
+        "CarSim"
+        // ... add other public dependencies that you statically link with here ...
+      }
+      );
 
 	 if (Target.Type == TargetType.Editor)
 	 {
@@ -68,6 +75,14 @@ public class Carla : ModuleRules
         // ... add private dependencies that you statically link with here ...
       }
       );
+    PrivateDependencyModuleNames.AddRange(
+      new string[]
+      {
+        "CarSim"
+        // ... add private dependencies that you statically link with here ...
+      }
+      );
+    PrivateIncludePathModuleNames.AddRange(new string[] { "CarSim" });
 
     DynamicallyLoadedModuleNames.AddRange(
       new string[]

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -26,13 +26,17 @@ public class Carla : ModuleRules
     string ConfigDir =  Path.GetFullPath(Path.Combine(CarlaPluginPath, "../../../../Config/"));
     string CarSimConfigFile = Path.Combine(ConfigDir, "CarSimConfig.ini");
     string[] text = System.IO.File.ReadAllLines(CarSimConfigFile);
+    Console.WriteLine("----------------------------------------------");
     foreach (string line in text)
     {
       Console.WriteLine(line);
-      if (line == "CarSim ON")
+      if (line.Contains("CarSim ON"))
       {
+        Console.WriteLine("Enabling carsim-----------");
         UsingCarSim = true;
         PublicDefinitions.Add("WITH_CARSIM");
+        PrivateDefinitions.Add("WITH_CARSIM");
+        Definitions.Add("WITH_CARSIM");
       }
     }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -6,6 +6,7 @@ using UnrealBuildTool;
 
 public class Carla : ModuleRules
 {
+  bool UsingCarSim = false;
   private bool IsWindows(ReadOnlyTargetRules Target)
   {
     return (Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32);
@@ -18,6 +19,21 @@ public class Carla : ModuleRules
     if (IsWindows(Target))
     {
       bEnableExceptions = true;
+    }
+
+    // Read config about carsim
+    string CarlaPluginPath = Path.GetFullPath( ModuleDirectory );
+    string ConfigDir =  Path.GetFullPath(Path.Combine(CarlaPluginPath, "../../../../Config/"));
+    string CarSimConfigFile = Path.Combine(ConfigDir, "CarSimConfig.ini");
+    string[] text = System.IO.File.ReadAllLines(CarSimConfigFile);
+    foreach (string line in text)
+    {
+      Console.WriteLine(line);
+      if (line == "CarSim ON")
+      {
+        UsingCarSim = true;
+        PublicDefinitions.Add("WITH_CARSIM");
+      }
     }
 
     PublicIncludePaths.AddRange(
@@ -42,13 +58,10 @@ public class Carla : ModuleRules
         // ... add other public dependencies that you statically link with here ...
       }
       );
-    PublicDependencyModuleNames.AddRange(
-      new string[]
-      {
-        "CarSim"
-        // ... add other public dependencies that you statically link with here ...
-      }
-      );
+    if (UsingCarSim)
+    {
+      PublicDependencyModuleNames.AddRange(new string[] { "CarSim" });
+    }
 
 	 if (Target.Type == TargetType.Editor)
 	 {
@@ -75,14 +88,12 @@ public class Carla : ModuleRules
         // ... add private dependencies that you statically link with here ...
       }
       );
-    PrivateDependencyModuleNames.AddRange(
-      new string[]
-      {
-        "CarSim"
-        // ... add private dependencies that you statically link with here ...
-      }
-      );
-    PrivateIncludePathModuleNames.AddRange(new string[] { "CarSim" });
+    if (UsingCarSim)
+    {
+      PrivateDependencyModuleNames.AddRange(new string[] { "CarSim" });
+      PrivateIncludePathModuleNames.AddRange(new string[] { "CarSim" });
+    }
+
 
     DynamicallyLoadedModuleNames.AddRange(
       new string[]

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1083,6 +1083,24 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
+  BIND_SYNC(set_carsim_enabled) << [this](
+      cr::ActorId ActorId,
+      bool bEnabled) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    auto ActorView = Episode->FindActor(ActorId);
+    if (!ActorView.IsValid())
+    {
+      RESPOND_ERROR("unable to set carsim: actor not found");
+    }
+    auto Vehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
+    if (Vehicle == nullptr)
+    {
+      RESPOND_ERROR("unable to set carsim: not actor is not a vehicle");
+    }
+    Vehicle->SetCarSimEnabled(bEnabled);
+    return R<void>::Success();
+  };
   // ~~ Traffic lights ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(set_traffic_light_state) << [this](

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1083,9 +1083,11 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
+//-----CARSIM--------------------------------
   BIND_SYNC(set_carsim_enabled) << [this](
       cr::ActorId ActorId,
-      bool bEnabled) -> R<void>
+      bool bEnabled,
+      std::string SimfilePath) -> R<void>
   {
     REQUIRE_CARLA_EPISODE();
     auto ActorView = Episode->FindActor(ActorId);
@@ -1098,9 +1100,29 @@ void FCarlaServer::FPimpl::BindActions()
     {
       RESPOND_ERROR("unable to set carsim: not actor is not a vehicle");
     }
-    Vehicle->SetCarSimEnabled(bEnabled);
+    Vehicle->SetCarSimEnabled(bEnabled, carla::rpc::ToFString(SimfilePath));
     return R<void>::Success();
   };
+
+  BIND_SYNC(use_carsim_road) << [this](
+      cr::ActorId ActorId,
+      bool bEnabled) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    auto ActorView = Episode->FindActor(ActorId);
+    if (!ActorView.IsValid())
+    {
+      RESPOND_ERROR("unable to set carsim road: actor not found");
+    }
+    auto Vehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
+    if (Vehicle == nullptr)
+    {
+      RESPOND_ERROR("unable to set carsim road: not actor is not a vehicle");
+    }
+    Vehicle->UseCarSimRoad(bEnabled);
+    return R<void>::Success();
+  };
+//-----CARSIM--------------------------------
   // ~~ Traffic lights ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(set_traffic_light_state) << [this](

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -942,7 +942,9 @@ void FCarlaServer::FPimpl::BindActions()
       if(Vehicle)
       {
         Vehicle->SetActorEnableCollision(true);
+        #ifdef WITH_CARSIM
         if(!Vehicle->IsCarSimEnabled())
+        #endif
         {
           RootComponent->SetSimulatePhysics(bEnabled);
           RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
@@ -1098,6 +1100,7 @@ void FCarlaServer::FPimpl::BindActions()
       bool bEnabled,
       std::string SimfilePath) -> R<void>
   {
+    #ifdef WITH_CARSIM
     REQUIRE_CARLA_EPISODE();
     auto ActorView = Episode->FindActor(ActorId);
     if (!ActorView.IsValid())
@@ -1111,12 +1114,16 @@ void FCarlaServer::FPimpl::BindActions()
     }
     Vehicle->SetCarSimEnabled(bEnabled, carla::rpc::ToFString(SimfilePath));
     return R<void>::Success();
+    #else
+      RESPOND_ERROR("CarSim plugin is not enabled");
+    #endif
   };
 
   BIND_SYNC(use_carsim_road) << [this](
       cr::ActorId ActorId,
       bool bEnabled) -> R<void>
   {
+    #ifdef WITH_CARSIM
     REQUIRE_CARLA_EPISODE();
     auto ActorView = Episode->FindActor(ActorId);
     if (!ActorView.IsValid())
@@ -1130,6 +1137,9 @@ void FCarlaServer::FPimpl::BindActions()
     }
     Vehicle->UseCarSimRoad(bEnabled);
     return R<void>::Success();
+    #else
+    RESPOND_ERROR("CarSim plugin is not enabled");
+    #endif
   };
 //-----CARSIM--------------------------------
   // ~~ Traffic lights ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1095,9 +1095,8 @@ void FCarlaServer::FPimpl::BindActions()
   };
 
 //-----CARSIM--------------------------------
-  BIND_SYNC(set_carsim_enabled) << [this](
+  BIND_SYNC(enable_carsim) << [this](
       cr::ActorId ActorId,
-      bool bEnabled,
       std::string SimfilePath) -> R<void>
   {
     #ifdef WITH_CARSIM
@@ -1112,7 +1111,11 @@ void FCarlaServer::FPimpl::BindActions()
     {
       RESPOND_ERROR("unable to set carsim: not actor is not a vehicle");
     }
-    Vehicle->SetCarSimEnabled(bEnabled, carla::rpc::ToFString(SimfilePath));
+    if (Vehicle->IsCarSimEnabled())
+    {
+      RESPOND_ERROR("unable to set carsim: carsim is already enabled");
+    }
+    Vehicle->EnableCarSim(carla::rpc::ToFString(SimfilePath));
     return R<void>::Success();
     #else
       RESPOND_ERROR("CarSim plugin is not enabled");

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -938,12 +938,21 @@ void FCarlaServer::FPimpl::BindActions()
       {
         RESPOND_ERROR("unable to set actor simulate physics: not supported by actor");
       }
-      RootComponent->SetSimulatePhysics(bEnabled);
-      RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-
       auto Vehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
       if(Vehicle)
+      {
         Vehicle->SetActorEnableCollision(true);
+        if(!Vehicle->IsCarSimEnabled())
+        {
+          RootComponent->SetSimulatePhysics(bEnabled);
+          RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+        }
+      }
+      else
+      {
+        RootComponent->SetSimulatePhysics(bEnabled);
+        RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+      }
     }
 
     return R<void>::Success();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/FrictionTrigger.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/FrictionTrigger.h
@@ -6,6 +6,7 @@
 
 #include "GameFramework/Actor.h"
 #include "Components/BoxComponent.h"
+#include "Carla/Game/CarlaEpisode.h"
 
 #include "FrictionTrigger.generated.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -34,6 +34,7 @@ ACarlaWheeledVehicle::ACarlaWheeledVehicle(const FObjectInitializer& ObjectIniti
   VelocityControl->Deactivate();
 
   CarSimMovementComponent = CreateDefaultSubobject<UCarSimMovementComponent>(TEXT("CarSimMovement"));
+  CarSimMovementComponent->DisableVehicle = true;
 
   GetVehicleMovementComponent()->bReverseAsBrake = false;
 }
@@ -498,6 +499,7 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
     carla::log_warning("Loading simfile:", carla::rpc::FromFString(SimfilePath));
     GetVehicleMovementComponent()->SetComponentTickEnabled(false);
     GetVehicleMovementComponent()->Deactivate();
+    CarSimMovementComponent->DisableVehicle = false;
     CarSimMovementComponent->VsConfigFile = SimfilePath;
     CarSimMovementComponent->Activate();
     CarSimMovementComponent->ResetVsVehicle(false);
@@ -509,6 +511,7 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
   {
     GetVehicleMovementComponent()->SetComponentTickEnabled(true);
     GetVehicleMovementComponent()->Activate();
+    CarSimMovementComponent->DisableVehicle = true;
     CarSimMovementComponent->SetComponentTickEnabled(false);
     CarSimMovementComponent->Deactivate();
     CarSimMovementComponent->VsConfigFile = "";

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -558,13 +558,17 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
     CarSimMovementComponent->DisableVehicle = false;
     CarSimMovementComponent->VsConfigFile = SimfilePath;
     CarSimMovementComponent->Activate();
+    // super hack to work arround CarSim component limitations to specify simfiles
+    CarSimMovementComponent->EndPlay(EEndPlayReason::Type::RemovedFromWorld);
+    CarSimMovementComponent->BeginPlay();
+
     CarSimMovementComponent->ResetVsVehicle(false);
     // set carsim position to actor's
     CarSimMovementComponent->SyncVsVehicleLocOri();
     CarSimMovementComponent->SetComponentTickEnabled(true);
     // set kinematic mode for root component and bones
     GetMesh()->PhysicsTransformUpdateMode = EPhysicsTransformUpdateMode::ComponentTransformIsKinematic;
-    auto * Bone = GetMesh()->GetBodyInstance("Vehicle_Base");
+    auto * Bone = GetMesh()->GetBodyInstance(NAME_None);
     if (Bone)
     {
       Bone->SetInstanceSimulatePhysics(false);
@@ -586,7 +590,7 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
     CarSimMovementComponent->Deactivate();
     CarSimMovementComponent->VsConfigFile = "";
     GetMesh()->PhysicsTransformUpdateMode = EPhysicsTransformUpdateMode::SimulationUpatesComponentTransform;
-    auto * Bone = GetMesh()->GetBodyInstance("Vehicle_Base");
+    auto * Bone = GetMesh()->GetBodyInstance(NAME_None);
     if (Bone)
     {
       Bone->SetInstanceSimulatePhysics(true);
@@ -598,6 +602,7 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
     OnActorHit.RemoveDynamic(this, &ACarlaWheeledVehicle::OnCarSimHit);
     GetMesh()->OnComponentBeginOverlap.RemoveDynamic(this, &ACarlaWheeledVehicle::OnCarSimOverlap);
     GetMesh()->SetCollisionResponseToChannel(ECollisionChannel::ECC_WorldStatic, ECollisionResponse::ECR_Block);
+    GetMesh()->SetCollisionProfileName("Vehicle");
   }
   bCarSimEnabled = bEnabled;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -183,6 +183,7 @@ void ACarlaWheeledVehicle::FlushVehicleControl()
 {
   if (bCarSimEnabled)
   {
+    //-----CARSIM--------------------------------
     CarSimMovementComponent->SetThrottleInput(InputControl.Control.Throttle);
     CarSimMovementComponent->SetSteeringInput(InputControl.Control.Steer);
     CarSimMovementComponent->SetBrakeInput(InputControl.Control.Brake);
@@ -205,6 +206,7 @@ void ACarlaWheeledVehicle::FlushVehicleControl()
     //   }
     // }
     InputControl.Control.Gear = CarSimMovementComponent->GetCurrentGear();
+    //-----------------------------------------
   }
   else
   {
@@ -487,14 +489,16 @@ void ACarlaWheeledVehicle::SetVehicleLightState(const FVehicleLightState &LightS
 }
 
 //-----CARSIM--------------------------------
-void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled)
+void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
 {
   carla::log_warning("Enabling CarSim", bEnabled);
   bCarSimEnabled = bEnabled;
   if (bCarSimEnabled)
   {
+    carla::log_warning("Loading simfile:", carla::rpc::FromFString(SimfilePath));
     GetVehicleMovementComponent()->SetComponentTickEnabled(false);
     GetVehicleMovementComponent()->Deactivate();
+    CarSimMovementComponent->VsConfigFile = SimfilePath;
     CarSimMovementComponent->Activate();
     CarSimMovementComponent->ResetVsVehicle(false);
     CarSimMovementComponent->SyncVsVehicleLocOri();
@@ -507,7 +511,16 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled)
     GetVehicleMovementComponent()->Activate();
     CarSimMovementComponent->SetComponentTickEnabled(false);
     CarSimMovementComponent->Deactivate();
+    CarSimMovementComponent->VsConfigFile = "";
     GetMesh()->SetSimulatePhysics(true);
   }
+}
+
+void ACarlaWheeledVehicle::UseCarSimRoad(bool bEnabled)
+{
+  carla::log_warning("Enabling CarSim Road", bEnabled);
+  CarSimMovementComponent->UseVehicleSimRoad = bEnabled;
+  CarSimMovementComponent->ResetVsVehicle(false);
+  CarSimMovementComponent->SyncVsVehicleLocOri();
 }
 //-------------------------------------------

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -144,7 +144,14 @@ void ACarlaWheeledVehicle::AdjustVehicleBounds()
 
 float ACarlaWheeledVehicle::GetVehicleForwardSpeed() const
 {
-  return GetVehicleMovementComponent()->GetForwardSpeed();
+  if (bCarSimEnabled)
+  {
+    return CarSimMovementComponent->GetForwardSpeed();
+  }
+  else
+  {
+    return GetVehicleMovementComponent()->GetForwardSpeed();
+  }
 }
 
 FVector ACarlaWheeledVehicle::GetVehicleOrientation() const
@@ -154,7 +161,14 @@ FVector ACarlaWheeledVehicle::GetVehicleOrientation() const
 
 int32 ACarlaWheeledVehicle::GetVehicleCurrentGear() const
 {
-  return GetVehicleMovementComponent()->GetCurrentGear();
+  if (bCarSimEnabled)
+  {
+    return CarSimMovementComponent->GetCurrentGear();
+  }
+  else
+  {
+    return GetVehicleMovementComponent()->GetCurrentGear();
+  }
 }
 
 FTransform ACarlaWheeledVehicle::GetVehicleBoundingBoxTransform() const
@@ -525,5 +539,22 @@ void ACarlaWheeledVehicle::UseCarSimRoad(bool bEnabled)
   CarSimMovementComponent->UseVehicleSimRoad = bEnabled;
   CarSimMovementComponent->ResetVsVehicle(false);
   CarSimMovementComponent->SyncVsVehicleLocOri();
+}
+
+FVector ACarlaWheeledVehicle::GetVelocity() const
+{
+  if (bCarSimEnabled)
+  {
+    return GetActorForwardVector() * CarSimMovementComponent->GetForwardSpeed();
+  }
+  else
+  {
+    return Super::GetVelocity();
+  }
+}
+
+bool ACarlaWheeledVehicle::IsCarSimEnabled() const
+{
+  return bCarSimEnabled;
 }
 //-------------------------------------------

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -533,7 +533,7 @@ void ACarlaWheeledVehicle::SwitchToUE4Physics()
   SetCarSimEnabled(false);
   FTimerHandle TimerHandler;
   GetWorld()->GetTimerManager().
-      SetTimer(TimerHandler, this, &ACarlaWheeledVehicle::RevertToCarSimPhysics, 1.0);
+      SetTimer(TimerHandler, this, &ACarlaWheeledVehicle::RevertToCarSimPhysics, 0.1);
   carla::log_warning("There was a hit");
 }
 
@@ -576,8 +576,9 @@ void ACarlaWheeledVehicle::SetCarSimEnabled(bool bEnabled, FString SimfilePath)
   }
   else
   {
-    auto Velocity = GetVelocity();
-    GetMesh()->SetPhysicsLinearVelocity(Velocity, false, "Vehicle_Base");
+    // auto Velocity = GetVelocity();
+    // GetMesh()->SetPhysicsLinearVelocity(Velocity, false, "Vehicle_Base");
+    GetMesh()->SetPhysicsLinearVelocity(FVector(0,0,0), false, "Vehicle_Base");
     GetVehicleMovementComponent()->SetComponentTickEnabled(true);
     GetVehicleMovementComponent()->Activate();
     CarSimMovementComponent->DisableVehicle = true;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -257,6 +257,26 @@ public:
 
 private:
 
+  UFUNCTION()
+  void OnCarSimHit(AActor *Actor,
+      AActor *OtherActor,
+      FVector NormalImpulse,
+      const FHitResult &Hit);
+
+  UFUNCTION()
+  void OnCarSimOverlap(UPrimitiveComponent* OverlappedComponent,
+      AActor* OtherActor,
+      UPrimitiveComponent* OtherComp,
+      int32 OtherBodyIndex,
+      bool bFromSweep,
+      const FHitResult & SweepResult);
+
+  UFUNCTION()
+  void SwitchToUE4Physics();
+
+  UFUNCTION()
+  void RevertToCarSimPhysics();
+
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere)
   bool bCarSimEnabled = false;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -250,6 +250,11 @@ public:
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
   void UseCarSimRoad(bool bEnabled);
 
+  virtual FVector GetVelocity() const override;
+
+  UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintPure)
+  bool IsCarSimEnabled() const;
+
 private:
 
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -19,7 +19,9 @@
 #include "CoreMinimal.h"
 
 //-----CARSIM--------------------------------
+#ifdef WITH_CARSIM
 #include "CarSimMovementComponent.h"
+#endif
 //-------------------------------------------
 
 #include "CarlaWheeledVehicle.generated.h"
@@ -241,7 +243,7 @@ private:
   FVehicleControl LastAppliedControl;
 
 
-  //-----CARSIM--------------------------------
+//-----CARSIM--------------------------------
 public:
 
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
@@ -250,7 +252,9 @@ public:
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
   void UseCarSimRoad(bool bEnabled);
 
+  #ifdef WITH_CARSIM
   virtual FVector GetVelocity() const override;
+  #endif
 
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintPure)
   bool IsCarSimEnabled() const;
@@ -281,6 +285,11 @@ private:
   bool bCarSimEnabled = false;
 
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+  UMovementComponent * ExternalMovementComponent;
+
+  #ifdef WITH_CARSIM
+  // Casted version of ExternalMovementComponent
   UCarSimMovementComponent * CarSimMovementComponent;
+  #endif
   //-------------------------------------------
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -18,6 +18,10 @@
 
 #include "CoreMinimal.h"
 
+//-----CARSIM--------------------------------
+#include "CarSimMovementComponent.h"
+//-------------------------------------------
+
 #include "CarlaWheeledVehicle.generated.h"
 
 class UBoxComponent;
@@ -235,4 +239,20 @@ private:
   InputControl;
 
   FVehicleControl LastAppliedControl;
+
+
+  //-----CARSIM--------------------------------
+public:
+
+  UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
+  void SetCarSimEnabled(bool bEnabled);
+
+private:
+
+  UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere)
+  bool bCarSimEnabled = false;
+
+  UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+  UCarSimMovementComponent * CarSimMovementComponent;
+  //-------------------------------------------
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -245,7 +245,10 @@ private:
 public:
 
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
-  void SetCarSimEnabled(bool bEnabled);
+  void SetCarSimEnabled(bool bEnabled, FString SimfilePath = "");
+
+  UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
+  void UseCarSimRoad(bool bEnabled);
 
 private:
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -246,9 +246,12 @@ private:
 //-----CARSIM--------------------------------
 public:
 
+  // Enables carsim once enabled it won't turn back to UE4 physics simulation
+  // (for some reason the UE4 physics get meesed up after enabling carsim)
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
-  void SetCarSimEnabled(bool bEnabled, FString SimfilePath = "");
+  void EnableCarSim(FString SimfilePath = "");
 
+  // Enables usage of carsim terrain
   UFUNCTION(Category="CARLA Wheeled Vehicle", BlueprintCallable)
   void UseCarSimRoad(bool bEnabled);
 
@@ -261,12 +264,15 @@ public:
 
 private:
 
+  // On car mesh hit, only works when carsim is enabled
   UFUNCTION()
   void OnCarSimHit(AActor *Actor,
       AActor *OtherActor,
       FVector NormalImpulse,
       const FHitResult &Hit);
 
+  // On car mesh overlap, only works when carsim is enabled
+  // (this event triggers when overlapping with static environment)
   UFUNCTION()
   void OnCarSimOverlap(UPrimitiveComponent* OverlappedComponent,
       AActor* OtherActor,
@@ -284,6 +290,7 @@ private:
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere)
   bool bCarSimEnabled = false;
 
+  // Small workarround to allow optional CarSim plugin usage
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
   UMovementComponent * ExternalMovementComponent;
 

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -17,6 +17,7 @@ rem ============================================================================
 set BUILD_UE4_EDITOR=false
 set LAUNCH_UE4_EDITOR=false
 set REMOVE_INTERMEDIATE=false
+set USE_CARSIM=false
 
 :arg-parse
 echo %1
@@ -29,6 +30,9 @@ if not "%1"=="" (
     )
     if "%1"=="--clean" (
         set REMOVE_INTERMEDIATE=true
+    )
+    if "%1"=="--carsim" (
+        set USE_CARSIM=true
     )
     if "%1"=="-h" (
         goto help
@@ -100,6 +104,12 @@ rem Build Carla Editor
 rem
 if %BUILD_UE4_EDITOR% == true (
     echo %FILE_N% Building Unreal Editor...
+
+    if %USE_CARSIM% == true (
+        echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
+    ) else (
+        echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
+    )
 
     call "%UE4_ROOT%Engine\Build\BatchFiles\Build.bat"^
         CarlaUE4Editor^

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -119,18 +119,18 @@ if ${BUILD_CARLAUE4} ; then
 
   if [ ! -f Makefile ]; then
 
+    if ${USE_CARSIM} ; then
+      echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
+    else
+      echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
+    fi
+
     # This command fails sometimes but normally we can continue anyway.
     set +e
     log "Generate Unreal project files."
     ${UE4_ROOT}/GenerateProjectFiles.sh -project="${PWD}/CarlaUE4.uproject" -game -engine -makefiles
     set -e
 
-  fi
-
-  if ${USE_CARSIM} ; then
-    echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
-  else
-    echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
   fi
 
   log "Build CarlaUE4 project."

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -24,11 +24,12 @@ REMOVE_INTERMEDIATE=false
 HARD_CLEAN=false
 BUILD_CARLAUE4=false
 LAUNCH_UE4_EDITOR=false
+USE_CARSIM=false
 
 GDB=
 RHI="-vulkan"
 
-OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl,carsim -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 
@@ -56,6 +57,9 @@ while [[ $# -gt 0 ]]; do
       shift ;;
     --opengl )
       RHI="-opengl";
+      shift ;;
+    --carsim )
+      USE_CARSIM=true;
       shift ;;
     -h | --help )
       echo "$DOC_STRING"
@@ -121,6 +125,12 @@ if ${BUILD_CARLAUE4} ; then
     ${UE4_ROOT}/GenerateProjectFiles.sh -project="${PWD}/CarlaUE4.uproject" -game -engine -makefiles
     set -e
 
+  fi
+
+  if ${USE_CARSIM} ; then
+    echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
+  else
+    echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
   fi
 
   log "Build CarlaUE4 project."

--- a/Util/BuildTools/BuildPythonAPI.sh
+++ b/Util/BuildTools/BuildPythonAPI.sh
@@ -17,7 +17,7 @@ REMOVE_INTERMEDIATE=false
 BUILD_RSS_VARIANT=false
 BUILD_PYTHONAPI=true
 
-OPTS=`getopt -o h --long help,config:,rebuild,clean,rss,python-version:,packages:,clean-intermediate,all,xml, -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,config:,rebuild,clean,rss,carsim,python-version:,packages:,clean-intermediate,all,xml, -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -23,6 +23,7 @@ set DO_COPY_FILES=true
 set DO_TARBALL=true
 set DO_CLEAN=false
 set PACKAGES=Carla
+set USE_CARSIM=false
 
 
 :arg-parse
@@ -48,6 +49,10 @@ if not "%1"=="" (
         set DO_COPY_FILES=false
         set PACKAGES=%~2
         shift
+    )
+
+    if "%1"=="--carsim" (
+        set USE_CARSIM=true
     )
 
     if "%1"=="-h" (
@@ -93,6 +98,13 @@ rem -- Create Carla package ----------------------------------------------------
 rem ============================================================================
 
 if %DO_PACKAGE%==true (
+
+    if %USE_CARSIM% == true (
+        echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
+    ) else (
+        echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
+    )
+
     if not exist "!BUILD_FOLDER!" mkdir "!BUILD_FOLDER!"
 
     call "%UE4_ROOT%\Engine\Build\BatchFiles\Build.bat"^

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -15,8 +15,9 @@ DO_TARBALL=true
 DO_CLEAN_INTERMEDIATE=false
 PROPS_MAP_NAME=PropsMap
 PACKAGE_CONFIG=Shipping
+USE_CARSIM=false
 
-OPTS=`getopt -o h --long help,config:,no-zip,clean-intermediate,packages:,python-version: -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,config:,no-zip,clean-intermediate,carsim,packages:,python-version: -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 
@@ -34,6 +35,9 @@ while [[ $# -gt 0 ]]; do
     --packages )
       PACKAGES="$2"
       shift 2 ;;
+    --carsim )
+      USE_CARSIM=true;
+      shift ;;
     -h | --help )
       echo "$DOC_STRING"
       echo "$USAGE_STRING"
@@ -86,6 +90,12 @@ log "Packaging version '${REPOSITORY_TAG}' (${PACKAGE_CONFIG})."
 if ${DO_CARLA_RELEASE} ; then
 
   pushd "${CARLAUE4_ROOT_FOLDER}" >/dev/null
+
+  if [ ${USE_CARSIM} ]; then
+    echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
+  else
+    echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
+  fi
 
   log "Cooking CARLA project."
 

--- a/Util/BuildTools/Windows.mk
+++ b/Util/BuildTools/Windows.mk
@@ -17,7 +17,7 @@ import: server
 	@"${CARLA_BUILD_TOOLS_FOLDER}/Import.py" $(ARGS)
 
 CarlaUE4Editor: LibCarla
-	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.bat" --build
+	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.bat" --build $(ARGS)
 
 launch: CarlaUE4Editor
 	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.bat" --launch


### PR DESCRIPTION
#### Description

Added initial support for CarSim.
This PR integrates carsim in our vehicles using the plugin provided by https://www.carsim.com/products/carsim/index.php.
The plugin needs to be present in the engine before running it.
You need to run `make clean` and then `make XXXX ARGS="--carsim"` to enable carsim capabilities.
Vehicles get a new function `enable_carsim` to enable carsim.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04, Windows
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3680)
<!-- Reviewable:end -->
