### PR TITLE
Use Python __repr__() method instead of __str__() for libcarla PythonAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - Added `enable_environment_objects`call to enable/disable objects of the level
     - Added `horizontal_fov` parameter to lidar sensor to allow for restriction of its field of view
     - Added `WorldSettings.deterministic_ragdolls` to enable deterministic or physically based ragdolls
+    - Added `__repr__` method for all classes that had the `__str__` method available.
   * Fixed RSSSensor python3 build and import of open drive maps by updating to ad-rss v4.2.0 and ad-map-access v2.3.0. Python import of dependent 'ad' python modules reflects now the namespaces of the C++ interface and follow doxygen documentation
   * Fixed sensor transformations and sensor data transformations mismatch in IMU and camera-based sensors
   * Fixed random dead-lock on synchronous mode at high frame rate

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -72,7 +72,7 @@ void export_actor() {
 
   class_<std::vector<int>>("vector_of_ints")
       .def(vector_indexing_suite<std::vector<int>>())
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::Actor, boost::noncopyable, boost::shared_ptr<cc::Actor>>("Actor", no_init)
@@ -109,7 +109,7 @@ void export_actor() {
       .def("set_simulate_physics", &cc::Actor::SetSimulatePhysics, (arg("enabled") = true))
       .def("set_enable_gravity", &cc::Actor::SetEnableGravity, (arg("enabled") = true))
       .def("destroy", CALL_WITHOUT_GIL(cc::Actor, Destroy))
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   enum_<cr::VehicleLightState::LightState>("VehicleLightState")
@@ -143,14 +143,14 @@ void export_actor() {
       .def("get_traffic_light", &cc::Vehicle::GetTrafficLight)
       .def("enable_carsim", &cc::Vehicle::EnableCarSim, (arg("simfile_path") = ""))
       .def("use_carsim_road", &cc::Vehicle::UseCarSimRoad, (arg("enabled")))
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::Walker, bases<cc::Actor>, boost::noncopyable, boost::shared_ptr<cc::Walker>>("Walker", no_init)
       .def("apply_control", &ApplyControl<cr::WalkerControl>, (arg("control")))
       .def("apply_control", &ApplyControl<cr::WalkerBoneControl>, (arg("control")))
       .def("get_control", &cc::Walker::GetWalkerControl)
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::WalkerAIController, bases<cc::Actor>, boost::noncopyable, boost::shared_ptr<cc::WalkerAIController>>("WalkerAIController", no_init)
@@ -158,7 +158,7 @@ void export_actor() {
     .def("stop", &cc::WalkerAIController::Stop)
     .def("go_to_location", &cc::WalkerAIController::GoToLocation, (arg("destination")))
     .def("set_max_speed", &cc::WalkerAIController::SetMaxSpeed, (arg("speed")))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::TrafficSign, bases<cc::Actor>, boost::noncopyable, boost::shared_ptr<cc::TrafficSign>>(
@@ -193,6 +193,6 @@ void export_actor() {
       .def("get_pole_index", &cc::TrafficLight::GetPoleIndex)
       .def("get_group_traffic_lights", &GetGroupTrafficLights)
       .def("reset_group", &cc::TrafficLight::ResetGroup)
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/AdRss.cpp
+++ b/PythonAPI/carla/source/libcarla/AdRss.cpp
@@ -138,7 +138,7 @@ void export_ad_rss() {
       .def_readwrite("route_accel_lon", &carla::rss::EgoDynamicsOnRoute::route_accel_lon)
       .def_readwrite("avg_route_accel_lat", &carla::rss::EgoDynamicsOnRoute::avg_route_accel_lat)
       .def_readwrite("avg_route_accel_lon", &carla::rss::EgoDynamicsOnRoute::avg_route_accel_lon)
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 
   class_<carla::rss::ActorConstellationResult>("RssActorConstellationResult")
       .def_readwrite("rss_calculation_mode", &carla::rss::ActorConstellationResult::rss_calculation_mode)
@@ -146,7 +146,7 @@ void export_ad_rss() {
       .def_readwrite("ego_vehicle_dynamics", &carla::rss::ActorConstellationResult::ego_vehicle_dynamics)
       .def_readwrite("actor_object_type", &carla::rss::ActorConstellationResult::actor_object_type)
       .def_readwrite("actor_dynamics", &carla::rss::ActorConstellationResult::actor_dynamics)
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 
   class_<carla::rss::ActorConstellationData, boost::noncopyable, boost::shared_ptr<carla::rss::ActorConstellationData>>(
       "RssActorConstellationData", no_init)
@@ -155,7 +155,7 @@ void export_ad_rss() {
       .def_readonly("ego_dynamics_on_route", &carla::rss::ActorConstellationData::ego_dynamics_on_route)
       .def_readonly("other_match_object", &carla::rss::ActorConstellationData::other_match_object)
       .def_readonly("other_actor", &carla::rss::ActorConstellationData::other_actor)
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 
   enum_<spdlog::level::level_enum>("RssLogLevel")
       .value("trace", spdlog::level::trace)
@@ -178,7 +178,7 @@ void export_ad_rss() {
       .add_property("situation_snapshot", CALL_RETURNING_COPY(csd::RssResponse, GetSituationSnapshot))
       .add_property("world_model", CALL_RETURNING_COPY(csd::RssResponse, GetWorldModel))
       .add_property("ego_dynamics_on_route", CALL_RETURNING_COPY(csd::RssResponse, GetEgoDynamicsOnRoute))
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 
   class_<cc::RssSensor, bases<cc::Sensor>, boost::noncopyable, boost::shared_ptr<cc::RssSensor>>("RssSensor", no_init)
       .add_property("ego_vehicle_dynamics", &GetEgoVehicleDynamics, &cc::RssSensor::SetEgoVehicleDynamics)
@@ -192,12 +192,12 @@ void export_ad_rss() {
       .def("drop_route", &cc::RssSensor::DropRoute)
       .def("set_log_level", &cc::RssSensor::SetLogLevel, (arg("log_level")))
       .def("set_map_log_level", &cc::RssSensor::SetMapLogLevel, (arg("map_log_level")))
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 
   class_<carla::rss::RssRestrictor, boost::noncopyable, boost::shared_ptr<carla::rss::RssRestrictor>>("RssRestrictor",
                                                                                                       no_init)
       .def(init<>())
       .def("restrict_vehicle_control", &carla::rss::RssRestrictor::RestrictVehicleControl,
            (arg("vehicle_control"), arg("proper_response"), arg("ego_dynamics_on_route"), arg("vehicle_physics")))
-      .def(self_ns::str(self_ns::self));
+      .def(self_ns::repr(self_ns::self));
 }

--- a/PythonAPI/carla/source/libcarla/Blueprint.cpp
+++ b/PythonAPI/carla/source/libcarla/Blueprint.cpp
@@ -94,7 +94,7 @@ void export_blueprint() {
     .def_readwrite("a", &csd::Color::a)
     .def("__eq__", &csd::Color::operator==)
     .def("__ne__", &csd::Color::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::ActorAttribute>("ActorAttribute", no_init)
@@ -124,7 +124,7 @@ void export_blueprint() {
     .def("__int__", &cc::ActorAttribute::As<int>)
     .def("__float__", &cc::ActorAttribute::As<float>)
     .def("__str__", &cc::ActorAttribute::As<std::string>)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::ActorBlueprint>("ActorBlueprint", no_init)
@@ -137,7 +137,7 @@ void export_blueprint() {
     .def("set_attribute", &cc::ActorBlueprint::SetAttribute)
     .def("__len__", &cc::ActorBlueprint::size)
     .def("__iter__", range(&cc::ActorBlueprint::begin, &cc::ActorBlueprint::end))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::BlueprintLibrary, boost::noncopyable, boost::shared_ptr<cc::BlueprintLibrary>>("BlueprintLibrary", no_init)
@@ -150,6 +150,6 @@ void export_blueprint() {
     })
     .def("__len__", &cc::BlueprintLibrary::size)
     .def("__iter__", range(&cc::BlueprintLibrary::begin, &cc::BlueprintLibrary::end))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/Control.cpp
+++ b/PythonAPI/carla/source/libcarla/Control.cpp
@@ -285,7 +285,7 @@ void export_control() {
     .def_readwrite("gear", &cr::VehicleControl::gear)
     .def("__eq__", &cr::VehicleControl::operator==)
     .def("__ne__", &cr::VehicleControl::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::WalkerControl>("WalkerControl")
@@ -298,19 +298,19 @@ void export_control() {
     .def_readwrite("jump", &cr::WalkerControl::jump)
     .def("__eq__", &cr::WalkerControl::operator==)
     .def("__ne__", &cr::WalkerControl::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::WalkerBoneControl>("WalkerBoneControl")
     .def("__init__", raw_function(WalkerBoneControl_init))
     .def(init<>())
     .add_property("bone_transforms", &GetBonesTransform, &SetBonesTransform)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<std::vector<cr::GearPhysicsControl>>("vector_of_gears")
       .def(boost::python::vector_indexing_suite<std::vector<cr::GearPhysicsControl>>())
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::GearPhysicsControl>("GearPhysicsControl")
@@ -323,12 +323,12 @@ void export_control() {
     .def_readwrite("up_ratio", &cr::GearPhysicsControl::up_ratio)
     .def("__eq__", &cr::GearPhysicsControl::operator==)
     .def("__ne__", &cr::GearPhysicsControl::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<std::vector<cr::WheelPhysicsControl>>("vector_of_wheels")
     .def(boost::python::vector_indexing_suite<std::vector<cr::WheelPhysicsControl>>())
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::WheelPhysicsControl>("WheelPhysicsControl")
@@ -349,7 +349,7 @@ void export_control() {
     .def_readwrite("position", &cr::WheelPhysicsControl::position)
     .def("__eq__", &cr::WheelPhysicsControl::operator==)
     .def("__ne__", &cr::WheelPhysicsControl::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::VehiclePhysicsControl>("VehiclePhysicsControl", no_init)
@@ -377,6 +377,6 @@ void export_control() {
     .def_readwrite("use_sweep_wheel_collision", &cr::VehiclePhysicsControl::use_sweep_wheel_collision)
     .def("__eq__", &cr::VehiclePhysicsControl::operator==)
     .def("__ne__", &cr::VehiclePhysicsControl::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/Geom.cpp
+++ b/PythonAPI/carla/source/libcarla/Geom.cpp
@@ -108,7 +108,7 @@ void export_geom() {
   namespace cg = carla::geom;
   class_<std::vector<cg::Vector2D>>("vector_of_vector2D")
       .def(boost::python::vector_indexing_suite<std::vector<cg::Vector2D>>())
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::Vector2D>("Vector2D")
@@ -127,7 +127,7 @@ void export_geom() {
     .def(self /= double())
     .def(self / double())
     .def(double() / self)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   implicitly_convertible<cg::Vector3D, cg::Location>();
@@ -151,7 +151,7 @@ void export_geom() {
     .def(self /= double())
     .def(self / double())
     .def(double() / self)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::Location, bases<cg::Vector3D>>("Location")
@@ -163,7 +163,7 @@ void export_geom() {
     .def("distance", &cg::Location::Distance, (arg("location")))
     .def("__eq__", &cg::Location::operator==)
     .def("__ne__", &cg::Location::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::Rotation>("Rotation")
@@ -176,7 +176,7 @@ void export_geom() {
     .def("get_up_vector", &cg::Rotation::GetUpVector)
     .def("__eq__", &cg::Rotation::operator==)
     .def("__ne__", &cg::Rotation::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::Transform>("Transform")
@@ -196,12 +196,12 @@ void export_geom() {
     .def("get_inverse_matrix", &GetInverseTransformMatrix)
     .def("__eq__", &cg::Transform::operator==)
     .def("__ne__", &cg::Transform::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<std::vector<cg::Transform>>("vector_of_transform")
       .def(boost::python::vector_indexing_suite<std::vector<cg::Transform>>())
-      .def(self_ns::str(self_ns::self))
+      .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::BoundingBox>("BoundingBox")
@@ -215,7 +215,7 @@ void export_geom() {
     .def("get_world_vertices", CALL_RETURNING_LIST_1(cg::BoundingBox, GetWorldVertices, const cg::Transform&), arg("bbox_transform"))
     .def("__eq__", &cg::BoundingBox::operator==)
     .def("__ne__", &cg::BoundingBox::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cg::GeoLocation>("GeoLocation")
@@ -225,6 +225,6 @@ void export_geom() {
     .def_readwrite("altitude", &cg::GeoLocation::altitude)
     .def("__eq__", &cg::GeoLocation::operator==)
     .def("__ne__", &cg::GeoLocation::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/Map.cpp
+++ b/PythonAPI/carla/source/libcarla/Map.cpp
@@ -170,7 +170,7 @@ void export_map() {
     .def("get_all_landmarks_from_id", CALL_RETURNING_LIST_1(cc::Map, GetLandmarksFromId, std::string), (args("opendrive_id")))
     .def("get_all_landmarks_of_type", CALL_RETURNING_LIST_1(cc::Map, GetAllLandmarksOfType, std::string), (args("type")))
     .def("get_landmark_group", CALL_RETURNING_LIST_1(cc::Map, GetLandmarkGroup, cc::Landmark), args("landmark"))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   // ===========================================================================
@@ -208,7 +208,7 @@ void export_map() {
     .def("get_junction", &cc::Waypoint::GetJunction)
     .def("get_landmarks", CALL_RETURNING_LIST_2(cc::Waypoint, GetAllLandmarksInDistance, double, bool), (arg("distance"), arg("stop_at_junction")=false))
     .def("get_landmarks_of_type", CALL_RETURNING_LIST_3(cc::Waypoint, GetLandmarksOfTypeInDistance, double, std::string, bool), (arg("distance"), arg("type"), arg("stop_at_junction")=false))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::Junction, boost::noncopyable, boost::shared_ptr<cc::Junction>>("Junction", no_init)

--- a/PythonAPI/carla/source/libcarla/OSM2ODR.cpp
+++ b/PythonAPI/carla/source/libcarla/OSM2ODR.cpp
@@ -29,7 +29,7 @@ void export_osm2odr() {
     .add_property("offset_y", &OSM2ODRSettings::offset_y, &OSM2ODRSettings::offset_y)
     .add_property("default_lane_width", &OSM2ODRSettings::default_lane_width, &OSM2ODRSettings::default_lane_width)
     .add_property("elevation_layer_height", &OSM2ODRSettings::elevation_layer_height, &OSM2ODRSettings::elevation_layer_height)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<OSM2ODR>("Osm2Odr", no_init)

--- a/PythonAPI/carla/source/libcarla/Sensor.cpp
+++ b/PythonAPI/carla/source/libcarla/Sensor.cpp
@@ -22,22 +22,22 @@ void export_sensor() {
     .add_property("is_listening", &cc::Sensor::IsListening)
     .def("listen", &SubscribeToStream, (arg("callback")))
     .def("stop", &cc::Sensor::Stop)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::ServerSideSensor, bases<cc::Sensor>, boost::noncopyable, boost::shared_ptr<cc::ServerSideSensor>>
       ("ServerSideSensor", no_init)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::ClientSideSensor, bases<cc::Sensor>, boost::noncopyable, boost::shared_ptr<cc::ClientSideSensor>>
       ("ClientSideSensor", no_init)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::LaneInvasionSensor, bases<cc::ClientSideSensor>, boost::noncopyable, boost::shared_ptr<cc::LaneInvasionSensor>>
       ("LaneInvasionSensor", no_init)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
 }

--- a/PythonAPI/carla/source/libcarla/SensorData.cpp
+++ b/PythonAPI/carla/source/libcarla/SensorData.cpp
@@ -269,7 +269,7 @@ void export_sensor_data() {
     .def("__setitem__", +[](csd::Image &self, size_t pos, csd::Color color) {
       self.at(pos) = color;
     })
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::LidarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::LidarMeasurement>>("LidarMeasurement", no_init)
@@ -286,7 +286,7 @@ void export_sensor_data() {
     .def("__setitem__", +[](csd::LidarMeasurement &self, size_t pos, const csd::LidarDetection &detection) {
       self.at(pos) = detection;
     })
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::SemanticLidarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::SemanticLidarMeasurement>>("SemanticLidarMeasurement", no_init)
@@ -303,41 +303,41 @@ void export_sensor_data() {
     .def("__setitem__", +[](csd::SemanticLidarMeasurement &self, size_t pos, const csd::SemanticLidarDetection &detection) {
       self.at(pos) = detection;
     })
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::CollisionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::CollisionEvent>>("CollisionEvent", no_init)
     .add_property("actor", &csd::CollisionEvent::GetActor)
     .add_property("other_actor", &csd::CollisionEvent::GetOtherActor)
     .add_property("normal_impulse", CALL_RETURNING_COPY(csd::CollisionEvent, GetNormalImpulse))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
     class_<csd::ObstacleDetectionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::ObstacleDetectionEvent>>("ObstacleDetectionEvent", no_init)
     .add_property("actor", &csd::ObstacleDetectionEvent::GetActor)
     .add_property("other_actor", &csd::ObstacleDetectionEvent::GetOtherActor)
     .add_property("distance", CALL_RETURNING_COPY(csd::ObstacleDetectionEvent, GetDistance))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::LaneInvasionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::LaneInvasionEvent>>("LaneInvasionEvent", no_init)
     .add_property("actor", &csd::LaneInvasionEvent::GetActor)
     .add_property("crossed_lane_markings", CALL_RETURNING_LIST(csd::LaneInvasionEvent, GetCrossedLaneMarkings))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::GnssMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::GnssMeasurement>>("GnssMeasurement", no_init)
     .add_property("latitude", &csd::GnssMeasurement::GetLatitude)
     .add_property("longitude", &csd::GnssMeasurement::GetLongitude)
     .add_property("altitude", &csd::GnssMeasurement::GetAltitude)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::IMUMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::IMUMeasurement>>("IMUMeasurement", no_init)
     .add_property("accelerometer", &csd::IMUMeasurement::GetAccelerometer)
     .add_property("gyroscope", &csd::IMUMeasurement::GetGyroscope)
     .add_property("compass", &csd::IMUMeasurement::GetCompass)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::RadarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::RadarMeasurement>>("RadarMeasurement", no_init)
@@ -351,7 +351,7 @@ void export_sensor_data() {
     .def("__setitem__", +[](csd::RadarMeasurement &self, size_t pos, const csd::RadarDetection &detection) {
       self.at(pos) = detection;
     })
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::RadarDetection>("RadarDetection")
@@ -359,13 +359,13 @@ void export_sensor_data() {
     .def_readwrite("azimuth", &csd::RadarDetection::azimuth)
     .def_readwrite("altitude", &csd::RadarDetection::altitude)
     .def_readwrite("depth", &csd::RadarDetection::depth)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::LidarDetection>("LidarDetection")
     .def_readwrite("point", &csd::LidarDetection::point)
     .def_readwrite("intensity", &csd::LidarDetection::intensity)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::SemanticLidarDetection>("SemanticLidarDetection")
@@ -373,7 +373,7 @@ void export_sensor_data() {
     .def_readwrite("cos_inc_angle", &csd::SemanticLidarDetection::cos_inc_angle)
     .def_readwrite("object_idx", &csd::SemanticLidarDetection::object_idx)
     .def_readwrite("object_tag", &csd::SemanticLidarDetection::object_tag)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::DVSEvent>("DVSEvent")
@@ -381,7 +381,7 @@ void export_sensor_data() {
     .add_property("y", &csd::DVSEvent::y)
     .add_property("t", &csd::DVSEvent::t)
     .add_property("pol", &csd::DVSEvent::pol)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<csd::DVSEventArray, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::DVSEventArray>>("DVSEventArray", no_init)
@@ -403,6 +403,6 @@ void export_sensor_data() {
     .def("to_array_y", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayY))
     .def("to_array_t", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayT))
     .def("to_array_pol", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayPol))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/Snapshot.cpp
+++ b/PythonAPI/carla/source/libcarla/Snapshot.cpp
@@ -37,7 +37,7 @@ void export_snapshot() {
     .def("get_velocity", +[](const cc::ActorSnapshot &self) { return self.velocity; })
     .def("get_angular_velocity", +[](const cc::ActorSnapshot &self) { return self.angular_velocity; })
     .def("get_acceleration", +[](const cc::ActorSnapshot &self) { return self.acceleration; })
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::WorldSnapshot>("WorldSnapshot", no_init)
@@ -56,6 +56,6 @@ void export_snapshot() {
     .def("__iter__", range(&cc::WorldSnapshot::begin, &cc::WorldSnapshot::end))
     .def("__eq__", &cc::WorldSnapshot::operator==)
     .def("__ne__", &cc::WorldSnapshot::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 }

--- a/PythonAPI/carla/source/libcarla/Weather.cpp
+++ b/PythonAPI/carla/source/libcarla/Weather.cpp
@@ -57,7 +57,7 @@ void export_weather() {
     .def_readwrite("wetness", &cr::WeatherParameters::wetness)
     .def("__eq__", &cr::WeatherParameters::operator==)
     .def("__ne__", &cr::WeatherParameters::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   cls.attr("Default") = cr::WeatherParameters::Default;

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -139,7 +139,7 @@ void export_world() {
     .def_readwrite("platform_timestamp", &cc::Timestamp::platform_timestamp)
     .def("__eq__", &cc::Timestamp::operator==)
     .def("__ne__", &cc::Timestamp::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cc::ActorList, boost::shared_ptr<cc::ActorList>>("ActorList", no_init)
@@ -148,7 +148,7 @@ void export_world() {
     .def("__getitem__", &cc::ActorList::at)
     .def("__len__", &cc::ActorList::size)
     .def("__iter__", range(&cc::ActorList::begin, &cc::ActorList::end))
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::EpisodeSettings>("WorldSettings")
@@ -178,7 +178,7 @@ void export_world() {
         })
     .def("__eq__", &cr::EpisodeSettings::operator==)
     .def("__ne__", &cr::EpisodeSettings::operator!=)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   class_<cr::EnvironmentObject>("EnvironmentObject", no_init)
@@ -187,7 +187,7 @@ void export_world() {
     .def_readwrite("id", &cr::EnvironmentObject::id)
     .def_readwrite("name", &cr::EnvironmentObject::name)
     .def_readwrite("type", &cr::EnvironmentObject::type)
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
   enum_<cr::AttachmentType>("AttachmentType")
@@ -293,7 +293,7 @@ void export_world() {
     .def("project_point", CALL_RETURNING_OPTIONAL_3(cc::World, ProjectPoint, cg::Location, cg::Vector3D, float), (arg("location"), arg("direction"), arg("search_distance")=10000.f))
     .def("ground_projection", CALL_RETURNING_OPTIONAL_2(cc::World, GroundProjection, cg::Location, float), (arg("location"), arg("search_distance")=10000.f))
 
-    .def(self_ns::str(self_ns::self))
+    .def(self_ns::repr(self_ns::self))
   ;
 
 #undef SPAWN_ACTOR_WITHOUT_GIL


### PR DESCRIPTION
This enables a better-debugging experience. By default, when calling the
__str__() method of an object who didn't define it's own __str__()
method, it will wall __repr__(). This means that this change is backward
compatible with any source code out there which is using some sort of
print(obj) or similar.

This means that every time we call an object from a python shell we will
call its "__str__" method, that now is implemented in __repr__.

Before:
```py
In [7]: vehicle
Out[7]: <carla.libcarla.ActorBlueprint at 0x7ff4d64742d0>

In [8]: vehicle.get_attribute('color')
Out[8]: <carla.libcarla.ActorAttribute at 0x7ff4fcec6f30>
```

After:
```py
In [6]: vehicle
Out[7]: ActorBlueprint(id=vehicle.dodge_charger.police,tags=[police, vehicle, dodge_charger])

In [8]: vehicle.get_attribute('color')
Out[8]: ActorAttribute(id=color,type=Color,value=Color(0,0,0,255))
```

#### Description

Just use the `boost::python::operator` wrapper that defines the `__repr__()` method for all the classes that already have defined their own `__str__()` method. This change is backward compatible and only improves debugging experience when running the CARLA client on a Python shell(in my experience)

#### Where has this been tested?

  * **Platform(s):** Ubuntu20.04
  * **Python version(s):** Python 3.8.5
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

 - This might be a bit "too" verbose for some people.
 - How do the docs get updated?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3832)
<!-- Reviewable:end -->
