### PR TITLE
fix crash in import script with no maps

### DIFF
--- a/Util/BuildTools/Import.py
+++ b/Util/BuildTools/Import.py
@@ -453,7 +453,7 @@ def import_assets_from_json_list(json_list, batch_size):
             if "props" in data:
                 props = data["props"]
 
-            if "tile_size" in maps[0]:
+            if len(maps) > 0 and "tile_size" in maps[0]:
                 tile_size = maps[0]["tile_size"]
             else:
                 tile_size = 2000
@@ -464,7 +464,7 @@ def import_assets_from_json_list(json_list, batch_size):
             thr = threading.Thread(target=build_binary_for_navigation, args=(package_name, dirname, maps,))
             thr.start()
 
-            if ("tiles" in maps[0]):
+            if len(maps) > 0 and "tiles" in maps[0]:
                 import_assets(package_name, dirname, props, maps, 1, tile_size, batch_size)
             else:
                 import_assets(package_name, dirname, props, maps, 0, 0, 0)


### PR DESCRIPTION


Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

#### Description

The Import.py build script currently crashes when a package with no maps (i.e props only) is imported. 

This pull request fixes the index out of range exceptions that occur.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4767)
<!-- Reviewable:end -->
