### PR TITLE
CARLA uses the old and new RoadRunner nomenclature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * Added 'check_lidar_bb' util script
   * Improved manual_control: now cameras are set in relation with car size
   * Added performance benchmarking section to documentation
+  * CARLA is compatible with the last RoadRunner nomenclature for road assets
+  * Fixed a bug when importing a FBX map with some **_** in the FBX name
 
 ## CARLA 0.9.11
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/MoveAssetsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/MoveAssetsCommandlet.cpp
@@ -36,13 +36,20 @@ namespace SSTags {
   //
   // meshType is a larger geographical tag (e.g. "Road", "Terrain")
   // meshSubType is a denomination of the tag (e.g. "Road", "Gutter", "Ground")
-  static const FString R_ROAD     = TEXT("Road_Road");
-  static const FString R_TERRAIN  = TEXT("Terrain");
-  static const FString R_GRASS    = TEXT("Road_Grass");
-  static const FString R_MARKING  = TEXT("Road_Marking");
-  static const FString R_SIDEWALK = TEXT("Road_Sidewalk");
-  static const FString R_CURB     = TEXT("Road_Curb");
-  static const FString R_GUTTER   = TEXT("Road_Gutter");
+  static const FString R_ROAD1     = TEXT("Road_Road");
+  static const FString R_ROAD2     = TEXT("Roads_Road");
+  static const FString R_GRASS1    = TEXT("Road_Grass");
+  static const FString R_GRASS2    = TEXT("Roads_Grass");
+  static const FString R_MARKING1  = TEXT("Road_Marking");
+  static const FString R_MARKING2  = TEXT("Roads_Marking");
+  static const FString R_SIDEWALK1 = TEXT("Road_Sidewalk");
+  static const FString R_SIDEWALK2 = TEXT("Roads_Sidewalk");
+  static const FString R_CURB1     = TEXT("Road_Curb");
+  static const FString R_CURB2     = TEXT("Roads_Curb");
+  static const FString R_GUTTER1   = TEXT("Road_Gutter");
+  static const FString R_GUTTER2   = TEXT("Roads_Gutter");
+
+  static const FString R_TERRAIN   = TEXT("Terrain");
 }
 
 FMovePackageParams UMoveAssetsCommandlet::ParseParams(const FString &InParams) const
@@ -149,11 +156,11 @@ void UMoveAssetsCommandlet::MoveAssetsFromMapForSemanticSegmentation(
 
       // Bind between tags and classify assets according to semantic
       // segmentation
-      if (AssetName.Contains(SSTags::R_ROAD))
+      if (AssetName.Contains(SSTags::R_ROAD1) || AssetName.Contains(SSTags::R_ROAD2))
       {
         AssetDataMap[SSTags::ROAD].Add(MeshAsset);
       }
-      else if (AssetName.Contains(SSTags::R_MARKING))
+      else if (AssetName.Contains(SSTags::R_MARKING1) || AssetName.Contains(SSTags::R_MARKING2))
       {
         AssetDataMap[SSTags::ROADLINES].Add(MeshAsset);
       }
@@ -161,15 +168,15 @@ void UMoveAssetsCommandlet::MoveAssetsFromMapForSemanticSegmentation(
       {
         AssetDataMap[SSTags::TERRAIN].Add(MeshAsset);
       }
-      else if (AssetName.Contains(SSTags::R_SIDEWALK))
+      else if (AssetName.Contains(SSTags::R_SIDEWALK1) || AssetName.Contains(SSTags::R_SIDEWALK2))
       {
         AssetDataMap[SSTags::SIDEWALK].Add(MeshAsset);
       }
-      else if (AssetName.Contains(SSTags::R_CURB))
+      else if (AssetName.Contains(SSTags::R_CURB1) || AssetName.Contains(SSTags::R_CURB2))
       {
         AssetDataMap[SSTags::CURB].Add(MeshAsset);
       }
-      else if (AssetName.Contains(SSTags::R_GUTTER))
+      else if (AssetName.Contains(SSTags::R_GUTTER1) || AssetName.Contains(SSTags::R_GUTTER2))
       {
         AssetDataMap[SSTags::GUTTER].Add(MeshAsset);
       }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -126,6 +126,25 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
   UStaticMesh *MeshAsset;
   AStaticMeshActor *MeshActor;
 
+  // try to get the name of the map that precedes all assets name
+  FString MapName, AssetName;
+  for (auto MapAsset : MapContents)
+  {
+    // Rename asset
+    MapAsset.AssetName.ToString(AssetName);
+    int32 FindIndex1 = AssetName.Find("Road_", ESearchCase::IgnoreCase, ESearchDir::FromStart, 0);
+    int32 FindIndex2 = AssetName.Find("Roads_", ESearchCase::IgnoreCase, ESearchDir::FromStart, 0);
+    if (FindIndex1 >= 0)
+    {
+      MapName = AssetName.Left(FindIndex1);
+      break;
+    } else if (FindIndex2 >= 0)
+    {
+      MapName = AssetName.Left(FindIndex2);
+      break;
+    }
+  }
+    
   for (auto MapAsset : MapContents)
   {
     // Spawn Static Mesh
@@ -137,14 +156,9 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
       MeshComponent->SetStaticMesh(CastChecked<UStaticMesh>(MeshAsset));
 
       // Rename asset
-      FString AssetName;
       MapAsset.AssetName.ToString(AssetName);
       // Remove the prefix with the FBX name
-      int32 FindIndex = AssetName.Find("_", ESearchCase::IgnoreCase, ESearchDir::FromStart, 0);
-      if (FindIndex >= 0)
-      {
-        AssetName.RemoveAt(0, FindIndex + 1, true);
-      }
+      AssetName.RemoveFromStart(MapName, ESearchCase::IgnoreCase);
       MeshActor->SetActorLabel(AssetName, true);
 
       // set complex collision as simple in asset
@@ -161,12 +175,12 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
       {
         // Set Carla Materials depending on RoadRunner's Semantic Segmentation
         // tag
-        if (AssetName.Contains(SSTags::R_MARKING))
+        if (AssetName.Contains(SSTags::R_MARKING1) || AssetName.Contains(SSTags::R_MARKING2))
         {
           MeshActor->GetStaticMeshComponent()->SetMaterial(0, MarkingNodeMaterial);
           MeshActor->GetStaticMeshComponent()->SetMaterial(1, MarkingNodeMaterialAux);
         }
-        else if (AssetName.Contains(SSTags::R_ROAD))
+        else if (AssetName.Contains(SSTags::R_ROAD1) || AssetName.Contains(SSTags::R_ROAD2))
         {
           MeshActor->GetStaticMeshComponent()->SetMaterial(0, RoadNodeMaterial);
         }
@@ -174,7 +188,7 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
         {
           MeshActor->GetStaticMeshComponent()->SetMaterial(0, TerrainNodeMaterial);
         }
-        else if (AssetName.Contains(SSTags::R_SIDEWALK))
+        else if (AssetName.Contains(SSTags::R_SIDEWALK1) || AssetName.Contains(SSTags::R_SIDEWALK2))
         {
           MeshActor->GetStaticMeshComponent()->SetMaterial(0, SidewalkNodeMaterial);
         }

--- a/Unreal/CarlaUE4/Plugins/CarlaExporter/Source/CarlaExporter/Private/CarlaExporter.cpp
+++ b/Unreal/CarlaUE4/Plugins/CarlaExporter/Source/CarlaExporter/Private/CarlaExporter.cpp
@@ -116,19 +116,19 @@ void FCarlaExporterModule::PluginButtonClicked()
       FString ActorName = TempActor->GetName();
 
       // check type by nomenclature
-      if (ActorName.StartsWith("Road_Road"))
+      if (ActorName.StartsWith("Road_Road") || ActorName.StartsWith("Roads_Road"))
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Marking"))
+      else if (ActorName.StartsWith("Road_Marking") || ActorName.StartsWith("Roads_Marking"))
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Curb"))
+      else if (ActorName.StartsWith("Road_Curb") || ActorName.StartsWith("Roads_Curb"))
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Gutter"))
+      else if (ActorName.StartsWith("Road_Gutter") || ActorName.StartsWith("Roads_Gutter"))
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Sidewalk"))
+      else if (ActorName.StartsWith("Road_Sidewalk") || ActorName.StartsWith("Roads_Sidewalk"))
         areaType = AreaType::SIDEWALK;
-      else if (ActorName.StartsWith("Road_Crosswalk"))
+      else if (ActorName.StartsWith("Road_Crosswalk") || ActorName.StartsWith("Roads_Crosswalk"))
         areaType = AreaType::CROSSWALK;
-      else if (ActorName.StartsWith("Road_Grass"))
+      else if (ActorName.StartsWith("Road_Grass") || ActorName.StartsWith("Roads_Grass"))
         areaType = AreaType::GRASS;
       else
         areaType = AreaType::BLOCK;

--- a/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
+++ b/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
@@ -59,19 +59,19 @@ void SetMaterials(FbxNode* pNode)
         pNode->RemoveAllMaterials();
         // check nomenclature
         const char *name = pNode->GetName();
-        if (StartsWith(name, "Road_Road"))
+        if (StartsWith(name, "Road_Road") || StartsWith(name, "Roads_Road"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Marking"))
+        else if (StartsWith(name, "Road_Marking") || StartsWith(name, "Roads_Marking"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Curb"))
+        else if (StartsWith(name, "Road_Curb") || StartsWith(name, "Roads_Curb"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Gutter"))
+        else if (StartsWith(name, "Road_Gutter") || StartsWith(name, "Roads_Gutter"))
             mat = gMatRoad;
-		else if (StartsWith(name, "Road_Sidewalk"))
+		else if (StartsWith(name, "Road_Sidewalk") || StartsWith(name, "Roads_Sidewalk"))
 			mat = gMatSidewalk;
-		else if (StartsWith(name, "Road_Crosswalk"))
+		else if (StartsWith(name, "Road_Crosswalk") || StartsWith(name, "Roads_Crosswalk"))
 			mat = gMatCross;
-		else if (StartsWith(name, "Road_Grass"))
+		else if (StartsWith(name, "Road_Grass") || StartsWith(name, "Roads_Grass"))
 			mat = gMatGrass;
 
         printf("Node %s : %s\n", name, mat->GetName());


### PR DESCRIPTION
#### Description

RoadRunner last release has changed the way they name assets for the road. Before it was starting by **Road_**, but in last version they changed to plural word **Roads_**. That broke our nomenclature for the semantic segmentation and also pedestrian navigation, that are based on the name of the asset to identify different parts of a road (sidewalks, crosswalks, markings...).
Now CARLA can use **Road_** and also **Roads_** as part of the nomenclature. All of these are valid now:

- Road_Road
- Roads_Road
- Road_Marking
- Roads_Marking
- Road_Curb
- Roads_Curb
- Road_Gutter
- Roads_Gutter
- Road_Sidewalk
- Roads_Sidewalk
- Road_Crosswalk
- Roads_Crosswalk
- Road_Grass
- Roads_Grass

Also, when a FBX amp was imported, the name of the FBX was added as a prefix of the name of all assets. We were removing that name but only until the first **_** that was found. That was problematic if the name of the FBX had some **_** already because part of the FBX name was not removed properly. Now that has been fixed, and the FBX name can have any **_**.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

We need to update documentation in a new PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3840)
<!-- Reviewable:end -->
