### PR TITLE
Fix bug in Apply Synchronous mode

### DIFF
--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -57,7 +57,7 @@ namespace client {
       using namespace std::literals::chrono_literals;
 
       const auto number_of_attemps = 15u;
-      int tics_correct = 0;
+      uint64_t tics_correct = 0;
       for (auto i = 0u; i < number_of_attemps; i++) {
         const auto curr_snapshot = GetSnapshot();
 

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -50,8 +50,30 @@ namespace client {
     return _episode.Lock()->GetEpisodeSettings();
   }
 
-  uint64_t World::ApplySettings(const rpc::EpisodeSettings &settings) {
-    return _episode.Lock()->SetEpisodeSettings(settings);
+  uint64_t World::ApplySettings(const rpc::EpisodeSettings &settings, time_duration timeout) {
+    rpc::EpisodeSettings new_settings = settings;
+    uint64_t id = _episode.Lock()->SetEpisodeSettings(settings);
+    if (settings.synchronous_mode) {
+      using namespace std::literals::chrono_literals;
+
+      const auto number_of_attemps = 15u;
+      int tics_correct = 0;
+      for (auto i = 0u; i < number_of_attemps; i++) {
+        const auto curr_snapshot = GetSnapshot();
+
+        const double error = abs(new_settings.fixed_delta_seconds.get() - curr_snapshot.GetTimestamp().delta_seconds);
+        if (error < std::numeric_limits<float>::epsilon())
+          tics_correct++;
+
+        if (tics_correct >= 2)
+          return id;
+
+        Tick(timeout);
+      }
+
+      log_warning("World::ApplySettings: After", number_of_attemps, ", the settings were not correctly setted. Please check that everything is consistent.");
+    }
+    return id;
   }
 
   rpc::WeatherParameters World::GetWeather() const {

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -81,7 +81,7 @@ namespace client {
     rpc::EpisodeSettings GetSettings() const;
 
     /// @return The id of the frame when the settings were applied.
-    uint64_t ApplySettings(const rpc::EpisodeSettings &settings);
+    uint64_t ApplySettings(const rpc::EpisodeSettings &settings, time_duration timeout);
 
     /// Retrieve the weather parameters currently active in the world.
     rpc::WeatherParameters GetWeather() const;

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -34,7 +34,13 @@ namespace rpc {
   std::ostream &operator<<(std::ostream &out, const EpisodeSettings &settings) {
     auto BoolToStr = [](bool b) { return b ? "True" : "False"; };
     out << "WorldSettings(synchronous_mode=" << BoolToStr(settings.synchronous_mode)
-        << ",no_rendering_mode=" << BoolToStr(settings.no_rendering_mode) << ')';
+        << ",no_rendering_mode=" << BoolToStr(settings.no_rendering_mode)
+        << ",fixed_delta_seconds=" << settings.fixed_delta_seconds.get()
+        << ",substepping=" << BoolToStr(settings.substepping)
+        << ",max_substep_delta_time=" << settings.max_substep_delta_time
+        << ",max_substeps=" << settings.max_substeps
+        << ",max_culling_distance=" << settings.max_culling_distance
+        << ",deterministic_ragdolls=" << BoolToStr(settings.deterministic_ragdolls) << ')';
     return out;
   }
 

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -69,6 +69,11 @@ static auto Tick(carla::client::World &world, double seconds) {
   return world.Tick(TimeDurationFromSeconds(seconds));
 }
 
+static auto ApplySettings(carla::client::World &world, carla::rpc::EpisodeSettings settings, double seconds) {
+  carla::PythonUtil::ReleaseGIL unlock;
+  return world.ApplySettings(settings, TimeDurationFromSeconds(seconds));
+}
+
 static auto GetActorsById(carla::client::World &self, const boost::python::list &actor_ids) {
   std::vector<carla::ActorId> ids{
       boost::python::stl_input_iterator<carla::ActorId>(actor_ids),
@@ -262,7 +267,7 @@ void export_world() {
     .def("get_random_location_from_navigation", CALL_RETURNING_OPTIONAL_WITHOUT_GIL(cc::World, GetRandomLocationFromNavigation))
     .def("get_spectator", CONST_CALL_WITHOUT_GIL(cc::World, GetSpectator))
     .def("get_settings", CONST_CALL_WITHOUT_GIL(cc::World, GetSettings))
-    .def("apply_settings", CALL_WITHOUT_GIL_1(cc::World, ApplySettings, cr::EpisodeSettings), arg("settings"))
+    .def("apply_settings", &ApplySettings, (arg("settings"), arg("seconds")=10.0))
     .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, GetWeather))
     .def("set_weather", &cc::World::SetWeather)
     .def("get_snapshot", &cc::World::GetSnapshot)


### PR DESCRIPTION
#### Description

This fixes a bug in the new synchronous pipeline of the server.
Coming from a simulation in asynchronous mode, after asking the server to apply the synchronous mode,
the apply_settings method checks that the server has correctly set all the options before returning the control to the client.


Fixes # 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3732)
<!-- Reviewable:end -->
