### PR TITLE
Lower timeout in SynchronousFrame for EpisodeSettings

### DIFF
--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -205,6 +205,9 @@ namespace detail {
     }
     const auto frame = _client.SetEpisodeSettings(settings);
 
+    using namespace std::literals::chrono_literals;
+    SynchronizeFrame(frame, *_episode, 1s);
+
     return frame;
   }
 


### PR DESCRIPTION
#### Description

Lower timeout in SynchronousFrame for EpisodeSettings. We lower because this was producing a delay in the ApplySettings that is not necessary.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3748)
<!-- Reviewable:end -->
