### PR TITLE
Fixed pedestrians being moved after dying.

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/CarlaActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/CarlaActor.cpp
@@ -1078,7 +1078,7 @@ ECarlaServerResponse FWalkerActor::SetWalkerState(
 
   FTransform NewTransform = Transform;
   NewTransform.SetLocation(NewLocation);
-  SetActorGlobalTransform(NewTransform);
+
   if (IsDormant())
   {
     FWalkerData* WalkerData = GetActorData<FWalkerData>();
@@ -1105,6 +1105,7 @@ ECarlaServerResponse FWalkerActor::SetWalkerState(
     }
     Controller->ApplyWalkerControl(WalkerControl);
   }
+  SetActorGlobalTransform(NewTransform);
   return ECarlaServerResponse::Success;
 }
 


### PR DESCRIPTION
#### Description

This PR fixes pedestrian animation death as motion commands where being executed despite the pedestrian being dead.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4454)
<!-- Reviewable:end -->
