### PR TITLE
Updating exposure value in Linux and UE 4.26

### DIFF
--- a/Docs/ref_sensors.md
+++ b/Docs/ref_sensors.md
@@ -449,7 +449,7 @@ Since these effects are provided by UE, please make sure to check their document
 | `min_fstop`    | float          | 1\.2           | Maximum aperture.    |
 | `blade_count`  | int            | 5  | Number of blades that make up the diaphragm mechanism.     |
 | `exposure_mode`      | str            | `histogram`    | Can be `manual` or `histogram`. More in [UE4 docs](<https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/AutomaticExposure/index.html>).  |
-| `exposure_compensation`          | float          | **Linux:** \-1.5<br>**Windows:** 0\.0        | Logarithmic adjustment for the exposure. 0: no adjustment, -1:2x darker, -2:4 darker, 1:2x brighter, 2:4x brighter.   |
+| `exposure_compensation`          | float          | **Linux:** \+0.75<br>**Windows:** 0\.0        | Logarithmic adjustment for the exposure. 0: no adjustment, -1:2x darker, -2:4 darker, 1:2x brighter, 2:4x brighter.   |
 | `exposure_min_bright`            | float          | 10\.0           | In `exposure_mode: "histogram"`. Minimum brightness for auto exposure. The lowest the eye can adapt within. Must be greater than 0 and less than or equal to `exposure_max_bright`.  |
 | `exposure_max_bright`            | float          | 12\.0           | In \`exposure\_mode: "histogram"\`. Maximum brightness for auto exposure. The highestthe eye can adapt within. Must be greater than 0 and greater than or equal to \`exposure\_min\_bright\`.          |
 | `exposure_speed_up`  | float          | 3\.0           | In `exposure_mode: "histogram"`. Speed at which the adaptation occurs from dark to bright environment.  |

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -118,7 +118,7 @@ void ASceneCaptureSensor::SetExposureCompensation(float Compensation)
 #if PLATFORM_LINUX
   // Looks like Windows and Linux have different outputs with the
   // same exposure compensation, this fixes it.
-  CaptureComponent2D->PostProcessSettings.AutoExposureBias = Compensation - 1.5f;
+  CaptureComponent2D->PostProcessSettings.AutoExposureBias = Compensation + 0.75f;
 #else
   CaptureComponent2D->PostProcessSettings.AutoExposureBias = Compensation;
 #endif

--- a/Util/BuildTools/Package.bat
+++ b/Util/BuildTools/Package.bat
@@ -275,6 +275,7 @@ for /f "tokens=* delims=" %%i in ("!PACKAGES!") do (
 
         echo   - prepare
         REM # Prepare cooking of package
+        echo call "%UE4_ROOT%/Engine/Binaries/Win64/UE4Editor.exe " "%CARLAUE4_ROOT_FOLDER%/CarlaUE4.uproject" -run=PrepareAssetsForCooking -PackageName=!PACKAGE_NAME! -OnlyPrepareMaps=false
         call "%UE4_ROOT%/Engine/Binaries/Win64/UE4Editor.exe "^
         "%CARLAUE4_ROOT_FOLDER%/CarlaUE4.uproject"^
         -run=PrepareAssetsForCooking^
@@ -286,6 +287,7 @@ for /f "tokens=* delims=" %%i in ("!PACKAGES!") do (
 
         echo   - cook
         REM # Cook maps
+        echo call "%UE4_ROOT%/Engine/Binaries/Win64/UE4Editor.exe " "%CARLAUE4_ROOT_FOLDER%/CarlaUE4.uproject" -run=cook -map="!MAPS_TO_COOK!" -cooksinglepackage -targetplatform="WindowsNoEditor" -OutputDir="!BUILD_FOLDER!"
         call "%UE4_ROOT%/Engine/Binaries/Win64/UE4Editor.exe "^
         "%CARLAUE4_ROOT_FOLDER%/CarlaUE4.uproject"^
         -run=cook^


### PR DESCRIPTION
#### Description

Updated the auto exposure value for Linux to compensate for UE 4.26

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** -
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3947)
<!-- Reviewable:end -->
