### PR TITLE
Packaging maps in a single package (new option --target-archive=<file>)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline
                             steps
                             {
                                 sh 'make package ARGS="--python-version=3.7,2 --carsim"'
-                                sh 'make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --clean-intermediate --python-version=3.7,2"'
+                                sh 'make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --target-archive=AdditionalMaps --clean-intermediate --python-version=3.7,2"'
                                 sh 'make examples ARGS="localhost 3654"'
                             }
                             post
@@ -287,7 +287,8 @@ pipeline
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --clean-intermediate"
+                                    make package ARGS="--packages=AdditionalMaps --target-archive=AdditionalMaps --clean-intermediate"
+                                    make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --target-archive=AdditionalMaps --clean-intermediate"
                                 """
                             }
                             post {

--- a/Util/BuildTools/BuildPythonAPI.sh
+++ b/Util/BuildTools/BuildPythonAPI.sh
@@ -17,7 +17,7 @@ REMOVE_INTERMEDIATE=false
 BUILD_RSS_VARIANT=false
 BUILD_PYTHONAPI=true
 
-OPTS=`getopt -o h --long help,config:,rebuild,clean,rss,carsim,python-version:,packages:,clean-intermediate,all,xml, -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,config:,rebuild,clean,rss,carsim,python-version:,packages:,clean-intermediate,all,xml,target-archive:, -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 


### PR DESCRIPTION

#### Description

We added a new command line option to collect all cooked packages in a single archive (ZIP or TAR.GZ).
The option is like: 

`make package ARGS="--packages=Town06_Opt,Town07_Opt --target-archive=MyArchive"`

If the **--target-archive** is not specified, each map will go to an individual archive like

- Town06_Opt.tar.gz
- Town07_Opt.tar.gz

But with the new option specified the result will collect those two packages into a single one:

- MyArchive.tar.gz

We use this option to collect all maps Town06, Town07, Town10HD and all their optimized version, inside the AdditionalMaps.

#### Where has this been tested?

  * **Platform(s):** Ubuntu, Windows
  * **Python version(s):** -
  * **Unreal Engine version(s):** UE 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3737)
<!-- Reviewable:end -->
