### PR TITLE
Fix get landmarks

### DIFF
--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -345,8 +345,8 @@ namespace road {
         }
         bool is_valid = false;
         for (auto &validity : signal->GetValidities()) {
-          if (waypoint.lane_id > validity._from_lane &&
-              waypoint.lane_id < validity._to_lane) {
+          if (waypoint.lane_id >= validity._from_lane &&
+              waypoint.lane_id <= validity._to_lane) {
             is_valid = true;
             break;
           }
@@ -381,8 +381,8 @@ namespace road {
       }
       bool is_valid = false;
       for (auto &validity : signal->GetValidities()) {
-        if (waypoint.lane_id > validity._from_lane &&
-            waypoint.lane_id < validity._to_lane) {
+        if (waypoint.lane_id >= validity._from_lane &&
+            waypoint.lane_id <= validity._to_lane) {
           is_valid = true;
           break;
         }

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -343,6 +343,17 @@ namespace road {
         } else {
           distance_to_signal = waypoint.s - signal->GetDistance();
         }
+        bool is_valid = false;
+        for (auto &validity : signal->GetValidities()) {
+          if (waypoint.lane_id > validity._from_lane &&
+              waypoint.lane_id < validity._to_lane) {
+            is_valid = true;
+            break;
+          }
+        }
+        if(!is_valid){
+          continue;
+        }
         if (distance_to_signal == 0) {
           result.emplace_back(SignalSearchData
               {signal, waypoint,
@@ -367,6 +378,17 @@ namespace road {
         distance_to_signal = signal->GetDistance() - waypoint.s;
       } else {
         distance_to_signal = waypoint.s - signal->GetDistance();
+      }
+      bool is_valid = false;
+      for (auto &validity : signal->GetValidities()) {
+        if (waypoint.lane_id > validity._from_lane &&
+            waypoint.lane_id < validity._to_lane) {
+          is_valid = true;
+          break;
+        }
+      }
+      if(!is_valid){
+        continue;
       }
       if (distance_to_signal == 0) {
         result.emplace_back(SignalSearchData

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -343,6 +343,7 @@ namespace road {
         } else {
           distance_to_signal = waypoint.s - signal->GetDistance();
         }
+        // check that the signal affects the waypoint
         bool is_valid = false;
         for (auto &validity : signal->GetValidities()) {
           if (waypoint.lane_id >= validity._from_lane &&
@@ -379,6 +380,7 @@ namespace road {
       } else {
         distance_to_signal = waypoint.s - signal->GetDistance();
       }
+      // check that the signal affects the waypoint
       bool is_valid = false;
       for (auto &validity : signal->GetValidities()) {
         if (waypoint.lane_id >= validity._from_lane &&

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -36,6 +36,7 @@ r.DistanceFieldBuild.Compress=False
 r.DistanceFields.AtlasSizeXY=1024
 r.DistanceFields.AtlasSizeZ=2048
 r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
+r.DefaultFeature.AntiAliasing=1
 
 [/Script/AIModule.AISense_Sight]
 bAutoRegisterAllPawnsAsSources=False

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
@@ -104,6 +104,11 @@ void FVehicleData::RecordActorData(FCarlaActor* CarlaActor, UCarlaEpisode* Carla
   }
   Control = Vehicle->GetVehicleControl();
   LightState = Vehicle->GetVehicleLightState();
+  auto Controller = Cast<AWheeledVehicleAIController>(Vehicle->GetController());
+  if (Controller)
+  {
+    SpeedLimit = Controller->GetSpeedLimit();
+  }
 }
 
 void FVehicleData::RestoreActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaEpisode)
@@ -118,6 +123,11 @@ void FVehicleData::RestoreActorData(FCarlaActor* CarlaActor, UCarlaEpisode* Carl
   }
   Vehicle->ApplyVehicleControl(Control, EVehicleInputPriority::Client);
   Vehicle->SetVehicleLightState(LightState);
+  auto Controller = Cast<AWheeledVehicleAIController>(Vehicle->GetController());
+  if (Controller)
+  {
+    Controller->SetSpeedLimit(SpeedLimit);
+  }
 }
 
 void FWalkerData::RecordActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaEpisode)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
@@ -150,7 +150,7 @@ AActor* FTrafficSignData::RespawnActor(UCarlaEpisode* CarlaEpisode, const FActor
   FActorSpawnParameters SpawnParams;
   SpawnParams.SpawnCollisionHandlingOverride =
       ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-  return CarlaEpisode->GetWorld()->SpawnActor<ATrafficLightBase>(
+  return CarlaEpisode->GetWorld()->SpawnActor<ATrafficSignBase>(
         Model,
         SpawnTransform,
         SpawnParams);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.h
@@ -59,6 +59,8 @@ public:
 
   FVehicleLightState LightState;
 
+  float SpeedLimit = 30;
+
   virtual void RecordActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaEpisode) override;
 
   virtual void RestoreActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaEpisode) override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Actor/CarlaActor.h"
 #include "GameFramework/Actor.h"
 
 #include "Engine/LevelStreamingDynamic.h"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
@@ -171,7 +171,7 @@ static auto FWorldObserver_GetDormantActorState(const FCarlaActor &View, const F
       state.vehicle_data.control = carla::rpc::VehicleControl{ActorData->Control};
       using TLS = carla::rpc::TrafficLightState;
       state.vehicle_data.traffic_light_state = TLS::Green;
-      state.vehicle_data.speed_limit = 30;
+      state.vehicle_data.speed_limit = ActorData->SpeedLimit;
       state.vehicle_data.has_traffic_light = false;
   }
   else if (AType::Walker == View.GetActorType())

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
@@ -47,7 +47,14 @@ static auto FWorldObserver_GetActorState(const FCarlaActor &View, const FActorRe
         {
           state.vehicle_data.has_traffic_light = true;
           auto* TrafficLightView = Registry.FindCarlaActor(TrafficLight);
-          state.vehicle_data.traffic_light_id = TrafficLightView->GetActorId();
+          if(TrafficLightView)
+          {
+            state.vehicle_data.traffic_light_id = TrafficLightView->GetActorId();
+          }
+          else
+          {
+            state.vehicle_data.has_traffic_light = false;
+          }
         }
         else
         {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -178,7 +178,7 @@ void UCarlaSettingsDelegate::LaunchLowQualityCommands(UWorld *world) const
   GEngine->Exec(world, TEXT("r.AmbientOcclusionLevels 0"));
   GEngine->Exec(world, TEXT("r.DefaultFeature.AmbientOcclusionStaticFraction 0"));
   GEngine->Exec(world, TEXT("r.RHICmdBypass 0"));
-  GEngine->Exec(world, TEXT("r.DefaultFeature.AntiAliasing 2"));
+  GEngine->Exec(world, TEXT("r.DefaultFeature.AntiAliasing 1"));
   GEngine->Exec(world, TEXT("r.Streaming.PoolSize 2000"));
   GEngine->Exec(world, TEXT("r.HZBOcclusion 0"));
   GEngine->Exec(world, TEXT("r.MinScreenRadiusForLights 0.01"));
@@ -375,7 +375,7 @@ void UCarlaSettingsDelegate::LaunchEpicQualityCommands(UWorld *world) const
 
   GEngine->Exec(world, TEXT("r.AmbientOcclusionLevels -1"));
   GEngine->Exec(world, TEXT("r.RHICmdBypass 1"));
-  GEngine->Exec(world, TEXT("r.DefaultFeature.AntiAliasing 2"));
+  GEngine->Exec(world, TEXT("r.DefaultFeature.AntiAliasing 1"));
   GEngine->Exec(world, TEXT("r.Streaming.PoolSize 2000"));
   GEngine->Exec(world, TEXT("r.MinScreenRadiusForLights 0.03"));
   GEngine->Exec(world, TEXT("r.SeparateTranslucency 1"));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.cpp
@@ -10,6 +10,7 @@
 #include <compiler/disable-ue4-macros.h>
 #include "carla/opendrive/OpenDriveParser.h"
 #include "carla/road/element/RoadInfoSignal.h"
+#include "carla/rpc/String.h"
 #include <compiler/enable-ue4-macros.h>
 
 USignComponent::USignComponent()
@@ -73,6 +74,16 @@ TArray<std::pair<cr::RoadId, const cre::RoadInfoSignal*>>
     }
   }
   return Result;
+}
+
+const cr::Signal* USignComponent::GetSignal(const cr::Map &Map) const
+{
+  std::string std_signal_id = carla::rpc::FromFString(GetSignId());
+  if (Map.GetSignals().count(std_signal_id))
+  {
+    return Map.GetSignals().at(std_signal_id).get();
+  }
+  return nullptr;
 }
 
 UBoxComponent* USignComponent::GenerateTriggerBox(const FTransform &BoxTransform,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.h
@@ -60,6 +60,8 @@ protected:
   TArray<std::pair<cr::RoadId, const cre::RoadInfoSignal*>>
       GetAllReferencesToThisSignal(const cr::Map &Map);
 
+  const cr::Signal* GetSignal(const cr::Map &Map) const;
+
   /// Generates a trigger box component in the parent actor
   /// BoxSize should be in Unreal units
   UBoxComponent* GenerateTriggerBox(const FTransform &BoxTransform,

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
@@ -18,6 +18,11 @@ void USpeedLimitComponent::InitializeSign(const carla::road::Map &Map)
   const double epsilon = 0.00001;
 
   auto References = GetAllReferencesToThisSignal(Map);
+  auto* Signal = GetSignal(Map);
+  if (Signal)
+  {
+    SetSpeedLimit(Signal->GetValue());
+  }
 
   for (auto& Reference : References)
   {
@@ -38,7 +43,7 @@ void USpeedLimitComponent::InitializeSign(const carla::road::Map &Map)
 
         // Get 90% of the half size of the width of the lane
         float BoxSize = static_cast<float>(
-            0.9f*Map.GetLaneWidth(signal_waypoint)*0.5);
+            0.7f*Map.GetLaneWidth(signal_waypoint)*0.5);
         // Prevent a situation where the road width is 0,
         // this could happen in a lane that is just appearing
         BoxSize = std::max(0.01f, BoxSize);
@@ -66,6 +71,7 @@ void USpeedLimitComponent::InitializeSign(const carla::road::Map &Map)
       }
     }
   }
+
 }
 
 void USpeedLimitComponent::GenerateSpeedBox(const FTransform BoxTransform, float BoxSize)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "SpeedLimitComponent.h"
+#include "Carla/Vehicle/CarlaWheeledVehicle.h"
+
+
+void USpeedLimitComponent::SetSpeedLimit(float Limit)
+{
+  SpeedLimit = Limit;
+}
+
+void USpeedLimitComponent::InitializeSign(const carla::road::Map &Map)
+{
+  const double epsilon = 0.00001;
+
+  auto References = GetAllReferencesToThisSignal(Map);
+
+  for (auto& Reference : References)
+  {
+    auto RoadId = Reference.first;
+    const auto* SignalReference = Reference.second;
+    for(auto &validity : SignalReference->GetValidities())
+    {
+      for(auto lane : carla::geom::Math::GenerateRange(validity._from_lane, validity._to_lane))
+      {
+        if(lane == 0)
+          continue;
+
+        auto signal_waypoint = Map.GetWaypoint(
+            RoadId, lane, SignalReference->GetS()).get();
+
+        if(Map.GetLane(signal_waypoint).GetType() != cr::Lane::LaneType::Driving)
+          continue;
+
+        // Get 90% of the half size of the width of the lane
+        float BoxSize = static_cast<float>(
+            0.9f*Map.GetLaneWidth(signal_waypoint)*0.5);
+        // Prevent a situation where the road width is 0,
+        // this could happen in a lane that is just appearing
+        BoxSize = std::max(0.01f, BoxSize);
+        // Get min and max
+        double LaneLength = Map.GetLane(signal_waypoint).GetLength();
+        double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
+        if(lane < 0)
+        {
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - BoxSize,
+              LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
+        }
+        else
+        {
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + BoxSize,
+              LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
+        }
+        float UnrealBoxSize = 100*BoxSize;
+        FTransform BoxTransform = Map.ComputeTransform(signal_waypoint);
+        ALargeMapManager* LargeMapManager = UCarlaStatics::GetLargeMapManager(GetWorld());
+        if (LargeMapManager)
+        {
+          BoxTransform = LargeMapManager->GlobalToLocalTransform(BoxTransform);
+        }
+        GenerateSpeedBox(BoxTransform, UnrealBoxSize);
+      }
+    }
+  }
+}
+
+void USpeedLimitComponent::GenerateSpeedBox(const FTransform BoxTransform, float BoxSize)
+{
+  UBoxComponent* BoxComponent = GenerateTriggerBox(BoxTransform, BoxSize);
+  BoxComponent->OnComponentBeginOverlap.AddDynamic(this, &USpeedLimitComponent::OnOverlapBeginSpeedLimitBox);
+  AddEffectTriggerVolume(BoxComponent);
+}
+
+void USpeedLimitComponent::OnOverlapBeginSpeedLimitBox(UPrimitiveComponent *OverlappedComp,
+    AActor *OtherActor,
+    UPrimitiveComponent *OtherComp,
+    int32 OtherBodyIndex,
+    bool bFromSweep,
+    const FHitResult &SweepResult)
+{
+  ACarlaWheeledVehicle* Vehicle = Cast<ACarlaWheeledVehicle>(OtherActor);
+  if (OtherActor)
+  {
+    auto Controller = Cast<AWheeledVehicleAIController>(Vehicle->GetController());
+    if (Controller)
+    {
+      Controller->SetSpeedLimit(SpeedLimit);
+    }
+  }
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.cpp
@@ -83,7 +83,7 @@ void USpeedLimitComponent::OnOverlapBeginSpeedLimitBox(UPrimitiveComponent *Over
     const FHitResult &SweepResult)
 {
   ACarlaWheeledVehicle* Vehicle = Cast<ACarlaWheeledVehicle>(OtherActor);
-  if (OtherActor)
+  if (Vehicle)
   {
     auto Controller = Cast<AWheeledVehicleAIController>(Vehicle->GetController());
     if (Controller)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SpeedLimitComponent.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SignComponent.h"
+#include "SpeedLimitComponent.generated.h"
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class CARLA_API USpeedLimitComponent : public USignComponent
+{
+  GENERATED_BODY()
+
+public:
+
+  virtual void InitializeSign(const carla::road::Map &Map) override;
+
+  void SetSpeedLimit(float Limit);
+
+private:
+
+  void GenerateSpeedBox(const FTransform BoxTransform, float BoxSize);
+
+  UFUNCTION(BlueprintCallable)
+  void OnOverlapBeginSpeedLimitBox(UPrimitiveComponent *OverlappedComp,
+      AActor *OtherActor,
+      UPrimitiveComponent *OtherComp,
+      int32 OtherBodyIndex,
+      bool bFromSweep,
+      const FHitResult &SweepResult);
+
+  UPROPERTY(Category = "Speed Limit", EditAnywhere)
+  float SpeedLimit = 30;
+
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -8,6 +8,7 @@
 #include "Game/CarlaStatics.h"
 #include "StopSignComponent.h"
 #include "YieldSignComponent.h"
+#include "SpeedLimitComponent.h"
 #include "Components/BoxComponent.h"
 
 #include <compiler/disable-ue4-macros.h>
@@ -47,6 +48,55 @@ ATrafficLightManager::ATrafficLightManager()
     TSubclassOf<AActor> YieldSignModel = YieldFinder.Class;
     TrafficSignsModels.Add(carla::road::SignalType::YieldSign().c_str(), YieldSignModel);
     SignComponentModels.Add(carla::road::SignalType::YieldSign().c_str(), UYieldSignComponent::StaticClass());
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit30Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit30" ) );
+  if (SpeedLimit30Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit30Finder.Class;
+    SpeedLimitModels.Add("30", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit40Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit40" ) );
+  if (SpeedLimit40Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit40Finder.Class;
+    SpeedLimitModels.Add("40", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit50Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit50" ) );
+  if (SpeedLimit50Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit50Finder.Class;
+    SpeedLimitModels.Add("50", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit60Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit60" ) );
+  if (SpeedLimit60Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit60Finder.Class;
+    SpeedLimitModels.Add("60", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit70Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit70" ) );
+  if (SpeedLimit70Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit70Finder.Class;
+    SpeedLimitModels.Add("70", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit80Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit80" ) );
+  if (SpeedLimit80Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit80Finder.Class;
+    SpeedLimitModels.Add("80", SpeedLimitModel);
+  }
+  static ConstructorHelpers::FClassFinder<AActor> SpeedLimit90Finder(
+      TEXT( "/Game/Carla/Static/TrafficSign/BP_SpeedLimit90" ) );
+  if (SpeedLimit90Finder.Succeeded())
+  {
+    TSubclassOf<AActor> SpeedLimitModel = SpeedLimit90Finder.Class;
+    SpeedLimitModels.Add("90", SpeedLimitModel);
   }
   TrafficLightGroupMissingId = -2;
 }
@@ -588,6 +638,64 @@ void ATrafficLightManager::SpawnSignals()
           TrafficSign->GetRootComponent(),
           FAttachmentTransformRules::KeepRelativeTransform);
       SignComponent->InitializeSign(GetMap().get());
+
+      auto ClosestWaypointToSignal =
+          GetMap()->GetClosestWaypointOnRoad(CarlaTransform.location);
+      if (ClosestWaypointToSignal)
+      {
+        auto SignalDistanceToRoad =
+            (GetMap()->ComputeTransform(ClosestWaypointToSignal.get()).location - CarlaTransform.location).Length();
+        double LaneWidth = GetMap()->GetLaneWidth(ClosestWaypointToSignal.get());
+
+        if(SignalDistanceToRoad < LaneWidth * 0.5)
+        {
+          carla::log_warning("Traffic sign",
+              TCHAR_TO_UTF8(*SignComponent->GetSignId()),
+              "overlaps a driving lane. Disabling collision...");
+
+          TArray<UPrimitiveComponent*> Primitives;
+          TrafficSign->GetComponents(Primitives);
+          for (auto* Primitive : Primitives)
+          {
+            Primitive->SetCollisionProfileName(TEXT("NoCollision"));
+          }
+        }
+      }
+      TrafficSignComponents.Add(SignComponent->GetSignId(), SignComponent);
+      TrafficSigns.Add(TrafficSign);
+    }
+    else if (Signal->GetType() == carla::road::SignalType::MaximumSpeed() &&
+            SpeedLimitModels.Contains(Signal->GetSubtype().c_str()))
+    {
+      auto CarlaTransform = Signal->GetTransform();
+      FTransform SpawnTransform(CarlaTransform);
+      FVector SpawnLocation = SpawnTransform.GetLocation();
+      FRotator SpawnRotation(SpawnTransform.GetRotation());
+      SpawnRotation.Yaw += 90;
+      // Remove road inclination
+      SpawnRotation.Roll = 0;
+      SpawnRotation.Pitch = 0;
+
+      FActorSpawnParameters SpawnParams;
+      SpawnParams.Owner = this;
+      SpawnParams.SpawnCollisionHandlingOverride =
+          ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+      SpawnParams.OverrideLevel = GM->GetULevelFromName("TrafficSigns");
+      ATrafficSignBase * TrafficSign = GetWorld()->SpawnActor<ATrafficSignBase>(
+          SpeedLimitModels[Signal->GetSubtype().c_str()],
+          SpawnLocation,
+          SpawnRotation,
+          SpawnParams);
+
+      USpeedLimitComponent *SignComponent =
+          NewObject<USpeedLimitComponent>(TrafficSign);
+      SignComponent->SetSignId(Signal->GetSignalId().c_str());
+      SignComponent->RegisterComponent();
+      SignComponent->AttachToComponent(
+          TrafficSign->GetRootComponent(),
+          FAttachmentTransformRules::KeepRelativeTransform);
+      SignComponent->InitializeSign(GetMap().get());
+      SignComponent->SetSpeedLimit(Signal->GetValue());
 
       auto ClosestWaypointToSignal =
           GetMap()->GetClosestWaypointOnRoad(CarlaTransform.location);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
@@ -93,6 +93,9 @@ private:
   UPROPERTY(EditAnywhere, Category= "Traffic Light Manager")
   TMap<FString, TSubclassOf<USignComponent>> SignComponentModels;
 
+  UPROPERTY(EditAnywhere, Category= "Traffic Light Manager")
+  TMap<FString, TSubclassOf<AActor>> SpeedLimitModels;
+
   UPROPERTY(Category = "Traffic Light Manager", VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
   USceneComponent *SceneComponent;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -7,6 +7,7 @@
 #include "Carla.h"
 #include "Carla/Util/DebugShapeDrawer.h"
 #include "Carla/Game/CarlaHUD.h"
+#include "Carla/Game/CarlaStatics.h"
 #include "Carla/MapGen/LargeMapManager.h"
 
 #include "DrawDebugHelpers.h"


### PR DESCRIPTION
#### Description

This PR fixes the GetLandmarks functions to detect if the landmark affects the lane following the waypoint where the call was being made from. Previously this issue caused the function to return landmarks affecting opposite lanes.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26
