### PR TITLE
Destroy PhysicsState of vehicles when physics is disable

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -915,10 +915,15 @@ void FCarlaServer::FPimpl::BindActions()
       RESPOND_ERROR("unable to set actor simulate physics: actor not found");
     }
 
-    auto Character = Cast<ACharacter>(ActorView.GetActor());
-    // The physics in the walkers works in a different way so to disable them,
+    auto* Character = Cast<ACharacter>(ActorView.GetActor());
+    auto* CarlaVehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
+    // The physics in the vehicles works in a different way so to disable them.
+    if (CarlaVehicle != nullptr){
+      CarlaVehicle->SetSimulatePhysics(bEnabled);
+    }
+    // The physics in the walkers also works in a different way so to disable them,
     // we need to do it in the UCharacterMovementComponent.
-    if (Character != nullptr)
+    else if (Character != nullptr)
     {
       auto CharacterMovement = Cast<UCharacterMovementComponent>(Character->GetCharacterMovement());
 
@@ -938,23 +943,9 @@ void FCarlaServer::FPimpl::BindActions()
       {
         RESPOND_ERROR("unable to set actor simulate physics: not supported by actor");
       }
-      auto Vehicle = Cast<ACarlaWheeledVehicle>(ActorView.GetActor());
-      if(Vehicle)
-      {
-        Vehicle->SetActorEnableCollision(true);
-        #ifdef WITH_CARSIM
-        if(!Vehicle->IsCarSimEnabled())
-        #endif
-        {
-          RootComponent->SetSimulatePhysics(bEnabled);
-          RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-        }
-      }
-      else
-      {
-        RootComponent->SetSimulatePhysics(bEnabled);
-        RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-      }
+
+      RootComponent->SetSimulatePhysics(bEnabled);
+      RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
     }
 
     return R<void>::Success();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -635,6 +635,34 @@ void ACarlaWheeledVehicle::EnableCarSim(FString SimfilePath)
   #endif
 }
 
+void ACarlaWheeledVehicle::SetSimulatePhysics(bool enabled) {
+  UWheeledVehicleMovementComponent4W *Vehicle4W = Cast<UWheeledVehicleMovementComponent4W>(
+      GetVehicleMovement());
+  check(Vehicle4W != nullptr);
+
+  if(bPhysicsEnabled == enabled)
+    return;
+
+  SetActorEnableCollision(true);
+  #ifdef WITH_CARSIM
+  if(!IsCarSimEnabled())
+  #endif
+  {
+    auto RootComponent = Cast<UPrimitiveComponent>(GetRootComponent());
+    RootComponent->SetSimulatePhysics(enabled);
+    RootComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+
+    GetWorld()->GetPhysicsScene()->GetPxScene()->lockWrite();
+    if(enabled)
+      Vehicle4W->RecreatePhysicsState();
+    else
+      Vehicle4W->DestroyPhysicsState();
+    GetWorld()->GetPhysicsScene()->GetPxScene()->unlockWrite();
+  }
+
+  bPhysicsEnabled = enabled;
+}
+
 void ACarlaWheeledVehicle::UseCarSimRoad(bool bEnabled)
 {
   #ifdef WITH_CARSIM

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -124,6 +124,8 @@ public:
 
   void ApplyVehiclePhysicsControl(const FVehiclePhysicsControl &PhysicsControl);
 
+  void SetSimulatePhysics(bool enabled);
+
   void SetWheelCollision(UWheeledVehicleMovementComponent4W *Vehicle4W, const FVehiclePhysicsControl &PhysicsControl);
 
   void SetVehicleLightState(const FVehicleLightState &LightState);
@@ -294,6 +296,9 @@ private:
 
   UPROPERTY(Category="CARLA Wheeled Vehicle", EditAnywhere)
   float CarSimOriginOffset = 150.f;
+
+  UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere)
+  bool bPhysicsEnabled = true;
 
   // Small workarround to allow optional CarSim plugin usage
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
#### Description

For performance reasons, we disable the PhysicsState of vehicles when the simulate_physics is set to false. Previously, even if the physics of the vehicle were disabled, the PhysXVehicleManager was still running impacting our performance.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3798)
<!-- Reviewable:end -->
