### PR TITLE
Enable the no_delay option on sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Fixed bug causing the RoadOptions at the BehaviorAgent to not work as intended
   * Upgrading to Unreal Engine 4.26
   * Added Lincoln 2020 vehicle dimensions for CarSim integration
+  * Enabling the **no_delay** option to RPC and stream sockets
   * Improved performance bencharmark script: sync, map and sensor selection, ...
   * Improved performance, destroyed PhysX state for vehicles when physics are disable
   * Added 'visualize_multiple_sensors' example

--- a/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
@@ -106,6 +106,9 @@ namespace tcp {
           if (_done) {
             return;
           }
+          // This forces not using Nagle's algorithm.
+          // Improves the sync mode velocity on Linux by a factor of ~3.
+          _socket.set_option(boost::asio::ip::tcp::no_delay(true));
           log_debug("streaming client: connected to", ep);
           // Send the stream id to subscribe to the stream.
           const auto &stream_id = _token.get_stream_id();

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -195,7 +195,7 @@ unset BOOST_BASENAME
 # -- Get rpclib and compile it with libc++ and libstdc++ -----------------------
 # ==============================================================================
 
-RPCLIB_PATCH=v2.2.1_c3
+RPCLIB_PATCH=v2.2.1_c5
 RPCLIB_BASENAME=rpclib-${RPCLIB_PATCH}-${CXX_TAG}
 
 RPCLIB_LIBCXX_INCLUDE=${PWD}/${RPCLIB_BASENAME}-libcxx-install/include

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -36,7 +36,7 @@ rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
 
-set RPC_VERSION=v2.2.1_c3
+set RPC_VERSION=v2.2.1_c5
 set RPC_SRC=rpclib-src
 set RPC_SRC_DIR=%BUILD_DIR%%RPC_SRC%\
 set RPC_INSTALL=rpclib-install


### PR DESCRIPTION
#### Description

The **no_delay** socket option was only enabled on stream sockets on the server side, but not on the client side (client send the stream id at the beginning through the steam) and also not in any of the RPC sockets, causing a discontinuous delay on the tick() packet.

We have changed the RPCLib fork to enable this option on both client and server RPC. 
Now we are using the RPCLib tag v2.2.1_c5

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** UE 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4041)
<!-- Reviewable:end -->
