### PR TITLE
Required files from server to client cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Added 'check_lidar_bb' util script
   * Added optional flag to `client.replay_file()` `replay_sensors` to enable or disable the replaying the sensors
   * Improved manual_control: now cameras are set in relation with car size
+  * Client required files are sent from the server to a local cache (OpenDRIVE, Traffic Manager...)
   * Added CHRONO library for vehicle dynamics simulation (https://projectchrono.org/)
     - Supported JSON vehicle definition
     - Unsupported collision dynamics

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -54,6 +54,18 @@ namespace client {
       return _simulator->GetAvailableMaps();
     }
 
+    bool SetFilesBaseFolder(const std::string &path) {
+      return _simulator->SetFilesBaseFolder(path);
+    }
+
+    std::vector<std::string> GetRequiredFiles(const std::string &folder = "", const bool download = true) const {
+      return _simulator->GetRequiredFiles(folder, download);
+    }
+
+    void RequestFile(const std::string &name) const {
+      _simulator->RequestFile(name);
+    }
+
     World ReloadWorld(bool reset_settings = true) const {
       return World{_simulator->ReloadEpisode(reset_settings)};
     }

--- a/LibCarla/source/carla/client/FIleTransfer.cpp
+++ b/LibCarla/source/carla/client/FIleTransfer.cpp
@@ -5,14 +5,62 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "FileTransfer.h"
+
 namespace carla {
 namespace client {
 
-#ifdef _WIN32
-      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
-#else
-      std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
-#endif
+  #ifdef _WIN32
+        std::string FileTransfer::_filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
+  #else
+        std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
+  #endif
+
+  bool FileTransfer::SetFilesBaseFolder(const std::string &path) {
+    if (path.empty()) return false;
+
+    // Check that the path ends in a slash, add it otherwise
+    if (path[path.size() - 1] != '/' && path[path.size() - 1] != '\\') {
+      _filesBaseFolder = path + "/";
+  }
+
+    return true;
+  }
+
+  const std::string& FileTransfer::GetFilesBaseFolder() {
+    return _filesBaseFolder;
+  }
+
+  bool FileTransfer::FileExists(std::string file) {
+    // Check if the file exists or not
+    struct stat buffer;
+    return (stat((_filesBaseFolder + file).c_str(), &buffer) == 0);
+  }
+
+  bool FileTransfer::WriteFile(std::string path, std::vector<uint8_t> content) {
+    std::string writePath = _filesBaseFolder + path;
+
+    // Validate and create the file path
+    carla::FileSystem::ValidateFilePath(writePath);
+
+    // Open the file to truncate it in binary mode
+    std::ofstream out(writePath, std::ios::trunc | std::ios::binary);
+    if(!out.good()) return false;
+
+    // Write the content on and close it
+    for(auto file : content) {
+          out << file;
+    }
+    out.close();
+
+    return true;
+  }
+
+  std::vector<uint8_t> FileTransfer::ReadFile(std::string path) {
+    // Read the binary file from the base folder
+    std::ifstream file(_filesBaseFolder + path, std::ios::binary);
+    std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
+    return content;
+  }
 
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/FIleTransfer.cpp
+++ b/LibCarla/source/carla/client/FIleTransfer.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "FileTransfer.h"
+namespace carla {
+namespace client {
+
+#ifdef _WIN32
+      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
+#else
+      std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
+#endif
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/FileTransfer.h
+++ b/LibCarla/source/carla/client/FileTransfer.h
@@ -1,0 +1,86 @@
+
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/FileSystem.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <sys/stat.h>
+
+namespace carla {
+namespace client {
+
+  class FileTransfer {
+
+  public:
+
+    FileTransfer() = delete;
+
+    static bool SetFilesBaseFolder(const std::string &path) {
+      if (path.empty()) return false;
+
+      // Check that the path ends in a slash, add it otherwise
+      if (path[path.size() - 1] != '/' && path[path.size() - 1] != '\\') {
+        _filesBaseFolder = path + "/";
+      }
+
+      return true;
+    }
+
+    static const std::string& GetFilesBaseFolder() {
+      return _filesBaseFolder;
+    }
+
+    static bool FileExists(std::string file) {
+      // Check if the file exists or not
+      struct stat buffer;
+      return (stat((_filesBaseFolder + file).c_str(), &buffer) == 0);
+    }
+
+    static bool WriteFile(std::string path, std::vector<uint8_t> content) {
+      std::string writePath = _filesBaseFolder + path;
+
+      // Validate and create the file path
+      carla::FileSystem::ValidateFilePath(writePath);
+
+      // Open the file to truncate it in binary mode
+      std::ofstream out(writePath, std::ios::trunc | std::ios::binary);
+      if(!out.good()) return false;
+
+      // Write the content on and close it
+      for(auto file : content) {
+        out << file;
+      }
+      out.close();
+
+      return true;
+    }
+
+    static std::vector<uint8_t> ReadFile(std::string path) {
+      // Read the binary file from the base folder
+      std::ifstream file(_filesBaseFolder + path, std::ios::binary);
+      std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
+      return content;
+    }
+
+  private:
+
+    static std::string _filesBaseFolder;
+
+  };
+
+    #ifdef _WIN32
+      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USER")) + "/carlaCache/";
+    #else
+      std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
+    #endif
+
+} // namespace client
+} // namespace carla

--- a/LibCarla/source/carla/client/FileTransfer.h
+++ b/LibCarla/source/carla/client/FileTransfer.h
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
@@ -75,12 +74,6 @@ namespace client {
     static std::string _filesBaseFolder;
 
   };
-
-    #ifdef _WIN32
-      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
-    #else
-      std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
-    #endif
 
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/FileTransfer.h
+++ b/LibCarla/source/carla/client/FileTransfer.h
@@ -22,52 +22,15 @@ namespace client {
 
     FileTransfer() = delete;
 
-    static bool SetFilesBaseFolder(const std::string &path) {
-      if (path.empty()) return false;
+    static bool SetFilesBaseFolder(const std::string &path);
 
-      // Check that the path ends in a slash, add it otherwise
-      if (path[path.size() - 1] != '/' && path[path.size() - 1] != '\\') {
-        _filesBaseFolder = path + "/";
-      }
+    static const std::string& GetFilesBaseFolder();
 
-      return true;
-    }
+    static bool FileExists(std::string file);
 
-    static const std::string& GetFilesBaseFolder() {
-      return _filesBaseFolder;
-    }
+    static bool WriteFile(std::string path, std::vector<uint8_t> content);
 
-    static bool FileExists(std::string file) {
-      // Check if the file exists or not
-      struct stat buffer;
-      return (stat((_filesBaseFolder + file).c_str(), &buffer) == 0);
-    }
-
-    static bool WriteFile(std::string path, std::vector<uint8_t> content) {
-      std::string writePath = _filesBaseFolder + path;
-
-      // Validate and create the file path
-      carla::FileSystem::ValidateFilePath(writePath);
-
-      // Open the file to truncate it in binary mode
-      std::ofstream out(writePath, std::ios::trunc | std::ios::binary);
-      if(!out.good()) return false;
-
-      // Write the content on and close it
-      for(auto file : content) {
-        out << file;
-      }
-      out.close();
-
-      return true;
-    }
-
-    static std::vector<uint8_t> ReadFile(std::string path) {
-      // Read the binary file from the base folder
-      std::ifstream file(_filesBaseFolder + path, std::ios::binary);
-      std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
-      return content;
-    }
+    static std::vector<uint8_t> ReadFile(std::string path);
 
   private:
 

--- a/LibCarla/source/carla/client/FileTransfer.h
+++ b/LibCarla/source/carla/client/FileTransfer.h
@@ -77,7 +77,7 @@ namespace client {
   };
 
     #ifdef _WIN32
-      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USER")) + "/carlaCache/";
+      std::string FileTransfer::_filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
     #else
       std::string FileTransfer::_filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
     #endif

--- a/LibCarla/source/carla/client/Map.cpp
+++ b/LibCarla/source/carla/client/Map.cpp
@@ -16,7 +16,7 @@
 
 namespace carla {
 namespace client {
-  
+
   static auto MakeMap(const std::string &opendrive_contents) {
     auto stream = std::istringstream(opendrive_contents);
     auto map = opendrive::OpenDriveParser::Load(stream.str());
@@ -29,7 +29,6 @@ namespace client {
   Map::Map(rpc::MapInfo description, std::string xodr_content)
     : _description(std::move(description)),
       _map(MakeMap(xodr_content)){}
-      
 
   Map::Map(std::string name, std::string xodr_content)
     : Map(rpc::MapInfo{

--- a/LibCarla/source/carla/client/Map.cpp
+++ b/LibCarla/source/carla/client/Map.cpp
@@ -16,7 +16,7 @@
 
 namespace carla {
 namespace client {
-
+  
   static auto MakeMap(const std::string &opendrive_contents) {
     auto stream = std::istringstream(opendrive_contents);
     auto map = opendrive::OpenDriveParser::Load(stream.str());
@@ -26,15 +26,15 @@ namespace client {
     return std::move(*map);
   }
 
-  Map::Map(rpc::MapInfo description)
+  Map::Map(rpc::MapInfo description, std::string xodr_content)
     : _description(std::move(description)),
-      _map(MakeMap(_description.open_drive_file)) {}
+      _map(MakeMap(xodr_content)){}
+      
 
   Map::Map(std::string name, std::string xodr_content)
     : Map(rpc::MapInfo{
     std::move(name),
-    std::move(xodr_content),
-    std::vector<geom::Transform>{}}) {}
+    std::vector<geom::Transform>{}}, xodr_content) {}
 
   Map::~Map() = default;
 

--- a/LibCarla/source/carla/client/Map.h
+++ b/LibCarla/source/carla/client/Map.h
@@ -29,7 +29,7 @@ namespace client {
       private NonCopyable {
   public:
 
-    explicit Map(rpc::MapInfo description);
+    explicit Map(rpc::MapInfo description, std::string xodr_content);
 
     explicit Map(std::string name, std::string xodr_content);
 
@@ -44,7 +44,7 @@ namespace client {
     }
 
     const std::string &GetOpenDrive() const {
-      return _description.open_drive_file;
+      return open_drive_file;
     }
 
     const std::vector<geom::Transform> &GetRecommendedSpawnPoints() const {
@@ -95,6 +95,8 @@ namespace client {
     std::vector<SharedPtr<Landmark>> GetLandmarkGroup(const Landmark &landmark) const;
 
   private:
+
+    std::string open_drive_file;
 
     const rpc::MapInfo _description;
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -8,6 +8,7 @@
 
 #include "carla/Exception.h"
 #include "carla/Version.h"
+#include "carla/client/FileTransfer.h"
 #include "carla/client/TimeoutException.h"
 #include "carla/rpc/ActorDescription.h"
 #include "carla/rpc/BoneTransformData.h"
@@ -172,6 +173,44 @@ namespace detail {
     return _pimpl->CallAndWait<std::vector<uint8_t>>("get_navigation_mesh");
   }
 
+  bool Client::SetFilesBaseFolder(const std::string &path) {
+    return FileTransfer::SetFilesBaseFolder(path);
+  }
+
+  std::vector<std::string> Client::GetRequiredFiles(const std::string &folder, const bool download) const {
+    // Get the list of required files
+    auto requiredFiles = _pimpl->CallAndWait<std::vector<std::string>>("get_required_files", folder);
+
+    if (download) {
+
+      // For each required file, check if it exists and request it otherwise
+      for(auto requiredFile : requiredFiles) {
+        if(!FileTransfer::FileExists(requiredFile)) {
+          RequestFile(requiredFile);
+        }
+      }
+    }
+    return requiredFiles;
+  }
+
+  void Client::RequestFile(const std::string &name) const {
+    // Download the binary content of the file from the server and write it on the client
+    auto content = _pimpl->CallAndWait<std::vector<uint8_t>>("request_file", name);
+    FileTransfer::WriteFile(name, content);
+  }
+
+  std::vector<uint8_t> Client::GetCacheFile(const std::string &name, const bool request_otherwise) const {
+    // Get the file from the cache in the file transfer
+    std::vector<uint8_t> file = FileTransfer::ReadFile(name);
+
+    // If it isn't in the cache, download it if request otherwise is true
+    if (file.empty() && request_otherwise) {
+      RequestFile(name);
+      file = FileTransfer::ReadFile(name);
+    }
+    return file;
+  }
+
   std::vector<std::string> Client::GetAvailableMaps() {
     return _pimpl->CallAndWait<std::vector<std::string>>("get_available_maps");
   }
@@ -231,7 +270,7 @@ namespace detail {
   void Client::SetWheelSteerDirection(
         rpc::ActorId vehicle,
         rpc::VehicleWheelLocation vehicle_wheel,
-        float angle_in_deg){
+        float angle_in_deg) {
     return _pimpl->AsyncCall("set_wheel_steer_direction", vehicle, vehicle_wheel, angle_in_deg);
   }
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -188,9 +188,12 @@ namespace detail {
     if (download) {
 
       // For each required file, check if it exists and request it otherwise
-      for(auto requiredFile : requiredFiles) {
-        if(!FileTransfer::FileExists(requiredFile)) {
+      for (auto requiredFile : requiredFiles) {
+        if (!FileTransfer::FileExists(requiredFile)) {
           RequestFile(requiredFile);
+          log_info("Could not find the required file in cache, downloading... ", requiredFile);
+        } else {
+          log_info("Found the required file in cache! ", requiredFile)
         }
       }
     }

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -193,7 +193,7 @@ namespace detail {
           RequestFile(requiredFile);
           log_info("Could not find the required file in cache, downloading... ", requiredFile);
         } else {
-          log_info("Found the required file in cache! ", requiredFile)
+          log_info("Found the required file in cache! ", requiredFile);
         }
       }
     }

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -169,6 +169,10 @@ namespace detail {
     return _pimpl->CallAndWait<rpc::MapInfo>("get_map_info");
   }
 
+  std::string Client::GetMapData() const{
+    return _pimpl->CallAndWait<std::string>("get_map_data");
+  }
+
   std::vector<uint8_t> Client::GetNavigationMesh() const {
     return _pimpl->CallAndWait<std::vector<uint8_t>>("get_navigation_mesh");
   }

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -107,6 +107,14 @@ namespace detail {
 
     std::vector<uint8_t> GetNavigationMesh() const;
 
+    bool SetFilesBaseFolder(const std::string &path);
+
+    std::vector<std::string> GetRequiredFiles(const std::string &folder = "", const bool download = true) const;
+
+    void RequestFile(const std::string &name) const;
+
+    std::vector<uint8_t> GetCacheFile(const std::string &name, const bool request_otherwise = true) const;
+
     std::vector<std::string> GetAvailableMaps();
 
     std::vector<rpc::ActorDefinition> GetActorDefinitions();

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -111,6 +111,8 @@ namespace detail {
 
     std::vector<std::string> GetRequiredFiles(const std::string &folder = "", const bool download = true) const;
 
+    std::string GetMapData() const;
+
     void RequestFile(const std::string &name) const;
 
     std::vector<uint8_t> GetCacheFile(const std::string &name, const bool request_otherwise = true) const;

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -159,6 +159,27 @@ namespace detail {
   }
 
   // ===========================================================================
+  // -- Required files ---------------------------------------------------------
+  // ===========================================================================
+
+
+    bool Simulator::SetFilesBaseFolder(const std::string &path) {
+      return _client.SetFilesBaseFolder(path);
+    }
+
+    std::vector<std::string> Simulator::GetRequiredFiles(const std::string &folder, const bool download) const {
+      return _client.GetRequiredFiles(folder, download);
+    }
+
+    void Simulator::RequestFile(const std::string &name) const {
+      _client.RequestFile(name);
+    }
+
+    std::vector<uint8_t> Simulator::GetCacheFile(const std::string &name, const bool request_otherwise) const {
+      return _client.GetCacheFile(name, request_otherwise);
+    }
+
+  // ===========================================================================
   // -- Tick -------------------------------------------------------------------
   // ===========================================================================
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -157,11 +157,10 @@ namespace detail {
       std::string map_name;
       std::string map_base_path;
       bool fill_base_string = false;
-      for(int i = map_info.name.size() - 1; i >= 0; --i){
-        if(fill_base_string == false && map_info.name[i] != '/'){
+      for (int i = map_info.name.size() - 1; i >= 0; --i) {
+        if (fill_base_string == false && map_info.name[i] != '/') {
           map_name += map_info.name[i];
-        }
-        else {
+        } else {
           map_base_path += map_info.name[i];
           fill_base_string = true;
         }
@@ -169,12 +168,11 @@ namespace detail {
       std::reverse(map_name.begin(), map_name.end());
       std::reverse(map_base_path.begin(), map_base_path.end());
       std::string XODRFolder = map_base_path + "/OpenDrive/" + map_name + ".xodr";
-      if(FileTransfer::FileExists(XODRFolder) == false){
-        _client.GetRequiredFiles();
-        _open_drive_file = _client.GetMapData();
-        _cached_map = MakeShared<Map>(map_info, _open_drive_file);
-      }
+      if (FileTransfer::FileExists(XODRFolder) == false) _client.GetRequiredFiles();
+      _open_drive_file = _client.GetMapData();
+      _cached_map = MakeShared<Map>(map_info, _open_drive_file);
     }
+    
     return _cached_map;
   }
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -172,7 +172,7 @@ namespace detail {
       _open_drive_file = _client.GetMapData();
       _cached_map = MakeShared<Map>(map_info, _open_drive_file);
     }
-    
+
     return _cached_map;
   }
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -11,6 +11,7 @@
 #include "carla/Logging.h"
 #include "carla/RecurrentSharedFuture.h"
 #include "carla/client/BlueprintLibrary.h"
+#include "carla/client/FileTransfer.h"
 #include "carla/client/Map.h"
 #include "carla/client/Sensor.h"
 #include "carla/client/TimeoutException.h"
@@ -143,7 +144,7 @@ namespace detail {
       return true;
     }
     if (map_info.name != _cached_map->GetName() ||
-        map_info.open_drive_file.size() != _cached_map->GetOpenDrive().size()) {
+        _open_drive_file.size() != _cached_map->GetOpenDrive().size()) {
       return true;
     }
     return false;
@@ -153,7 +154,26 @@ namespace detail {
     DEBUG_ASSERT(_episode != nullptr);
     if (!_cached_map || _episode->HasMapChangedSinceLastCall()) {
       rpc::MapInfo map_info = _client.GetMapInfo();
-      _cached_map = MakeShared<Map>(map_info);
+      std::string map_name;
+      std::string map_base_path;
+      bool fill_base_string = false;
+      for(int i = map_info.name.size() - 1; i >= 0; --i){
+        if(fill_base_string == false && map_info.name[i] != '/'){
+          map_name += map_info.name[i];
+        }
+        else {
+          map_base_path += map_info.name[i];
+          fill_base_string = true;
+        }
+      }
+      std::reverse(map_name.begin(), map_name.end());
+      std::reverse(map_base_path.begin(), map_base_path.end());
+      std::string XODRFolder = map_base_path + "/OpenDrive/" + map_name + ".xodr";
+      if(FileTransfer::FileExists(XODRFolder) == false){
+        _client.GetRequiredFiles();
+        _open_drive_file = _client.GetMapData();
+        _cached_map = MakeShared<Map>(map_info, _open_drive_file);
+      }
     }
     return _cached_map;
   }

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -123,6 +123,20 @@ namespace detail {
 
     /// @}
     // =========================================================================
+    /// @name Required files related methods
+    // =========================================================================
+    /// @{
+
+    bool SetFilesBaseFolder(const std::string &path);
+
+    std::vector<std::string> GetRequiredFiles(const std::string &folder = "", const bool download = true) const;
+
+    void RequestFile(const std::string &name) const;
+
+    std::vector<uint8_t> GetCacheFile(const std::string &name, const bool request_otherwise) const;
+
+    /// @}
+    // =========================================================================
     /// @name Garbage collection policy
     // =========================================================================
     /// @{

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -665,6 +665,8 @@ namespace detail {
     const GarbageCollectionPolicy _gc_policy;
 
     SharedPtr<Map> _cached_map;
+
+    std::string _open_drive_file;
   };
 
 } // namespace detail

--- a/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
+++ b/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
@@ -22,7 +22,8 @@ namespace detail {
 
   WalkerNavigation::WalkerNavigation(Client &client) : _client(client), _next_check_index(0) {
     // Here call the server to retrieve the navmesh data.
-    _nav.Load(_client.GetNavigationMesh());
+    auto files = _client.GetRequiredFiles("Nav");
+    _nav.Load(_client.GetCacheFile(files[0]));
   }
 
   void WalkerNavigation::Tick(std::shared_ptr<Episode> episode) {

--- a/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
+++ b/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
@@ -23,7 +23,9 @@ namespace detail {
   WalkerNavigation::WalkerNavigation(Client &client) : _client(client), _next_check_index(0) {
     // Here call the server to retrieve the navmesh data.
     auto files = _client.GetRequiredFiles("Nav");
-    _nav.Load(_client.GetCacheFile(files[0]));
+    if (!files.empty()) {
+      _nav.Load(_client.GetCacheFile(files[0]));
+    }
   }
 
   void WalkerNavigation::Tick(std::shared_ptr<Episode> episode) {

--- a/LibCarla/source/carla/rpc/MapInfo.h
+++ b/LibCarla/source/carla/rpc/MapInfo.h
@@ -20,11 +20,9 @@ namespace rpc {
 
     std::string name;
 
-    std::string open_drive_file;
-
     std::vector<geom::Transform> recommended_spawn_points;
 
-    MSGPACK_DEFINE_ARRAY(name, open_drive_file, recommended_spawn_points);
+    MSGPACK_DEFINE_ARRAY(name, recommended_spawn_points);
   };
 
 } // namespace rpc

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -30,6 +30,22 @@ static auto GetAvailableMaps(const carla::client::Client &self) {
   return result;
 }
 
+static auto SetFilesBaseFolder(carla::client::Client &self, const std::string &path) {
+  return self.SetFilesBaseFolder(path);
+}
+
+static auto GetRequiredFiles(const carla::client::Client &self, const std::string &folder, const bool download) {
+  boost::python::list result;
+  for (const auto &str : self.GetRequiredFiles(folder, download)) {
+    result.append(str);
+  }
+  return result;
+}
+
+static void RequestFile(const carla::client::Client &self, const std::string &name) {
+  self.RequestFile(name);
+}
+
 static void ApplyBatchCommands(
     const carla::client::Client &self,
     const boost::python::object &commands,
@@ -180,6 +196,9 @@ void export_client() {
     .def("get_server_version", CONST_CALL_WITHOUT_GIL(cc::Client, GetServerVersion))
     .def("get_world", &cc::Client::GetWorld)
     .def("get_available_maps", &GetAvailableMaps)
+    .def("set_files_base_folder", &SetFilesBaseFolder, (arg("path")))
+    .def("get_required_files", &GetRequiredFiles, (arg("folder")="", arg("download")=true))
+    .def("request_file", &RequestFile, (arg("name")))
     .def("reload_world", CONST_CALL_WITHOUT_GIL_1(cc::Client, ReloadWorld, bool), (arg("reset_settings")=true))
     .def("load_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, LoadWorld, std::string, bool, rpc::MapLayer), (arg("map_name"), arg("reset_settings")=true, arg("map_layers")=rpc::MapLayer::All))
     .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, GenerateOpenDriveWorld, std::string,

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -30,20 +30,12 @@ static auto GetAvailableMaps(const carla::client::Client &self) {
   return result;
 }
 
-static auto SetFilesBaseFolder(carla::client::Client &self, const std::string &path) {
-  return self.SetFilesBaseFolder(path);
-}
-
 static auto GetRequiredFiles(const carla::client::Client &self, const std::string &folder, const bool download) {
   boost::python::list result;
   for (const auto &str : self.GetRequiredFiles(folder, download)) {
     result.append(str);
   }
   return result;
-}
-
-static void RequestFile(const carla::client::Client &self, const std::string &name) {
-  self.RequestFile(name);
 }
 
 static void ApplyBatchCommands(
@@ -196,9 +188,9 @@ void export_client() {
     .def("get_server_version", CONST_CALL_WITHOUT_GIL(cc::Client, GetServerVersion))
     .def("get_world", &cc::Client::GetWorld)
     .def("get_available_maps", &GetAvailableMaps)
-    .def("set_files_base_folder", &SetFilesBaseFolder, (arg("path")))
+    .def("set_files_base_folder", &cc::Client::SetFilesBaseFolder, (arg("path")))
     .def("get_required_files", &GetRequiredFiles, (arg("folder")="", arg("download")=true))
-    .def("request_file", &RequestFile, (arg("name")))
+    .def("request_file", &cc::Client::RequestFile, (arg("name")))
     .def("reload_world", CONST_CALL_WITHOUT_GIL_1(cc::Client, ReloadWorld, bool), (arg("reset_settings")=true))
     .def("load_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, LoadWorld, std::string, bool, rpc::MapLayer), (arg("map_name"), arg("reset_settings")=true, arg("map_layers")=rpc::MapLayer::All))
     .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, GenerateOpenDriveWorld, std::string,

--- a/PythonAPI/util/environment.py
+++ b/PythonAPI/util/environment.py
@@ -109,7 +109,6 @@ def apply_weather_values(args, weather):
     if args.miescatteringscale is not None:
         weather.mie_scattering_scale = args.miescatteringscale
     if args.rayleighscatteringscale is not None:
-        print(weather.rayleigh_scattering_scale)
         weather.rayleigh_scattering_scale = args.rayleighscatteringscale
 
 
@@ -245,19 +244,19 @@ def main():
         type=float,
         help='Wetness intensity [0.0, 100.0]')
     argparser.add_argument(
-        '--scatteringintensity',
-        metavar='Si',
+        '--scatteringintensity', '-si'
+        metavar='si',
         default=None,
         type=float,
         help='Scattering intensity [0.0, inf]')
     argparser.add_argument(
-        '--rayleighscatteringscale',
+        '--rayleighscatteringscale', '-rss'
         metavar='rss',
         default=None,
         type=float,
         help='Rayleigh scattering scale [0.0, 2.0]')
     argparser.add_argument(
-        '--miescatteringscale',
+        '--miescatteringscale', '-mss'
         metavar='mss',
         default=None,
         type=float,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
@@ -130,7 +130,7 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
       TileData.XODRName = LoadedMapName.LeftChop((LoadedMapName.GetCharArray().Num() - 1) - LoadedMapName.Find("_", ESearchCase::IgnoreCase, ESearchDir::Type::FromStart));
       // As the OpenDrive file has the same name as level, build the path to the
       // xodr file using the label name and the game content directory.
-      const FString XodrContent = UOpenDrive::LoadXODR(TileData.XODRName);
+      const FString XodrContent = UOpenDrive::GetXODR(GetWorld());
       XODRMap = carla::opendrive::OpenDriveParser::Load(carla::rpc::FromLongFString(XodrContent));
 
       // Acquire the TilesInfo.txt file for storing the tile data (offset and size)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
@@ -127,7 +127,6 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
 
     if (FilledData == false) {
 
-      TileData.XODRName = LoadedMapName.LeftChop((LoadedMapName.GetCharArray().Num() - 1) - LoadedMapName.Find("_", ESearchCase::IgnoreCase, ESearchDir::Type::FromStart));
       // As the OpenDrive file has the same name as level, build the path to the
       // xodr file using the label name and the game content directory.
       const FString XodrContent = UOpenDrive::GetXODR(GetWorld());

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.h
@@ -27,9 +27,6 @@ struct CARLA_API FLargeMapTileData
   GENERATED_USTRUCT_BODY()
 
   UPROPERTY()
-  FString XODRName;
-
-  UPROPERTY()
   float FirstTileCenterX;
 
   UPROPERTY()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -69,8 +69,10 @@ bool UCarlaEpisode::LoadNewEpisode(const FString &MapString, bool ResetSettings)
     }
     // Some conversions...
     FinalPath = FinalPath.Replace(TEXT("/Game/"), *FPaths::ProjectContentDir());
-    if (FPaths::FileExists(IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*FinalPath)))
-    {
+    FinalPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*FinalPath);
+
+    if (FPaths::FileExists(FinalPath)) {
+      UCarlaStatics::GetGameInstance(GetWorld())->SetMapPath(FinalPath);
       bIsFileFound = true;
       FinalPath = MapString;
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.cpp
@@ -17,6 +17,8 @@ UCarlaGameInstance::UCarlaGameInstance() {
   check(CarlaSettings != nullptr);
   CarlaSettings->LoadSettings();
   CarlaSettings->LogSettings();
+
+  SetDefaultMapPath();
 }
 
 UCarlaGameInstance::~UCarlaGameInstance() = default;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
@@ -103,6 +103,39 @@ public:
     return CurrentMapLayer;
   }
 
+  UFUNCTION(BlueprintCallable)
+  void SetDefaultMapPath() {
+    // Read the config file
+    FConfigFile ConfigFile = FConfigFile();
+    FString configFStr = FPaths::ProjectDir();
+    configFStr += "Config/DefaultEngine.ini";
+    ConfigFile.Read(configFStr);
+
+    // Depending on where we are, set the editor or game default map
+#ifdef UE_EDITOR
+    ConfigFile.GetString(TEXT("/Script/EngineSettings.GameMapsSettings"), TEXT("EditorStartupMap"), _MapPath);
+#else
+    ConfigFile.GetString(TEXT("/Script/EngineSettings.GameMapsSettings"), TEXT("GameDefaultMap"), _MapPath);
+#endif
+
+    // Format and convert the path to absolute
+    _MapPath = _MapPath.Replace(TEXT("/Game/"), *FPaths::ProjectContentDir());
+    _MapPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*_MapPath);
+    _MapPath = FPaths::GetBaseFilename(_MapPath, false);
+  }
+
+  UFUNCTION(BlueprintCallable)
+  void SetMapPath(const FString &MapPath)
+  {
+    _MapPath = MapPath;
+  }
+
+  UFUNCTION(BlueprintCallable)
+  const FString &GetMapPath() const
+  {
+    return _MapPath;
+  }
+
 private:
 
   UPROPERTY(Category = "CARLA Settings", EditAnywhere)
@@ -117,5 +150,8 @@ private:
 
   UPROPERTY(Category = "CARLA Game Instance", EditAnywhere)
   int32 CurrentMapLayer = static_cast<int32>(carla::rpc::MapLayer::All);
+
+  UPROPERTY()
+  FString _MapPath;
 
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
@@ -119,7 +119,8 @@ public:
 #endif
 
     // Format and convert the path to absolute
-    _MapPath = _MapPath.Replace(TEXT("/Game/"), *FPaths::ProjectContentDir());
+    _MapPath.RemoveFromStart(TEXT("/Game/"));
+    _MapPath = FPaths::ProjectContentDir() + _MapPath;
     _MapPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*_MapPath);
     _MapPath = FPaths::GetBaseFilename(_MapPath, false);
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -292,7 +292,7 @@ void ACarlaGameModeBase::GenerateSpawnPoints()
 
 void ACarlaGameModeBase::ParseOpenDrive(const FString &MapName)
 {
-  std::string opendrive_xml = carla::rpc::FromLongFString(UOpenDrive::LoadXODR(MapName));
+  std::string opendrive_xml = carla::rpc::FromLongFString(UOpenDrive::GetXODR(GetWorld()));
   Map = carla::opendrive::OpenDriveParser::Load(opendrive_xml);
   if (!Map.has_value()) {
     UE_LOG(LogCarla, Error, TEXT("Invalid Map"));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -128,7 +128,7 @@ void ACarlaGameModeBase::InitGame(
   Recorder->SetEpisode(Episode);
   Episode->SetRecorder(Recorder);
 
-  ParseOpenDrive(Episode->MapName);
+  ParseOpenDrive();
 
   if(Map.has_value())
   {
@@ -290,7 +290,7 @@ void ACarlaGameModeBase::GenerateSpawnPoints()
   }
 }
 
-void ACarlaGameModeBase::ParseOpenDrive(const FString &MapName)
+void ACarlaGameModeBase::ParseOpenDrive()
 {
   std::string opendrive_xml = carla::rpc::FromLongFString(UOpenDrive::GetXODR(GetWorld()));
   Map = carla::opendrive::OpenDriveParser::Load(opendrive_xml);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -109,7 +109,7 @@ private:
 
   void GenerateSpawnPoints();
 
-  void ParseOpenDrive(const FString &MapName);
+  void ParseOpenDrive();
 
   void RegisterEnvironmentObjects();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
@@ -9,73 +9,40 @@
 
 #include "Runtime/Core/Public/HAL/FileManagerGeneric.h"
 
-FString UOpenDrive::FindPathToXODRFile(const FString &InMapName)
+
+FString UOpenDrive::GetXODR(const UWorld *World)
 {
-  FString MapName = InMapName;
-#if WITH_EDITOR
-    {
-      // When playing in editor the map name gets an extra prefix, here we
-      // remove it.
-      FString CorrectedMapName = MapName;
-      constexpr auto PIEPrefix = TEXT("UEDPIE_0_");
-      CorrectedMapName.RemoveFromStart(PIEPrefix);
-      UE_LOG(LogCarla, Log, TEXT("UOpenDrive: Corrected map name from %s to %s"), *MapName, *CorrectedMapName);
-      MapName = CorrectedMapName;
-    }
-#endif // WITH_EDITOR
+  const auto mapName = World->GetMapName();
+  const auto mapDir = FPaths::GetPath(UCarlaStatics::GetGameInstance(World)->GetMapPath());
+  const auto folderDir = mapDir + "/OpenDrive/";
+  const auto fileName = mapDir.EndsWith(mapName) ? "*" : mapName;
 
-  MapName += TEXT(".xodr");
-
-  const FString DefaultFilePath =
-      FPaths::ProjectContentDir() +
-      TEXT("Carla/Maps/OpenDrive/") +
-      MapName;
-
-  auto &FileManager = IFileManager::Get();
-
-  if (FileManager.FileExists(*DefaultFilePath))
-  {
-    return DefaultFilePath;
-  }
-
-  TArray<FString> FilesFound;
-  FileManager.FindFilesRecursive(
-      FilesFound,
-      *FPaths::ProjectContentDir(),
-      *MapName,
-      true,
-      false,
-      false);
-
-  return FilesFound.Num() > 0 ? FilesFound[0u] : FString{};
-}
-
-FString UOpenDrive::LoadXODR(const FString &MapName)
-{
-  const auto FilePath = FindPathToXODRFile(MapName);
+  // Find all the xodr and bin files from the map
+  TArray<FString> Files;
+  IFileManager::Get().FindFilesRecursive(Files, *folderDir, *FString(fileName + ".xodr"), true, false, false);
 
   FString Content;
 
-  if (FilePath.IsEmpty())
+  if (!Files.Num())
   {
-    UE_LOG(LogTemp, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *MapName);
+    UE_LOG(LogTemp, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *mapName);
   }
-  else if (FFileHelper::LoadFileToString(Content, *FilePath))
+  else if (FFileHelper::LoadFileToString(Content, *Files[0]))
   {
-    UE_LOG(LogTemp, Log, TEXT("Loaded OpenDrive file '%s'"), *FilePath);
+    UE_LOG(LogTemp, Log, TEXT("Loaded OpenDrive file '%s'"), *Files[0]);
   }
   else
   {
-    UE_LOG(LogTemp, Error, TEXT("Failed to load OpenDrive file '%s'"), *FilePath);
+    UE_LOG(LogTemp, Error, TEXT("Failed to load OpenDrive file '%s'"), *Files[0]);
   }
 
   return Content;
 }
 
-UOpenDriveMap *UOpenDrive::LoadOpenDriveMap(const FString &MapName)
+UOpenDriveMap *UOpenDrive::LoadOpenDriveMap(const UWorld *World)
 {
   UOpenDriveMap *Map = nullptr;
-  auto XODRContent = LoadXODR(MapName);
+  auto XODRContent = GetXODR(World);
   if (!XODRContent.IsEmpty())
   {
     Map = NewObject<UOpenDriveMap>();
@@ -87,7 +54,5 @@ UOpenDriveMap *UOpenDrive::LoadOpenDriveMap(const FString &MapName)
 UOpenDriveMap *UOpenDrive::LoadCurrentOpenDriveMap(const UObject *WorldContextObject)
 {
   UWorld *World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
-  return World != nullptr ?
-      LoadOpenDriveMap(World->GetMapName()) :
-      nullptr;
+  return World != nullptr ? LoadOpenDriveMap(World) : nullptr;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
@@ -19,19 +19,15 @@ class CARLA_API UOpenDrive : public UBlueprintFunctionLibrary
 
 public:
 
-  /// Find the path to the XODR file associated to MapName. Return empty if no
-  /// such file is found.
-  static FString FindPathToXODRFile(const FString &MapName);
-
   /// Return the OpenDrive XML associated to @a MapName, or empty if the file
   /// is not found.
   UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
-  static FString LoadXODR(const FString &MapName);
+  static FString GetXODR(const UWorld *World);
 
   /// Load OpenDriveMap associated to the given MapName. Return nullptr if no
   /// XODR can be found with same MapName.
   UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
-  static UOpenDriveMap *LoadOpenDriveMap(const FString &MapName);
+  static UOpenDriveMap *LoadOpenDriveMap(const UWorld *World);
 
   /// Load OpenDriveMap associated to the currently loaded map. Return nullptr
   /// if no XODR can be found that matches the current map.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
@@ -136,7 +136,7 @@ void AOpenDriveActor::BuildRoutes(FString MapName)
 
   // As the OpenDrive file has the same name as level, build the path to the
   // xodr file using the lavel name and the game content directory.
-  const FString XodrContent = UOpenDrive::LoadXODR(MapName);
+  const FString XodrContent = UOpenDrive::GetXODR(GetWorld());
 
   auto map = carla::opendrive::OpenDriveParser::Load(carla::rpc::FromLongFString(XodrContent));
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
@@ -170,7 +170,7 @@ void AOpenDriveGenerator::BeginPlay()
   Super::BeginPlay();
 
   // Search for "{project_content_folder}/Carla/Maps/OpenDrive/{current_map_name}.xodr"
-  const FString XodrContent = UOpenDrive::LoadXODR(GetWorld()->GetMapName());
+  const FString XodrContent = UOpenDrive::GetXODR(GetWorld());
   LoadOpenDrive(XodrContent);
 
   GenerateAll();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveGenerator.cpp
@@ -169,7 +169,6 @@ void AOpenDriveGenerator::BeginPlay()
 {
   Super::BeginPlay();
 
-  // Search for "{project_content_folder}/Carla/Maps/OpenDrive/{current_map_name}.xodr"
   const FString XodrContent = UOpenDrive::GetXODR(GetWorld());
   LoadOpenDrive(XodrContent);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -374,7 +374,7 @@ void FCarlaServer::FPimpl::BindActions()
     if (folder[folder.size() - 1] != '/' && folder[folder.size() - 1] != '\\') {
       folder += "/";
     }
-    
+
     // Get the map's folder absolute path and check if it's in its own folder
     const auto mapDir = FPaths::GetPath(UCarlaStatics::GetGameInstance(Episode->GetWorld())->GetMapPath());
     const auto folderDir = mapDir + "/" + folder.c_str();
@@ -394,7 +394,7 @@ void FCarlaServer::FPimpl::BindActions()
 
     return result;
   };
-  
+
   BIND_SYNC(request_file) << [this](std::string name) -> R<std::vector<uint8_t>>
   {
     REQUIRE_CARLA_EPISODE();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -341,7 +341,7 @@ void FCarlaServer::FPimpl::BindActions()
   BIND_SYNC(get_map_info) << [this]() -> R<cr::MapInfo>
   {
     REQUIRE_CARLA_EPISODE();
-    auto FileContents = UOpenDrive::LoadXODR(Episode->GetMapName());
+    auto FileContents = UOpenDrive::GetXODR(Episode->GetWorld());
     const auto &SpawnPoints = Episode->GetRecommendedSpawnPoints();
     return cr::MapInfo{
       cr::FromFString(Episode->GetMapName()),
@@ -369,14 +369,14 @@ void FCarlaServer::FPimpl::BindActions()
     }
     
     // Get the map's folder absolute path and check if it's in its own folder
-    auto mapDir = FPaths::GetPath(UCarlaStatics::GetGameInstance(Episode->GetWorld())->GetMapPath()) + "/" + folder.c_str();
-    auto fileName = mapDir.EndsWith(Episode->GetMapName() + "/") ? "*" : Episode->GetMapName();
+    const auto mapDir = FPaths::GetPath(UCarlaStatics::GetGameInstance(Episode->GetWorld())->GetMapPath());
+    const auto folderDir = mapDir + "/" + folder.c_str();
+    const auto fileName = mapDir.EndsWith(Episode->GetMapName()) ? "*" : Episode->GetMapName();
 
     // Find all the xodr and bin files from the map
     TArray<FString> Files;
-    auto &FileManager = IFileManager::Get();
-    FileManager.FindFilesRecursive(Files, *mapDir, *FString(fileName + ".xodr"), true, false, false);
-    FileManager.FindFilesRecursive(Files, *mapDir, *FString(fileName + ".bin"), true, false, false);
+    IFileManager::Get().FindFilesRecursive(Files, *folderDir, *FString(fileName + ".xodr"), true, false, false);
+    IFileManager::Get().FindFilesRecursive(Files, *folderDir, *FString(fileName + ".bin"), true, false, false);
 
     // Remove the start of the path until the content folder and put each file in the result
     std::vector<std::string> result;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -24,6 +24,7 @@
 #include "Carla/Actor/ActorData.h"
 #include "CarlaServerResponse.h"
 #include "Carla/Util/BoundingBoxCalculator.h"
+#include "Misc/FileHelper.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/Functional.h>
@@ -355,6 +356,52 @@ void FCarlaServer::FPimpl::BindActions()
     // make a mem copy (from TArray to std::vector)
     std::vector<uint8_t> Result(FileContents.Num());
     memcpy(&Result[0], FileContents.GetData(), FileContents.Num());
+    return Result;
+  };
+
+  BIND_SYNC(get_required_files) << [this](std::string folder = "") -> R<std::vector<std::string>>
+  {
+    REQUIRE_CARLA_EPISODE();
+
+    // Check that the path ends in a slash, add it otherwise
+    if (folder[folder.size() - 1] != '/' && folder[folder.size() - 1] != '\\') {
+      folder += "/";
+    }
+    
+    // Get the map's folder absolute path and check if it's in its own folder
+    auto mapDir = FPaths::GetPath(UCarlaStatics::GetGameInstance(Episode->GetWorld())->GetMapPath()) + "/" + folder.c_str();
+    auto fileName = mapDir.EndsWith(Episode->GetMapName() + "/") ? "*" : Episode->GetMapName();
+
+    // Find all the xodr and bin files from the map
+    TArray<FString> Files;
+    auto &FileManager = IFileManager::Get();
+    FileManager.FindFilesRecursive(Files, *mapDir, *FString(fileName + ".xodr"), true, false, false);
+    FileManager.FindFilesRecursive(Files, *mapDir, *FString(fileName + ".bin"), true, false, false);
+
+    // Remove the start of the path until the content folder and put each file in the result
+    std::vector<std::string> result;
+    for (auto File : Files) {
+      File.RemoveFromStart(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
+      result.emplace_back(TCHAR_TO_UTF8(*File));
+    }
+
+    return result;
+  };
+  
+  BIND_SYNC(request_file) << [this](std::string name) -> R<std::vector<uint8_t>>
+  {
+    REQUIRE_CARLA_EPISODE();
+
+    // Get the absolute path of the file
+    FString path(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
+    path.Append(name.c_str());
+
+    // Copy the binary data of the file into the result and return it
+    TArray<uint8_t> Content;
+    FFileHelper::LoadFileToArray(Content, *path, 0);
+    std::vector<uint8_t> Result(Content.Num());
+    memcpy(&Result[0], Content.GetData(), Content.Num());
+
     return Result;
   };
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -341,12 +341,19 @@ void FCarlaServer::FPimpl::BindActions()
   BIND_SYNC(get_map_info) << [this]() -> R<cr::MapInfo>
   {
     REQUIRE_CARLA_EPISODE();
-    auto FileContents = UOpenDrive::GetXODR(Episode->GetWorld());
     const auto &SpawnPoints = Episode->GetRecommendedSpawnPoints();
+    FString FullMapPath = FPaths::GetPath(UCarlaStatics::GetGameInstance(Episode->GetWorld())->GetMapPath());
+    FString MapDir = FullMapPath.RightChop(FullMapPath.Find("Content/", ESearchCase::CaseSensitive) + 8);
+    MapDir += "/" + Episode->GetMapName();
     return cr::MapInfo{
-      cr::FromFString(Episode->GetMapName()),
-      cr::FromLongFString(FileContents),
+      cr::FromFString(MapDir),
       MakeVectorFromTArray<cg::Transform>(SpawnPoints)};
+  };
+
+  BIND_SYNC(get_map_data) << [this]() -> R<std::string>
+  {
+    REQUIRE_CARLA_EPISODE();
+    return cr::FromFString(UOpenDrive::GetXODR(Episode->GetWorld()));  
   };
 
   BIND_SYNC(get_navigation_mesh) << [this]() -> R<std::vector<uint8_t>>

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -271,8 +271,7 @@ void ATrafficLightManager::MatchTrafficLightActorsWithOpenDriveSignals()
   TArray<AActor*> Actors;
   UGameplayStatics::GetAllActorsOfClass(GetWorld(), ATrafficLightBase::StaticClass(), Actors);
 
-  FString MapName = GetWorld()->GetName();
-  std::string opendrive_xml = carla::rpc::FromFString(UOpenDrive::LoadXODR(MapName));
+  std::string opendrive_xml = carla::rpc::FromFString(UOpenDrive::GetXODR(GetWorld()));
   auto Map = carla::opendrive::OpenDriveParser::Load(opendrive_xml);
 
   if (!Map)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/NavigationMesh.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/NavigationMesh.cpp
@@ -22,32 +22,24 @@ TArray<uint8> FNavigationMesh::Load(FString MapName)
     }
 #endif // WITH_EDITOR
 
-  FString FilePath =
-      FPaths::ProjectContentDir() +
-      TEXT("Carla/Maps/Nav/") +
-      MapName + TEXT(".bin");
+  const auto FileName = MapName + ".bin";
 
-  auto &FileManager = IFileManager::Get();
-  if (!FileManager.FileExists(*FilePath))
-  {
-    TArray<FString> FilesFound;
-    FileManager.FindFilesRecursive(
-      FilesFound,
-      *FPaths::ProjectContentDir(),
-      *(MapName + TEXT(".bin")),
-      true,
-      false,
-      false);
-    if (FilesFound.Num() > 0)
-      FilePath = FilesFound[0u];
-  }
+  TArray<FString> Files;
+  IFileManager::Get().FindFilesRecursive(Files, *FPaths::ProjectContentDir(), *FileName, true, false, false);
 
   TArray<uint8> Content;
-  UE_LOG(LogCarla, Log, TEXT("Loading Navigation Mesh file '%s'"), *FilePath);
 
-  if (!FFileHelper::LoadFileToArray(Content, *FilePath, 0))
+  if (!Files.Num())
   {
-    UE_LOG(LogTemp, Error, TEXT("Failed to load Navigation Mesh file '%s'"), *FilePath);
+    UE_LOG(LogTemp, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *MapName);
+  }
+  else if (FFileHelper::LoadFileToArray(Content, *Files[0], 0))
+  {
+    UE_LOG(LogCarla, Log, TEXT("Loading Navigation Mesh file '%s'"), *Files[0]);
+  }
+  else
+  {
+    UE_LOG(LogTemp, Error, TEXT("Failed to load Navigation Mesh file '%s'"), *Files[0]);
   }
 
   return Content;


### PR DESCRIPTION
#### Description

Required map files (OpenDRIVE, Traffic Manager...) are now downloaded from the server to the client local cache.

This local cache is stored by default in a folder called carlaCache under the User (Windows) or Home (Linux) folder.
It can be changed with the `set_files_base_folder` command.

To get the names of the required files for the current map use the `get_required_files` command.
Optionally, you can specify a folder under the current loaded ".umap" location to look for the files (e.g. "OpenDrive" to just get the files inside that folder), and you can either store the files or just get the names.

To download a exact file for the current map use the `request_file` command, passing its path and name starting from the current loaded ".umap" location (e.g. "OpenDrive/Map_1.xodr").

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04.5
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.26.2

#### Possible Drawbacks

Possible automatic data transfer from server to client.

In this version, it's checked if the file is already present on the client cache folder to avoid downloading it again, the content is not checked. If a file is updated, the system won't detect that. The file will have to be removed and downloaded again.

If a map is loaded in the server by Unreal's content explorer, the `get_required_files` command will not work correctly. The proper way to change the map is with the `load_world` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4356)
<!-- Reviewable:end -->
