### PR TITLE
Replacing FPaths::GameDir() 

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -379,7 +379,7 @@ void UPrepareAssetsForCookingCommandlet::GenerateMapPathsFile(
     if (Map.Path.StartsWith(TEXT("/Game/")))
     {
       // replacing relative /Game/... address by absolute address to be able to parse files
-      FString FullPath(FPaths::GameDir() + TEXT("/Content/") + Map.Path.Mid(6, Map.Path.Len() - 6) + TEXT("/Sublevels/") + Map.Name);
+      FString FullPath(FPaths::ProjectDir() + TEXT("/Content/") + Map.Path.Mid(6, Map.Path.Len() - 6) + TEXT("/Sublevels/") + Map.Name);
       TArray<FString> Sublevels;
       FileManager.FindFiles(Sublevels, *FullPath, TEXT("*.umap"));
       for (auto Sublevel : Sublevels)


### PR DESCRIPTION
#### Description

FPaths::GameDir() is deprecated in next UE4 4.25, so we replaced by the new FPaths::ProjectDir()

#### Where has this been tested?

  * **Platform(s):** -
  * **Python version(s):** -
  * **Unreal Engine version(s):** UE 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3717)
<!-- Reviewable:end -->
