### PR TITLE
Improved local planner set_global_plan function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Added performance benchmarking section to documentation
   * CARLA is compatible with the last RoadRunner nomenclature for road assets
   * Fixed a bug when importing a FBX map with some **_** in the FBX name
+  * When setting a global plan at the LocalPlanner, it is now optional to stop the automatic fill of the waypoint buffer.
 
 ## CARLA 0.9.11
 

--- a/PythonAPI/carla/agents/navigation/local_planner_behavior.py
+++ b/PythonAPI/carla/agents/navigation/local_planner_behavior.py
@@ -52,7 +52,7 @@ class LocalPlanner(object):
         self._next_waypoints = None
         self.target_waypoint = None
         self._vehicle_controller = None
-        self._global_plan = None
+        self._stop_waypoint_creation = None
         self._pid_controller = None
         self.waypoints_queue = deque(maxlen=20000)  # queue with tuples of (waypoint, RoadOption)
         self._buffer_size = 5
@@ -107,7 +107,7 @@ class LocalPlanner(object):
 
         self._current_waypoint = self._map.get_waypoint(self._vehicle.get_location())
 
-        self._global_plan = False
+        self._stop_waypoint_creation = False
 
         self._target_speed = self._vehicle.get_speed_limit()
 
@@ -122,11 +122,13 @@ class LocalPlanner(object):
 
         self._target_speed = speed
 
-    def set_global_plan(self, current_plan, clean=False):
+    def set_global_plan(self, current_plan, clean=False, stop_waypoint_creation=True):
         """
         Sets new global plan.
 
             :param current_plan: list of waypoints in the actual plan
+            :param clean: bool
+            :param stop_waypoint_creation: bool
         """
         for elem in current_plan:
             self.waypoints_queue.append(elem)
@@ -140,7 +142,7 @@ class LocalPlanner(object):
                 else:
                     break
 
-        self._global_plan = True
+        self._stop_waypoint_creation = stop_waypoint_creation
 
     def get_incoming_waypoint_and_direction(self, steps=3):
         """


### PR DESCRIPTION
### Description

By default, the local planner never stops adding waypoints to the buffer, making the vehicle move aimlessly around the town forever. However, this behavior is stopped whenever a global plan is set up. This PR adds a new argument that makes it optional.

With an example:
- Random control around town -> Set a lane change plan -> vehicle stops at the end of the lane change
- Random control around town -> Set a lane change plan -> vehicle stops at the end of the lane change / keeps moving randomly (both options are available, being the first one the default one)

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3954)
<!-- Reviewable:end -->
