### PR TITLE
Check pointer before accessing it. I have experienced segmentation fault because map.GetMarkRecord returns nullptr, but it is not managed in CrossingAtSameSection

### DIFF
--- a/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
+++ b/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
@@ -37,15 +37,15 @@ namespace element {
     auto w1_marks = map.GetMarkRecord(*w1);
 
     if (dest_is_at_right) {
-      if (w0_is_offroad) {
+      if (w0_is_offroad && w1_marks.second) {
         return { LaneMarking(*w1_marks.second) };
-      } else {
+      } else if(w0_marks.first) {
         return { LaneMarking(*w0_marks.first) };
       }
     } else {
-      if (w0_is_offroad) {
+      if (w0_is_offroad && w1_marks.first) {
         return { LaneMarking(*w1_marks.first) };
-      } else {
+      } else if(w0_marks.second) {
         return { LaneMarking(*w0_marks.second) };
       }
     }


### PR DESCRIPTION
Check pointer before accessing it. I have experienced segmentation fault because map.GetMarkRecord returns nullptr, but it is not managed in CrossingAtSameSection.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [X] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
It is very simple, only check if the pointers have nullptr value before using them. The method GetMarkRecord of Map class can return nullptr (and I found situations where it does), but the nullptr value is not checked in the CrossingAtSameSection function of the LaneCrossingCalculator.cpp file. Therefore, I have experienced segmentation faults in my clients. The proposed code avoids potential segmentation faults.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->
The code solves an issue but it has not been created. 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** 4.24 with carla patches

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Maybe the lane invasor sensor has to contemplate the situations where the nullptr is returned, in order to calculate the result correctly. But the proposed change avoids access violation errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3956)
<!-- Reviewable:end -->
