### PR TITLE
Removed synchronization causing timeout in apply_settings

### DIFF
--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -53,10 +53,10 @@ namespace client {
   uint64_t World::ApplySettings(const rpc::EpisodeSettings &settings, time_duration timeout) {
     rpc::EpisodeSettings new_settings = settings;
     uint64_t id = _episode.Lock()->SetEpisodeSettings(settings);
-    if (settings.synchronous_mode) {
+    if (settings.fixed_delta_seconds.has_value()) {
       using namespace std::literals::chrono_literals;
 
-      const auto number_of_attemps = 15u;
+      const auto number_of_attemps = 30u;
       uint64_t tics_correct = 0;
       for (auto i = 0u; i < number_of_attemps; i++) {
         const auto curr_snapshot = GetSnapshot();
@@ -71,7 +71,7 @@ namespace client {
         Tick(timeout);
       }
 
-      log_warning("World::ApplySettings: After", number_of_attemps, ", the settings were not correctly setted. Please check that everything is consistent.");
+      log_warning("World::ApplySettings: After", number_of_attemps, " attemps, the settings were not correctly set. Please check that everything is consistent.");
     }
     return id;
   }

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -204,8 +204,7 @@ namespace detail {
       }
     }
     const auto frame = _client.SetEpisodeSettings(settings);
-    using namespace std::literals::chrono_literals;
-    SynchronizeFrame(frame, *_episode, 10s);
+
     return frame;
   }
 


### PR DESCRIPTION
#### Description

Fix a delay in the apply_settings when changing from synchronous mode to asynchronous mode.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3739)
<!-- Reviewable:end -->
