### PR TITLE
Fix global route planner python agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Added API functions to 3D vectors: `squared_length`, `length`, `make_unit_vector`, `dot`, `dot_2d`, `distance`, `distance_2d`, `distance_squared`, `distance_squared_2d`, `get_vector_angle`
   * Added API functions to 2D vectors: `squared_length`, `length`, `make_unit_vector`
   * Added missing dependency `libomp5` to Release.Dockerfile
+  * Fixed global route planner crash when being used at maps without lane markings
 
 ## CARLA 0.9.12
 

--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -227,7 +227,7 @@ class GlobalRoutePlanner(object):
                 if not segment['entry'].is_junction:
                     next_waypoint, next_road_option, next_segment = None, None, None
 
-                    if waypoint.right_lane_marking.lane_change & carla.LaneChange.Right and not right_found:
+                    if waypoint.right_lane_marking and waypoint.right_lane_marking.lane_change & carla.LaneChange.Right and not right_found:
                         next_waypoint = waypoint.get_right_lane()
                         if next_waypoint is not None \
                                 and next_waypoint.lane_type == carla.LaneType.Driving \
@@ -240,7 +240,7 @@ class GlobalRoutePlanner(object):
                                     exit_waypoint=next_waypoint, intersection=False, exit_vector=None,
                                     path=[], length=0, type=next_road_option, change_waypoint=next_waypoint)
                                 right_found = True
-                    if waypoint.left_lane_marking.lane_change & carla.LaneChange.Left and not left_found:
+                    if waypoint.left_lane_marking and waypoint.left_lane_marking.lane_change & carla.LaneChange.Left and not left_found:
                         next_waypoint = waypoint.get_left_lane()
                         if next_waypoint is not None \
                                 and next_waypoint.lane_type == carla.LaneType.Driving \


### PR DESCRIPTION
Ensure waypoint.right_lane_marking/left_lane_marking exist before
accessing

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4676)
<!-- Reviewable:end -->
