### PR TITLE
Fix colision sensor

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -244,6 +244,8 @@ carla::rpc::Actor UCarlaEpisode::SerializeActor(FCarlaActor *CarlaActor) const
   return Actor;
 }
 
+static FString GetRelevantTagAsString(const TSet<crp::CityObjectLabel> &SemanticTags);
+
 carla::rpc::Actor UCarlaEpisode::SerializeActor(AActor* Actor) const
 {
   FCarlaActor* CarlaActor = FindCarlaActor(Actor);
@@ -255,10 +257,12 @@ carla::rpc::Actor UCarlaEpisode::SerializeActor(AActor* Actor) const
   {
     carla::rpc::Actor SerializedActor;
     SerializedActor.id = 0u;
-    SerializedActor.description = FActorDescription();
     SerializedActor.bounding_box = UBoundingBoxCalculator::GetActorBoundingBox(Actor);
     TSet<crp::CityObjectLabel> SemanticTags;
     ATagger::GetTagsOfTaggedActor(*Actor, SemanticTags);
+    FActorDescription Description;
+    Description.Id = TEXT("static.") + GetRelevantTagAsString(SemanticTags);
+    SerializedActor.description = Description;
     SerializedActor.semantic_tags.reserve(SemanticTags.Num());
     for (auto &&Tag : SemanticTags)
     {


### PR DESCRIPTION
#### Description

This PR fixes the collision sensor as it was reporting blank names of the collided objects. Now the correct string is used to identify the type of object the sensor has detected.

#### Where has this been tested?
  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4449)
<!-- Reviewable:end -->
