### PR TITLE
CarSim broken pipeline fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline
                         {
                             steps
                             {
+                                sh 'git update-index --skip-worktree Unreal/CarlaUE4/CarlaUE4.uproject'
                                 sh 'make setup ARGS="--python-version=3.7,2"'
                             }
                         }
@@ -230,6 +231,10 @@ pipeline
                         {
                             steps
                             {
+                                bat """
+                                    call ../setEnv64.bat
+                                    git update-index --skip-worktree Unreal/CarlaUE4/CarlaUE4.uproject
+                                """
                                 bat """
                                     call ../setEnv64.bat
                                     make setup

--- a/Unreal/CarlaUE4/.gitignore
+++ b/Unreal/CarlaUE4/.gitignore
@@ -12,11 +12,12 @@ Plugins/Carla/Debug
 Plugins/Carla/DerivedDataCache
 Plugins/Carla/Intermediate
 Plugins/Carla/Saved
-CarlaUE4.uproject
 
 /Content
 Config/CarlaSettings.ini
 Config/DefaultEditor.ini
+Config/CarSimConfig.ini
+CarlaUE4.uproject
 
 *.code-workspace
 .idea

--- a/Unreal/CarlaUE4/.gitignore
+++ b/Unreal/CarlaUE4/.gitignore
@@ -17,7 +17,6 @@ Plugins/Carla/Saved
 Config/CarlaSettings.ini
 Config/DefaultEditor.ini
 Config/CarSimConfig.ini
-CarlaUE4.uproject
 
 *.code-workspace
 .idea

--- a/Unreal/CarlaUE4/.gitignore
+++ b/Unreal/CarlaUE4/.gitignore
@@ -12,6 +12,7 @@ Plugins/Carla/Debug
 Plugins/Carla/DerivedDataCache
 Plugins/Carla/Intermediate
 Plugins/Carla/Saved
+CarlaUE4.uproject
 
 /Content
 Config/CarlaSettings.ini

--- a/Unreal/CarlaUE4/CarlaUE4.uproject
+++ b/Unreal/CarlaUE4/CarlaUE4.uproject
@@ -102,7 +102,7 @@
 		},
 		{
 			"Name": "CarSim",
-			"Enabled": true,
+			"Enabled": false,
 			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/2d712649ca864c80812da7b5252f5608"
 		}
 	]

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -106,8 +106,10 @@ if %BUILD_UE4_EDITOR% == true (
     echo %FILE_N% Building Unreal Editor...
 
     if %USE_CARSIM% == true (
+        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
+        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -106,10 +106,10 @@ if %BUILD_UE4_EDITOR% == true (
     echo %FILE_N% Building Unreal Editor...
 
     if %USE_CARSIM% == true (
-        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
-        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -106,10 +106,10 @@ if %BUILD_UE4_EDITOR% == true (
     echo %FILE_N% Building Unreal Editor...
 
     if %USE_CARSIM% == true (
-        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="%ROOT_PATH%Unreal/CarlaUE4/CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
-        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="%ROOT_PATH%Unreal/CarlaUE4/CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -117,13 +117,15 @@ fi
 
 if ${BUILD_CARLAUE4} ; then
 
-  if [ ! -f Makefile ]; then
+  if ${USE_CARSIM} ; then
+    python ${PWD}/../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
+    echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
+  else
+    python ${PWD}/../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
+    echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
+  fi
 
-    if ${USE_CARSIM} ; then
-      echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
-    else
-      echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
-    fi
+  if [ ! -f Makefile ]; then
 
     # This command fails sometimes but normally we can continue anyway.
     set +e

--- a/Util/BuildTools/Environment.sh
+++ b/Util/BuildTools/Environment.sh
@@ -2,7 +2,7 @@
 
 # Sets the environment for other shell scripts.
 
-set -e
+# set -e
 
 CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 source $(dirname "$0")/Vars.mk

--- a/Util/BuildTools/Linux.mk
+++ b/Util/BuildTools/Linux.mk
@@ -36,7 +36,7 @@ rebuild: setup
 	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --rebuild
 	@${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.sh --rebuild
 	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --rebuild $(ARGS)
-	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --rebuild
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --rebuild $(ARGS)
 
 hard-clean:
 	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --hard-clean
@@ -80,7 +80,7 @@ run-examples:
 	@for D in ${CARLA_EXAMPLES_FOLDER}/*; do [ -d "$${D}" ] && make -C $${D} run.only; done
 
 CarlaUE4Editor: LibCarla.server.release
-	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --build
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --build $(ARGS)
 
 .PHONY: PythonAPI
 PythonAPI: LibCarla.client.release osm2odr

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -100,10 +100,10 @@ rem ============================================================================
 if %DO_PACKAGE%==true (
 
     if %USE_CARSIM% == true (
-        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="%ROOT_PATH%Unreal/CarlaUE4/CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
-        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="%ROOT_PATH%Unreal/CarlaUE4/CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -100,10 +100,10 @@ rem ============================================================================
 if %DO_PACKAGE%==true (
 
     if %USE_CARSIM% == true (
-        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
-        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
+        py -3 %ROOT_PATH%Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -100,8 +100,10 @@ rem ============================================================================
 if %DO_PACKAGE%==true (
 
     if %USE_CARSIM% == true (
+        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
         echo CarSim ON > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     ) else (
+        py -3 %ROOT_PATH%../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
         echo CarSim OFF > "%ROOT_PATH%Unreal/CarlaUE4/Config/CarSimConfig.ini"
     )
 

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -91,9 +91,11 @@ if ${DO_CARLA_RELEASE} ; then
 
   pushd "${CARLAUE4_ROOT_FOLDER}" >/dev/null
 
-  if [ ${USE_CARSIM} ]; then
+  if ${USE_CARSIM} ; then
+    python ${PWD}/../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject" -e
     echo "CarSim ON" > ${PWD}/Config/CarSimConfig.ini
   else
+    python ${PWD}/../../Util/BuildTools/enable_carsim_to_uproject.py -f="CarlaUE4.uproject"
     echo "CarSim OFF" > ${PWD}/Config/CarSimConfig.ini
   fi
 

--- a/Util/BuildTools/enable_carsim_to_uproject.py
+++ b/Util/BuildTools/enable_carsim_to_uproject.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+import glob
+import os
+import sys
+import argparse
+import json
+
+def main():
+    """Edits the uproject file to enable and disable the CarSim plugin
+    """
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        '-f', '--file',
+        metavar='F',
+        default="",
+        type=str,
+        help='Path to the uproject file')
+    argparser.add_argument(
+        '-e', '--enable',
+        action='store_true',
+        help='enable carsim')
+    args = argparser.parse_args()
+
+    # Read uproject (json) file
+    uproject_file = open(args.file, 'r')
+    uproject_json = json.load(uproject_file)
+    uproject_file.close()
+
+    # Get the plugin list
+    plugin_list = uproject_json["Plugins"]
+
+    # Edit plugin
+    should_do_changes = False
+    carsim_found = False
+    for plugin in plugin_list:
+        if plugin['Name'] == 'CarSim':
+            if args.enable:
+                if not plugin['Enabled']:
+                    should_do_changes = True
+                    plugin['Enabled'] = True
+            else:
+                if plugin['Enabled']:
+                    should_do_changes = True
+                    plugin['Enabled'] = False
+            carsim_found = True
+    if not carsim_found and args.enable:
+        should_do_changes = True
+        plugin_list.append({'Name':'CarSim', 'MarketplaceURL': 'com.epicgames.launcher://ue/marketplace/content/2d712649ca864c80812da7b5252f5608', "Enabled": True})
+
+    # Save file if there are changes to do
+    if should_do_changes:
+        uproject_file = open(args.file, 'w')
+        uproject_file.write(json.dumps(uproject_json, indent = 4, sort_keys=True))
+        uproject_file.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### Description

Added fixes to compile unreal engine without requiring the CarSim plugin.
This PR adds a small step in the compilation to edit the `.uproject` file to add or remove the CarSim plugin dependency.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3704)
<!-- Reviewable:end -->
