### PR TITLE
Adding optional lane_type argument to generate_waypoints in libCarla client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Added optional lane_type argument to the `generate_waypoints` method.
   * Added API functions to 3D vectors: `squared_length`, `length`, `make_unit_vector`, `dot`, `dot_2d`, `distance`, `distance_2d`, `distance_squared`, `distance_squared_2d`, `get_vector_angle`
   * Added API functions to 2D vectors: `squared_length`, `length`, `make_unit_vector`
 

--- a/LibCarla/source/carla/client/Map.cpp
+++ b/LibCarla/source/carla/client/Map.cpp
@@ -92,9 +92,9 @@ namespace client {
     return result;
   }
 
-  std::vector<SharedPtr<Waypoint>> Map::GenerateWaypoints(double distance) const {
+  std::vector<SharedPtr<Waypoint>> Map::GenerateWaypoints(double distance, road::Lane::LaneType lane_type) const {
     std::vector<SharedPtr<Waypoint>> result;
-    const auto waypoints = _map.GenerateWaypoints(distance);
+    const auto waypoints = _map.GenerateWaypoints(distance, lane_type);
     result.reserve(waypoints.size());
     for (const auto &waypoint : waypoints) {
       result.emplace_back(SharedPtr<Waypoint>(new Waypoint{shared_from_this(), waypoint}));

--- a/LibCarla/source/carla/client/Map.h
+++ b/LibCarla/source/carla/client/Map.h
@@ -65,7 +65,7 @@ namespace client {
 
     TopologyList GetTopology() const;
 
-    std::vector<SharedPtr<Waypoint>> GenerateWaypoints(double distance) const;
+    std::vector<SharedPtr<Waypoint>> GenerateWaypoints(double distance, road::Lane::LaneType lane_type = road::Lane::LaneType::Driving) const;
 
     std::vector<road::element::LaneMarking> CalculateCrossedLanes(
         const geom::Location &origin,

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -143,6 +143,19 @@ namespace road {
     }
   }
 
+  /// Return a waypoint for each lane of the specified type at @a distance on @a road.
+  template <typename FuncT>
+  static void ForEachLaneAt(const Road &road, double distance, Lane::LaneType lane_type, FuncT &&func) {
+    for (const auto &lane_section : road.GetLaneSectionsAt(distance)) {
+      ForEachLaneImpl(
+          road.GetId(),
+          lane_section,
+          distance,
+          lane_type,
+          std::forward<FuncT>(func));
+    }
+  }
+
   /// Assumes road_id and section_id are valid.
   static bool IsLanePresent(const MapData &data, Waypoint waypoint) {
     const auto &section = data.GetRoad(waypoint.road_id).GetLaneSectionById(waypoint.section_id);
@@ -630,13 +643,13 @@ namespace road {
     return IsLanePresent(_data, waypoint) ? waypoint : boost::optional<Waypoint>{};
   }
 
-  std::vector<Waypoint> Map::GenerateWaypoints(const double distance) const {
+  std::vector<Waypoint> Map::GenerateWaypoints(const double distance, Lane::LaneType lane_type) const {
     RELEASE_ASSERT(distance > 0.0);
     std::vector<Waypoint> result;
     for (const auto &pair : _data.GetRoads()) {
       const auto &road = pair.second;
       for (double s = EPSILON; s < (road.GetLength() - EPSILON); s += distance) {
-        ForEachDrivableLaneAt(road, s, [&](auto &&waypoint) {
+        ForEachLaneAt(road, s, lane_type, [&](auto &&waypoint) {
           result.emplace_back(waypoint);
         });
       }

--- a/LibCarla/source/carla/road/Map.h
+++ b/LibCarla/source/carla/road/Map.h
@@ -127,8 +127,8 @@ namespace road {
     /// Return a waypoint at the lane of @a waypoint's left lane.
     boost::optional<Waypoint> GetLeft(Waypoint waypoint) const;
 
-    /// Generate all the waypoints in @a map separated by @a approx_distance.
-    std::vector<Waypoint> GenerateWaypoints(double approx_distance) const;
+    /// Generate all the waypoints in @a map separated by @a approx_distance of the specified type.
+    std::vector<Waypoint> GenerateWaypoints(double approx_distance, Lane::LaneType lane_type = Lane::LaneType::Driving) const;
 
     /// Generate waypoints on each @a lane at the start of each @a road
     std::vector<Waypoint> GenerateWaypointsOnRoadEntries(Lane::LaneType lane_type = Lane::LaneType::Driving) const;

--- a/PythonAPI/carla/source/libcarla/Map.cpp
+++ b/PythonAPI/carla/source/libcarla/Map.cpp
@@ -161,7 +161,7 @@ void export_map() {
     .def("get_waypoint", &cc::Map::GetWaypoint, (arg("location"), arg("project_to_road")=true, arg("lane_type")=cr::Lane::LaneType::Driving))
     .def("get_waypoint_xodr", &cc::Map::GetWaypointXODR, (arg("road_id"), arg("lane_id"), arg("s")))
     .def("get_topology", &GetTopology)
-    .def("generate_waypoints", CALL_RETURNING_LIST_1(cc::Map, GenerateWaypoints, double), (args("distance")))
+    .def("generate_waypoints", CALL_RETURNING_LIST_2(cc::Map, GenerateWaypoints, double, cr::Lane::LaneType), (args("distance"), arg("lane_type")=cr::Lane::LaneType::Driving))
     .def("transform_to_geolocation", &ToGeolocation, (arg("location")))
     .def("to_opendrive", CALL_RETURNING_COPY(cc::Map, GetOpenDrive))
     .def("save_to_disk", &SaveOpenDriveToDisk, (arg("path")=""))

--- a/PythonAPI/docs/map.yml
+++ b/PythonAPI/docs/map.yml
@@ -159,6 +159,11 @@
         param_units: meters
         doc: >
           Approximate distance between waypoints.
+      - param_name: lane_type
+        type: carla.LaneType
+        default: carla.LaneType.Driving
+        doc: >
+          Limits the waypoint generation to the specified type of lanes.
       return: list(carla.Waypoint)
       doc: >
         Returns a list of waypoints with a certain distance between them for every lane and centered inside of it. Waypoints are not listed in any particular order. Remember that waypoints closer than 2cm within the same road, section and lane will have the same identificator.


### PR DESCRIPTION
Hi everyone. I would like to submit a small patch to extend the `generate_waypoints` function of the client PythonAPI to allow the user to specify the lane_type of the generated waypoints.
Currently, the `Map.generate_waypoints` method of the LibCarla client API is restricted to generate waypoints only with a Driving lane type, and this restriction is hardcoded in the C++ LibCarla code. 

I would like to propose you a change in the generate_waypoints API that passes from:
    `map.generate_waypoints(approx_distance)`
to:
    `map.generate_waypoints(approx_distance, lane_type = carla.LaneType.Driving)`
by adding an optional lane_type argument to also get access to other types of waypoints. The modified method is backward compatible, since the argument is optional and the default value is equivalent to the current behaviour.

The change involves changing the C++ API in both client::Map and road::Map. In the latter, the `road::Map::GenerateWaypoints` method uses ForEachLaneAt instead of ForEachDrivableLaneAt in order to use a parametric lane_type. The PythonAPI/docs/map.yml documentation is changed accordingly.

-------------------------
Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
        Currently, the dev branch does not pass all the tests with make change on my system, but this is not related to this pull request. I have tested the submitted code with my scripts, to ensure that the Python call is performed correctly and the waypoints with different lane types are correctly generated.
  - [x] If relevant, update CHANGELOG.md with your changes

#### Where has this been tested?

  * **Platform(s):**  Linux, Ubuntu 20.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

The change should be fully backward-compatible with the existing code, so I do not expect drawbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4544)
<!-- Reviewable:end -->
