### PR TITLE
Ignore any error coming from a closed socket

### DIFF
--- a/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
@@ -203,7 +203,7 @@ namespace tcp {
               _socket,
               message->buffer(),
               boost::asio::bind_executor(_strand, handle_read_data));
-        } else {
+        } else if (!_done) {
           log_info("streaming client: failed to read header:", ec.message());
           DEBUG_ONLY(log_debug("size  = ", message->size()));
           DEBUG_ONLY(log_debug("bytes = ", bytes));


### PR DESCRIPTION
#### Description

At the time we close a stream, we were receiving an error because the socket was closed by the local system, showing the warning in the log console. If that happens when we close the stream, then we don't need to show the warning because that is something decided by the user.

#### Where has this been tested?

  * **Platform(s):** Windows, Ubuntu
  * **Python version(s):** -
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Not sure why we didn't get this warning message in previous versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3948)
<!-- Reviewable:end -->
