### PR TITLE
Town10 by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline
                             steps
                             {
                                 sh 'make package ARGS="--python-version=3.7,2 --chrono"'
-                                sh 'make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --target-archive=AdditionalMaps --clean-intermediate --python-version=3.7,2"'
+                                sh 'make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt --target-archive=AdditionalMaps --clean-intermediate --python-version=3.7,2"'
                                 sh 'make examples ARGS="localhost 3654"'
                             }
                             post
@@ -295,7 +295,7 @@ pipeline
                                 """
                                 bat """
                                     call ../setEnv64.bat
-                                    make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt,Town10HD_Opt --target-archive=AdditionalMaps --clean-intermediate"
+                                    make package ARGS="--packages=AdditionalMaps,Town06_Opt,Town07_Opt --target-archive=AdditionalMaps --clean-intermediate"
                                 """
                             }
                             post {

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -9,12 +9,12 @@ DefaultGraphicsPerformance=Maximum
 AppliedDefaultGraphicsPerformance=Maximum
 
 [/Script/EngineSettings.GameMapsSettings]
-EditorStartupMap=/Game/Carla/Maps/Town03.Town03
-GameDefaultMap=/Game/Carla/Maps/Town03.Town03
-ServerDefaultMap=/Game/Carla/Maps/Town03.Town03
+EditorStartupMap=/Game/Carla/Maps/Town10HD_Opt.Town10HD_Opt
+GameDefaultMap=/Game/Carla/Maps/Town10HD_Opt.Town10HD_Opt
+ServerDefaultMap=/Game/Carla/Maps/Town10HD_Opt.Town10HD_Opt
 GlobalDefaultGameMode=/Game/Carla/Blueprints/Game/CarlaGameMode.CarlaGameMode_C
 GameInstanceClass=/Script/Carla.CarlaGameInstance
-TransitionMap=/Game/Carla/Maps/Town03.Town03
+TransitionMap=/Game/Carla/Maps/Town10HD_Opt.Town10HD_Opt
 GlobalDefaultServerGameMode=/Game/Carla/Blueprints/Game/CarlaGameMode.CarlaGameMode_C
 
 [/Script/Engine.RendererSettings]

--- a/Unreal/CarlaUE4/Config/DefaultGame.ini
+++ b/Unreal/CarlaUE4/Config/DefaultGame.ini
@@ -59,6 +59,8 @@ bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/Town04_Opt")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Town05")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Town05_Opt")
++MapsToCook=(FilePath="/Game/Carla/Maps/Town10HD")
++MapsToCook=(FilePath="/Game/Carla/Maps/Town10HD_Opt")
 +MapsToCook=(FilePath="/Game/Carla/Maps/OpenDriveMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +DirectoriesToAlwaysCook=(Path="Carla/Static/GenericMaterials/Licenseplates/Textures")


### PR DESCRIPTION
#### Description

Now Town10HD_Opt is the default one when you start the server or UE4 editor.
So, the maps on each package are:
* Carla:
  * Town01 and Town01_Opt
  * Town02 and Town02_Opt
  * Town03 and Town03_Opt
  * Town04 and Town04_Opt
  * Town05 and Town05_Opt
  * Town10HD and Town10HD_Opt (loaded by default)
* AdditionalMaps:
  * Town06 and Town06_Opt
  * Town07 and Town07_Opt

#### Where has this been tested?

  * **Platform(s):** -
  * **Python version(s):** -
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3951)
<!-- Reviewable:end -->
