### PR TITLE
[TM] Fix bug reading cached InMemoryMap

### DIFF
--- a/LibCarla/source/carla/trafficmanager/InMemoryMap.cpp
+++ b/LibCarla/source/carla/trafficmanager/InMemoryMap.cpp
@@ -128,6 +128,8 @@ namespace traffic_manager {
 
       WaypointPtr waypoint_ptr = _world_map->GetWaypointXODR(cached_wp.road_id, cached_wp.lane_id, cached_wp.s);
       SimpleWaypointPtr wp = std::make_shared<SimpleWaypoint>(waypoint_ptr);
+      wp->SetGeodesicGridId(cached_wp.geodesic_grid_id);
+      wp->SetIsJunction(cached_wp.is_junction);
       dense_topology.push_back(wp);
     }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR fixes a bug reading the `is_junction` and `geodesic_grid_id` parameters in the cached InMemoryMap.

<!-- Please explain the changes you made here as detailed as possible. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4642)
<!-- Reviewable:end -->
