### PR TITLE
Update PrepareAssetsForCookingCommandlet.cpp

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -379,7 +379,7 @@ void UPrepareAssetsForCookingCommandlet::GenerateMapPathsFile(
     if (Map.Path.StartsWith(TEXT("/Game/")))
     {
       // replacing relative /Game/... address by absolute address to be able to parse files
-      FString FullPath(FPaths::GameDir() + TEXT("/Content/") + Map.Path.Mid(6, Map.Path.Len() - 6) + TEXT("/Sublevels/") + Map.Name);
+      FString FullPath(FPaths::ProjectDir() + TEXT("/Content/") + Map.Path.Mid(6, Map.Path.Len() - 6) + TEXT("/Sublevels/") + Map.Name);
       TArray<FString> Sublevels;
       FileManager.FindFiles(Sublevels, *FullPath, TEXT("*.umap"));
       for (auto Sublevel : Sublevels)


### PR DESCRIPTION
UnrealEngine API for version 4.26 doesn't have the method GameDir anymore

<!--
  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
Replaced the call to GameDir with ProjectDir

Fixes #  
[A build issue with the dev branch](https://github.com/carla-simulator/carla/issues/4103)

  * **Platform(s):** All
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26
#### Possible Drawbacks
..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4308)
<!-- Reviewable:end -->
