### PR TITLE
Fix streetlights for opt maps

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -7,6 +7,7 @@
 #include "Carla.h"
 #include "Carla/Game/CarlaGameModeBase.h"
 #include "Carla/Game/CarlaHUD.h"
+#include "Carla/Lights/CarlaLight.h"
 #include "Engine/DecalActor.h"
 #include "Engine/LevelStreaming.h"
 #include "Engine/LocalPlayer.h"
@@ -195,6 +196,19 @@ void ACarlaGameModeBase::BeginPlay()
 
   if (LMManager) {
     LMManager->RegisterInitialObjects();
+  }
+
+  // Manually run begin play on lights as it may not run on sublevels
+  TArray<AActor*> FoundActors;
+  UGameplayStatics::GetAllActorsOfClass(World, AActor::StaticClass(), FoundActors);
+  for(AActor* Actor : FoundActors)
+  {
+    TArray<UCarlaLight*> Lights;
+    Actor->GetComponents(Lights, false);
+    for(UCarlaLight* Light : Lights)
+    {
+      Light->BeginPlay();
+    }
   }
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
@@ -15,6 +15,11 @@ UCarlaLight::UCarlaLight()
 
 void UCarlaLight::BeginPlay()
 {
+  if(bRegistered)
+  {
+    return;
+  }
+
   Super::BeginPlay();
 
   UWorld *World = GetWorld();
@@ -23,6 +28,7 @@ void UCarlaLight::BeginPlay()
     UCarlaLightSubsystem* CarlaLightSubsystem = World->GetSubsystem<UCarlaLightSubsystem>();
     CarlaLightSubsystem->RegisterLight(this);
   }
+  bRegistered = true;
 }
 
 void UCarlaLight::OnComponentDestroyed(bool bDestroyingHierarchy)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.h
@@ -104,4 +104,6 @@ protected:
   private:
 
   void RecordLightChange() const;
+
+  bool bRegistered = false;
 };


### PR DESCRIPTION
#### Description

This PR fixes an issue where the street lights did not register in _Opt maps when starting the map. The GameMode now ensures that the lights are registered and ready to use.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4416)
<!-- Reviewable:end -->
