### PR TITLE
Fix editor crash with playback

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
@@ -112,7 +112,6 @@ FCarlaActor* FActorRegistry::Register(AActor &Actor, FActorDescription Descripti
 
 void FActorRegistry::Deregister(IdType Id)
 {
-  check(Contains(Id));
   FCarlaActor* CarlaActor = FindCarlaActor(Id);
 
   if(!CarlaActor) return;


### PR DESCRIPTION
#### Description

This PR removes a redundant and unnecessary check in actor deletion that caused a crash on the server when using the playback feature.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4657)
<!-- Reviewable:end -->
