### PR TITLE
Fix crash when unreal destroys an actor

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -150,7 +150,7 @@ bool UActorDispatcher::DestroyActor(FCarlaActor::IdType ActorId)
     }
   }
 
-  Registry.Deregister(ActorId, View->IsDormant());
+  Registry.Deregister(ActorId);
 
   return true;
 }
@@ -163,7 +163,7 @@ FCarlaActor* UActorDispatcher::RegisterActor(
   if (View)
   {
     // TODO: support external actor destruction
-    // Actor.OnDestroyed.AddDynamic(this, &UActorDispatcher::OnActorDestroyed);
+    Actor.OnDestroyed.AddDynamic(this, &UActorDispatcher::OnActorDestroyed);
   }
   return View;
 }
@@ -176,4 +176,16 @@ void UActorDispatcher::PutActorToSleep(FCarlaActor::IdType Id, UCarlaEpisode* Ca
 void UActorDispatcher::WakeActorUp(FCarlaActor::IdType Id, UCarlaEpisode* CarlaEpisode)
 {
   Registry.WakeActorUp(Id, CarlaEpisode);
+}
+
+void UActorDispatcher::OnActorDestroyed(AActor *Actor)
+{
+  FCarlaActor* CarlaActor = Registry.FindCarlaActor(Actor);
+  if (CarlaActor)
+  {
+    if (CarlaActor->IsActive())
+    {
+      Registry.Deregister(CarlaActor->GetActorId());
+    }
+  }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.h
@@ -72,12 +72,6 @@ public:
 
   bool DestroyActor(FCarlaActor::IdType ActorId);
 
-  UFUNCTION()
-  void OnActorDestroyed(AActor *Actor)
-  {
-    Registry.Deregister(Actor);
-  }
-
   /// Register an actor that was not created using "SpawnActor" function but
   /// that should be kept in the registry.
   FCarlaActor* RegisterActor(
@@ -101,6 +95,9 @@ public:
   }
 
 private:
+
+  UFUNCTION()
+  void OnActorDestroyed(AActor *Actor);
 
   TArray<FActorDefinition> Definitions;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
@@ -110,7 +110,7 @@ FCarlaActor* FActorRegistry::Register(AActor &Actor, FActorDescription Descripti
   return Result.Get();
 }
 
-void FActorRegistry::Deregister(IdType Id, bool KeepId)
+void FActorRegistry::Deregister(IdType Id)
 {
   check(Contains(Id));
   FCarlaActor* CarlaActor = FindCarlaActor(Id);
@@ -119,19 +119,8 @@ void FActorRegistry::Deregister(IdType Id, bool KeepId)
 
   AActor *Actor = CarlaActor->GetActor();
 
-  // If the ID will be reused again by other actor (like dormant actors)
-  // we need to keep the ID <-> FCarlaActor relation
-  // but we need to remove all AActor pointers since they will not be valid anymore
-  if(KeepId)
-  {
-    Actors[Id] = nullptr;
-  }
-  else
-  {
-    ActorDatabase.Remove(Id);
-    Actors.Remove(Id);
-  }
-
+  ActorDatabase.Remove(Id);
+  Actors.Remove(Id);
   Ids.Remove(Actor);
 
   CarlaActor->TheActor = nullptr;
@@ -139,12 +128,12 @@ void FActorRegistry::Deregister(IdType Id, bool KeepId)
   check(static_cast<size_t>(Actors.Num()) == ActorDatabase.Num());
 }
 
-void FActorRegistry::Deregister(AActor *Actor, bool KeepId)
+void FActorRegistry::Deregister(AActor *Actor)
 {
   check(Actor != nullptr);
   FCarlaActor* CarlaActor = FindCarlaActor(Actor);
   check(CarlaActor->GetActor() == Actor);
-  Deregister(CarlaActor->GetActorId(), KeepId);
+  Deregister(CarlaActor->GetActorId());
 }
 
 TSharedPtr<FCarlaActor> FActorRegistry::MakeCarlaActor(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.h
@@ -41,9 +41,9 @@ public:
   /// @warning Undefined if an actor is registered more than once.
   FCarlaActor* Register(AActor &Actor, FActorDescription Description, IdType DesiredId = 0);
 
-  void Deregister(IdType Id, bool KeepId = false);
+  void Deregister(IdType Id);
 
-  void Deregister(AActor *Actor, bool KeepId = false);
+  void Deregister(AActor *Actor);
 
   /// @}
   // ===========================================================================


### PR DESCRIPTION
#### Description

Added capability to detect when an UE actor has been destroyed by unreal (out of bounds) or by the large map system. When unreal destroys an actor, it is removed from the registry. This fixes crashes when actors move out of bounds or other reasons.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks
Destroying actors is very slightly more expensive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4364)
<!-- Reviewable:end -->
