### PR TITLE
Fix to register crosswalks in environment objects

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -374,10 +374,6 @@ void UBoundingBoxCalculator::GetBBsOfStaticMeshComponents(
       OutBB.Emplace(BoundingBox);
       OutTag.Emplace(static_cast<uint8>(Tag));
     }
-    else
-    {
-      // UE_LOG(LogCarla, Error, TEXT("%s has no SM assigned"), *Comp->GetOwner()->GetName());
-    }
   }
 }
 


### PR DESCRIPTION
#### Description

Fix to register crosswalks in environment objects. They were ignored previously.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3794)
<!-- Reviewable:end -->
