### PR TITLE
Fix speedlimit matching for 70 and 80 signals

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -394,6 +394,16 @@ bool MatchSignalAndActor(const carla::road::Signal &Signal, ATrafficSignBase* Cl
       {
         return true;
       }
+      else if (Signal.GetSubtype() == "70" &&
+        ClosestTrafficSign->GetTrafficSignState() == ETrafficSignState::SpeedLimit_60)
+      {
+        return true;
+      }
+      else if (Signal.GetSubtype() == "80" &&
+        ClosestTrafficSign->GetTrafficSignState() == ETrafficSignState::SpeedLimit_90)
+      {
+        return true;
+      }
       else if (Signal.GetSubtype() == "90" &&
         ClosestTrafficSign->GetTrafficSignState() == ETrafficSignState::SpeedLimit_90)
       {


### PR DESCRIPTION
#### Description

Quick fix for detecting speed limits of 70 and 80 and match with signals placed in the map.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4464)
<!-- Reviewable:end -->
