### PR TITLE
Corkyw10/latest docs warning

### DIFF
--- a/Docs/extra.css
+++ b/Docs/extra.css
@@ -244,3 +244,18 @@ table tbody td{
 	top: 70px;
 	left: 1100px;
 }
+
+/************************* LATEST WARNING BANNER **************************/
+
+.dev-version-warning {
+	padding-top: 15px;
+	padding-bottom: 15px;
+	padding-left: 15px;
+	padding-right: 15px;
+	margin-bottom: 8px;
+	color: #404040;
+	font-weight: bold;
+	background-color: #f55c47;
+	text-align: center;
+	border-radius: 5px;
+}

--- a/Docs/extra.js
+++ b/Docs/extra.js
@@ -1,0 +1,10 @@
+$(document).ready(function () {
+    if(window.location.href.indexOf("latest") != -1) {
+        var banner = document.createElement("div");
+        banner.className = "dev-version-warning";
+        banner.innerHTML = "You are currently reading documentation for the \"dev\" branch of CARLA. This documentation refers to features currently in development and may result in unexpected behaviour. To read documentation for previous releases, select the desired version in the bottom, right-hand corner of the screen.";
+        var x = document.getElementsByClassName("section");
+        console.log(x)
+        x[0].insertBefore(banner,x[0].childNodes[0]);
+    }
+});

--- a/Docs/extra.js
+++ b/Docs/extra.js
@@ -1,10 +1,9 @@
 $(document).ready(function () {
-    if(window.location.href.indexOf("latest") != -1) {
+    if(window.location.href.indexOf("/latest/") != -1) {
         var banner = document.createElement("div");
+        var section = document.getElementsByClassName("section");
         banner.className = "dev-version-warning";
         banner.innerHTML = "You are currently reading documentation for the \"dev\" branch of CARLA. This documentation refers to features currently in development and may result in unexpected behaviour. To read documentation for previous releases, select the desired version in the bottom, right-hand corner of the screen.";
-        var x = document.getElementsByClassName("section");
-        console.log(x)
-        x[0].insertBefore(banner,x[0].childNodes[0]);
+        section[0].insertBefore(banner,section[0].childNodes[0]);
     }
 });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ docs_dir: Docs
 edit_uri: 'edit/master/Docs/'
 theme: readthedocs
 extra_css: [extra.css]
+extra_javascript: [extra.js]
 
 nav:
 - Home: 'index.md'


### PR DESCRIPTION
# Banner warning that latest version of docs in the dev branch

I have added a javascript file that will trigger a warning banner on the "latest" version of the documentation to warn people that it refers to the development branch of CARLA. This functionality is not natively available in mkdocs. 

The banner looks like:

![banner](https://user-images.githubusercontent.com/38050983/118104568-98efe380-b3db-11eb-81fc-75accb7d988e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4201)
<!-- Reviewable:end -->
