### PR TITLE
Extended mutex to Traffic Manager operation stages

### DIFF
--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -175,7 +175,6 @@ void TrafficManagerLocal::Run() {
 
       registered_vehicles_state = registered_vehicles.GetState();
     }
-    registration_lock.unlock();
 
     // Reset frames for current cycle.
     localization_frame.clear();
@@ -200,6 +199,8 @@ void TrafficManagerLocal::Run() {
       traffic_light_stage.Update(index);
       motion_plan_stage.Update(index);
     }
+
+    registration_lock.unlock();
 
     // Sending the current cycle's batch command to the simulator.
     if (synchronous_mode) {


### PR DESCRIPTION
#### Description

This change protects UnregisterVehicle calls when an actor is still running TM-related operations, by extending the mutex lock to include stage specific calculations. It has been introduced to comply with the new synchronous pipeline.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
 
#### Possible Drawbacks

None, although now to unregister a vehicle it will be necessary for it to have finished its frame-related calculations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3723)
<!-- Reviewable:end -->
