### PR TITLE
Fixes nullptr bug in CarlaRecorder::AddCollision 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug causing the server to sigsegv when a vehicle collides an environment object in recording mode.
   * Added API functions to 3D vectors: `squared_length`, `length`, `make_unit_vector`, `dot`, `dot_2d`, `distance`, `distance_2d`, `distance_squared`, `distance_squared_2d`, `get_vector_angle`
   * Added API functions to 2D vectors: `squared_length`, `length`, `make_unit_vector`
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -469,22 +469,34 @@ void ACarlaRecorder::AddCollision(AActor *Actor1, AActor *Actor2)
     Collision.IsActor2Hero = false;
 
     // check actor 1
-    if (Episode->GetActorRegistry().FindCarlaActor(Actor1)->GetActorInfo() != nullptr)
-    {
-      auto *Role = Episode->GetActorRegistry().FindCarlaActor(Actor1)->GetActorInfo()->Description.Variations.Find("role_name");
-      if (Role != nullptr)
-        Collision.IsActor1Hero = (Role->Value == "hero");
+    FCarlaActor *foundActor1 = Episode->GetActorRegistry().FindCarlaActor(Actor1);
+    if (foundActor1 != nullptr) { 
+      if (foundActor1->GetActorInfo() != nullptr)
+      {
+        auto Role = foundActor1->GetActorInfo()->Description.Variations.Find("role_name");
+        if (Role != nullptr)
+          Collision.IsActor1Hero = (Role->Value == "hero");
+      }
+      Collision.DatabaseId1 = foundActor1->GetActorId();
     }
-    Collision.DatabaseId1 = Episode->GetActorRegistry().FindCarlaActor(Actor1)->GetActorId();
+    else {
+      Collision.DatabaseId1 = -1; // actor1 is not a registered Carla actor
+    }
 
     // check actor 2
-    if (Episode->GetActorRegistry().FindCarlaActor(Actor2)->GetActorInfo() != nullptr)
-    {
-      auto Role = Episode->GetActorRegistry().FindCarlaActor(Actor2)->GetActorInfo()->Description.Variations.Find("role_name");
-      if (Role != nullptr)
-        Collision.IsActor2Hero = (Role->Value == "hero");
+    FCarlaActor *foundActor2 = Episode->GetActorRegistry().FindCarlaActor(Actor2);
+    if (foundActor2 != nullptr) { 
+      if (foundActor2->GetActorInfo() != nullptr)
+      {
+        auto Role = foundActor2->GetActorInfo()->Description.Variations.Find("role_name");
+        if (Role != nullptr)
+          Collision.IsActor2Hero = (Role->Value == "hero");
+      }
+      Collision.DatabaseId2 = foundActor2->GetActorId();
     }
-    Collision.DatabaseId2 = Episode->GetActorRegistry().FindCarlaActor(Actor2)->GetActorId();
+    else {
+      Collision.DatabaseId2 = -1; // actor2 is not a registered Carla actor
+    }
 
     Collisions.Add(std::move(Collision));
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -664,9 +664,20 @@ std::string CarlaRecorderQuery::QueryCollisions(std::string Filename, char Categ
           Collision.Read(File);
 
           int Valid = 0;
+
           // get categories for both actors
-          uint8_t Type1 = Categories[Actors[Collision.DatabaseId1].Type];
-          uint8_t Type2 = Categories[Actors[Collision.DatabaseId2].Type];
+          // uint8_t Type1 = Categories[Actors[Collision.DatabaseId1].Type];
+          // uint8_t Type2 = Categories[Actors[Collision.DatabaseId2].Type];
+          uint8_t Type1, Type2;
+          if (Collision.DatabaseId1 >= 0)
+            Type1 = Categories[Actors[Collision.DatabaseId1].Type];
+          else
+            Type1 = 'o'; // other non-actor object
+          
+          if (Collision.DatabaseId2 >= 0)
+            Type2 = Categories[Actors[Collision.DatabaseId2].Type];
+          else
+            Type2 = 'o'; // other non-actor object
 
           // filter actor 1
           if (Category1 == 'a')


### PR DESCRIPTION
#### Description

Bugfix for a segmentation fault that happens in the server when a vehicle collides with an environment object when the recording is in progress.

How to reproduce the bug:
 1. start the manual_control
 2. start recording (ctrl+R)
 3. make a collision with an environment object (a flower, a fountain, ...). This should cause the server to trigger a segmentation fault in ACarlaRecorder::AddCollision.

The segmentation fault is triggered in ACarlaRecorder::AddCollision since one of the colliding objects is not a registered Carla actor, but no check is done on the pointer returned by the Episode->GetActorRegistry().FindCarlaActor() method.

The submitted patch does these things:
1. In ACarlaRecorder::AddCollision an additional check is performed to ensure that each colliding actor is a registered Carla actor, otherwise a non-valid id (-1) is set in the Collision.DatabaseId* field written in the recording file.
2. when the CarlaRecorderQuery::QueryCollisions reads back the recording file, the code checks if the Collision.DatabaseId* are valid Carla actor ids, otherwise sets the actor type to 'o' ('other' actor).


Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux) -> All 48 tests passes.
  Currently, the dev branch does not pass all the tests with make change on my system, but this is not related to this pull request. I have tested the submitted code with my scripts, to ensure that the bug is fixed, and the client.show_recorder_collisions() works correctly.
  - [x] If relevant, update CHANGELOG.md with your changes


#### Where has this been tested?

  * **Platform(s):** Linux Ubuntu 20.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

The code is a bugfix, preventing the server to crash. 
However a different solution could be considered: instead of writing the DatabaseId* in the .rec file (which assumes that only registered Carla actors may collide, which is not true), the server could write the blueprint id, and search if the id correspond to a carla actor in the CarlaRecorderQuery::QueryCollisions method. This however would break the backward compatibility with the .rec file format.
