### PR TITLE
Docker now uses CARLA forked UE4.26 version, instead of the official

### DIFF
--- a/Util/BuildTools/Linux.mk
+++ b/Util/BuildTools/Linux.mk
@@ -12,7 +12,7 @@ launch-only:
 import: CarlaUE4Editor PythonAPI
 	@${CARLA_BUILD_TOOLS_FOLDER}/Import.py $(ARGS)
 
-package: CarlaUE4Editor PythonAPI.rebuild
+package: CarlaUE4Editor PythonAPI
 	@${CARLA_BUILD_TOOLS_FOLDER}/Package.sh $(ARGS)
 
 package.rss: CarlaUE4Editor PythonAPI.rss.rebuild

--- a/Util/Docker/Carla.Dockerfile
+++ b/Util/Docker/Carla.Dockerfile
@@ -2,17 +2,18 @@ FROM carla-prerequisites:latest
 
 ARG GIT_BRANCH
 
-USER ue4
+USER carla
+WORKDIR /home/carla
 
-RUN cd /home/ue4 && \
+RUN cd /home/carla/ && \
   if [ -z ${GIT_BRANCH+x} ]; then git clone --depth 1 https://github.com/carla-simulator/carla.git; \
   else git clone --depth 1 --branch $GIT_BRANCH https://github.com/carla-simulator/carla.git; fi && \
-  cd /home/ue4/carla && \
+  cd /home/carla/carla && \
   ./Update.sh && \
   make CarlaUE4Editor && \
   make PythonAPI && \
   make build.utils && \
   make package && \
-  rm -r /home/ue4/carla/Dist
+  rm -r /home/carla/carla/Dist
 
-WORKDIR /home/ue4/carla
+WORKDIR /home/carla/carla

--- a/Util/Docker/Prerequisites.Dockerfile
+++ b/Util/Docker/Prerequisites.Dockerfile
@@ -1,10 +1,10 @@
-ARG UE4_V=4.26.1
-FROM adamrehn/ue4-source:${UE4_V}-opengl
+FROM ubuntu:18.04
 
 USER root
 
-ENV UE4_ROOT /home/ue4/UnrealEngine
-
+ARG EPIC_USER=user
+ARG EPIC_PASS=pass
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update ; \
   apt-get install -y wget software-properties-common && \
   add-apt-repository ppa:ubuntu-toolchain-r/test && \
@@ -34,17 +34,24 @@ RUN apt-get update ; \
     libtool \
     rsync \
     libxml2-dev \
+    git \
     aria2 && \
   pip3 install -Iv setuptools==47.3.1 && \
   pip3 install distro && \
   update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-8/bin/clang++ 180 && \
   update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-8/bin/clang 180
 
-USER ue4
+RUN useradd -m carla
+COPY --chown=carla:carla . /home/carla
+USER carla
+WORKDIR /home/carla
+ENV UE4_ROOT /home/carla/UE4.26
+
+RUN git clone --depth 1 -b carla "https://${EPIC_USER}:${EPIC_PASS}@github.com/CarlaUnreal/UnrealEngine.git" ${UE4_ROOT}
 
 RUN cd $UE4_ROOT && \
   ./Setup.sh && \
   ./GenerateProjectFiles.sh && \
   make
 
-WORKDIR /home/ue4
+WORKDIR /home/carla/

--- a/Util/Docker/docker_tools.py
+++ b/Util/Docker/docker_tools.py
@@ -84,14 +84,14 @@ def main():
 
     args = parse_args()
     carla_image_name = "carla:latest"
-    inbox_assets_path = '/home/ue4/carla/Import'
+    inbox_assets_path = '/home/carla/carla/Import'
     client = docker.from_env()
 
     # All possible Docker arguments are here:
     # https://docker-py.readthedocs.io/en/stable/containers.html
     container_args = {
         "image": carla_image_name,
-        "user": 'ue4',
+        "user": 'carla',
         "auto_remove": True,
         "stdin_open": True,
         "tty": True,
@@ -114,24 +114,24 @@ def main():
             docker_utils.exec_command(
                 carla_container,
                 'make import',
-                user='ue4', verbose=args.verbose, ignore_error=False)
+                user='carla', verbose=args.verbose, ignore_error=False)
 
             docker_utils.exec_command(
                 carla_container,
                 'make package ARGS="--packages=' + str(args.packages) + '"',
-                user='ue4', verbose=args.verbose, ignore_error=False)
+                user='carla', verbose=args.verbose, ignore_error=False)
         else:
             # Just create a package of the whole project
             docker_utils.exec_command(
                 carla_container,
                 'make package',
-                user='ue4', verbose=args.verbose, ignore_error=False)
+                user='carla', verbose=args.verbose, ignore_error=False)
 
         # Get the files routes to export
         files_to_copy = docker_utils.get_file_paths(
             carla_container,
-            '/home/ue4/carla/Dist/*.tar.gz',
-            user='ue4', verbose=args.verbose)
+            '/home/carla/carla/Dist/*.tar.gz',
+            user='carla', verbose=args.verbose)
 
         # Copy these fles to the output folder
         docker_utils.extract_files(carla_container, files_to_copy, args.output)


### PR DESCRIPTION
#### Description

Until now CARLA and its docker were using official versions of UE4.
With the new upcoming version 0.9.12 CARLA uses a new forked version of UE 4.26, so we need to download that for the docker also. That means that the user needs to provide to the docker commands the login credentials of Github-Epic account to be able to download the repo.

Also we remove the use of **ue4-docker** because it was using official versions.
The user in docker now is **carla**, instead of **ue4**.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** Python 3
  * **Unreal Engine version(s):** UE 4.26

#### Possible Drawbacks

To build the docker pre-requisites, we need to provide credentials of the user Epic account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4450)
<!-- Reviewable:end -->
