### PR TITLE
Fix for import process in UE 4.26

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/MoveAssetsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/MoveAssetsCommandlet.cpp
@@ -96,13 +96,12 @@ void MoveFiles(const TArray<UObject *> &Assets, const FString &DestPath)
     {
       continue;
     }
-
-    new(AssetsAndNames) FAssetRenameData(Asset, DestPath, Asset->GetName());
+    AssetsAndNames.Emplace(Asset, DestPath, Asset->GetName());
   }
 
   if (AssetsAndNames.Num() > 0)
   {
-    AssetToolsModule.Get().RenameAssetsWithDialog(AssetsAndNames);
+    AssetToolsModule.Get().RenameAssets(AssetsAndNames);
   }
 }
 
@@ -181,6 +180,7 @@ void UMoveAssetsCommandlet::MoveAssetsFromMapForSemanticSegmentation(
   for (const auto &Elem : AssetDataMap)
   {
     FString DestPath = TEXT("/Game/") + PackageName + TEXT("/Static/") + Elem.Key + "/" + MapName;
+    
     MoveFiles(Elem.Value, DestPath);
   }
 }


### PR DESCRIPTION
#### Description

Fix the import process for UE 4.26
The process was failing when moving assets to the corresponding folder for semantic segmentation.

#### Where has this been tested?

  * **Platform(s):** Windows, Ubuntu
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3929)
<!-- Reviewable:end -->
