### PR TITLE
Warning that "latest" version of docs is dev branch

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -14,8 +14,10 @@ The CARLA forum is available to post any doubts or suggestions that may arise du
 CARLA forum</a>
 </div>
 
+<br>
+
 !!! Warning
-    Change the docs version to fit the CARLA version you are using. Use the pannel in the bottom-right side of this window to change to previous versions. ![docs_version_panel](img/docs_version_panel.jpg)
+    __Change the docs version to fit the CARLA version you are using__. Use the panel in the bottom-right side of this window to change to previous versions. __The _Latest_ version points to documentation in the `dev` branch__ which may refer to features currently in development and __not available__ in any packaged version of CARLA, as well general documentation improvements. ![docs_version_panel](img/docs_version_panel.jpg)
 
 ---
 

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -1,5 +1,5 @@
 #Python API reference
-This reference contains all the details the Python API. To consult a previous reference for a specific CARLA release, change the documentation version using the panel in the bottom right corner.<br>This will change the whole documentation to a previous state. Remember to go back to <i>latest</i> to get the details of the current state of CARLA.<hr>  
+This reference contains all the details the Python API. To consult a previous reference for a specific CARLA release, change the documentation version using the panel in the bottom right corner.<br>This will change the whole documentation to a previous state. Remember that the <i>latest</i> version is the `dev` branch and may show features not available in any packaged versions of CARLA.<hr>  
 
 ## carla.Actor<a name="carla.Actor"></a>
 CARLA defines actors as anything that plays a role in the simulation or can be moved around. That includes: pedestrians, vehicles, sensors and traffic signs (considering traffic lights as part of these). Actors are spawned in the simulation by [carla.World](#carla.World) and they need for a [carla.ActorBlueprint](#carla.ActorBlueprint) to be created. These blueprints belong into a library provided by CARLA, find more about them [here](bp_library.md).  

--- a/PythonAPI/docs/doc_gen.py
+++ b/PythonAPI/docs/doc_gen.py
@@ -654,7 +654,7 @@ class Documentation:
         md.first_title()
         md.textn(
         "This reference contains all the details the Python API. To consult a previous reference for a specific CARLA release, change the documentation version using the panel in the bottom right corner.<br>"
-        +"This will change the whole documentation to a previous state. Remember to go back to <i>latest</i> to get the details of the current state of CARLA.<hr>")
+        +"This will change the whole documentation to a previous state. Remember that the <i>latest</i> version is the `dev` branch and may show features not available in any packaged versions of CARLA.<hr>")
         for module_name in sorted(self.master_dict):
             module = self.master_dict[module_name]
             module_key = module_name


### PR DESCRIPTION
I have put a warning on the Docs home page and on the Python API to warn users that they should change the docs to the correct version of the docs they want. I have clarified that "Latest" points to documentation from the dev branch so it will contain references to features that are not available in packaged versions as well as improved documentation.

I have not yet changed where the "latest' branch points to on readthedocs.org's admin panel because I want there to be information about it on the documentation first so that people don't get confused. What I will do is change:
- Default version -> 0.9.11 (The version of your project that / redirects to)
- Default branch -> dev (What branch "latest" points to.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3927)
<!-- Reviewable:end -->
