### PR TITLE
Enabled overlap events on static meshes and log error messages when meshes in world are empty

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -343,7 +343,7 @@ void ACarlaGameModeBase::CheckForEmptyMeshes()
 {
   TArray<AActor*> WorldActors;
   UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);
-  
+
   for(AActor *Actor : WorldActors)
   {
     AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
@@ -358,7 +358,7 @@ void ACarlaGameModeBase::EnableOverlapEvents()
 {
   TArray<AActor*> WorldActors;
   UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);
-  
+
   for(AActor *Actor : WorldActors)
   {
     AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -24,7 +24,6 @@
 #include "DynamicRHI.h"
 
 #include "DrawDebugHelpers.h"
-#include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 
 namespace cr = carla::road;
@@ -71,6 +70,7 @@ void ACarlaGameModeBase::InitGame(
     const FString &Options,
     FString &ErrorMessage)
 {
+  TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaGameModeBase::InitGame);
   Super::InitGame(MapName, Options, ErrorMessage);
 
   UWorld* World = GetWorld();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -344,10 +344,10 @@ void ACarlaGameModeBase::CheckForEmptyMeshes()
   TArray<AActor*> WorldActors;
   UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);
 
-  for(AActor *Actor : WorldActors)
+  for (AActor *Actor : WorldActors)
   {
     AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
-    if(MeshActor->GetStaticMeshComponent()->GetStaticMesh() == NULL)
+    if (MeshActor->GetStaticMeshComponent()->GetStaticMesh() == NULL)
     {
       UE_LOG(LogTemp, Error, TEXT("The object : %s has no mesh"), *MeshActor->GetFullName());
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -225,6 +225,7 @@ void ACarlaGameModeBase::BeginPlay()
       Light->BeginPlay();
     }
   }
+  EnableOverlapEvents();
 }
 
 void ACarlaGameModeBase::Tick(float DeltaSeconds)
@@ -345,15 +346,15 @@ void ACarlaGameModeBase::CheckForEmptyMeshes()
   
   for(AActor *Actor : WorldActors)
   {
-  	AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
-  	if(MeshActor->GetStaticMeshComponent()->GetStaticMesh() == NULL)
-  	{
-  		UE_LOG(LogTemp, Error, TEXT("The object : %s has no mesh"), *MeshActor->GetFullName());
-  	}
+    AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
+    if(MeshActor->GetStaticMeshComponent()->GetStaticMesh() == NULL)
+    {
+      UE_LOG(LogTemp, Error, TEXT("The object : %s has no mesh"), *MeshActor->GetFullName());
+    }
   }
 }
 
-void ACarlaGameModeBase::EnableCarSimChronoOverlapEvents()
+void ACarlaGameModeBase::EnableOverlapEvents()
 {
   TArray<AActor*> WorldActors;
   UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -24,6 +24,7 @@
 #include "DynamicRHI.h"
 
 #include "DrawDebugHelpers.h"
+#include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 
 namespace cr = carla::road;
@@ -70,7 +71,6 @@ void ACarlaGameModeBase::InitGame(
     const FString &Options,
     FString &ErrorMessage)
 {
-  TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaGameModeBase::InitGame);
   Super::InitGame(MapName, Options, ErrorMessage);
 
   UWorld* World = GetWorld();
@@ -336,6 +336,39 @@ ATrafficLightManager* ACarlaGameModeBase::GetTrafficLightManager()
     }
   }
   return TrafficLightManager;
+}
+
+void ACarlaGameModeBase::CheckForEmptyMeshes()
+{
+  TArray<AActor*> WorldActors;
+  UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);
+  
+  for(AActor *Actor : WorldActors)
+  {
+  	AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
+  	if(MeshActor->GetStaticMeshComponent()->GetStaticMesh() == NULL)
+  	{
+  		UE_LOG(LogTemp, Error, TEXT("The object : %s has no mesh"), *MeshActor->GetFullName());
+  	}
+  }
+}
+
+void ACarlaGameModeBase::EnableCarSimChronoOverlapEvents()
+{
+  TArray<AActor*> WorldActors;
+  UGameplayStatics::GetAllActorsOfClass(GetWorld(), AStaticMeshActor::StaticClass(), WorldActors);
+  
+  for(AActor *Actor : WorldActors)
+  {
+    AStaticMeshActor *MeshActor = CastChecked<AStaticMeshActor>(Actor);
+    if(MeshActor->GetStaticMeshComponent()->GetStaticMesh() != NULL)
+    {
+      if (MeshActor->GetStaticMeshComponent()->GetGenerateOverlapEvents() == false)
+      {
+        MeshActor->GetStaticMeshComponent()->SetGenerateOverlapEvents(true);
+      }
+    }
+  }
 }
 
 void ACarlaGameModeBase::DebugShowSignals(bool enable)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -75,6 +75,10 @@ public:
 
   void EnableEnvironmentObjects(const TSet<uint64>& EnvObjectIds, bool Enable);
 
+  void EnableCarSimChronoOverlapEvents();
+
+  void CheckForEmptyMeshes();
+
   UFUNCTION(Category = "Carla Game Mode", BlueprintCallable, CallInEditor, Exec)
   void LoadMapLayer(int32 MapLayers);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -75,7 +75,7 @@ public:
 
   void EnableEnvironmentObjects(const TSet<uint64>& EnvObjectIds, bool Enable);
 
-  void EnableCarSimChronoOverlapEvents();
+  void EnableOverlapEvents();
 
   void CheckForEmptyMeshes();
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [ x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [x ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Enabled overlap events on all meshes in the world so CarSim and Chrono detect collisions correctly. Also added error messages to log if there are empty meshes detected in the world.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4088)
<!-- Reviewable:end -->
