### PR TITLE
Optional sensor replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Improved performance, destroyed PhysX state for vehicles when physics are disable
   * Added 'visualize_multiple_sensors' example
   * Added 'check_lidar_bb' util script
+  * Added optional flag to `client.replay_file()` `replay_sensors` to enable or disable the replaying the sensors
   * Improved manual_control: now cameras are set in relation with car size
   * Added CHRONO library for vehicle dynamics simulation (https://projectchrono.org/)
   * Added performance benchmarking section to documentation

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -108,8 +108,9 @@ namespace client {
       return _simulator->ShowRecorderActorsBlocked(name, min_time, min_distance);
     }
 
-    std::string ReplayFile(std::string name, double start, double duration, uint32_t follow_id) {
-      return _simulator->ReplayFile(name, start, duration, follow_id);
+    std::string ReplayFile(std::string name, double start, double duration,
+        uint32_t follow_id, bool replay_sensors) {
+      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors);
     }
 
     void StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -229,7 +229,7 @@ namespace detail {
   }
 
   void Client::SetWheelSteerDirection(
-        rpc::ActorId vehicle, 
+        rpc::ActorId vehicle,
         rpc::VehicleWheelLocation vehicle_wheel,
         float angle_in_deg){
     return _pimpl->AsyncCall("set_wheel_steer_direction", vehicle, vehicle_wheel, angle_in_deg);
@@ -440,8 +440,10 @@ namespace detail {
     return _pimpl->CallAndWait<std::string>("show_recorder_actors_blocked", name, min_time, min_distance);
   }
 
-  std::string Client::ReplayFile(std::string name, double start, double duration, uint32_t follow_id) {
-    return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration, follow_id);
+  std::string Client::ReplayFile(std::string name, double start, double duration,
+      uint32_t follow_id, bool replay_sensors) {
+    return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration,
+        follow_id, replay_sensors);
   }
 
   void Client::StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -221,7 +221,7 @@ namespace detail {
         bool enabled);
 
     void SetWheelSteerDirection(
-        rpc::ActorId vehicle, 
+        rpc::ActorId vehicle,
         rpc::VehicleWheelLocation vehicle_wheel,
         float angle_in_deg
     );
@@ -230,7 +230,7 @@ namespace detail {
         rpc::ActorId vehicle,
         rpc::VehicleWheelLocation wheel_location
     );
-    
+
     void EnableChronoPhysics(
         rpc::ActorId vehicle,
         uint64_t MaxSubsteps,
@@ -292,7 +292,8 @@ namespace detail {
 
     std::string ShowRecorderActorsBlocked(std::string name, double min_time, double min_distance);
 
-    std::string ReplayFile(std::string name, double start, double duration, uint32_t follow_id);
+    std::string ReplayFile(std::string name, double start, double duration,
+        uint32_t follow_id, bool replay_sensors);
 
     void SetReplayerTimeFactor(double time_factor);
 

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -505,8 +505,9 @@ namespace detail {
       return _client.ShowRecorderActorsBlocked(std::move(name), min_time, min_distance);
     }
 
-    std::string ReplayFile(std::string name, double start, double duration, uint32_t follow_id) {
-      return _client.ReplayFile(std::move(name), start, duration, follow_id);
+    std::string ReplayFile(std::string name, double start, double duration,
+        uint32_t follow_id, bool replay_sensors) {
+      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors);
     }
 
     void SetReplayerTimeFactor(double time_factor) {

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -190,7 +190,7 @@ void export_client() {
     .def("show_recorder_file_info", CALL_WITHOUT_GIL_2(cc::Client, ShowRecorderFileInfo, std::string, bool), (arg("name"), arg("show_all")))
     .def("show_recorder_collisions", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderCollisions, std::string, char, char), (arg("name"), arg("type1"), arg("type2")))
     .def("show_recorder_actors_blocked", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderActorsBlocked, std::string, double, double), (arg("name"), arg("min_time"), arg("min_distance")))
-    .def("replay_file", CALL_WITHOUT_GIL_4(cc::Client, ReplayFile, std::string, double, double, uint32_t), (arg("name"), arg("time_start"), arg("duration"), arg("follow_id")))
+    .def("replay_file", CALL_WITHOUT_GIL_5(cc::Client, ReplayFile, std::string, double, double, uint32_t, bool), (arg("name"), arg("time_start"), arg("duration"), arg("follow_id"), arg("replay_sensors")=false))
     .def("stop_replayer", &cc::Client::StopReplayer, (arg("keep_actors")))
     .def("set_replayer_time_factor", &cc::Client::SetReplayerTimeFactor, (arg("time_factor")))
     .def("set_replayer_ignore_hero", &cc::Client::SetReplayerIgnoreHero, (arg("ignore_hero")))

--- a/PythonAPI/carla/source/libcarla/libcarla.cpp
+++ b/PythonAPI/carla/source/libcarla/libcarla.cpp
@@ -47,6 +47,12 @@ static boost::python::object OptionalToPythonObject(OptionalT &optional) {
       return self.fn(std::forward<T1_>(t1), std::forward<T2_>(t2), std::forward<T3_>(t3), std::forward<T4_>(t4)); \
     }
 
+// Convenient for requests with 5 arguments.
+#define CALL_WITHOUT_GIL_5(cls, fn, T1_, T2_, T3_, T4_, T5_) +[](cls &self, T1_ t1, T2_ t2, T3_ t3, T4_ t4, T5_ t5) { \
+      carla::PythonUtil::ReleaseGIL unlock; \
+      return self.fn(std::forward<T1_>(t1), std::forward<T2_>(t2), std::forward<T3_>(t3), std::forward<T4_>(t4), std::forward<T5_>(t5)); \
+    }
+
 // Convenient for const requests without arguments.
 #define CONST_CALL_WITHOUT_GIL(cls, fn) CALL_WITHOUT_GIL(const cls, fn)
 #define CONST_CALL_WITHOUT_GIL_1(cls, fn, T1_) CALL_WITHOUT_GIL_1(const cls, fn, T1_)

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -140,6 +140,10 @@
         type: int
         doc: >
           ID of the actor to follow. If this is 0 then camera is disabled.
+      - param_name: replay_sensors
+        type: bool
+        doc: >
+          Flag to enable or disable the spawn of sensors during playback.
       doc: >
         Load a new world with default settings using `map_name` map. All actors
         present in the current world will be destroyed, __but__ traffic manager instances will stay alive.

--- a/PythonAPI/examples/start_replaying.py
+++ b/PythonAPI/examples/start_replaying.py
@@ -71,6 +71,10 @@ def main():
         '-i', '--ignore-hero',
         action='store_true',
         help='ignore hero vehicles')
+    argparser.add_argument(
+        '--spawn-sensors',
+        action='store_true',
+        help='spawn sensors in the replayed world')
     args = argparser.parse_args()
 
     try:
@@ -85,7 +89,7 @@ def main():
         client.set_replayer_ignore_hero(args.ignore_hero)
 
         # replay the session
-        print(client.replay_file(args.recorder_filename, args.start, args.duration, args.camera))
+        print(client.replay_file(args.recorder_filename, args.start, args.duration, args.camera, args.spawn_sensors))
 
     finally:
         pass

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -47,10 +47,11 @@ std::string ACarlaRecorder::ShowFileActorsBlocked(std::string Name, double MinTi
   return Query.QueryBlocked(Name, MinTime, MinDistance);
 }
 
-std::string ACarlaRecorder::ReplayFile(std::string Name, double TimeStart, double Duration, uint32_t FollowId)
+std::string ACarlaRecorder::ReplayFile(std::string Name, double TimeStart, double Duration,
+    uint32_t FollowId, bool ReplaySensors)
 {
   Stop();
-  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId);
+  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, ReplaySensors);
 }
 
 inline void ACarlaRecorder::SetReplayerTimeFactor(double TimeFactor)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -147,7 +147,8 @@ public:
   std::string ShowFileActorsBlocked(std::string Name, double MinTime = 30, double MinDistance = 10);
 
   // replayer
-  std::string ReplayFile(std::string Name, double TimeStart, double Duration, uint32_t FollowId);
+  std::string ReplayFile(std::string Name, double TimeStart, double Duration,
+      uint32_t FollowId, bool ReplaySensors);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);
   void StopReplayer(bool KeepActors = false);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 
 // structure to save replaying info when need to load a new map (static member by now)
-CarlaReplayer::PlayAfterLoadMap CarlaReplayer::Autoplay { false, "", "", 0.0, 0.0, 0, 1.0 };
+CarlaReplayer::PlayAfterLoadMap CarlaReplayer::Autoplay { false, "", "", 0.0, 0.0, 0, 1.0, false };
 
 void CarlaReplayer::Stop(bool bKeepActors)
 {
@@ -101,7 +101,8 @@ double CarlaReplayer::GetTotalTime(void)
   return Frame.Elapsed;
 }
 
-std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, double Duration, uint32_t ThisFollowId)
+std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, double Duration,
+    uint32_t ThisFollowId, bool ReplaySensors)
 {
   std::stringstream Info;
   std::string s;
@@ -149,6 +150,7 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
     Autoplay.Duration = Duration;
     Autoplay.FollowId = ThisFollowId;
     Autoplay.TimeFactor = TimeFactor;
+    Autoplay.ReplaySensors = ReplaySensors;
   }
 
   // get Total time of recorder
@@ -175,6 +177,7 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
   // set the follow Id
   FollowId = ThisFollowId;
 
+  bReplaySensors = ReplaySensors;
   // if we don't need to load a new map, then start
   if (!Autoplay.Enabled)
   {
@@ -234,6 +237,8 @@ void CarlaReplayer::CheckPlayAfterMapLoaded(void)
 
   // set the follow Id
   FollowId = Autoplay.FollowId;
+
+  bReplaySensors = Autoplay.ReplaySensors;
 
   // apply time factor
   TimeFactor = Autoplay.TimeFactor;
@@ -401,7 +406,8 @@ void CarlaReplayer::ProcessEventsAdd(void)
         EventAdd.Rotation,
         EventAdd.Description,
         EventAdd.DatabaseId,
-        IgnoreHero);
+        IgnoreHero,
+        bReplaySensors);
 
     switch (Result.first)
     {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -44,6 +44,7 @@ public:
     double Duration;
     uint32_t FollowId;
     double TimeFactor;
+    bool ReplaySensors;
   };
 
   static PlayAfterLoadMap Autoplay;
@@ -51,7 +52,8 @@ public:
   CarlaReplayer() {};
   ~CarlaReplayer() { Stop(); };
 
-  std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f, uint32_t FollowId = 0);
+  std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f,
+      uint32_t FollowId = 0, bool ReplaySensors = false);
 
   // void Start(void);
   void Stop(bool KeepActors = false);
@@ -93,6 +95,7 @@ public:
 private:
 
   bool Enabled;
+  bool bReplaySensors = false;
   UCarlaEpisode *Episode = nullptr;
   // binary file reader
   std::ifstream File;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -20,7 +20,8 @@ std::pair<int, FActorView>CarlaReplayerHelper::TryToCreateReplayerActor(
     FVector &Location,
     FVector &Rotation,
     FActorDescription &ActorDesc,
-    uint32_t DesiredId)
+    uint32_t DesiredId,
+    bool SpawnSensors)
 {
   check(Episode != nullptr);
 
@@ -44,7 +45,7 @@ std::pair<int, FActorView>CarlaReplayerHelper::TryToCreateReplayerActor(
       return std::pair<int, FActorView>(0, view_empty);
     }
   }
-  else
+  else if (SpawnSensors || !ActorDesc.Id.StartsWith("sensor."))
   {
     // check if an actor of that type already exist with same id
     if (Episode->GetActorRegistry().Contains(DesiredId))
@@ -78,6 +79,11 @@ std::pair<int, FActorView>CarlaReplayerHelper::TryToCreateReplayerActor(
       UE_LOG(LogCarla, Log, TEXT("Actor could't be created by replayer"));
       return std::pair<int, FActorView>(0, Result.Value);
     }
+  }
+  else
+  {
+    // actor ignored
+    return std::pair<int, FActorView>(0, view_empty);
   }
 }
 
@@ -156,7 +162,8 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
     FVector Rotation,
     CarlaRecorderActorDescription Description,
     uint32_t DesiredId,
-    bool bIgnoreHero)
+    bool bIgnoreHero,
+    bool ReplaySensors)
 {
   check(Episode != nullptr);
   FActorDescription ActorDesc;
@@ -177,7 +184,12 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
       IsHero = true;
   }
 
-  auto result = TryToCreateReplayerActor(Location, Rotation, ActorDesc, DesiredId);
+  auto result = TryToCreateReplayerActor(
+      Location,
+      Rotation,
+      ActorDesc,
+      DesiredId,
+      ReplaySensors);
 
   if (result.first != 0)
   {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -27,7 +27,8 @@ public:
       FVector Rotation,
       CarlaRecorderActorDescription Description,
       uint32_t DesiredId,
-      bool bIgnoreHero);
+      bool bIgnoreHero,
+      bool ReplaySensors);
 
   // replay event for removing actor
   bool ProcessReplayerEventDel(uint32_t DatabaseId);
@@ -75,7 +76,8 @@ private:
     FVector &Location,
     FVector &Rotation,
     FActorDescription &ActorDesc,
-    uint32_t DesiredId);
+    uint32_t DesiredId,
+    bool SpawnSensors);
 
   AActor *FindTrafficLightAt(FVector Location);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1447,14 +1447,16 @@ void FCarlaServer::FPimpl::BindActions()
       std::string name,
       double start,
       double duration,
-      uint32_t follow_id) -> R<std::string>
+      uint32_t follow_id,
+      bool replay_sensors) -> R<std::string>
   {
     REQUIRE_CARLA_EPISODE();
     return R<std::string>(Episode->GetRecorder()->ReplayFile(
         name,
         start,
         duration,
-        follow_id));
+        follow_id,
+        replay_sensors));
   };
 
   BIND_SYNC(set_replayer_time_factor) << [this](double time_factor) -> R<void>


### PR DESCRIPTION
#### Description

This PR adds a new flag to the replayer to enable/disable the spawn of sensors from the recorded session.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4046)
<!-- Reviewable:end -->
