### PR TITLE
Make /Plugins/ folder optional when packaging

### DIFF
--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -173,9 +173,8 @@ if %DO_COPY_FILES%==true (
     echo f | xcopy /y "!XCOPY_FROM!Docs\release_readme.md"                          "!XCOPY_TO!README"
     echo f | xcopy /y "!XCOPY_FROM!Util\Docker\Release.Dockerfile"                  "!XCOPY_TO!Dockerfile"
     echo f | xcopy /y "!XCOPY_FROM!PythonAPI\carla\dist\*.egg"                      "!XCOPY_TO!PythonAPI\carla\dist\"
-    echo f | xcopy /y /s "!XCOPY_FROM!PythonAPI\carla\data\*"                          "!XCOPY_TO!PythonAPI\carla\data\"
+    echo f | xcopy /y /s "!XCOPY_FROM!PythonAPI\carla\data\*"                       "!XCOPY_TO!PythonAPI\carla\data\"
     echo d | xcopy /y /s "!XCOPY_FROM!Co-Simulation"                                "!XCOPY_TO!Co-Simulation"
-    echo d | xcopy /y /s "!XCOPY_FROM!Plugins"                                      "!XCOPY_TO!Plugins"
     echo d | xcopy /y /s "!XCOPY_FROM!PythonAPI\carla\agents"                       "!XCOPY_TO!PythonAPI\carla\agents"
     echo f | xcopy /y "!XCOPY_FROM!PythonAPI\carla\scene_layout.py"                 "!XCOPY_TO!PythonAPI\carla\"
     echo f | xcopy /y "!XCOPY_FROM!PythonAPI\carla\requirements.txt"                "!XCOPY_TO!PythonAPI\carla\"
@@ -186,6 +185,9 @@ if %DO_COPY_FILES%==true (
     echo f | xcopy /y "!XCOPY_FROM!PythonAPI\util\requirements.txt"                 "!XCOPY_TO!PythonAPI\util\"
     echo f | xcopy /y "!XCOPY_FROM!Unreal\CarlaUE4\Content\Carla\HDMaps\*.pcd"      "!XCOPY_TO!HDMaps\"
     echo f | xcopy /y "!XCOPY_FROM!Unreal\CarlaUE4\Content\Carla\HDMaps\Readme.md"  "!XCOPY_TO!HDMaps\README"
+    if exist "!XCOPY_FROM!Plugins" (
+        echo d | xcopy /y /s "!XCOPY_FROM!Plugins"                                  "!XCOPY_TO!Plugins"
+    )
 )
 
 rem ==============================================================================

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -163,7 +163,9 @@ if ${DO_CARLA_RELEASE} ; then
 
   copy_if_changed "./Co-Simulation/" "${DESTINATION}/Co-Simulation/"
 
-  copy_if_changed "./Plugins/" "${DESTINATION}/Plugins/"
+  if [ -d "./Plugins/" ] ; then
+    copy_if_changed "./Plugins/" "${DESTINATION}/Plugins/"
+  fi
 
   copy_if_changed "./Unreal/CarlaUE4/Content/Carla/HDMaps/*.pcd" "${DESTINATION}/HDMaps/"
   copy_if_changed "./Unreal/CarlaUE4/Content/Carla/HDMaps/Readme.md" "${DESTINATION}/HDMaps/README"


### PR DESCRIPTION
#### Description

Now when we make the default package (_make package_) it tries to copy the folder **Plugins** to the package, without checking first if it exists (this folder is optional).

This fix checks if the folder exist before copying its content.
Some issues where reported by this using Docker.

Fixes #3758

#### Where has this been tested?

  * **Platform(s):** Windows 10, Ubuntu 18
  * **Python version(s):** -
  * **Unreal Engine version(s):** UE 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3784)
<!-- Reviewable:end -->
