### PR TITLE
Fix for warnings of mobility type in buildings

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.cpp
@@ -46,6 +46,14 @@ UHierarchicalInstancedStaticMeshComponent* AProceduralBuilding::GetHISMComp(
   return HISMComp;
 }
 
+void AProceduralBuilding::FixMobility() {
+
+  for (UChildActorComponent *ChildComp : ChildActorComps) {
+
+    ChildComp->SetMobility(EComponentMobility::Type::Static);
+  }
+}
+
 void AProceduralBuilding::ConvertOldBP_ToNativeCodeObject(AActor* BP_Building)
 {
   AProceduralBuilding* ProceduralBuilding = nullptr;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.cpp
@@ -81,6 +81,7 @@ void AProceduralBuilding::ConvertOldBP_ToNativeCodeObject(AActor* BP_Building)
     // Create a new ChildActorComponent
     UChildActorComponent* ChildActorComp = NewObject<UChildActorComponent>(this,
       FName(*FString::Printf(TEXT("ChildActorComp_%d"), ChildActorComps.Num() )));
+    ChildActorComp->SetMobility(EComponentMobility::Type::Static);
     ChildActorComp->SetupAttachment(RootComponent);
 
     // Set the class that it will use
@@ -521,6 +522,7 @@ float AProceduralBuilding::AddChunck(
     // Create a new ChildActorComponent
     UChildActorComponent* ChildActorComp = NewObject<UChildActorComponent>(this,
       FName(*FString::Printf(TEXT("ChildActorComp_%d"), ChildActorComps.Num() )));
+    ChildActorComp->SetMobility(EComponentMobility::Type::Static);
     ChildActorComp->SetupAttachment(RootComponent);
 
     // Set the class that it will use

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/ProceduralBuilding.h
@@ -94,6 +94,9 @@ protected:
   UFUNCTION(BlueprintCallable, CallInEditor, Category="Procedural Building")
   void Reset();
 
+  UFUNCTION(BlueprintCallable, CallInEditor, Category="Procedural Building")
+  void FixMobility();
+
   // TODO: AdvancedDisplay
   // Map containing the pair with the name of the mesh and the component that uses it
   UPROPERTY(BlueprintReadOnly, EditAnywhere, Category="Procedural Building|Debug")


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Fix for mobility warnings in Town10HD. This will avoid future warnings when creating new buildings, however town10HD buildings themselves have to be modified (via editor) in order to stop those warnings. This is because the instances have already been made with the old version of "ProceduralBuilding.cpp" (before this fix).

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows & Linux
  * **Python version(s):** 3.7.9
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4156)
<!-- Reviewable:end -->
