### PR TITLE
Included DVS sensor in Core sensors page, fixed some links in Python …

### DIFF
--- a/Docs/core_sensors.md
+++ b/Docs/core_sensors.md
@@ -102,16 +102,17 @@ Sensor data differs a lot between sensor types. Take a look at the [sensors refe
  
 ### Cameras
 
-Take a shot of the world from their point of view. The helper class [carla.ColorConverter](python_api.md#carla.ColorConverter) will modify said image to represent different information.
+Take a shot of the world from their point of view. For cameras that return [carla.Image](<../python_api#carlaimage>), you can use the helper class [carla.ColorConverter](python_api.md#carla.ColorConverter) to modify the image to represent different information.
 
 * __Retrieve data__ every simulation step.  
 
 
-| Sensor                                                                                                                                                                                          | Output                                                                                                                                                                                          | Overview                                                                                                                                                                                        |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Depth                                                                                | [carla.Image](<../python_api#carlaimage>)                                            | Renders the depth of the elements in the field of view in a gray-scale map.          |
-| RGB                                                                                  | [carla.Image](<../python_api#carlaimage>)                                            | Provides clear vision of the surroundings. Looks like a normal photo of the scene.   |
-| Semantic segmentation                                                                | [carla.Image](<../python_api#carlaimage>)                                            | Renders elements in the field of view with a specific color according to their tags. |
+|Sensor |Output | Overview       |
+| ----------------- | ---------- | ------------------ |
+| Depth | [carla.Image](<../python_api#carlaimage>)  |Renders the depth of the elements in the field of view in a gray-scale map.          |
+| RGB      | [carla.Image](<../python_api#carlaimage>)   | Provides clear vision of the surroundings. Looks like a normal photo of the scene.   |
+| Semantic segmentation    | [carla.Image](<../python_api#carlaimage>)  | Renders elements in the field of view with a specific color according to their tags. |
+| DVS    | [carla.DVSEventArray](<../python_api#carladvseventarray>)  | Measures changes of brightness intensity asynchronously as an event stream.  |
 
 <br>
 

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -588,7 +588,7 @@ Polarity of the event. __True__ for positive and __False__ for negative.
 ---
 
 ## carla.DVSEventArray<a name="carla.DVSEventArray"></a>
-Class that defines a stream of events in [[carla.DVSEvent](#carla.DVSEvent)](#[carla.DVSEvent](#carla.DVSEvent)). Such stream is an array of arbitrary size depending on the number of events. This class also stores the field of view, the height and width of the image and the timestamp from convenience. Learn more about them [here](ref_sensors.md).  
+Class that defines a stream of events in [carla.DVSEvent](#carla.DVSEvent). Such stream is an array of arbitrary size depending on the number of events. This class also stores the field of view, the height and width of the image and the timestamp from convenience. Learn more about them [here](ref_sensors.md).  
 
 ### Instance Variables
 - <a name="carla.DVSEventArray.fov"></a>**<font color="#f8805a">fov</font>** (_float<small> – degrees</small>_)  

--- a/Docs/ref_sensors.md
+++ b/Docs/ref_sensors.md
@@ -793,7 +793,7 @@ The following tags are currently available:
 
 A Dynamic Vision Sensor (DVS) or Event camera is a sensor that works radically differently from a conventional camera. Instead of capturing
 intensity images at a fixed rate, event cameras measure changes of intensity asynchronously, in the form of a stream of events, which encode per-pixel
-brightness changes. Event cameras possess outstanding properties when compared to standard cameras. They have a very high dynamic range (140 dB
+brightness changes. Event cameras possess distinct properties when compared to standard cameras. They have a very high dynamic range (140 dB
 versus 60 dB), no motion blur, and high temporal resolution (in the order of microseconds). Event cameras are thus sensors that can provide high-quality
 visual information even in challenging high-speed scenarios and high dynamic range environments, enabling new application domains for vision-based
 algorithms.
@@ -816,10 +816,14 @@ contrast threshold `C` for one dimension `x` over time `t`. Observe how the even
 
 The current implementation of the DVS camera works in a uniform sampling manner between two consecutive synchronous frames. Therefore, in order to
 emulate the high temporal resolution (order of microseconds) of a real event camera, the sensor requires to execute at a high frequency (much higher
-frequency than a conventional camera). Effectively, the number of events increases as faster a CARLA car drives. Therefore, the sensor frequency
-should increase accordingly with the dynamic of the scene. The user should find their balance between time accuracy and computational cost.
+frequency than a conventional camera). Effectively, the number of events increases the faster a CARLA car drives. Therefore, the sensor frequency
+should increase accordingly with the dynamics of the scene. The user should find a balance between time accuracy and computational cost.
 
-The provided script `manual_control.py` uses the DVS camera in order to show how to configure the sensor, how to get the stream of events and how to depict such events in an image format, usually called event frame.
+The provided script [`manual_control.py`][manual_control] uses the DVS camera in order to show how to configure the sensor, how to get the stream of events and how to depict such events in an image format, usually called event frame.
+
+[manual_control]: https://github.com/carla-simulator/carla/blob/master/PythonAPI/examples/manual_control.py
+
+Note that due to the sampling method of the DVS camera, if there is no pixel difference between two consecutive synchronous frames the camera will not return an image. This will always occur in the first frame, as there is no previous frame to compare to and also in the event that there has been no movement between frames. 
 
 ![DVSCameraWorkingPrinciple](img/sensor_dvs.gif)
 

--- a/PythonAPI/docs/sensor_data.yml
+++ b/PythonAPI/docs/sensor_data.yml
@@ -741,7 +741,7 @@
   - class_name: DVSEventArray
     # - DESCRIPTION ------------------------
     doc: >
-      Class that defines a stream of events in [carla.DVSEvent](#carla.DVSEvent). Such stream is an array of arbitrary size depending on the number of events. This class also stores the field of view, the height and width of the image and the timestamp from convenience. Learn more about them [here](ref_sensors.md).
+      Class that defines a stream of events in carla.DVSEvent. Such stream is an array of arbitrary size depending on the number of events. This class also stores the field of view, the height and width of the image and the timestamp from convenience. Learn more about them [here](ref_sensors.md).
     # - PROPERTIES -------------------------
     instance_variables:
     - var_name: fov


### PR DESCRIPTION
# DVS Sensor Documentation

- I have added the DVS sensor to the "Camera" table in the core Sensor docs
- I clarified that `carla.ColorConverter` will only work with `carla.Image` (not on the image returned by the DVS sensor.)
- Fixed a link in the Python API related to the image returned by DS sensor
- Explained under what circumstances the DVS sensor won't return an image in the sensor reference
- Linked to the manual_control.py script so users can see the method to use the DVS sensor easily
- Changed some wording in the DVS sensor ref section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3870)
<!-- Reviewable:end -->
