### PR TITLE
Fixed bug related to RoadOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Latest
+
+  * Fixed bug causing the RoadOptions at the BehaviorAgent to not work as intended
+
+
 ## CARLA 0.9.11
 
   * Improved the documentation for use with pandoc tool by converting html tags to their markdown equivalent

--- a/PythonAPI/carla/agents/navigation/behavior_agent.py
+++ b/PythonAPI/carla/agents/navigation/behavior_agent.py
@@ -12,7 +12,8 @@ import random
 import numpy as np
 import carla
 from agents.navigation.agent import Agent
-from agents.navigation.local_planner_behavior import LocalPlanner, RoadOption
+from agents.navigation.local_planner_behavior import LocalPlanner
+from agents.navigation.local_planner import RoadOption
 from agents.navigation.global_route_planner import GlobalRoutePlanner
 from agents.navigation.global_route_planner_dao import GlobalRoutePlannerDAO
 from agents.navigation.types_behavior import Cautious, Aggressive, Normal

--- a/PythonAPI/carla/agents/navigation/local_planner_behavior.py
+++ b/PythonAPI/carla/agents/navigation/local_planner_behavior.py
@@ -14,21 +14,8 @@ from enum import Enum
 
 import carla
 from agents.navigation.controller import VehiclePIDController
+from agents.navigation.local_planner import RoadOption
 from agents.tools.misc import distance_vehicle, draw_waypoints
-
-
-class RoadOption(Enum):
-    """
-    RoadOption represents the possible topological configurations
-    when moving from a segment of lane to other.
-    """
-    VOID = -1
-    LEFT = 1
-    RIGHT = 2
-    STRAIGHT = 3
-    LANEFOLLOW = 4
-    CHANGELANELEFT = 5
-    CHANGELANERIGHT = 6
 
 
 class LocalPlanner(object):


### PR DESCRIPTION
### Description

Fixed a bug at the BehaviourAgent causing the RoadOptions to not work as intended.

This was caused by having two instances of the RoadOption enumerator, one at the *local_planner.py* and another one at the *local_planner_behavior.py*. Despite the fact that the latter file has one, this same file also uses the *global_route_planner.py* to calculate the route of the agent, which in turn uses the RoadOptions at the *local_planner.py*. This causes some unintended equality checks between these two different RoadOption enums, which will always be False.

This has been fixed by removing the RoadOptions enum at the *local_planner_behavior.py*, and always using the one at the *local_planner.py*

Fixes  #3462

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3833)
<!-- Reviewable:end -->
