### PR TITLE
Smoke test are now executed in a predetermined order

### DIFF
--- a/PythonAPI/test/smoke/__init__.py
+++ b/PythonAPI/test/smoke/__init__.py
@@ -30,6 +30,7 @@ class SmokeTest(unittest.TestCase):
         self.client.set_timeout(120.0)
 
     def tearDown(self):
+        self.client.load_world("Town03")
         self.client = None
 
 

--- a/PythonAPI/test/smoke/__init__.py
+++ b/PythonAPI/test/smoke/__init__.py
@@ -10,7 +10,7 @@ import sys
 import unittest
 
 try:
-    sys.path.append(glob.glob('../../carla/dist/carla-*%d.%d-%s.egg' % (
+    sys.path.append(glob.glob('../carla/dist/carla-*%d.%d-%s.egg' % (
         sys.version_info.major,
         sys.version_info.minor,
         'win-amd64' if os.name == 'nt' else 'linux-x86_64'))[0])

--- a/PythonAPI/test/smoke/test_sensor_determinism.py
+++ b/PythonAPI/test/smoke/test_sensor_determinism.py
@@ -4,7 +4,7 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
-from __init__ import SyncSmokeTest
+from . import SyncSmokeTest
 
 import carla
 import time
@@ -335,3 +335,5 @@ class TestSensorDeterminism(SyncSmokeTest):
 
         # Remove all the output files
         shutil.rmtree(output_path)
+
+        self.client.load_world("Town03")

--- a/PythonAPI/test/smoke_test_list.txt
+++ b/PythonAPI/test/smoke_test_list.txt
@@ -1,0 +1,1 @@
+smoke.test_client smoke.test_props_loading smoke.test_sensor_tick_time smoke.test_map smoke.test_snapshot smoke.test_streamming smoke.test_spawnpoints smoke.test_blueprint smoke.test_world smoke.test_sync smoke.test_sensor_determinism smoke.test_determinism

--- a/PythonAPI/test/smoke_test_list.txt
+++ b/PythonAPI/test/smoke_test_list.txt
@@ -1,1 +1,1 @@
-smoke.test_client smoke.test_props_loading smoke.test_sensor_tick_time smoke.test_map smoke.test_snapshot smoke.test_streamming smoke.test_spawnpoints smoke.test_blueprint smoke.test_world smoke.test_sync smoke.test_sensor_determinism smoke.test_determinism
+smoke.test_client smoke.test_sync smoke.test_sensor_determinism smoke.test_props_loading smoke.test_sensor_tick_time smoke.test_map smoke.test_snapshot smoke.test_streamming smoke.test_spawnpoints smoke.test_blueprint smoke.test_world smoke.test_determinism

--- a/Util/BuildTools/Check.sh
+++ b/Util/BuildTools/Check.sh
@@ -210,17 +210,11 @@ fi
 
 pushd "${CARLA_PYTHONAPI_ROOT_FOLDER}/test" >/dev/null
 
-if ${XML_OUTPUT} ; then
-  EXTRA_ARGS="-X"
-else
-  EXTRA_ARGS=
-fi
-
 if ${SMOKE_TESTS} ; then
   smoke_list=`cat smoke_test_list.txt`
   for PY_VERSION in ${PY_VERSION_LIST[@]} ; do
     log "Running smoke tests for Python ${PY_VERSION}."
-    /usr/bin/env python${PY_VERSION} -m nose2 ${EXTRA_ARGS} -v ${smoke_list}
+    /usr/bin/env python${PY_VERSION} -m nose2 -v ${smoke_list}
   done
 
   if ${XML_OUTPUT} ; then

--- a/Util/BuildTools/Check.sh
+++ b/Util/BuildTools/Check.sh
@@ -208,7 +208,7 @@ if ${SMOKE_TESTS} ; then
   popd >/dev/null
 fi
 
-pushd "${CARLA_PYTHONAPI_ROOT_FOLDER}/test/smoke" >/dev/null
+pushd "${CARLA_PYTHONAPI_ROOT_FOLDER}/test" >/dev/null
 
 if ${XML_OUTPUT} ; then
   EXTRA_ARGS="-X"
@@ -217,10 +217,10 @@ else
 fi
 
 if ${SMOKE_TESTS} ; then
-
+  smoke_list=`cat smoke_test_list.txt`
   for PY_VERSION in ${PY_VERSION_LIST[@]} ; do
     log "Running smoke tests for Python ${PY_VERSION}."
-    /usr/bin/env python${PY_VERSION} -m nose2 ${EXTRA_ARGS}
+    /usr/bin/env python${PY_VERSION} -m nose2 ${EXTRA_ARGS} -v ${smoke_list}
   done
 
   if ${XML_OUTPUT} ; then

--- a/Util/BuildTools/Check.sh
+++ b/Util/BuildTools/Check.sh
@@ -210,11 +210,17 @@ fi
 
 pushd "${CARLA_PYTHONAPI_ROOT_FOLDER}/test" >/dev/null
 
+if ${XML_OUTPUT} ; then
+  EXTRA_ARGS="-c smoke/unittest.cfg -X"
+else
+  EXTRA_ARGS=
+fi
+
 if ${SMOKE_TESTS} ; then
   smoke_list=`cat smoke_test_list.txt`
   for PY_VERSION in ${PY_VERSION_LIST[@]} ; do
     log "Running smoke tests for Python ${PY_VERSION}."
-    /usr/bin/env python${PY_VERSION} -m nose2 -v ${smoke_list}
+    /usr/bin/env python${PY_VERSION} -m nose2 -v ${EXTRA_ARGS} ${smoke_list}
   done
 
   if ${XML_OUTPUT} ; then


### PR DESCRIPTION
#### Description

Minor modification of the smoke test pipeline to execute all the tests in a predetermined order. This allows us to have consistency between local and build executions and to have a more robust test pipeline.

The list of smoke tests is stored in the file  `smoke_test_list.txt`. In extra tests are added this file need to be updated.

Fixes # 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3942)
<!-- Reviewable:end -->
