### PR TITLE
Fixed missing lanechange in OSM maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   * Fixed bug causing camera-based sensors to stop sending data
   * Added `WorldSettings.deterministic_ragdolls` to enable deterministic or physically based ragdolls
   * Fixed the lack of determinism on the output of raycast sensors
+  * Fixed missing `laneChange` record in converted OSM maps
   * Fixed bug in the actor's id returned by the semantic lidar
   * Fixed error when using `--config` parameter in `make package`
   * Fixed dependency of library **Xerces-c** on package

--- a/Util/OSM2ODR/src/netwrite/NWWriter_OpenDrive.cpp
+++ b/Util/OSM2ODR/src/netwrite/NWWriter_OpenDrive.cpp
@@ -286,7 +286,8 @@ NWWriter_OpenDrive::writeNormalEdge(OutputDevice& device, const NBEdge* e,
     writeEmptyCenterLane(device, centerMark, 0.13);
     device << "                <right>\n";
     for (int j = e->getNumLanes(); --j >= 0;) {
-        device << "                    <lane id=\"-" << e->getNumLanes() - j << "\" type=\"" << getLaneType(e->getPermissions(j)) << "\" level=\"true\">\n";
+        std::string laneType = getLaneType(e->getPermissions(j));
+        device << "                    <lane id=\"-" << e->getNumLanes() - j << "\" type=\"" << laneType << "\" level=\"true\">\n";
         device << "                        <link/>\n";
         // this could be used for geometry-link junctions without u-turn,
         // predecessor and sucessors would be lane indices,
@@ -307,7 +308,15 @@ NWWriter_OpenDrive::writeNormalEdge(OutputDevice& device, const NBEdge* e,
             // solid road mark to the right of a forbidden lane
             markType = "solid";
         }
-        device << "                        <roadMark sOffset=\"0\" type=\"" << markType << "\" weight=\"standard\" color=\"standard\" width=\"0.13\"/>\n";
+        std::string laneChange = "both";
+        if (j == 0) {
+            laneChange = "none";
+        } else if (getLaneType(e->getPermissions(j - 1)) == laneType) {
+            laneChange = "both";
+        } else {
+            laneChange = "none";
+        }
+        device << "                        <roadMark sOffset=\"0\" type=\"" << markType << "\" weight=\"standard\" color=\"standard\" width=\"0.13\" laneChange=\"" << laneChange << "\"/>\n";
         device << "                        <speed sOffset=\"0\" max=\"" << lanes[j].speed << "\"/>\n";
         device << "                    </lane>\n";
     }
@@ -509,7 +518,8 @@ NWWriter_OpenDrive::writeEmptyCenterLane(OutputDevice& device, const std::string
     device << "                <center>\n";
     device << "                    <lane id=\"0\" type=\"none\" level=\"true\">\n";
     device << "                        <link/>\n";
-    device << "                        <roadMark sOffset=\"0\" type=\"" << mark << "\" weight=\"standard\" color=\"standard\" width=\"" << markWidth << "\"/>\n";
+    // laneChange = none as roads contain lanes in one direction only
+    device << "                        <roadMark sOffset=\"0\" type=\"" << mark << "\" weight=\"standard\" color=\"standard\" width=\"" << markWidth << "\" laneChange=\"none\"/>\n";
     device << "                    </lane>\n";
     device << "                </center>\n";
 }


### PR DESCRIPTION
#### Description

When converting OSM maps to OpenDRIVE the `laneChange` attribute in the roadMark record was missing.
This PR adds this information to the converted OpenDRIVE to fit the OpenDRIVE standard and enable lane changes in CARLA.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3747)
<!-- Reviewable:end -->
