### PR TITLE
Chrono JSON vehicle definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added 'visualize_multiple_sensors' example
   * Added 'check_lidar_bb' util script
   * Improved manual_control: now cameras are set in relation with car size
+  * Added CHRONO library for vehicle dynamics simulation (https://projectchrono.org/)
   * Added performance benchmarking section to documentation
   * CARLA is compatible with the last RoadRunner nomenclature for road assets
   * Fixed a bug when importing a FBX map with some **_** in the FBX name

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline
                             steps
                             {
                                 sh 'git update-index --skip-worktree Unreal/CarlaUE4/CarlaUE4.uproject'
-                                sh 'make setup ARGS="--python-version=3.7,2"'
+                                sh 'make setup ARGS="--python-version=3.7,2 --chrono"'
                             }
                         }
                         stage('ubuntu build')
@@ -53,7 +53,7 @@ pipeline
                             {
                                 sh 'make LibCarla'
                                 sh 'make PythonAPI ARGS="--python-version=3.7,2"'
-                                sh 'make CarlaUE4Editor'
+                                sh 'make CarlaUE4Editor ARGS="--chrono"'
                                 sh 'make plugins'
                                 sh 'make examples'
                             }
@@ -92,7 +92,7 @@ pipeline
                         {
                             steps
                             {
-                                sh 'make package ARGS="--python-version=3.7,2"'
+                                sh 'make package ARGS="--python-version=3.7,2 --chrono"'
                                 sh 'make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --target-archive=AdditionalMaps --clean-intermediate --python-version=3.7,2"'
                                 sh 'make examples ARGS="localhost 3654"'
                             }
@@ -238,7 +238,7 @@ pipeline
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make setup
+                                    make setup ARGS="--chrono"
                                 """
                             }
                         }
@@ -256,7 +256,7 @@ pipeline
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make CarlaUE4Editor
+                                    make CarlaUE4Editor ARGS="--chrono"
                                 """
                                 bat """
                                     call ../setEnv64.bat
@@ -288,7 +288,7 @@ pipeline
                             {
                                 bat """
                                     call ../setEnv64.bat
-                                    make package
+                                    make package ARGS="--chrono"
                                 """
                                 bat """
                                     call ../setEnv64.bat

--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -96,8 +96,20 @@ namespace client {
     GetEpisode().Lock()->UseCarSimRoad(*this, enabled);
   }
 
-  void Vehicle::EnableChronoPhysics(uint64_t MaxSubsteps, float MaxSubstepDeltaTime) {
-    GetEpisode().Lock()->EnableChronoPhysics(*this, MaxSubsteps, MaxSubstepDeltaTime);
+  void Vehicle::EnableChronoPhysics(
+      uint64_t MaxSubsteps,
+      float MaxSubstepDeltaTime,
+      std::string VehicleJSON,
+      std::string PowertrainJSON,
+      std::string TireJSON,
+      std::string BaseJSONPath) {
+    GetEpisode().Lock()->EnableChronoPhysics(*this,
+        MaxSubsteps,
+        MaxSubstepDeltaTime,
+        VehicleJSON,
+        PowertrainJSON,
+        TireJSON,
+        BaseJSONPath);
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/Vehicle.h
+++ b/LibCarla/source/carla/client/Vehicle.h
@@ -93,7 +93,13 @@ namespace client {
     /// Enables the use of CarSim internal road definition instead of unreal's
     void UseCarSimRoad(bool enabled);
 
-    void EnableChronoPhysics(uint64_t MaxSubsteps, float MaxSubstepDeltaTime);
+    void EnableChronoPhysics(
+        uint64_t MaxSubsteps,
+        float MaxSubstepDeltaTime,
+        std::string VehicleJSON = "",
+        std::string PowertrainJSON = "",
+        std::string TireJSON = "",
+        std::string BaseJSONPath = "");
 
   private:
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -338,8 +338,22 @@ namespace detail {
     _pimpl->AsyncCall("use_carsim_road", vehicle, enabled);
   }
 
-  void Client::EnableChronoPhysics(rpc::ActorId vehicle, uint64_t MaxSubsteps, float MaxSubstepDeltaTime) {
-    _pimpl->AsyncCall("enable_chrono_physics", vehicle, MaxSubsteps, MaxSubstepDeltaTime);
+  void Client::EnableChronoPhysics(
+      rpc::ActorId vehicle,
+      uint64_t MaxSubsteps,
+      float MaxSubstepDeltaTime,
+      std::string VehicleJSON,
+      std::string PowertrainJSON,
+      std::string TireJSON,
+      std::string BaseJSONPath) {
+    _pimpl->AsyncCall("enable_chrono_physics",
+        vehicle,
+        MaxSubsteps,
+        MaxSubstepDeltaTime,
+        VehicleJSON,
+        PowertrainJSON,
+        TireJSON,
+        BaseJSONPath);
   }
 
   void Client::ApplyControlToWalker(rpc::ActorId walker, const rpc::WalkerControl &control) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -222,7 +222,11 @@ namespace detail {
     void EnableChronoPhysics(
         rpc::ActorId vehicle,
         uint64_t MaxSubsteps,
-        float MaxSubstepDeltaTime);
+        float MaxSubstepDeltaTime,
+        std::string VehicleJSON,
+        std::string PowertrainJSON,
+        std::string TireJSON,
+        std::string BaseJSONPath);
 
     void ApplyControlToWalker(
         rpc::ActorId walker,

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -454,8 +454,20 @@ namespace detail {
       _client.UseCarSimRoad(vehicle.GetId(), enabled);
     }
 
-    void EnableChronoPhysics(Vehicle &vehicle, uint64_t MaxSubsteps, float MaxSubstepDeltaTime) {
-      _client.EnableChronoPhysics(vehicle.GetId(), MaxSubsteps, MaxSubstepDeltaTime);
+    void EnableChronoPhysics(Vehicle &vehicle,
+        uint64_t MaxSubsteps,
+        float MaxSubstepDeltaTime,
+        std::string VehicleJSON,
+        std::string PowertrainJSON,
+        std::string TireJSON,
+        std::string BaseJSONPath) {
+      _client.EnableChronoPhysics(vehicle.GetId(),
+          MaxSubsteps,
+          MaxSubstepDeltaTime,
+          VehicleJSON,
+          PowertrainJSON,
+          TireJSON,
+          BaseJSONPath);
     }
 
     /// @}

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -143,7 +143,7 @@ void export_actor() {
       .def("get_traffic_light", &cc::Vehicle::GetTrafficLight)
       .def("enable_carsim", &cc::Vehicle::EnableCarSim, (arg("simfile_path") = ""))
       .def("use_carsim_road", &cc::Vehicle::UseCarSimRoad, (arg("enabled")))
-      .def("enable_chrono_physics", &cc::Vehicle::EnableChronoPhysics, (arg("max_substeps")=30, arg("max_substep_delta_time")=0.002))
+      .def("enable_chrono_physics", &cc::Vehicle::EnableChronoPhysics, (arg("max_substeps")=30, arg("max_substep_delta_time")=0.002, arg("vehicle_json")="", arg("powetrain_json")="", arg("tire_json")="", arg("base_json_path")=""))
       .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -180,6 +180,7 @@ public class Carla : ModuleRules
         PublicDelayLoadDLLs.Add(Path.Combine(LibCarlaInstallPath, "dll", "ChronoEngine_vehicle.dll"));
         PublicDelayLoadDLLs.Add(Path.Combine(LibCarlaInstallPath, "dll", "ChronoModels_vehicle.dll"));
         PublicDelayLoadDLLs.Add(Path.Combine(LibCarlaInstallPath, "dll", "ChronoModels_robot.dll"));
+        bUseRTTI = true;
       }
     }
     else
@@ -204,6 +205,7 @@ public class Carla : ModuleRules
         RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_vehicle.so"));
         RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_robot.so"));
         bUseRTTI = true;
+        bEnableExceptions = true;
       }
     }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -129,6 +129,13 @@ public class Carla : ModuleRules
     }
   }
 
+  private void AddDynamicLibrary(string library)
+  {
+    PublicAdditionalLibraries.Add(library);
+    RuntimeDependencies.Add(library);
+    PublicDelayLoadDLLs.Add(library);
+  }
+
   delegate string ADelegate(string s);
 
   private void AddBoostLibs(string LibPath)
@@ -196,14 +203,16 @@ public class Carla : ModuleRules
       }
       if (UsingChrono)
       {
-        PublicAdditionalLibraries.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoEngine.so"));
-        PublicAdditionalLibraries.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoEngine_vehicle.so"));
-        PublicAdditionalLibraries.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_vehicle.so"));
-        PublicAdditionalLibraries.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_robot.so"));
-        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoEngine.so"));
-        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoEngine_vehicle.so"));
-        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_vehicle.so"));
-        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib/libChronoModels_robot.so"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++.so"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++.so.1"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++.so.1.0"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++abi.so"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++abi.so.1"));
+        RuntimeDependencies.Add(Path.Combine(LibCarlaInstallPath, "lib", "libc++abi.so.1.0"));
+        AddDynamicLibrary(Path.Combine(LibCarlaInstallPath, "lib", "libChronoEngine.so"));
+        AddDynamicLibrary(Path.Combine(LibCarlaInstallPath, "lib", "libChronoEngine_vehicle.so"));
+        AddDynamicLibrary(Path.Combine(LibCarlaInstallPath, "lib", "libChronoModels_vehicle.so"));
+        AddDynamicLibrary(Path.Combine(LibCarlaInstallPath, "lib", "libChronoModels_robot.so"));
         bUseRTTI = true;
         bEnableExceptions = true;
       }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1136,7 +1136,11 @@ void FCarlaServer::FPimpl::BindActions()
   BIND_SYNC(enable_chrono_physics) << [this](
       cr::ActorId ActorId,
       uint64_t MaxSubsteps,
-      float MaxSubstepDeltaTime) -> R<void>
+      float MaxSubstepDeltaTime,
+      std::string VehicleJSON,
+      std::string PowertrainJSON,
+      std::string TireJSON,
+      std::string BaseJSONPath) -> R<void>
   {
     REQUIRE_CARLA_EPISODE();
     auto ActorView = Episode->FindActor(ActorId);
@@ -1149,7 +1153,14 @@ void FCarlaServer::FPimpl::BindActions()
     {
       RESPOND_ERROR("unable to set chrono physics: not actor is not a vehicle");
     }
-    UChronoMovementComponent::CreateChronoMovementComponent(Vehicle, MaxSubsteps, MaxSubstepDeltaTime);
+    UChronoMovementComponent::CreateChronoMovementComponent(
+        Vehicle,
+        MaxSubsteps,
+        MaxSubstepDeltaTime,
+        cr::ToFString(VehicleJSON),
+        cr::ToFString(PowertrainJSON),
+        cr::ToFString(TireJSON),
+        cr::ToFString(BaseJSONPath));
     return R<void>::Success();
   };
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/BaseCarlaMovementComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/BaseCarlaMovementComponent.h
@@ -20,6 +20,7 @@ class CARLA_API UBaseCarlaMovementComponent : public UMovementComponent
 
 protected:
 
+  UPROPERTY()
   ACarlaWheeledVehicle* CarlaVehicle;
 
 public:

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.cpp
@@ -181,12 +181,12 @@ void UChronoMovementComponent::BeginPlay()
   // Create JSON vehicle
   Vehicle = chrono_types::make_shared<WheeledVehicle>(
       &Sys,
-	  VehiclePath_string);
+      VehiclePath_string);
   Vehicle->Initialize(ChCoordsys<>(ChronoLocation, ChronoRotation));
   Vehicle->GetChassis()->SetFixed(false);
   // Create and initialize the powertrain System
   auto powertrain = ReadPowertrainJSON(
-	  PowerTrain_string);
+      PowerTrain_string);
   Vehicle->InitializePowertrain(powertrain);
   // Create and initialize the tires
   for (auto& axle : Vehicle->GetAxles()) {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.cpp
@@ -8,7 +8,9 @@
 #include "ChronoMovementComponent.h"
 #include "compiler/disable-ue4-macros.h"
 #include <carla/rpc/String.h>
+#ifdef WITH_CHRONO
 #include "chrono_vehicle/utils/ChUtilsJSON.h"
+#endif
 #include "compiler/enable-ue4-macros.h"
 #include "Carla/Util/RayTracer.h"
 
@@ -154,7 +156,7 @@ void UChronoMovementComponent::BeginPlay()
 
   // Set base path for vehicle JSON files
   vehicle::SetDataPath(carla::rpc::FromFString(BaseJSONPath));
-  
+
   std::string BasePath_string = carla::rpc::FromFString(BaseJSONPath);
 
   // Create full path for json files
@@ -167,12 +169,12 @@ void UChronoMovementComponent::BeginPlay()
   std::string PowerTrainJSON_string = carla::rpc::FromFString(PowertrainJSON);
   std::string PowerTrain_string = BasePath_string + PowerTrainJSON_string;
   FString PowerTrainJSONPath = carla::rpc::ToFString(PowerTrain_string);
-  
+
   std::string TireJSON_string = carla::rpc::FromFString(TireJSON);
   std::string Tire_string = BasePath_string + TireJSON_string;
   FString TireJSONPath = carla::rpc::ToFString(Tire_string);
-  
-  UE_LOG(LogCarla, Log, TEXT("Loading Chrono files: Vehicle: %s, PowerTrain: %s, Tire: %s"), 
+
+  UE_LOG(LogCarla, Log, TEXT("Loading Chrono files: Vehicle: %s, PowerTrain: %s, Tire: %s"),
       *VehicleJSONPath,
       *PowerTrainJSONPath,
       *TireJSONPath);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.h
@@ -17,7 +17,7 @@
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/ChTerrain.h"
 #include "chrono_vehicle/driver/ChDataDriver.h"
-#include "chrono_models/vehicle/hmmwv/HMMWV.h"
+#include "chrono_vehicle/wheeled_vehicle/vehicle/WheeledVehicle.h"
 
 #include "compiler/enable-ue4-macros.h"
 #endif
@@ -45,19 +45,31 @@ class CARLA_API UChronoMovementComponent : public UBaseCarlaMovementComponent
   GENERATED_BODY()
 
 #ifdef WITH_CHRONO
-  chrono::ChSystemNSC sys;
-  chrono::vehicle::hmmwv::HMMWV_Full my_hmmwv;
-  std::shared_ptr<UERayCastTerrain> terrain;
+  chrono::ChSystemNSC Sys;
+  // chrono::vehicle::hmmwv::HMMWV_Full my_hmmwv;
+  std::shared_ptr<chrono::vehicle::WheeledVehicle> Vehicle;
+  std::shared_ptr<UERayCastTerrain> Terrain;
 #endif
 
   uint64_t MaxSubsteps = 10;
   float MaxSubstepDeltaTime = 0.01;
   FVehicleControl VehicleControl;
+  FString VehicleJSON =    "hmmwv/vehicle/HMMWV_Vehicle.json";
+  FString PowertrainJSON = "hmmwv/powertrain/HMMWV_ShaftsPowertrain.json";
+  FString TireJSON =       "hmmwv/tire/HMMWV_Pac02Tire.json";
+  FString BaseJSONPath = "";
 
 public:
 
 
-  static void CreateChronoMovementComponent(ACarlaWheeledVehicle* Vehicle, uint64_t MaxSubsteps, float MaxSubstepDeltaTime);
+  static void CreateChronoMovementComponent(
+      ACarlaWheeledVehicle* Vehicle,
+      uint64_t MaxSubsteps,
+      float MaxSubstepDeltaTime,
+      FString VehicleJSON = "",
+      FString PowertrainJSON = "",
+      FString TireJSON = "",
+      FString BaseJSONPath = "");
 
   #ifdef WITH_CHRONO
   virtual void BeginPlay() override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/MovementComponents/ChronoMovementComponent.h
@@ -81,5 +81,11 @@ public:
       FActorComponentTickFunction* ThisTickFunction) override;
 
   void AdvanceChronoSimulation(float StepSize);
+
+  virtual FVector GetVelocity() const override;
+
+  virtual int32 GetVehicleCurrentGear() const override;
+
+  virtual float GetVehicleForwardSpeed() const override;
   #endif
 };

--- a/Util/InstallersWin/install_zlib.bat
+++ b/Util/InstallersWin/install_zlib.bat
@@ -5,6 +5,7 @@ rem BAT script that downloads and installs a ready to use
 rem x64 zlib build for CARLA (carla.org).
 rem Run it through a cmd with the x64 Visual C++ Toolset enabled.
 
+set MAKEFLAGS=
 set LOCAL_PATH=%~dp0
 set FILE_N=    -[%~n0]:
 


### PR DESCRIPTION
#### Description

This PR adds the capability to define chrono vehicles with JSON files that can be set from the python side.
API changes:
`actor.enable_chrono_physics(max_substeps, max_substep_delta_time, vehicle_json, powetrain_json, tire_json, base_json_path)`
- **max_substeps**: max number of chrono substeps 
- **max_substep_delta_time**: max size of substep 
- **vehicle_json**: relative path to vehicle json file with respect to `base_json_path` (e.g.: `hmmwv/vehicle/HMMWV_Vehicle.json`)
- **powetrain_json**: relative path to powertrain json file with respect to `base_json_path` (e.g.: `hmmwv/powertrain/HMMWV_ShaftsPowertrain.json`)
- **tire_json**: relative path to tire json file with respect to `base_json_path` (e.g.: `hmmwv/tire/HMMWV_Pac02Tire.json`)
- **base_json_path**: path to `chrono/data/vehicle` folder (e.g.: `/home/user/carla/Build/chrono-install/share/chrono/data/vehicle/`) (final `/` character is required)

Reminder: in order to activate chrono the make commands need to include the `ARGS="--chrono"`.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04, Windows
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks
Invalid JSON files or paths will cause a crash in the UE4 side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3928)
<!-- Reviewable:end -->
