### PR TITLE
New import process to cook large maps divided in tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Upgrading to Unreal Engine 4.26
   * Added Lincoln 2020 vehicle dimensions for CarSim integration
   * Enabling the **no_delay** option to RPC and stream sockets
+  * The special nomenclature to define roads (ROAD_ROAD), sidewalks (ROAD_SIDEWALK)... can be at any position of the asset name
   * Improved performance bencharmark script: sync, map and sensor selection, ...
   * Improved performance, destroyed PhysX state for vehicles when physics are disable
   * Improved parallelism of raycast sensors in system with large number of cores

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -133,7 +133,7 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
   TArray<AStaticMeshActor *> SpawnedMeshes;
 
   // Create default Transform for all assets to spawn
-  const FTransform zeroTransform = FTransform();
+  const FTransform ZeroTransform = FTransform();
 
   // Load assets specified in AssetsPaths by using an object library
   // for building map world
@@ -168,7 +168,7 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
       // check to ignore meshes from other tiles
       if (i == -1 || (i != -1 && AssetName.Contains(TileName)))
       {
-        MeshActor = World->SpawnActor<AStaticMeshActor>(AStaticMeshActor::StaticClass(), zeroTransform);
+        MeshActor = World->SpawnActor<AStaticMeshActor>(AStaticMeshActor::StaticClass(), ZeroTransform);
         UStaticMeshComponent *MeshComponent = MeshActor->GetStaticMeshComponent();
         MeshComponent->SetStaticMesh(CastChecked<UStaticMesh>(MeshAsset));
         MeshActor->SetActorLabel(AssetName, true);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -128,24 +128,7 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
   AStaticMeshActor *MeshActor;
 
   // try to get the name of the map that precedes all assets name
-  FString MapName, AssetName;
-  for (auto MapAsset : MapContents)
-  {
-    // Rename asset
-    MapAsset.AssetName.ToString(AssetName);
-    int32 FindIndex1 = AssetName.Find("Road_", ESearchCase::IgnoreCase, ESearchDir::FromStart, 0);
-    int32 FindIndex2 = AssetName.Find("Roads_", ESearchCase::IgnoreCase, ESearchDir::FromStart, 0);
-    if (FindIndex1 >= 0)
-    {
-      MapName = AssetName.Left(FindIndex1);
-      break;
-    } else if (FindIndex2 >= 0)
-    {
-      MapName = AssetName.Left(FindIndex2);
-      break;
-    }
-  }
-    
+  FString AssetName;
   for (auto MapAsset : MapContents)
   {
     // Spawn Static Mesh
@@ -158,9 +141,6 @@ TArray<AStaticMeshActor *> UPrepareAssetsForCookingCommandlet::SpawnMeshesToWorl
 
       // Rename asset
       MapAsset.AssetName.ToString(AssetName);
-      // Remove the prefix with the FBX name
-      AssetName.RemoveFromStart(MapName, ESearchCase::IgnoreCase);
-      MeshActor->SetActorLabel(AssetName, true);
 
       // set complex collision as simple in asset
       UBodySetup *BodySetup = MeshAsset->BodySetup;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.h
@@ -74,6 +74,10 @@ public:
   /// structure.
   void LoadWorld(FAssetData &AssetData);
 
+  /// Loads a UWorld object contained in Carla BaseTile into @a AssetData data
+  /// structure.
+  void LoadWorldTile(FAssetData &AssetData);
+
   /// Spawns all the static meshes located in @a AssetsPaths inside the World.
   /// There is an option to use Carla materials by setting @a bUseCarlaMaterials
   /// to true, otherwise it will use RoadRunner materials.
@@ -82,7 +86,9 @@ public:
   /// @pre World is expected to be previously loaded
   TArray<AStaticMeshActor *> SpawnMeshesToWorld(
       const TArray<FString> &AssetsPaths,
-      bool bUseCarlaMaterials);
+      bool bUseCarlaMaterials,
+      int i = -1, 
+      int j = -1);
 
   /// Saves the current World, contained in @a AssetData, into @a DestPath
   /// composed of @a PackageName and with @a WorldName.
@@ -115,6 +121,9 @@ public:
   /// all the props inside the world and saves it in .umap format
   /// in a destination path built from @a PackageName and @a MapDestPath.
   void PreparePropsForCooking(FString &PackageName, const TArray<FString> &PropsPaths, FString &MapDestPath);
+
+  /// Return if there is any tile between the assets to cook
+  bool IsMapInTiles(const TArray<FString> &AssetsPaths);
 
 public:
 

--- a/Unreal/CarlaUE4/Plugins/CarlaExporter/Source/CarlaExporter/Private/CarlaExporter.cpp
+++ b/Unreal/CarlaUE4/Plugins/CarlaExporter/Source/CarlaExporter/Private/CarlaExporter.cpp
@@ -116,19 +116,19 @@ void FCarlaExporterModule::PluginButtonClicked()
       FString ActorName = TempActor->GetName();
 
       // check type by nomenclature
-      if (ActorName.StartsWith("Road_Road") || ActorName.StartsWith("Roads_Road"))
+      if (ActorName.Find("Road_Road") != -1 || ActorName.Find("Roads_Road") != -1)
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Marking") || ActorName.StartsWith("Roads_Marking"))
+      else if (ActorName.Find("Road_Marking") != -1 || ActorName.Find("Roads_Marking") != -1)
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Curb") || ActorName.StartsWith("Roads_Curb"))
+      else if (ActorName.Find("Road_Curb") != -1 || ActorName.Find("Roads_Curb") != -1)
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Gutter") || ActorName.StartsWith("Roads_Gutter"))
+      else if (ActorName.Find("Road_Gutter") != -1 || ActorName.Find("Roads_Gutter") != -1)
         areaType = AreaType::ROAD;
-      else if (ActorName.StartsWith("Road_Sidewalk") || ActorName.StartsWith("Roads_Sidewalk"))
+      else if (ActorName.Find("Road_Sidewalk") != -1 || ActorName.Find("Roads_Sidewalk") != -1)
         areaType = AreaType::SIDEWALK;
-      else if (ActorName.StartsWith("Road_Crosswalk") || ActorName.StartsWith("Roads_Crosswalk"))
+      else if (ActorName.Find("Road_Crosswalk") != -1 || ActorName.Find("Roads_Crosswalk") != -1)
         areaType = AreaType::CROSSWALK;
-      else if (ActorName.StartsWith("Road_Grass") || ActorName.StartsWith("Roads_Grass"))
+      else if (ActorName.Find("Road_Grass") != -1 || ActorName.Find("Roads_Grass") != -1)
         areaType = AreaType::GRASS;
       else
         areaType = AreaType::BLOCK;

--- a/Util/BuildTools/Import.py
+++ b/Util/BuildTools/Import.py
@@ -56,12 +56,17 @@ def generate_json_package(folder, package_name, use_carla_materials):
     # search for all .fbx and .xodr pair of files
     maps = []
     for root, _, filenames in os.walk(folder):
-        files = fnmatch.filter(filenames, "*.fbx")
+        files = fnmatch.filter(filenames, "*.xodr")
         for file_name in files:
-            fbx = file_name[:-4]
-            # check if exist the .xodr file
-            if os.path.exists("%s/%s.xodr" % (root, fbx)):
-                maps.append([os.path.relpath(root, folder), fbx])
+            xodr = file_name[:-5]
+            # check if exist the .fbx file
+            if os.path.exists("%s/%s.fbx" % (root, xodr)):
+                maps.append([os.path.relpath(root, folder), xodr, ["%s.fbx" % xodr]])
+            else:
+                # check if exist the map by tiles
+                tiles = fnmatch.filter(filenames, "*_Tile_*.fbx")
+                if (len(tiles) > 0):
+                    maps.append([os.path.relpath(root, folder), xodr, tiles])
 
     # write the json
     if (len(maps) > 0):
@@ -70,12 +75,20 @@ def generate_json_package(folder, package_name, use_carla_materials):
         for map_name in maps:
             path = map_name[0].replace('\\', '/')
             name = map_name[1]
-            json_maps.append({
+            tiles = map_name[2]
+            tiles = ["%s/%s" % (path, x) for x in tiles]
+            map_dict = {
                 'name': name, 
-                'source': '%s/%s.fbx'  % (path, name), 
                 'xodr':   '%s/%s.xodr' % (path, name), 
                 'use_carla_materials': use_carla_materials
-                })
+            }
+            # check for only one 'source' or map in 'tiles'
+            if (len(tiles) == 1):
+                map_dict['source'] = tiles[0]
+            else:
+                map_dict['tiles'] = tiles
+            # write
+            json_maps.append(map_dict)
         # build and write the .json
         f = open("%s/%s.json" % (folder, package_name), "w")
         my_json = {'maps': json_maps, 'props': []}
@@ -194,8 +207,6 @@ def invoke_commandlet(name, arguments):
         subprocess.call([full_command], shell=True)
 
 
-
-
 def generate_import_setting_file(package_name, json_dirname, props, maps):
     """Creates the PROPS and MAPS import_setting.json file needed
     as an argument for using the ImportAssets commandlet
@@ -241,13 +252,16 @@ def generate_import_setting_file(package_name, json_dirname, props, maps):
         for umap in maps:
             maps_dest = "/" + "/".join(["Game", package_name, "Maps", umap["name"]])
 
-            file_names = [os.path.join(json_dirname, umap["source"])]
+            if "source" in umap:
+                tiles = [os.path.join(json_dirname, umap["source"])]
+            else:
+                tiles = ["%s" % (os.path.join(json_dirname, x)) for x in umap["tiles"]]
             import_groups.append({
                 "ImportSettings": import_settings,
                 "FactoryName": "FbxFactory",
                 "DestinationPath": maps_dest,
                 "bReplaceExisting": "true",
-                "FileNames": file_names
+                "FileNames": tiles
             })
 
         fh.write(json.dumps({"ImportGroups": import_groups}))
@@ -389,17 +403,17 @@ def import_assets_from_json_list(json_list):
             build_binary_for_navigation(package_name, dirname, maps)
 
             # We prepare only the maps for cooking after moving them. Props cooking will be done from Package.sh script.
-            prepare_maps_commandlet_for_cooking(package_name, only_prepare_maps=True)
+            if len(maps) > 0:
+                prepare_maps_commandlet_for_cooking(package_name, only_prepare_maps=True)
 
-            # We apply the carla materials to the imported maps
-            load_asset_materials_commandlet(package_name)
+                # We apply the carla materials to the imported maps
+                load_asset_materials_commandlet(package_name)
 
 
 def load_asset_materials_commandlet(package_name):
     commandlet_name = "LoadAssetMaterials"
     commandlet_arguments = ["-PackageName=%s" % package_name]
     invoke_commandlet(commandlet_name, commandlet_arguments)
-
 
 def prepare_maps_commandlet_for_cooking(package_name, only_prepare_maps):
     commandlet_name = "PrepareAssetsForCooking"
@@ -427,58 +441,68 @@ def build_binary_for_navigation(package_name, dirname, maps):
     # process each map
     for umap in maps:
 
+        # get the sources for the map (single or tiles)
+        if ("source" in umap):
+            tiles = [umap["source"]]
+        elif ("tiles" in umap):
+            tiles = umap["tiles"]       
+        else:
+            continue
+
         # get the target name
         target_name = umap["name"]
+        xodr_filename = os.path.basename(umap["xodr"])
 
         # copy the XODR file into docker utils folder
         if "xodr" in umap and umap["xodr"] and os.path.isfile(os.path.join(dirname, umap["xodr"])):
             # Make sure the `.xodr` file have the same name than the `.umap`
             xodr_path_source = os.path.abspath(os.path.join(dirname, umap["xodr"]))
-            xodr_name = '.'.join([target_name, "xodr"])
-            xodr_path_target = os.path.join(folder, xodr_name)
+            xodr_path_target = os.path.join(folder, xodr_filename)
             # copy
             print('Copying "' + xodr_path_source + '" to "' + xodr_path_target + '"')
             shutil.copy2(xodr_path_source, xodr_path_target)
+        
+        for tile in tiles:
 
-        # copy the FBX file into docker utils folder
-        if "source" in umap and umap["source"] and os.path.isfile(os.path.join(dirname, umap["source"])):
-            # Make sure the `.fbx` file have the same name than the `.umap`
-            fbx_path_source = os.path.abspath(os.path.join(dirname, umap["source"]))
-            fbx_name = '.'.join([target_name, "fbx"])
-            fbx_path_target = os.path.join(folder, fbx_name)
-            # copy
-            print('Copying "' + fbx_path_source + '" to "' + fbx_path_target + '"')
-            shutil.copy2(fbx_path_source, fbx_path_target)
+            fbx_filename = os.path.basename(tile)
+            fbx_name_no_ext = os.path.splitext(fbx_filename)[0]
 
-        # make the conversion
-        if os.name == "nt":
-            subprocess.call(["build.bat", target_name], cwd=folder, shell=True)
-        else:
-            subprocess.call(["chmod +x build.sh"], cwd=folder, shell=True)
-            subprocess.call("./build.sh %s" % target_name, cwd=folder, shell=True)
+            # copy the FBX file into docker utils folder
+            if os.path.isfile(os.path.join(dirname, tile)):
+                # Make sure the `.fbx` file have the same name than the `.umap`
+                fbx_path_source = os.path.abspath(os.path.join(dirname, tile))
+                fbx_path_target = os.path.join(folder, fbx_filename)
+                # copy
+                print('Copying "' + fbx_path_source + '" to "' + fbx_path_target + '"')
+                shutil.copy2(fbx_path_source, fbx_path_target)
 
-        # copy the binary file
-        nav_folder_target = os.path.join(
-            CARLA_ROOT_PATH,
-            "Unreal",
-            "CarlaUE4",
-            "Content",
-            package_name,
-            "Maps",
-            target_name,
-            "Nav")
+            # rename the xodr with the same name of the source/tile
+            os.rename(os.path.join(folder, xodr_filename), os.path.join(folder, "%s.xodr" % fbx_name_no_ext))
 
-        nav_path_source = os.path.join(folder, "%s.bin" % target_name)
-        if os.path.exists(nav_path_source):
-            # Skip this step for maps that do not use ped navmesh
-            if not os.path.exists(nav_folder_target):
-                os.makedirs(nav_folder_target)
-            nav_path_target = os.path.join(nav_folder_target, "%s.bin" % target_name)
-            print('Copying "' + nav_path_source + '" to "' + nav_path_target + '"')
-            shutil.copy2(nav_path_source, nav_path_target)
+            # make the conversion
+            if os.name == "nt":
+                subprocess.call(["build.bat", fbx_name_no_ext], cwd=folder, shell=True)
+            else:
+                subprocess.call(["chmod +x build.sh"], cwd=folder, shell=True)
+                subprocess.call("./build.sh %s" % fbx_name_no_ext, cwd=folder, shell=True)
 
-        # remove files
-        os.remove(fbx_path_target)
+            # rename the xodr with the original name
+            os.rename(os.path.join(folder, "%s.xodr" % fbx_name_no_ext), os.path.join(folder, xodr_filename))
+
+            # copy the binary file
+            nav_path_source = os.path.join(folder, "%s.bin" % fbx_name_no_ext)
+            nav_folder_target = os.path.join(CARLA_ROOT_PATH, "Unreal", "CarlaUE4", "Content", package_name, "Maps", target_name, "Nav")
+            if os.path.exists(nav_path_source):
+                if not os.path.exists(nav_folder_target):
+                    os.makedirs(nav_folder_target)
+                nav_path_target = os.path.join(nav_folder_target, "%s.bin" % fbx_name_no_ext)
+                print('Copying "' + nav_path_source + '" to "' + nav_path_target + '"')
+                shutil.copy2(nav_path_source, nav_path_target)
+
+            # remove files
+            os.remove(nav_path_source)
+            os.remove(fbx_path_target)
+
         os.remove(xodr_path_target)
 
 def main():

--- a/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
+++ b/Util/DockerUtils/fbx/src/FBX2OBJ.cpp
@@ -35,14 +35,17 @@ FbxSurfacePhong* CreateMaterial(FbxScene* pScene, char *name)
     return lMaterial;
 }
 
-bool StartsWith(const char *name, const char *str)
+bool Find(const char *name, const char *str)
 {
     size_t lenName = strlen(name);
     size_t lenStr = strlen(str);
 
     if (lenName == 0 || lenStr == 0 || lenStr > lenName) return false;
 
-    return (memcmp(name, str, lenStr) == 0);
+    std::string strName(name);
+    std::string strSub(str);
+
+    return (strName.find(strSub) != std::string::npos);
 }
 
 void SetMaterials(FbxNode* pNode)
@@ -59,19 +62,19 @@ void SetMaterials(FbxNode* pNode)
         pNode->RemoveAllMaterials();
         // check nomenclature
         const char *name = pNode->GetName();
-        if (StartsWith(name, "Road_Road") || StartsWith(name, "Roads_Road"))
+        if (Find(name, "Road_Road") || Find(name, "Roads_Road"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Marking") || StartsWith(name, "Roads_Marking"))
+        else if (Find(name, "Road_Marking") || Find(name, "Roads_Marking"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Curb") || StartsWith(name, "Roads_Curb"))
+        else if (Find(name, "Road_Curb") || Find(name, "Roads_Curb"))
             mat = gMatRoad;
-        else if (StartsWith(name, "Road_Gutter") || StartsWith(name, "Roads_Gutter"))
+        else if (Find(name, "Road_Gutter") || Find(name, "Roads_Gutter"))
             mat = gMatRoad;
-		else if (StartsWith(name, "Road_Sidewalk") || StartsWith(name, "Roads_Sidewalk"))
+		else if (Find(name, "Road_Sidewalk") || Find(name, "Roads_Sidewalk"))
 			mat = gMatSidewalk;
-		else if (StartsWith(name, "Road_Crosswalk") || StartsWith(name, "Roads_Crosswalk"))
+		else if (Find(name, "Road_Crosswalk") || Find(name, "Roads_Crosswalk"))
 			mat = gMatCross;
-		else if (StartsWith(name, "Road_Grass") || StartsWith(name, "Roads_Grass"))
+		else if (Find(name, "Road_Grass") || Find(name, "Roads_Grass"))
 			mat = gMatGrass;
 
         printf("Node %s : %s\n", name, mat->GetName());
@@ -226,11 +229,11 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    gMatRoad = CreateMaterial(lScene, "road");
+    gMatRoad     = CreateMaterial(lScene, "road");
     gMatSidewalk = CreateMaterial(lScene, "sidewalk");
-    gMatCross = CreateMaterial(lScene, "crosswalk");
-    gMatGrass = CreateMaterial(lScene, "grass");
-    gMatBlock = CreateMaterial(lScene, "block");
+    gMatCross    = CreateMaterial(lScene, "crosswalk");
+    gMatGrass    = CreateMaterial(lScene, "grass");
+    gMatBlock    = CreateMaterial(lScene, "block");
 
     // export
     r = SaveScene(gSdkManager, lScene, argv[2], -1,	false);


### PR DESCRIPTION

#### Description

Now we can import large maps in tiles, resulting in a individual .umap per tile.
As before, if you don't specify a .json file when importing, one is created automatically. A sample one is like this:

> {
>    "maps": [
>       {
>          "name": "testmap",
>          "xodr": "./testmap.xodr",
>          "use_carla_materials": true,
>          "tiles": [
>             "./testmap_Tile_0_0.fbx",
>             "./testmap_Tile_0_1.fbx",
>             "./testmap_Tile_1_0.fbx",
>             "./testmap_Tile_1_1.fbx"
>          ]
>       }
>    ],
>    "props": []
> }

For the automatic generation of .json to work, we need to be sure that the tile have this nomenclature ..._Tile_i_j...
the _i_ and _j_ are the index of the tile, starting at (0,0). The import process will end as soon as one tile is not found.

When a map is in tiles, then the **tiles** keyword are in use with the list of all the tiles in .fbx form.
If the map is in single mode, then we use the **source** keyword with the single .fbx. for the map.
The .umap tiles are intended to be used as map containers, so there is no sky light on those maps, or any other information. Just meshes.

Other than the map, each tile will have its own .bin file for the pedestrian navigation.
The .xodr is a single one that is for the whole map, like in single maps.

#### Where has this been tested?

  * **Platform(s):** Ubuntu / Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** UE 4.26

#### Possible Drawbacks

We need more code to manage the large map tiles, so this PR is only for the cooking process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4094)
<!-- Reviewable:end -->
