### PR TITLE
Improved visualization of the OpenDRIVE Standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CARLA 0.9.11
 
   * Improved the documentation for use with pandoc tool by converting html tags to their markdown equivalent
+  * Improved visuals of OpenDRIVE Standalone mode generated maps
   * Refactored FAQ section of docs to use minimal html and fix broken layout
   * Extended the local planner with a lateral `offset`
   * Upgraded to DirectX 12 on Windows
@@ -17,6 +18,13 @@
     - Added `enable_environment_objects`call to enable/disable objects of the level
     - Added `horizontal_fov` parameter to lidar sensor to allow for restriction of its field of view
     - Added `WorldSettings.deterministic_ragdolls` to enable deterministic or physically based ragdolls
+    - Added `GenerateMarkMesh()` function that generates a mesh for lane markings to the OpenDRIVE map generation
+    - Added textures for the road/marking meshes to the OpenDRIVE map generation
+    - Added new method to `Map`: `GenerateMarkMesh(Parameters)`
+    - Added new methods to `MeshFactory`: `GenerateMarkWithMaxLen(LaneSection)`, `GenerateMark(LaneSection)`, `GenerateMark(Lane)` and `GenerateMark(Lane, s_start, s_end)`
+    - Added new paramters to `road_params`: `mark_height`, `broken_mark_len` and `broken_gap_len`
+    - Added `unordered_map connections` to track the successor RoadIds of every road (to circumvent JunctionIds) to `MeshFactory`
+    - Added `unordered_map mark_lane_memory` to track information about markings of type _broken_ to `MeshFactory`
   * Fixed RSSSensor python3 build and import of open drive maps by updating to ad-rss v4.2.0 and ad-map-access v2.3.0. Python import of dependent 'ad' python modules reflects now the namespaces of the C++ interface and follow doxygen documentation
   * Fixed sensor transformations and sensor data transformations mismatch in IMU and camera-based sensors
   * Fixed random dead-lock on synchronous mode at high frame rate

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -1100,7 +1100,7 @@ namespace road {
       std::vector<road::RoadId> succs;
       if (_data.ContainsRoad(road.GetSuccessor())) {
         succs.push_back(road.GetSuccessor());
-      } else if (road.GetSuccessor() >= 0) { 
+      } else { 
         for (auto tmp : road.GetNexts()) {
           if (tmp->GetJunctionId() != -1 && tmp->GetPredecessor() == road.GetId()) {
             succs.push_back(tmp->GetId());

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -150,7 +150,7 @@ namespace road {
     std::unordered_map<road::RoadId, std::unordered_set<road::RoadId>>
         ComputeJunctionConflicts(JuncId id) const;
 
-    /// Buids a mesh based on the OpenDRIVE
+    /// Builds a mesh based on the OpenDRIVE
     geom::Mesh GenerateMesh(
         const double distance,
         const float extra_width = 0.6f,
@@ -159,7 +159,11 @@ namespace road {
     std::vector<std::unique_ptr<geom::Mesh>> GenerateChunkedMesh(
         const rpc::OpendriveGenerationParameters& params) const;
 
-    /// Buids a mesh of all crosswalks based on the OpenDRIVE
+    /// Builds a mesh of all roadmarkings based on the OpenDRIVE
+    std::vector<std::unique_ptr<geom::Mesh>> GenerateMarkMesh(
+        const rpc::OpendriveGenerationParameters& params) const;
+
+    /// Builds a mesh of all crosswalks based on the OpenDRIVE
     geom::Mesh GetAllCrosswalkMesh() const;
 
     geom::Mesh GenerateWalls(const double distance, const float wall_height) const;

--- a/LibCarla/source/carla/road/MeshFactory.cpp
+++ b/LibCarla/source/carla/road/MeshFactory.cpp
@@ -34,7 +34,7 @@ namespace geom {
 
   // Holds information for a successor/predecessor lane if a mark/gap went past a section/road
   typedef std::pair<road::RoadId, road::LaneId> pair;
-  static std::unordered_map<pair, std::pair<bool,float>, boost::hash<pair>> mark_lane_memory;
+  static std::unordered_map<pair, std::pair<bool,double>, boost::hash<pair>> mark_lane_memory;
   static std::unordered_map<road::RoadId, std::vector<road::RoadId>> connections;
 
   std::unique_ptr<Mesh> MeshFactory::Generate(const road::Road &road) const {

--- a/LibCarla/source/carla/road/MeshFactory.h
+++ b/LibCarla/source/carla/road/MeshFactory.h
@@ -8,6 +8,8 @@
 
 #include <memory>
 #include <vector>
+#include <utility>
+#include <unordered_map>
 
 #include <carla/geom/Mesh.h>
 #include <carla/road/Road.h>
@@ -58,6 +60,18 @@ namespace geom {
     std::unique_ptr<Mesh> GenerateLeftWall(
         const road::Lane &lane, const double s_start, const double s_end) const;
 
+    // -- Markings --
+
+    /// Generates a mesh for the markings that define a lane section
+    std::unique_ptr<Mesh> GenerateMark(const road::LaneSection &lane_section) const;
+
+    /// Generates a mesh for the markings that define a lane from a given s start and end
+    std::unique_ptr<Mesh> GenerateMark(
+        const road::Lane &lane, const double s_start, const double s_end) const;
+
+    /// Generates a mesh for the markings that define the whole lane
+    std::unique_ptr<Mesh> GenerateMark(const road::Lane &lane) const;
+
     // -- Chunked --
 
     /// Generates a list of meshes that defines a road with a maximum length
@@ -66,6 +80,10 @@ namespace geom {
 
     /// Generates a list of meshes that defines a lane_section with a maximum length
     std::vector<std::unique_ptr<Mesh>> GenerateWithMaxLen(
+        const road::LaneSection &lane_section) const;
+
+    /// Generates a list of meshes that defines a marking with a maximum length
+    std::vector<std::unique_ptr<Mesh>> GenerateMarkWithMaxLen(
         const road::LaneSection &lane_section) const;
 
     /// Generates a list of meshes that defines a road safety wall with a maximum length
@@ -94,6 +112,9 @@ namespace geom {
       float max_road_len                = 50.0f;
       float extra_lane_width            =  1.0f;
       float wall_height                 =  0.6f;
+      float mark_height                 =0.005f;
+      float broken_mark_len             =  6.0f;
+      float broken_gap_len              = 12.0f;
       // Road mesh smoothness:
       float max_weight_distance         =  5.0f;
       float same_lane_weight_multiplier =  2.0f;
@@ -102,6 +123,7 @@ namespace geom {
 
     RoadParameters road_param;
 
+    std::unordered_map<road::RoadId, std::vector<road::RoadId>> connections;
   };
 
 } // namespace geom

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.h
@@ -8,6 +8,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "ProceduralMeshComponent.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Materials/Material.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <boost/optional.hpp>
@@ -27,6 +29,12 @@ public:
 
   UPROPERTY(Category = "Procedural Mesh Actor", VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
   UProceduralMeshComponent* MeshComponent;
+
+  UPROPERTY(EditAnywhere)
+  UMaterial* RoadMaterial;
+
+  UPROPERTY(EditAnywhere)
+  UMaterial* RoadMarkMaterial;
 };
 
 UCLASS()
@@ -50,6 +58,9 @@ public:
 
   /// Generates the road and sidewalk mesh based on the OpenDRIVE information.
   void GenerateRoadMesh();
+
+  /// Generates the road marking mesh based on the OpenDRIVE information.
+  void GenerateMarkMesh();
 
   /// Generates pole meshes based on the OpenDRIVE information.
   void GeneratePoles();


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

The code changes improve the visualization of the road mesh for a given .xodr file. For one a texture gets applied to the generated road mesh and additionally a separated mesh for the lane markings gets generated. This is necessary since only one texture can be applied to one mesh. Currently only the marking types _"solid"_ and _"broken"_ are supported and for anything else will default to _"solid"_.

The code for the mark mesh follows the same scheme as the generation of the road mesh, i.e. a **ChunkedGeneration** iterating over every Road -> every Section -> every Lane. The differences follow from the fact that _"broken"_ markings are more complex to handle, since one needs to remember if currently a _"line"_ or a _"gap"_ has to be generated and the remaining length of said line/gap as well. A HashMap is used to track this information for a pair of **<RoadId, LaneId>**, I will refer to this as the _"mark_info"_ in the following. This mark_info is particular important if one road ends and another starts. Thus the successor(s) of a road are needed. If the successor is a junction the information about the _actual_ RoadIds cannot be accessed in **MeshFactory.cpp**. Hence an additional HashMap gets generated in **Map.cpp** that maps a RoadId to a vector of RoadIds i.e. the successors of the road. Thus the order in which the roads are handled is important, currently this is done in ascending order of their RoadId. The reason for this decision follows from the fact that in general the road network can be viewed as a _cyclic_ graph and I am not aware of an algorithm that can order such a graph. Hence the assumption "for every road _x_ the Id(s) of the successor road(s) are bigger than x.Id" was made. The code still works in case this assumption is violated, but might generate lines/gaps of varying length around transitions of roads. The overall length of the line/gap of a _broken_ mark are defined in **road_params**.

When **GenerateMark** is called on a lane the **RoadInfoMarkRecord** gets looked up first, to acquire the information about the type of marking (solid, broken) and the width. Then a key with the current RoadId and LaneId is used to check if there is already a mark_info in the HashMap and if not then a new entry is generated. The 3d points of the marking gets calculated similarly to the points of a road. In a loop the corner points of the lane at the current position are calculated and depending on the LaneId one or the other is used as the center for the marking. Using this point and the width of the marking the actual two points are calculated and recorded. Additionally if the remaining length of a line/gap is less then the **road_param.resolution** then the end points of the line/gap are calculated and the mark_info gets updated, i.e. switch line to gap and vice versa and set the new remaining length. Finally depending if it is the end of a section or the end of the road the mark_info gets recorded for the current key or for the successors.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8.5
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

None that I could think of, as only visuals are added.

#### Screenshots

Before:
![OpenDriveBefore](https://user-images.githubusercontent.com/17295978/111368291-fb578c80-8695-11eb-9495-c8f4c4516124.png)
After:
![OpenDrive-final](https://user-images.githubusercontent.com/17295978/111368294-fe527d00-8695-11eb-9e93-1ccdea7f05a9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/3990)
<!-- Reviewable:end -->
