### PR TITLE
Corkyw10/hybrid physics mode typo

### DIFF
--- a/Docs/adv_traffic_manager.md
+++ b/Docs/adv_traffic_manager.md
@@ -318,7 +318,7 @@ The hybrid mode is disabled by default. There are two ways to enable it.
 
 The are two parameters ruling the hybrid mode. One is the __radius__ that states the proximity area around any ego vehicle where physics are enabled. The other is the __vehicle__ with , that will act as center of this radius.  
 
-*   __Radius__ *(default = 70 meters)* — States the proximity area around the ego vehicle where physics are enabled. The value be changed with [traffic_manager.set_hybrid_mode_radius(r)](https://carla.readthedocs.io/en/latest/python_api/#carla.TrafficManager.set_hybrid_mode_radius).  
+*   __Radius__ *(default = 70 meters)* — States the proximity area around the ego vehicle where physics are enabled. The value can be changed via [traffic_manager.set_hybrid_physics_radius(r)](python_api.md#carla.TrafficManager.set_hybrid_physics_radius).  
 *   __Ego vehicle__ — A vehicle tagged with `role_name='hero'` that will act of the radius.
 	*   __If there is none,__ all the vehicles will disable physics.
 	*   __If there are many,__ the radius will be considered for all of them. That will create different areas of influence with physics enabled.  

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -2136,14 +2136,14 @@ Returns the port where the Traffic Manager is connected. If the object is a TM-C
 Sets the minimum distance in meters that vehicles have to keep with the rest. The distance is in meters and will affect the minimum moving distance. It is computed from center to center of the vehicle objects.  
     - **Parameters:**
         - `distance` (_float<small> – meters</small>_) – Meters between vehicles.  
-- <a name="carla.TrafficManager.set_hybrid_mode_radius"></a>**<font color="#7fb800">set_hybrid_mode_radius</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**r**=70.0</font>)  
-With hybrid physics on, changes the radius of the area of influence where physics are enabled.  
-    - **Parameters:**
-        - `r` (_float<small> – meters</small>_) – New radius where physics are enabled.  
 - <a name="carla.TrafficManager.set_hybrid_physics_mode"></a>**<font color="#7fb800">set_hybrid_physics_mode</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**enabled**=False</font>)  
 Enables or disables the hybrid physics mode. In this mode, vehicle's farther than a certain radius from the ego vehicle will have their physics disabled. Computation cost will be reduced by not calculating vehicle dynamics. Vehicles will be teleported.  
     - **Parameters:**
         - `enabled` (_bool_) – If __True__, enables the hybrid physics.  
+- <a name="carla.TrafficManager.set_hybrid_physics_radius"></a>**<font color="#7fb800">set_hybrid_physics_radius</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**r**=70.0</font>)  
+With hybrid physics on, changes the radius of the area of influence where physics are enabled.  
+    - **Parameters:**
+        - `r` (_float<small> – meters</small>_) – New radius where physics are enabled.  
 - <a name="carla.TrafficManager.set_osm_mode"></a>**<font color="#7fb800">set_osm_mode</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**mode_switch**=True</font>)  
 Enables or disables the OSM mode. This mode allows the user to run TM in a map created with the [OSM feature](tuto_G_openstreetmap.md). These maps allow having dead-end streets. Normally, if vehicles cannot find the next waypoint, TM crashes. If OSM mode is enabled, it will show a warning, and destroy vehicles when necessary.  
     - **Parameters:**

--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -2117,8 +2117,6 @@ During the collision detection stage, which runs every frame, this method sets a
     - **Parameters:**
         - `actor` (_[carla.Actor](#carla.Actor)_) – The vehicle that is going to ignore walkers on scene.  
         - `perc` (_float_) – Between 0 and 100. Amount of times collisions will be ignored.  
-- <a name="carla.TrafficManager.reset_traffic_lights"></a>**<font color="#7fb800">reset_traffic_lights</font>**(<font color="#00a6ed">**self**</font>)  
-Resets every traffic light in the map to its initial state.  
 - <a name="carla.TrafficManager.vehicle_percentage_speed_difference"></a>**<font color="#7fb800">vehicle_percentage_speed_difference</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**actor**</font>, <font color="#00a6ed">**percentage**</font>)  
 Sets the difference the vehicle's intended speed and its current speed limit. Speed limits can be exceeded by setting the `perc` to a negative value.
 Default is 30. Exceeding a speed limit can be done using negative percentages.  

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -5,7 +5,7 @@ This guide shows how to download and install the packaged version of CARLA. The 
 * __[Before you begin](#before-you-begin)__  
 * __[CARLA installation](#carla-installation)__  
 	* [A. Debian CARLA installation](#a-debian-carla-installation)  
-	* [B. Binary installation](#b-binary-installation)  
+	* [B. Package installation](#b-package-installation)  
 * __[Import additional assets](#import-additional-assets)__  
 * __[Running CARLA](#running-carla)__  
 	* [Command-line options](#command-line-options)  
@@ -17,10 +17,10 @@ This guide shows how to download and install the packaged version of CARLA. The 
 
 The following requirements should be fulfilled before installing CARLA:
 
-* __System requirements.__ Any 64-bits OS should run CARLA. However, since release 0.9.9, __CARLA cannot run in 16.04 Linux systems with default compilers__. These should be upgraded to work with CARLA.  
+* __System requirements.__ Any 64-bits OS should run CARLA.
 * __An adequate GPU.__ CARLA aims for realistic simulations, so the server needs at least a 6 GB GPU although we would recommend 8 GB. A dedicated GPU is highly recommended for machine learning. 
 * __Disk space.__ CARLA will use about 20 GB of space.
-* __Python.__ [Python]((https://www.python.org/downloads/)) is the main scripting language in CARLA. CARLA supports both Python 2 and Python 3 although Python 3 is recommended.
+* __Python.__ [Python]((https://www.python.org/downloads/)) is the main scripting language in CARLA. CARLA supports both Python 2 and Python 3.7.
 * __Two TCP ports and good internet connection.__ 2000 and 2001 by default. Make sure that these ports are not blocked by firewalls or any other applications. 
 * __Other requirements.__  Two Python modules: [Pygame](https://pypi.org/project/pygame/) to create graphics directly with Python, and [Numpy](https://pypi.org/project/numpy/) for calculus. Install them using:
 
@@ -34,7 +34,7 @@ There are two methods to download and install CARLA as a package:
 
 __A)__ [Download the Debian package.](#a-debian-carla-installation)
 
-__B)__ [Download the binary from GitHub.](#b-binary-installation) 
+__B)__ [Download the package from GitHub.](#b-package-installation) 
 
 ### A. Debian CARLA installation
 
@@ -62,7 +62,7 @@ This repository contains CARLA 0.9.10 and later versions. To install a specific 
 !!! Important
     To install CARLA versions prior to 0.9.10, change to a previous version of the documentation using the panel in the bottom right corner of the window, and follow the old instructions.  
 
-### B. Binary installation
+### B. Package installation
 
 <div class="build-buttons">
 <p>
@@ -90,6 +90,7 @@ __2.__ Extract the package:
 
 ```sh
         cd path/to/carla/root
+
         ./ImportAssets.sh
 ```
 
@@ -106,20 +107,23 @@ The method to start a CARLA server depends on the installation method you used a
 
 ```sh
     cd /opt/carla-simulator/bin/
+
     ./CarlaUE4.sh
 ```
 
-- Linux binary installation:
+- Linux package installation:
 
 ```sh
     cd path/to/carla/root
+
     ./CarlaUE4.sh
 ```
 
-- Windows binary installation:
+- Windows package installation:
 
 ```sh
     cd path/to/carla/root
+
     CarlaUE4.exe
 ```
 
@@ -130,11 +134,14 @@ This is the server simulator which is now running and waiting for a client to co
 ```sh
         # Terminal A 
         cd PythonAPI\examples
+
         python3 -m pip install -r requirements.txt # Support for Python2 is provided in the CARLA release packages
+
         python3 spawn_npc.py  
 
         # Terminal B
         cd PythonAPI\examples
+
         python3 manual_control.py 
 ```
 
@@ -153,7 +160,7 @@ There are some configuration options available when launching CARLA and they can
 
 [ue4clilink]: https://docs.unrealengine.com/en-US/Programming/Basics/CommandLineArguments
 
-The script [`PythonAPI/util/config.py`][config] provides more configuration options and should be run when the server has been started up:
+The script [`PythonAPI/util/config.py`][config] provides more configuration options and should be run when the server has been started:
 
 [config]: https://github.com/carla-simulator/carla/blob/master/PythonAPI/util/config.py
 

--- a/Docs/tuto_G_scenic.md
+++ b/Docs/tuto_G_scenic.md
@@ -1,6 +1,6 @@
 # Scenic
 
-This guide provides an overview of how to use Scenic with CARLA. It assumes that users have prior knowledge of the Scenic syntax. If you need to learn more about Scenic, then read their ["Getting Started with Scenic"](https://scenic-lang.readthedocs.io/en/latest/quickstart.html) guide and have a look at their tutorials for creating [simple](https://scenic-lang.readthedocs.io/en/latest/tutorials/tutorial.html) and [dynamic](https://scenic-lang.readthedocs.io/en/latest/tutorials/dynamics.html) scenarios.
+This guide provides an overview of how to use Scenic with CARLA to generate multiple, diverse scenarios with a single scenario definition. It assumes that users have prior knowledge of the Scenic syntax. If you need to learn more about Scenic, then read their ["Getting Started with Scenic"](https://scenic-lang.readthedocs.io/en/latest/quickstart.html) guide and have a look at their tutorials for creating [simple](https://scenic-lang.readthedocs.io/en/latest/tutorials/tutorial.html) and [dynamic](https://scenic-lang.readthedocs.io/en/latest/tutorials/dynamics.html) scenarios.
 
 By the end of the guide you will know:
 
@@ -128,7 +128,7 @@ require (distance to intersection) > 80
 
 __6.__ Set an end point so the script knows when the scene is finished:
 
-The scenario will end with the speed of the ego vehicle goes below 0.1 meters per second and is situated less than 30 meters from the obstacle.
+The scenario will end when the speed of the ego vehicle goes below 0.1 meters per second and is situated less than 30 meters from the obstacle.
 
 ```scenic
 terminate when ego.speed < 0.1 and (distance to obstacle) < 30
@@ -160,8 +160,8 @@ Below is a table of configurable parameters in the CARLA model:
 
 | Name | Value | Description |
 |------|-------|-------------|
-| `carla_map` | `str` | Name of the CARLA map to use, e.g. 'Town01'. If set to ``None``, CARLA will attempt to create a world from the `.xodr` file defined in the [`map`][scenic_map] parameter. |
-| `timestep` | `float` | Timestep to use for simulations (i.e., how frequently Scenic interrupts CARLA to run behaviors, check requirements, etc.) in seconds. Default is 0.1 seconds. |
+| `carla_map` | `str` | Name of the CARLA map to use (e.g. 'Town01'). If set to ``None``, CARLA will attempt to create a world from the `.xodr` file defined in the [`map`][scenic_map] parameter. |
+| `timestep` | `float` | Timestep to use for simulations (how frequently Scenic interrupts CARLA to run behaviors, check requirements, etc.) in seconds. Default is 0.1 seconds. |
 | `weather` | `str` or `dict` | Weather to use for the simulation. Can be either a string identifying one of the CARLA weather presets (e.g. 'ClearSunset') or a dictionary specifying all the [weather parameters](python_api.md#carla.WeatherParameters)). Default is a uniform distribution over all the weather presets. |
 | `address` | `str` | IP address to connect to CARLA. Default is localhost (127.0.0.1).|
 | `port` | `int` | Port to connect to CARLA. Default is 2000. |

--- a/Docs/tuto_G_scenic.md
+++ b/Docs/tuto_G_scenic.md
@@ -1,0 +1,172 @@
+# Scenic
+
+This guide provides an overview of how to use Scenic with CARLA. It assumes that users have prior knowledge of the Scenic syntax. If you need to learn more about Scenic, then read their ["Getting Started with Scenic"](https://scenic-lang.readthedocs.io/en/latest/quickstart.html) guide and have a look at their tutorials for creating [simple](https://scenic-lang.readthedocs.io/en/latest/tutorials/tutorial.html) and [dynamic](https://scenic-lang.readthedocs.io/en/latest/tutorials/dynamics.html) scenarios.
+
+By the end of the guide you will know:
+
+- The minimum requirements needed to run a Scenic script on CARLA.
+- How to write a simple scenario definition to generate a multitude of scenario simulations.
+- How to run a Scenic script on CARLA.
+- Parameters used to configure Scenic simulations on CARLA.
+
+---
+
+- [__Before you begin__](#before-you-begin)
+- [__Creating a Scenic scenario to use with CARLA__](#creating-a-scenic-scenario-to-use-with-carla)
+- [__Run the scenario__](#run-the-scenario)
+- [__Additional parameters__](#additional-parameters)
+
+---
+
+## Before you begin
+
+Before using Scenic with CARLA, you will need to fulfill the following requirements:
+
+- Install [Python 3.8](https://www.python.org/downloads/) or higher. 
+- Install [Scenic](https://scenic-lang.readthedocs.io/en/latest/quickstart.html#installation).
+
+---
+
+## Creating a Scenic scenario to use with CARLA
+
+This section walks through how to write a basic Scenic script in which a leading vehicle decelerates suddenly due to an obstacle in the road. An ego vehicle then needs to brake suddenly to avoid a collison with the leading vehicle. The [full script](https://github.com/BerkeleyLearnVerify/Scenic/blob/master/examples/carla/Carla_Challenge/carlaChallenge2.scenic) is found in the Scenic repository along with other examples involving more complex road networks. 
+
+__1.__ Set the map parameters and declare the model to be used in the scenario:
+
+- An `.xodr` file should be set as the value for the [`map`][scenic_map] parameter, this will be used later to generate road network information. 
+- The parameter `carla_map` refers to the name of the CARLA map you would like to use in the simulation. If this is not defined then the `.xodr` file in `map` will also be used to generate the simulation map.
+- The model includes all the utilities specific to running scenarios on CARLA. This should be defined in all the scripts you want to run on CARLA.
+
+```scenic
+## SET MAP AND MODEL
+param map = localPath('../../../tests/formats/opendrive/maps/CARLA/Town01.xodr')
+param carla_map = 'Town01'
+model scenic.simulators.carla.model
+```
+
+[scenic_map]: https://scenic-lang.readthedocs.io/en/latest/modules/scenic.domains.driving.model.html?highlight=map#module-scenic.domains.driving.model
+
+__2.__ Define the constants to be used in the scenario:
+
+The scenario involves two vehicles, the leading vehicle and the ego vehicle. We will define the ego vehicle model, the speeds of both cars, the distance threshold for braking and the amount of brake to apply.
+
+```scenic
+## CONSTANTS
+EGO_MODEL = "vehicle.lincoln.mkz2017"
+EGO_SPEED = 10
+EGO_BRAKING_THRESHOLD = 12
+
+LEAD_CAR_SPEED = 10
+LEADCAR_BRAKING_THRESHOLD = 10
+
+BRAKE_ACTION = 1.0
+```
+
+__3__. Define the scenario behaviours:
+
+Behaviours can be defined using the native Scenic [behaviours library](https://scenic-lang.readthedocs.io/en/latest/modules/scenic.domains.driving.behaviors.html) as well as the CARLA specific [behaviours library](https://scenic-lang.readthedocs.io/en/latest/modules/scenic.simulators.carla.behaviors.html). In this scenario we will instruct the ego vehicle to follow the lane at the predefined speed and then brake hard when it gets within a certain distance of another vehicle. The leading vehicle will also follow the lane at the predefined speed and brake hard within a certain distance of any objects:
+
+```scenic
+## DEFINING BEHAVIORS
+# EGO BEHAVIOR: Follow lane, and brake after passing a threshold distance to the leading car
+behavior EgoBehavior(speed=10):
+    try:
+        do FollowLaneBehavior(speed)
+
+    interrupt when withinDistanceToAnyCars(self, EGO_BRAKING_THRESHOLD):
+        take SetBrakeAction(BRAKE_ACTION)
+
+# LEAD CAR BEHAVIOR: Follow lane, and brake after passing a threshold distance to obstacle
+behavior LeadingCarBehavior(speed=10):
+    try: 
+        do FollowLaneBehavior(speed)
+
+    interrupt when withinDistanceToAnyObjs(self, LEADCAR_BRAKING_THRESHOLD):
+        take SetBrakeAction(BRAKE_ACTION)
+```
+
+__4.__ Generate the road network:
+
+The Scenic [roads library](https://scenic-lang.readthedocs.io/en/latest/modules/scenic.domains.driving.roads.html) is used to generate the road network geometry and traffic information. The road network is represented by an instance of the [`Network`](https://scenic-lang.readthedocs.io/en/latest/modules/scenic.domains.driving.roads.html#scenic.domains.driving.roads.Network) class and is generated from the `.xodr` file defined at the beginning of the script.
+
+```scenic
+## DEFINING SPATIAL RELATIONS
+# make sure to put '*' to uniformly randomly select from all elements of the list, 'lanes'
+lane = Uniform(*network.lanes)
+```
+
+__5.__ Set the scene:
+
+We will now define the starting positions for the vehicles and placement of objects. 
+
+- Place a trash can in the middle of the lane:
+
+```scenic
+obstacle = Trash on lane.centerline
+```
+
+- Place the leading car driving at the predefined speed along the road at a distance of between 50 and 30 meters behind the obstacle:
+
+```scenic
+leadCar = Car following roadDirection from obstacle for Range(-50, -30),
+        with behavior LeadingCarBehavior(LEAD_CAR_SPEED)
+```
+
+- Place the ego vehicle driving at the predefined speed along the road at a distance of between 15 to 10 meters behind the leading vehicle:
+
+```scenic
+ego = Car following roadDirection from leadCar for Range(-15, -10),
+        with blueprint EGO_MODEL,
+        with behavior EgoBehavior(EGO_SPEED)
+```
+
+- Make it a requirement that the scene takes place more than 80 meters from an intersection:
+
+```scenic
+require (distance to intersection) > 80
+```
+
+__6.__ Set an end point so the script knows when the scene is finished:
+
+The scenario will end with the speed of the ego vehicle goes below 0.1 meters per second and is situated less than 30 meters from the obstacle.
+
+```scenic
+terminate when ego.speed < 0.1 and (distance to obstacle) < 30
+```
+
+---
+
+### Run the scenario
+
+To run the Scenic scenario:
+
+__1.__ Start the CARLA server.
+
+__2.__ Run the following command:
+
+```scenic
+scenic path/to/scenic/script.scenic --simulate
+```
+
+A pygame window will appear and the scenario will play out repeatedly, each time generating a unique scenario within the bounds of the restrictions set in the script. To stop the scenario generation, press `ctrl + C` in the terminal. 
+
+---
+
+### Additional parameters
+
+The CARLA model provides several global parameters than can be overridden in scenarios using the [`param` statement](https://scenic-lang.readthedocs.io/en/latest/syntax_details.html#param-identifier-value) or via the command line using the [`--param` option](https://scenic-lang.readthedocs.io/en/latest/options.html#cmdoption-p).
+
+Below is a table of configurable parameters in the CARLA model:
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `carla_map` | `str` | Name of the CARLA map to use, e.g. 'Town01'. If set to ``None``, CARLA will attempt to create a world from the `.xodr` file defined in the [`map`][scenic_map] parameter. |
+| `timestep` | `float` | Timestep to use for simulations (i.e., how frequently Scenic interrupts CARLA to run behaviors, check requirements, etc.) in seconds. Default is 0.1 seconds. |
+| `weather` | `str` or `dict` | Weather to use for the simulation. Can be either a string identifying one of the CARLA weather presets (e.g. 'ClearSunset') or a dictionary specifying all the [weather parameters](python_api.md#carla.WeatherParameters)). Default is a uniform distribution over all the weather presets. |
+| `address` | `str` | IP address to connect to CARLA. Default is localhost (127.0.0.1).|
+| `port` | `int` | Port to connect to CARLA. Default is 2000. |
+| `timeout` | `float` | Maximum time in seconds to wait when attempting to connect to CARLA. Default is 10.|
+| `render` | `int` | Whether or not to have CARLA create a window showing the simulations from the point of view of the ego object: `1` for yes, `0` for no. Default `1`. |
+| `record` | `str` | If nonempty, folder in which to save CARLA record files for replaying simulations. |
+
+<br>

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -471,7 +471,7 @@
       doc: >
         Enables or disables the hybrid physics mode. In this mode, vehicle's farther than a certain radius from the ego vehicle will have their physics disabled. Computation cost will be reduced by not calculating vehicle dynamics. Vehicles will be teleported.
     # --------------------------------------
-    - def_name: set_hybrid_mode_radius
+    - def_name: set_hybrid_physics_radius
       params:
       - param_name: r
         type: float

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -426,10 +426,6 @@
       doc: >
         During the collision detection stage, which runs every frame, this method sets a percent chance that collisions with walkers will be ignored for a vehicle.
     # --------------------------------------
-    - def_name: reset_traffic_lights
-      doc: >
-        Resets every traffic light in the map to its initial state.
-    # --------------------------------------
     - def_name: vehicle_percentage_speed_difference
       params:
       - param_name: actor

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - 'Retrieve simulation data': "tuto_G_retrieve_data.md"
   - 'CarSim Integration (Beta)': "tuto_G_carsim_integration.md"
   - 'RLlib Integration': "tuto_G_rllib_integration.md"
+  - 'Scenic': 'tuto_G_scenic.md'
 - Tutorials (assets):
   - 'Add a new map': 'tuto_A_add_map.md'
   - 'Add a new vehicle': 'tuto_A_add_vehicle.md'


### PR DESCRIPTION
Fixed typo in Python API for set_hybrid_physics_radius and corrected link reference to it in the TM docs

Fixes #3926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3987)
<!-- Reviewable:end -->
