### PR TITLE
Changed forum links to point to GitHub discussions

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -12,7 +12,7 @@ Steps to reproduce:
 Other information (documentation you consulted, workarounds you tried):
 
 If you are asking a question please make sure your question was not asked before
-by searching among the existing issues and checking the CARLA forum https://forum.carla.org. Also make sure you have read ourdocumentation and FAQ at http://carla.readthedocs.io. 
+by searching among the existing issues and checking the CARLA forum https://github.com/carla-simulator/carla/discussions. Also make sure you have read ourdocumentation and FAQ at http://carla.readthedocs.io. 
 
 If your question is about creating content (assets, levels) you'll most likely
 have all the info you need in the Unreal Engine's documentation

--- a/Docs/adv_benchmarking.md
+++ b/Docs/adv_benchmarking.md
@@ -197,7 +197,7 @@ If you have any questions regarding the performance benchmarks then don't hesita
 <div class="build-buttons">
 <!-- Latest release button -->
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_opendrive.md
+++ b/Docs/adv_opendrive.md
@@ -76,7 +76,7 @@ Doubts and suggestions in the forum.
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_ptv.md
+++ b/Docs/adv_ptv.md
@@ -60,7 +60,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_recorder.md
+++ b/Docs/adv_recorder.md
@@ -311,7 +311,7 @@ Now it is time to experiment for a while. Use the recorder to playback a simulat
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_rendering_options.md
+++ b/Docs/adv_rendering_options.md
@@ -207,7 +207,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_rss.md
+++ b/Docs/adv_rss.md
@@ -124,7 +124,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_sumo.md
+++ b/Docs/adv_sumo.md
@@ -125,7 +125,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_synchrony_timestep.md
+++ b/Docs/adv_synchrony_timestep.md
@@ -192,7 +192,7 @@ Open CARLA and mess around for a while. Any suggestions or doubts are welcome in
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/adv_traffic_manager.md
+++ b/Docs/adv_traffic_manager.md
@@ -452,7 +452,7 @@ The Traffic Manager is one of the most complex features in CARLA and so, one tha
 <div class="build-buttons">
 <!-- Latest release button -->
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/build_faq.md
+++ b/Docs/build_faq.md
@@ -4,7 +4,7 @@ Some of the most common issues regarding CARLA installation and builds are liste
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>
@@ -99,7 +99,7 @@ CARLA forum</a>
 > * __Delete CARLA and clone it again.__ Just in case something went wrong. Delete CARLA and clone or download it again.  
 > * __Meet system requirements.__ Ubuntu version should be 16.04 or later. CARLA needs around 15GB of disk space and a dedicated GPU (or at least one with 4GB) to run.
 > 
-> Other specific reasons for a system to show conflicts with CARLA may occur. Please, post these on the [forum](https://forum.carla.org/) so the team can get to know more about them.   
+> Other specific reasons for a system to show conflicts with CARLA may occur. Please, post these on the [forum](https://github.com/carla-simulator/carla/discussions/) so the team can get to know more about them.   
 
 <!-- ======================================================================= -->
 
@@ -265,7 +265,7 @@ CARLA forum</a>
 > * __Delete CARLA and clone it again.__ Just in case something went wrong. Delete CARLA and clone or download it again.  
 > * __Meet system requirements.__ CARLA needs around 30-50GB of disk space and a dedicated GPU (or at least one with 4GB) to run.  
 >
-> Other specific reasons for a system to show conflicts with CARLA may occur. Please, post these on the [forum](https://forum.carla.org/) so the team can get to know more about them.
+> Other specific reasons for a system to show conflicts with CARLA may occur. Please, post these on the [forum](https://github.com/carla-simulator/carla/discussions/) so the team can get to know more about them.
 
 <!-- ======================================================================= -->
 
@@ -308,7 +308,7 @@ CARLA forum</a>
 
 ###### Can't run CARLA neither binary nor source build.
 
-> NVIDIA drivers may be outdated. Make sure that this is not the case. If the issue is still unresolved, take a look at the [forum](https://forum.carla.org/) and post the specific issue. 
+> NVIDIA drivers may be outdated. Make sure that this is not the case. If the issue is still unresolved, take a look at the [forum](https://github.com/carla-simulator/carla/discussions/) and post the specific issue. 
 
 <!-- ======================================================================= -->
 

--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -4,7 +4,7 @@ This guide details how to build CARLA from source on Linux. There are two parts.
 
 The build process is long (4 hours or more) and involves several kinds of software. It is highly recommended to read through the guide fully before starting. 
 
-If you come across errors or difficulties then have a look at the **[F.A.Q.](build_faq.md)** page which offers solutions for the most common complications. Alternatively, use the [CARLA forum](https://forum.carla.org/c/installation-issues/linux) to post any queries you may have.
+If you come across errors or difficulties then have a look at the **[F.A.Q.](build_faq.md)** page which offers solutions for the most common complications. Alternatively, use the [CARLA forum](https://github.com/carla-simulator/carla/discussions) to post any queries you may have.
 
 - [__Part One: Prerequisites__](#part-one-prerequisites)
     - [System requirements](#system-requirements)
@@ -202,7 +202,7 @@ Optionally, to compile the PythonAPI for Python 2, run the following command in 
 ```
 
 !!! Note
-    __Note that when the compilation is done, you may see a successful output in the terminal even if the compilation of the Python API client was unsuccessful.__ Check for any errors in the terminal output and check that a `.egg` file exists in `PythonAPI\carla\dist`. If you come across any errors, check the [F.A.Q.](build_faq.md) or post in the [CARLA forum](https://forum.carla.org/c/installation-issues/linux).
+    __Note that when the compilation is done, you may see a successful output in the terminal even if the compilation of the Python API client was unsuccessful.__ Check for any errors in the terminal output and check that a `.egg` file exists in `PythonAPI\carla\dist`. If you come across any errors, check the [F.A.Q.](build_faq.md) or post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions).
 
 __2.__ __Compile the server__:
 
@@ -334,7 +334,7 @@ make PythonAPI ARGS="--python-version=2"
 
 ---
 
-Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://forum.carla.org/c/installation-issues/linux) for any issues regarding this guide.  
+Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions) for any issues regarding this guide.  
 
 Up next, learn how to update the CARLA build or take your first steps in the simulation, and learn some core concepts.  
 <div class="build-buttons">

--- a/Docs/build_update.md
+++ b/Docs/build_update.md
@@ -13,7 +13,7 @@ To post unexpected issues, doubts or suggestions, feel free to login in the CARL
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -4,7 +4,7 @@ This guide details how to build CARLA from source on Windows. There are two part
 
 The build process is long (4 hours or more) and involves several kinds of software. It is highly recommended to read through the guide fully before starting. 
 
-If you come across errors or difficulties then have a look at the **[F.A.Q.](build_faq.md)** page which offers solutions for the most common complications. Alternatively, use the [CARLA forum](https://forum.carla.org/c/installation-issues/linux) to post any queries you may have.
+If you come across errors or difficulties then have a look at the **[F.A.Q.](build_faq.md)** page which offers solutions for the most common complications. Alternatively, use the [CARLA forum](https://github.com/carla-simulator/carla/discussions) to post any queries you may have.
 
 - [__Part One: Prerequisites__](#part-one-prerequisites)
     - [System requirements](#system-requirements)
@@ -183,7 +183,7 @@ Optionally, to compile the PythonAPI for Python2, run the following command in t
 ```
 
 !!! Note
-    __Note that when the compilation is done, you may see a successful output in the terminal even if the compilation of the Python API client was unsuccessful.__ Check for any errors in the terminal output and check that a `.egg` file exists in `PythonAPI\carla\dist`. If you come across any errors, check the [F.A.Q.](build_faq.md) or post in the [CARLA forum](https://forum.carla.org/c/installation-issues/windows).
+    __Note that when the compilation is done, you may see a successful output in the terminal even if the compilation of the Python API client was unsuccessful.__ Check for any errors in the terminal output and check that a `.egg` file exists in `PythonAPI\carla\dist`. If you come across any errors, check the [F.A.Q.](build_faq.md) or post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions).
 
 
 __2.__ __Compile the server__:
@@ -282,7 +282,7 @@ python3 dynamic_weather.py
 
 ---
 
-Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://forum.carla.org/c/installation-issues/windows) for any issues regarding this guide.  
+Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions) for any issues regarding this guide.  
 
 Now that you have built CARLA, learn how to update the CARLA build or take your first steps in the simulation, and learn some core concepts.
 

--- a/Docs/core_actors.md
+++ b/Docs/core_actors.md
@@ -2,7 +2,7 @@
 
 Actors not only include vehicles and walkers, but also sensors, traffic signs, traffic lights, and the spectator. It is crucial to have full understanding on how to operate on them.  
 
-This section will cover spawning, destruction, types, and how to manage them. However, the possibilities are almost endless. Experiment, take a look at the __tutorials__ in this documentation and share doubts and ideas in the [CARLA forum](https://forum.carla.org/).  
+This section will cover spawning, destruction, types, and how to manage them. However, the possibilities are almost endless. Experiment, take a look at the __tutorials__ in this documentation and share doubts and ideas in the [CARLA forum](https://github.com/carla-simulator/carla/discussions/).  
 
 *   [__Blueprints__](#blueprints)  
 	*   [Managing the blueprint library](#managing-the-blueprint-library)  
@@ -307,7 +307,7 @@ Keep reading to learn more or visit the forum to post any doubts or suggestions 
 <div text-align: center>
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/core_concepts.md
+++ b/Docs/core_concepts.md
@@ -81,7 +81,7 @@ Keep reading to learn more. Visit the forum to post any doubts or suggestions th
 <div text-align: center>
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/core_map.md
+++ b/Docs/core_map.md
@@ -270,7 +270,7 @@ Keep reading to learn more or visit the forum to post any doubts or suggestions 
 <div text-align: center>
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/core_sensors.md
+++ b/Docs/core_sensors.md
@@ -185,7 +185,7 @@ Python API reference</a>
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/core_world.md
+++ b/Docs/core_world.md
@@ -2,7 +2,7 @@
 
 The client and the world are two of the fundamentals of CARLA, a necessary abstraction to operate the simulation and its actors.  
 
-This tutorial goes from defining the basics and creation of these elements, to describing their possibilities. If any doubt or issue arises during the reading, the [CARLA forum](https://forum.carla.org/) is there to solve them.  
+This tutorial goes from defining the basics and creation of these elements, to describing their possibilities. If any doubt or issue arises during the reading, the [CARLA forum](https://github.com/carla-simulator/carla/discussions/) is there to solve them.  
 
 *   [__The client__](#the-client)  
 	*   [Client creation](#client-creation)  
@@ -264,7 +264,7 @@ Keep reading to learn more. Visit the forum to post any doubts or suggestions th
 <div text-align: center>
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -10,7 +10,7 @@ This home page contains an index with a brief description of the different secti
 
 The CARLA forum is available to post any doubts or suggestions that may arise during the reading.
 <div class="build-buttons">
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 CARLA forum</a>
 </div>
 

--- a/Docs/plugins_carlaviz.md
+++ b/Docs/plugins_carlaviz.md
@@ -149,7 +149,7 @@ That is all there is to know about the carlaviz plugin. If there are any doubts,
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -217,7 +217,7 @@ python3 spawn_npc.py # Support for Python 2 is provided in the CARLA release pac
 ---
 ## Follow-up
 
-By now you should have a packaged version of CARLA up and running. If you came across any difficulties during the installation process, feel free to post in the [CARLA forum](https://forum.carla.org/) or in the [Discord](https://discord.gg/8kqACuC) channel.
+By now you should have a packaged version of CARLA up and running. If you came across any difficulties during the installation process, feel free to post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions/) or in the [Discord](https://discord.gg/8kqACuC) channel.
 
 The next step is to learn more about the core concepts in CARLA. Read the __First steps__ section to start learning. You can also find all the information about the Python API classes and methods in the [Python API reference](python_api.md).
 

--- a/Docs/ts_traffic_simulation_overview.md
+++ b/Docs/ts_traffic_simulation_overview.md
@@ -89,11 +89,11 @@ Go to SUMO Co-Simulation</a>
 
 ---
 
-If you have any doubts about the different options available to simulate traffic in CARLA, feel free to post in the [forum](https://forum.carla.org/) or in [Discord](https://discord.gg/8kqACuC).
+If you have any doubts about the different options available to simulate traffic in CARLA, feel free to post in the forum or in [Discord](https://discord.gg/8kqACuC).
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_A_add_map/add_map_alternative.md
+++ b/Docs/tuto_A_add_map/add_map_alternative.md
@@ -303,4 +303,4 @@ The resulting `.json` file should resemble the following:
 
 ---
 
-It is recommended to use the automated processes for importing maps detailed in the guides for [CARLA packages](add_map_package.md) and [CARLA source build](add_map_source.md), however the methods listed in this section can be used if required. If you encounter any issues with the alternative methods, feel free to post in the [forum](https://forum.carla.org/).
+It is recommended to use the automated processes for importing maps detailed in the guides for [CARLA packages](add_map_package.md) and [CARLA source build](add_map_source.md), however the methods listed in this section can be used if required. If you encounter any issues with the alternative methods, feel free to post in the [forum](https://github.com/carla-simulator/carla/discussions/).

--- a/Docs/tuto_A_add_map/add_map_package.md
+++ b/Docs/tuto_A_add_map/add_map_package.md
@@ -74,4 +74,4 @@ __7.__ To run a simulation with the new map, run CARLA and then change the map u
 ---
 
 
-Your map is now ready to run simulations in CARLA. If you have any questions about the process then you can ask in the [forum](https://forum.carla.org/) or you can try running some of our [example scripts](https://github.com/carla-simulator/carla/tree/master/PythonAPI/examples) on your new map to test it out.
+Your map is now ready to run simulations in CARLA. If you have any questions about the process then you can ask in the [forum](https://github.com/carla-simulator/carla/discussions/) or you can try running some of our [example scripts](https://github.com/carla-simulator/carla/tree/master/PythonAPI/examples) on your new map to test it out.

--- a/Docs/tuto_A_add_map/add_map_source.md
+++ b/Docs/tuto_A_add_map/add_map_source.md
@@ -89,4 +89,4 @@ __6.__ A `<mapName>.bin` file will be created. This file contains the informatio
 
 ---
 
-Your map is now ready to run simulations in CARLA. If you have any questions about the process then you can ask in the [forum](https://forum.carla.org/) or you can try running some of our [example scripts](https://github.com/carla-simulator/carla/tree/master/PythonAPI/examples) on your new map to test it out.
+Your map is now ready to run simulations in CARLA. If you have any questions about the process then you can ask in the [forum](https://github.com/carla-simulator/carla/discussions/) or you can try running some of our [example scripts](https://github.com/carla-simulator/carla/tree/master/PythonAPI/examples) on your new map to test it out.

--- a/Docs/tuto_A_add_map_overview.md
+++ b/Docs/tuto_A_add_map_overview.md
@@ -49,11 +49,11 @@ We provide a section that details alternative methods of importing maps to CARLA
 
 ## Summary
 
-If you have any questions about the process to create and import a new map into CARLA, feel free to post these in the [forum](https://forum.carla.org/). 
+If you have any questions about the process to create and import a new map into CARLA, feel free to post these in the forum. 
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_A_add_props.md
+++ b/Docs/tuto_A_add_props.md
@@ -161,7 +161,7 @@ That is all there is to know about the different ways to import new props into C
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_A_create_standalone.md
+++ b/Docs/tuto_A_create_standalone.md
@@ -43,7 +43,7 @@ That sumps up how to create and use standalone packages in CARLA. If there is an
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_A_map_customization.md
+++ b/Docs/tuto_A_map_customization.md
@@ -172,7 +172,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_A_material_customization.md
+++ b/Docs/tuto_A_material_customization.md
@@ -273,7 +273,7 @@ Any doubts that may arise are more than welcomed in the forum.
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_D_create_semantic_tags.md
+++ b/Docs/tuto_D_create_semantic_tags.md
@@ -68,7 +68,7 @@ __Open `World.cpp`__ in `carla/PythonAPI/carla/sourc/libcarla` and add the new t
 
 ---
 
-Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://forum.carla.org/c/installation-issues/linux) for any issues, doubts or suggestions.  
+Read the **[F.A.Q.](build_faq.md)** page or post in the [CARLA forum](https://github.com/carla-simulator/carla/discussions) for any issues, doubts or suggestions.  
 
 <p style="font-size: 20px">What's next?</p>
 

--- a/Docs/tuto_D_customize_vehicle_suspension.md
+++ b/Docs/tuto_D_customize_vehicle_suspension.md
@@ -120,7 +120,7 @@ Use the forum to post any doubts, issues or suggestions regarding this topic.
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_D_generate_colliders.md
+++ b/Docs/tuto_D_generate_colliders.md
@@ -134,7 +134,7 @@ Open CARLA and mess around for a while. If there are any doubts, feel free to po
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_G_openstreetmap.md
+++ b/Docs/tuto_G_openstreetmap.md
@@ -117,7 +117,7 @@ For issues and doubts related with this topic can be posted in the CARLA forum.
 
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="Go to the CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_G_retrieve_data.md
+++ b/Docs/tuto_G_retrieve_data.md
@@ -1338,7 +1338,7 @@ Visit the forum to post any doubts or suggestions that have come to mind during 
 <div text-align: center>
 <div class="build-buttons">
 <p>
-<a href="https://forum.carla.org/" target="_blank" class="btn btn-neutral" title="CARLA forum">
+<a href="https://github.com/carla-simulator/carla/discussions/" target="_blank" class="btn btn-neutral" title="CARLA forum">
 CARLA forum</a>
 </p>
 </div>

--- a/Docs/tuto_G_rllib_integration.md
+++ b/Docs/tuto_G_rllib_integration.md
@@ -231,4 +231,4 @@ To run the DQN example on AWS:
 
 ---
 
-This guide has outlined how to install and run the RLlib integration on AWS and on a local machine. If you have any questions or ran into any issues working through the guide, feel free to post in the [forum](https://forum.carla.org/) or raise an issue on [GitHub](https://github.com/carla-simulator/rllib-integration).
+This guide has outlined how to install and run the RLlib integration on AWS and on a local machine. If you have any questions or ran into any issues working through the guide, feel free to post in the [forum](https://github.com/carla-simulator/carla/discussions/) or raise an issue on [GitHub](https://github.com/carla-simulator/rllib-integration).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CARLA Simulator
 [![carla.org](Docs/img/btn/web.png)](http://carla.org)
 [![download](Docs/img/btn/download.png)](https://github.com/carla-simulator/carla/blob/master/Docs/download.md)
 [![documentation](Docs/img/btn/docs.png)](http://carla.readthedocs.io)
-[![forum](Docs/img/btn/forum.png)](https://forum.carla.org)
+[![forum](Docs/img/btn/forum.png)](https://github.com/carla-simulator/carla/discussions)
 [![discord](Docs/img/btn/chat.png)](https://discord.gg/8kqACuC)
 
 CARLA is an open-source simulator for autonomous driving research. CARLA has been developed from the ground up to support development, training, and


### PR DESCRIPTION
#### New forum URLs

We are migrating our forum to GitHub discussions, I have replaced all links to the old forum with the new URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4111)
<!-- Reviewable:end -->
