### PR TITLE
Runtime texture update

### DIFF
--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -291,5 +291,25 @@ namespace client {
     return Result;
   }
 
+  void World::ApplyColorTextureToObject(
+      const std::string &object_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureColor& Texture,
+      int material_index) {
+    _episode.Lock()->ApplyColorTextureToObject(object_name, parameter, Texture, material_index);
+  }
+
+  void World::ApplyFloatColorTextureToObject(
+      const std::string &object_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureFloatColor& Texture,
+      int material_index) {
+    _episode.Lock()->ApplyColorTextureToObject(object_name, parameter, Texture, material_index);
+  }
+
+  std::vector<std::string> World::GetNamesOfAllObjects() const {
+    return _episode.Lock()->GetNamesOfAllObjects();
+  }
+
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -294,21 +294,89 @@ namespace client {
   void World::ApplyColorTextureToObject(
       const std::string &object_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureColor& Texture,
-      int material_index) {
-    _episode.Lock()->ApplyColorTextureToObject(object_name, parameter, Texture, material_index);
+      const rpc::TextureColor& Texture) {
+    _episode.Lock()->ApplyColorTextureToObjects({object_name}, parameter, Texture);
+  }
+
+  void World::ApplyColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureColor& Texture) {
+    _episode.Lock()->ApplyColorTextureToObjects(objects_name, parameter, Texture);
   }
 
   void World::ApplyFloatColorTextureToObject(
       const std::string &object_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureFloatColor& Texture,
-      int material_index) {
-    _episode.Lock()->ApplyColorTextureToObject(object_name, parameter, Texture, material_index);
+      const rpc::TextureFloatColor& Texture) {
+    _episode.Lock()->ApplyColorTextureToObjects({object_name}, parameter, Texture);
+  }
+
+  void World::ApplyFloatColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureFloatColor& Texture) {
+    _episode.Lock()->ApplyColorTextureToObjects(objects_name, parameter, Texture);
   }
 
   std::vector<std::string> World::GetNamesOfAllObjects() const {
     return _episode.Lock()->GetNamesOfAllObjects();
+  }
+
+  void World::ApplyTexturesToObject(
+      const std::string &object_name,
+      const rpc::TextureColor& diffuse_texture,
+      const rpc::TextureFloatColor& emissive_texture,
+      const rpc::TextureFloatColor& normal_texture,
+      const rpc::TextureFloatColor& ao_roughness_metallic_emissive_texture)
+  {
+    if (diffuse_texture.GetWidth() && diffuse_texture.GetHeight()) {
+      ApplyColorTextureToObject(
+          object_name, rpc::MaterialParameter::Tex_Diffuse, diffuse_texture);
+    }
+    if (normal_texture.GetWidth() && normal_texture.GetHeight()) {
+      ApplyFloatColorTextureToObject(
+          object_name, rpc::MaterialParameter::Tex_Normal, normal_texture);
+    }
+    if (ao_roughness_metallic_emissive_texture.GetWidth() &&
+        ao_roughness_metallic_emissive_texture.GetHeight()) {
+      ApplyFloatColorTextureToObject(
+          object_name,
+          rpc::MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive,
+          ao_roughness_metallic_emissive_texture);
+    }
+    if (emissive_texture.GetWidth() && emissive_texture.GetHeight()) {
+      ApplyFloatColorTextureToObject(
+          object_name, rpc::MaterialParameter::Tex_Emissive, emissive_texture);
+    }
+  }
+
+  void World::ApplyTexturesToObjects(
+      const std::vector<std::string> &objects_names,
+      const rpc::TextureColor& diffuse_texture,
+      const rpc::TextureFloatColor& emissive_texture,
+      const rpc::TextureFloatColor& normal_texture,
+      const rpc::TextureFloatColor& ao_roughness_metallic_emissive_texture)
+  {
+    if (diffuse_texture.GetWidth() && diffuse_texture.GetHeight()) {
+      ApplyColorTextureToObjects(
+          objects_names, rpc::MaterialParameter::Tex_Diffuse, diffuse_texture);
+    }
+    if (normal_texture.GetWidth() && normal_texture.GetHeight()) {
+      ApplyFloatColorTextureToObjects(
+          objects_names, rpc::MaterialParameter::Tex_Normal, normal_texture);
+    }
+    if (ao_roughness_metallic_emissive_texture.GetWidth() &&
+        ao_roughness_metallic_emissive_texture.GetHeight()) {
+      ApplyFloatColorTextureToObjects(
+          objects_names,
+          rpc::MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive,
+          ao_roughness_metallic_emissive_texture);
+    }
+    if (emissive_texture.GetWidth() && emissive_texture.GetHeight()) {
+      ApplyFloatColorTextureToObjects(
+          objects_names, rpc::MaterialParameter::Tex_Emissive, emissive_texture);
+    }
   }
 
 } // namespace client

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -26,6 +26,8 @@
 #include "carla/rpc/VehiclePhysicsControl.h"
 #include "carla/rpc/WeatherParameters.h"
 #include "carla/rpc/VehicleLightStateList.h"
+#include "carla/rpc/Texture.h"
+#include "carla/rpc/MaterialParameter.h"
 
 #include <boost/optional.hpp>
 
@@ -186,6 +188,22 @@ namespace client {
 
     std::vector<SharedPtr<Actor>> GetTrafficLightsInJunction(
         const road::JuncId junc_id) const;
+
+    // std::vector<std::string> GetObjectNameList();
+
+    void ApplyColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureColor& Texture,
+        int material_index);
+
+    void ApplyFloatColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureFloatColor& Texture,
+        int material_index);
+
+    std::vector<std::string> GetNamesOfAllObjects() const;
 
   private:
 

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -194,14 +194,36 @@ namespace client {
     void ApplyColorTextureToObject(
         const std::string &actor_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureColor& Texture,
-        int material_index);
+        const rpc::TextureColor& Texture);
+
+    void ApplyColorTextureToObjects(
+        const std::vector<std::string> &objects_names,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureColor& Texture);
 
     void ApplyFloatColorTextureToObject(
         const std::string &actor_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureFloatColor& Texture,
-        int material_index);
+        const rpc::TextureFloatColor& Texture);
+
+    void ApplyFloatColorTextureToObjects(
+        const std::vector<std::string> &objects_names,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureFloatColor& Texture);
+
+    void ApplyTexturesToObject(
+        const std::string &actor_name,
+        const rpc::TextureColor& diffuse_texture,
+        const rpc::TextureFloatColor& emissive_texture,
+        const rpc::TextureFloatColor& normal_texture,
+        const rpc::TextureFloatColor& ao_roughness_metallic_emissive_texture);
+
+    void ApplyTexturesToObjects(
+        const std::vector<std::string> &objects_names,
+        const rpc::TextureColor& diffuse_texture,
+        const rpc::TextureFloatColor& emissive_texture,
+        const rpc::TextureFloatColor& normal_texture,
+        const rpc::TextureFloatColor& ao_roughness_metallic_emissive_texture);
 
     std::vector<std::string> GetNamesOfAllObjects() const;
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -161,20 +161,18 @@ namespace detail {
     _pimpl->CallAndWait<void>("copy_opendrive_to_file", std::move(opendrive), params);
   }
 
-  void Client::ApplyColorTextureToObject(
-      const std::string &actor_name,
+  void Client::ApplyColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureColor& Texture,
-      int material_index) {
-    _pimpl->CallAndWait<void>("apply_color_texture_to_object", actor_name, parameter, Texture, material_index);
+      const rpc::TextureColor& Texture) {
+    _pimpl->CallAndWait<void>("apply_color_texture_to_objects", objects_name, parameter, Texture);
   }
 
-  void Client::ApplyColorTextureToObject(
-      const std::string &actor_name,
+  void Client::ApplyColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureFloatColor& Texture,
-      int material_index) {
-    _pimpl->CallAndWait<void>("apply_float_color_texture_to_object", actor_name, parameter, Texture, material_index);
+      const rpc::TextureFloatColor& Texture) {
+    _pimpl->CallAndWait<void>("apply_float_color_texture_to_objects", objects_name, parameter, Texture);
   }
 
   std::vector<std::string> Client::GetNamesOfAllObjects() const {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -161,6 +161,26 @@ namespace detail {
     _pimpl->CallAndWait<void>("copy_opendrive_to_file", std::move(opendrive), params);
   }
 
+  void Client::ApplyColorTextureToObject(
+      const std::string &actor_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureColor& Texture,
+      int material_index) {
+    _pimpl->CallAndWait<void>("apply_color_texture_to_object", actor_name, parameter, Texture, material_index);
+  }
+
+  void Client::ApplyColorTextureToObject(
+      const std::string &actor_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureFloatColor& Texture,
+      int material_index) {
+    _pimpl->CallAndWait<void>("apply_float_color_texture_to_object", actor_name, parameter, Texture, material_index);
+  }
+
+  std::vector<std::string> Client::GetNamesOfAllObjects() const {
+    return _pimpl->CallAndWait<std::vector<std::string>>("get_names_of_all_objects");
+  }
+
   rpc::EpisodeInfo Client::GetEpisodeInfo() {
     return _pimpl->CallAndWait<rpc::EpisodeInfo>("get_episode_info");
   }

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -104,17 +104,15 @@ namespace detail {
     void CopyOpenDriveToServer(
         std::string opendrive, const rpc::OpendriveGenerationParameters & params);
 
-    void ApplyColorTextureToObject(
-        const std::string &actor_name,
+    void ApplyColorTextureToObjects(
+        const std::vector<std::string> &objects_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureColor& Texture,
-        int material_index);
+        const rpc::TextureColor& Texture);
 
-    void ApplyColorTextureToObject(
-        const std::string &actor_name,
+    void ApplyColorTextureToObjects(
+        const std::vector<std::string> &objects_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureFloatColor& Texture,
-        int material_index);
+        const rpc::TextureFloatColor& Texture);
 
     std::vector<std::string> GetNamesOfAllObjects() const;
 

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -31,6 +31,8 @@
 #include "carla/rpc/VehiclePhysicsControl.h"
 #include "carla/rpc/VehicleWheels.h"
 #include "carla/rpc/WeatherParameters.h"
+#include "carla/rpc/Texture.h"
+#include "carla/rpc/MaterialParameter.h"
 
 #include <functional>
 #include <memory>
@@ -101,6 +103,20 @@ namespace detail {
 
     void CopyOpenDriveToServer(
         std::string opendrive, const rpc::OpendriveGenerationParameters & params);
+
+    void ApplyColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureColor& Texture,
+        int material_index);
+
+    void ApplyColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureFloatColor& Texture,
+        int material_index);
+
+    std::vector<std::string> GetNamesOfAllObjects() const;
 
     rpc::EpisodeInfo GetEpisodeInfo();
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -380,6 +380,30 @@ namespace detail {
     _client.FreezeAllTrafficLights(frozen);
   }
 
+  // =========================================================================
+  /// -- Texture updating operations
+  // =========================================================================
+
+  void Simulator::ApplyColorTextureToObject(
+      const std::string &actor_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureColor& Texture,
+      int material_index) {
+    _client.ApplyColorTextureToObject(actor_name, parameter, Texture, material_index);
+  }
+
+  void Simulator::ApplyColorTextureToObject(
+      const std::string &actor_name,
+      const rpc::MaterialParameter& parameter,
+      const rpc::TextureFloatColor& Texture,
+      int material_index) {
+    _client.ApplyColorTextureToObject(actor_name, parameter, Texture, material_index);
+  }
+
+  std::vector<std::string> Simulator::GetNamesOfAllObjects() const {
+    return _client.GetNamesOfAllObjects();
+  }
+
 } // namespace detail
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -384,20 +384,18 @@ namespace detail {
   /// -- Texture updating operations
   // =========================================================================
 
-  void Simulator::ApplyColorTextureToObject(
-      const std::string &actor_name,
+  void Simulator::ApplyColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureColor& Texture,
-      int material_index) {
-    _client.ApplyColorTextureToObject(actor_name, parameter, Texture, material_index);
+      const rpc::TextureColor& Texture) {
+    _client.ApplyColorTextureToObjects(objects_name, parameter, Texture);
   }
 
-  void Simulator::ApplyColorTextureToObject(
-      const std::string &actor_name,
+  void Simulator::ApplyColorTextureToObjects(
+      const std::vector<std::string> &objects_name,
       const rpc::MaterialParameter& parameter,
-      const rpc::TextureFloatColor& Texture,
-      int material_index) {
-    _client.ApplyColorTextureToObject(actor_name, parameter, Texture, material_index);
+      const rpc::TextureFloatColor& Texture) {
+    _client.ApplyColorTextureToObjects(objects_name, parameter, Texture);
   }
 
   std::vector<std::string> Simulator::GetNamesOfAllObjects() const {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -25,6 +25,8 @@
 #include "carla/rpc/VehicleLightStateList.h"
 #include "carla/rpc/LabelledPoint.h"
 #include "carla/rpc/VehicleWheels.h"
+#include "carla/rpc/Texture.h"
+#include "carla/rpc/MaterialParameter.h"
 
 #include <boost/optional.hpp>
 
@@ -661,6 +663,26 @@ namespace detail {
     }
 
     void FreezeAllTrafficLights(bool frozen);
+
+    /// @}
+    // =========================================================================
+    /// @name Texture updating operations
+    // =========================================================================
+    /// @{
+
+    void ApplyColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureColor& Texture,
+        int material_index);
+
+    void ApplyColorTextureToObject(
+        const std::string &actor_name,
+        const rpc::MaterialParameter& parameter,
+        const rpc::TextureFloatColor& Texture,
+        int material_index);
+
+    std::vector<std::string> GetNamesOfAllObjects() const;
 
     /// @}
 

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -670,17 +670,15 @@ namespace detail {
     // =========================================================================
     /// @{
 
-    void ApplyColorTextureToObject(
-        const std::string &actor_name,
+    void ApplyColorTextureToObjects(
+        const std::vector<std::string> &objects_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureColor& Texture,
-        int material_index);
+        const rpc::TextureColor& Texture);
 
-    void ApplyColorTextureToObject(
-        const std::string &actor_name,
+    void ApplyColorTextureToObjects(
+        const std::vector<std::string> &objects_name,
         const rpc::MaterialParameter& parameter,
-        const rpc::TextureFloatColor& Texture,
-        int material_index);
+        const rpc::TextureFloatColor& Texture);
 
     std::vector<std::string> GetNamesOfAllObjects() const;
 

--- a/LibCarla/source/carla/rpc/FloatColor.h
+++ b/LibCarla/source/carla/rpc/FloatColor.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+
+#include <cstdint>
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+#  include "Math/Color.h"
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+
+namespace carla {
+namespace rpc {
+
+#pragma pack(push, 1)
+  struct FloatColor {
+  public:
+
+    float r = 0.f;
+    float g = 0.f;
+    float b = 0.f;
+    float a = 1.f;
+
+    FloatColor() = default;
+    FloatColor(const FloatColor &) = default;
+
+    FloatColor(float r, float g, float b, float a = 1.f)
+      : r(r), g(g), b(b), a(a) {}
+
+    FloatColor &operator=(const FloatColor &) = default;
+
+    bool operator==(const FloatColor &rhs) const  {
+      return (r == rhs.r) && (g == rhs.g) && (b == rhs.b) && (a == rhs.a);
+    }
+
+    bool operator!=(const FloatColor &rhs) const  {
+      return !(*this == rhs);
+    }
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    FloatColor(const FColor &color)
+      : FloatColor(color.R / 255.f, color.G / 255.f, color.B / 255.f, color.A / 255.f) {}
+
+    FloatColor(const FLinearColor &color)
+      : FloatColor(color.R, color.G, color.B, color.A) {}
+
+    FColor ToFColor() const {
+      return FColor{
+        static_cast<uint8>(r * 255),
+        static_cast<uint8>(g * 255),
+        static_cast<uint8>(b * 255),
+        static_cast<uint8>(a * 255)};
+    }
+
+    operator FLinearColor() const {
+      return FLinearColor{ r, g, b, a };
+    }
+
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+
+    MSGPACK_DEFINE_ARRAY(r, g, b, a);
+  };
+#pragma pack(pop)
+
+} // namespace rpc
+} // namespace carla

--- a/LibCarla/source/carla/rpc/MaterialParameter.cpp
+++ b/LibCarla/source/carla/rpc/MaterialParameter.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "MaterialParameter.h"
+
+namespace carla {
+namespace rpc {
+
+std::string MaterialParameterToString(MaterialParameter material_parameter)
+{
+  switch(material_parameter)
+  {
+    case MaterialParameter::Tex_Normal:                         return "Normal";
+    case MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive: return "AO / Roughness / Metallic / Emissive";
+    case MaterialParameter::Tex_BaseColor:                      return "BaseColor";
+    case MaterialParameter::Tex_Emissive:                       return "Emissive";
+    default:                                                    return "Invalid";
+  }
+}
+
+}
+}

--- a/LibCarla/source/carla/rpc/MaterialParameter.cpp
+++ b/LibCarla/source/carla/rpc/MaterialParameter.cpp
@@ -15,7 +15,7 @@ std::string MaterialParameterToString(MaterialParameter material_parameter)
   {
     case MaterialParameter::Tex_Normal:                         return "Normal";
     case MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive: return "AO / Roughness / Metallic / Emissive";
-    case MaterialParameter::Tex_BaseColor:                      return "BaseColor";
+    case MaterialParameter::Tex_Diffuse:                      return "Diffuse";
     case MaterialParameter::Tex_Emissive:                       return "Emissive";
     default:                                                    return "Invalid";
   }

--- a/LibCarla/source/carla/rpc/MaterialParameter.h
+++ b/LibCarla/source/carla/rpc/MaterialParameter.h
@@ -17,7 +17,7 @@ enum class MaterialParameter
 {
   Tex_Normal,
   Tex_Ao_Roughness_Metallic_Emissive,
-  Tex_BaseColor,
+  Tex_Diffuse,
   Tex_Emissive
 };
 

--- a/LibCarla/source/carla/rpc/MaterialParameter.h
+++ b/LibCarla/source/carla/rpc/MaterialParameter.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+
+#include <cstdint>
+
+namespace carla {
+namespace rpc {
+
+enum class MaterialParameter
+{
+  Tex_Normal,
+  Tex_Ao_Roughness_Metallic_Emissive,
+  Tex_BaseColor,
+  Tex_Emissive
+};
+
+std::string MaterialParameterToString(MaterialParameter material_parameter);
+
+} // namespace rpc
+} // namespace carla
+
+MSGPACK_ADD_ENUM(carla::rpc::MaterialParameter);

--- a/LibCarla/source/carla/rpc/Texture.h
+++ b/LibCarla/source/carla/rpc/Texture.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+#include "carla/rpc/FloatColor.h"
+#include "carla/sensor/data/Color.h"
+
+#include <vector>
+
+namespace carla {
+namespace rpc {
+
+  template<typename T>
+  class Texture {
+  public:
+
+    Texture() = default;
+
+    Texture(uint32_t width, uint32_t height)
+      : _width(width), _height(height) {
+      _texture_data.resize(_width*_height);
+    }
+
+    uint32_t GetWidth() const {
+      return _width;
+    }
+
+    uint32_t GetHeight() const {
+      return _height;
+    }
+
+    void SetDimensions(uint32_t width, uint32_t height) {
+      _width = width;
+      _height = height;
+      _texture_data.resize(_width*_height);
+    }
+
+    T& At (uint32_t x, uint32_t y) {
+      return _texture_data[y*_width + x];
+    }
+
+    const T& At (uint32_t x, uint32_t y) const {
+      return _texture_data[y*_width + x];
+    }
+
+    const T* GetDataPtr() const {
+      return _texture_data.data();
+    }
+
+  private:
+
+    uint32_t _width = 0;
+    uint32_t _height = 0;
+    std::vector<T> _texture_data;
+
+  public:
+
+    MSGPACK_DEFINE_ARRAY(_width, _height, _texture_data);
+  };
+
+  using TextureColor = Texture<sensor::data::Color>;
+  using TextureFloatColor = Texture<FloatColor>;
+
+}
+}

--- a/LibCarla/source/carla/sensor/data/Color.h
+++ b/LibCarla/source/carla/sensor/data/Color.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "carla/rpc/Color.h"
+#include "carla/rpc/FloatColor.h"
 
 #include <cstdint>
 
@@ -36,11 +37,15 @@ namespace data {
     operator rpc::Color() const {
       return {r, g, b};
     }
+    operator rpc::FloatColor() const {
+      return {r/255.f, g/255.f, b/255.f, a/255.f};
+    }
 
     uint8_t b = 0u;
     uint8_t g = 0u;
     uint8_t r = 0u;
     uint8_t a = 0u;
+    MSGPACK_DEFINE_ARRAY(r, g, b, a);
   };
 #pragma pack(pop)
 

--- a/PythonAPI/carla/source/libcarla/Blueprint.cpp
+++ b/PythonAPI/carla/source/libcarla/Blueprint.cpp
@@ -103,6 +103,17 @@ void export_blueprint() {
     .def(self_ns::str(self_ns::self))
   ;
 
+  class_<crpc::FloatColor>("FloatColor")
+    .def(init<float, float, float, float>(
+        (arg("r")=0, arg("g")=0.f, arg("b")=0.f, arg("a")=1.0f)))
+    .def_readwrite("r", &crpc::FloatColor::r)
+    .def_readwrite("g", &crpc::FloatColor::g)
+    .def_readwrite("b", &crpc::FloatColor::b)
+    .def_readwrite("a", &crpc::FloatColor::a)
+    .def("__eq__", &crpc::FloatColor::operator==)
+    .def("__ne__", &crpc::FloatColor::operator!=)
+  ;
+
   class_<csd::OpticalFlowPixel>("OpticalFlowPixel")
     .def(init<float, float>(
         (arg("x")=0, arg("y")=0)))

--- a/PythonAPI/carla/source/libcarla/SensorData.cpp
+++ b/PythonAPI/carla/source/libcarla/SensorData.cpp
@@ -365,7 +365,7 @@ void export_sensor_data() {
   namespace css = carla::sensor::s11n;
 
   // Fake image returned from optical flow to color conversion
-  // fakes the regular image object
+  // fakes the regular image object. Only used for visual purposes
   class_<FakeImage>("FakeImage", no_init)
       .def(vector_indexing_suite<std::vector<uint8_t>>())
       .add_property("width", &FakeImage::Width)

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -249,7 +249,7 @@ void export_world() {
   enum_<cr::MaterialParameter>("MaterialParameter")
     .value("Normal", cr::MaterialParameter::Tex_Normal)
     .value("AO_Roughness_Metallic_Emissive", cr::MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive)
-    .value("BaseColor", cr::MaterialParameter::Tex_BaseColor)
+    .value("Diffuse", cr::MaterialParameter::Tex_Diffuse)
     .value("Emissive", cr::MaterialParameter::Tex_Emissive)
   ;
 
@@ -334,8 +334,18 @@ void export_world() {
     .def("project_point", CALL_RETURNING_OPTIONAL_3(cc::World, ProjectPoint, cg::Location, cg::Vector3D, float), (arg("location"), arg("direction"), arg("search_distance")=10000.f))
     .def("ground_projection", CALL_RETURNING_OPTIONAL_2(cc::World, GroundProjection, cg::Location, float), (arg("location"), arg("search_distance")=10000.f))
     .def("get_names_of_all_objects", CALL_RETURNING_LIST(cc::World, GetNamesOfAllObjects))
-    .def("apply_color_texture_to_object", &cc::World::ApplyColorTextureToObject, (arg("object_name"), arg("material_parameter"), arg("texture"), arg("material_index") = 0))
-    .def("apply_float_color_texture_to_object", &cc::World::ApplyFloatColorTextureToObject, (arg("object_name"), arg("material_parameter"), arg("texture"), arg("material_index") = 0))
+    .def("apply_color_texture_to_object", &cc::World::ApplyColorTextureToObject, (arg("object_name"), arg("material_parameter"), arg("texture")))
+    .def("apply_float_color_texture_to_object", &cc::World::ApplyFloatColorTextureToObject, (arg("object_name"), arg("material_parameter"), arg("texture")))
+    .def("apply_textures_to_object", &cc::World::ApplyTexturesToObject, (arg("object_name"), arg("diffuse_texture"), arg("emissive_texture"), arg("normal_texture"), arg("ao_roughness_metallic_emissive_texture")))
+    .def("apply_color_texture_to_objects", +[](cc::World &self, boost::python::list &list, const cr::MaterialParameter& parameter, const cr::TextureColor& Texture) {
+        self.ApplyColorTextureToObjects(PythonLitstToVector<std::string>(list), parameter, Texture);
+      }, (arg("objects_name_list"), arg("material_parameter"), arg("texture")))
+    .def("apply_float_color_texture_to_objects", +[](cc::World &self, boost::python::list &list, const cr::MaterialParameter& parameter, const cr::TextureFloatColor& Texture) {
+        self.ApplyFloatColorTextureToObjects(PythonLitstToVector<std::string>(list), parameter, Texture);
+      }, (arg("objects_name_list"), arg("material_parameter"), arg("texture")))
+    .def("apply_textures_to_objects", +[](cc::World &self, boost::python::list &list, const cr::TextureColor& diffuse_texture, const cr::TextureFloatColor& emissive_texture, const cr::TextureFloatColor& normal_texture, const cr::TextureFloatColor& ao_roughness_metallic_emissive_texture) {
+        self.ApplyTexturesToObjects(PythonLitstToVector<std::string>(list), diffuse_texture, emissive_texture, normal_texture, ao_roughness_metallic_emissive_texture);
+      }, (arg("objects_name_list"), arg("diffuse_texture"), arg("emissive_texture"), arg("normal_texture"), arg("ao_roughness_metallic_emissive_texture")))
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -288,9 +288,9 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureFloatCo
 {
   FlushRenderingCommands();
   TArray<FFloat16Color> Colors;
-  for (int x = 0; x < Texture.GetWidth(); x++)
+  for (int y = 0; y < Texture.GetHeight(); y++)
   {
-    for (int y = 0; y < Texture.GetHeight(); y++)
+    for (int x = 0; x < Texture.GetWidth(); x++)
     {
       auto& Color = Texture.At(x,y);
       Colors.Add(FLinearColor(Color.r, Color.g, Color.b, Color.a));
@@ -310,8 +310,7 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureFloatCo
 void ACarlaGameModeBase::ApplyTextureToActor(
     AActor* Actor,
     UTexture2D* Texture,
-    const carla::rpc::MaterialParameter& TextureParam,
-    int MaterialIndex)
+    const carla::rpc::MaterialParameter& TextureParam)
 {
   namespace cr = carla::rpc;
   TArray<UStaticMeshComponent*> StaticMeshes;
@@ -330,7 +329,7 @@ void ACarlaGameModeBase::ApplyTextureToActor(
 
       switch(TextureParam)
       {
-        case cr::MaterialParameter::Tex_BaseColor:
+        case cr::MaterialParameter::Tex_Diffuse:
           DynamicMaterial->SetTextureParameterValue("BaseColor", Texture);
           DynamicMaterial->SetTextureParameterValue("Difuse", Texture);
           DynamicMaterial->SetTextureParameterValue("Difuse 2", Texture);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -265,9 +265,9 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureColor& 
 {
   FlushRenderingCommands();
   TArray<FColor> Colors;
-  for (int y = 0; y < Texture.GetHeight(); y++)
+  for (uint32_t y = 0; y < Texture.GetHeight(); y++)
   {
-    for (int x = 0; x < Texture.GetWidth(); x++)
+    for (uint32_t x = 0; x < Texture.GetWidth(); x++)
     {
       auto& Color = Texture.At(x,y);
       Colors.Add(FColor(Color.r, Color.g, Color.b, Color.a));
@@ -288,9 +288,9 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureFloatCo
 {
   FlushRenderingCommands();
   TArray<FFloat16Color> Colors;
-  for (int y = 0; y < Texture.GetHeight(); y++)
+  for (uint32_t y = 0; y < Texture.GetHeight(); y++)
   {
-    for (int x = 0; x < Texture.GetWidth(); x++)
+    for (uint32_t x = 0; x < Texture.GetWidth(); x++)
     {
       auto& Color = Texture.At(x,y);
       Colors.Add(FLinearColor(Color.r, Color.g, Color.b, Color.a));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -11,6 +11,7 @@
 #include "Engine/DecalActor.h"
 #include "Engine/LevelStreaming.h"
 #include "Engine/LocalPlayer.h"
+#include "Materials/MaterialInstanceDynamic.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include "carla/opendrive/OpenDriveParser.h"
@@ -226,6 +227,135 @@ void ACarlaGameModeBase::BeginPlay()
     }
   }
   EnableOverlapEvents();
+}
+
+TArray<FString> ACarlaGameModeBase::GetNamesOfAllActors()
+{
+  TArray<FString> Names;
+  TArray<AActor*> Actors;
+  UGameplayStatics::GetAllActorsOfClass(GetWorld(), AActor::StaticClass(), Actors);
+  for (AActor* Actor : Actors)
+  {
+    TArray<UStaticMeshComponent*> StaticMeshes;
+    Actor->GetComponents(StaticMeshes);
+    if (StaticMeshes.Num())
+    {
+      Names.Add(Actor->GetName());
+    }
+  }
+  return Names;
+}
+
+AActor* ACarlaGameModeBase::FindActorByName(const FString& ActorName)
+{
+  TArray<AActor*> Actors;
+  UGameplayStatics::GetAllActorsOfClass(GetWorld(), AActor::StaticClass(), Actors);
+  for (AActor* Actor : Actors)
+  {
+    if(Actor->GetName() == ActorName)
+    {
+      return Actor;
+      break;
+    }
+  }
+  return nullptr;
+}
+
+UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureColor& Texture)
+{
+  FlushRenderingCommands();
+  TArray<FColor> Colors;
+  for (int y = 0; y < Texture.GetHeight(); y++)
+  {
+    for (int x = 0; x < Texture.GetWidth(); x++)
+    {
+      auto& Color = Texture.At(x,y);
+      Colors.Add(FColor(Color.r, Color.g, Color.b, Color.a));
+    }
+  }
+  UTexture2D* UETexture = UTexture2D::CreateTransient(Texture.GetWidth(), Texture.GetHeight(), EPixelFormat::PF_B8G8R8A8);
+  FTexture2DMipMap& Mip = UETexture->PlatformData->Mips[0];
+  void* Data = Mip.BulkData.Lock( LOCK_READ_WRITE );
+  FMemory::Memcpy( Data,
+      &Colors[0],
+      Texture.GetWidth()*Texture.GetHeight()*sizeof(FColor));
+  Mip.BulkData.Unlock();
+  UETexture->UpdateResource();
+  return UETexture;
+}
+
+UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureFloatColor& Texture)
+{
+  FlushRenderingCommands();
+  TArray<FFloat16Color> Colors;
+  for (int x = 0; x < Texture.GetWidth(); x++)
+  {
+    for (int y = 0; y < Texture.GetHeight(); y++)
+    {
+      auto& Color = Texture.At(x,y);
+      Colors.Add(FLinearColor(Color.r, Color.g, Color.b, Color.a));
+    }
+  }
+  UTexture2D* UETexture = UTexture2D::CreateTransient(Texture.GetWidth(), Texture.GetHeight(), EPixelFormat::PF_FloatRGBA);
+  FTexture2DMipMap& Mip = UETexture->PlatformData->Mips[0];
+  void* Data = Mip.BulkData.Lock( LOCK_READ_WRITE );
+  FMemory::Memcpy( Data,
+      &Colors[0],
+      Texture.GetWidth()*Texture.GetHeight()*sizeof(FFloat16Color));
+  Mip.BulkData.Unlock();
+  UETexture->UpdateResource();
+  return UETexture;
+}
+
+void ACarlaGameModeBase::ApplyTextureToActor(
+    AActor* Actor,
+    UTexture2D* Texture,
+    const carla::rpc::MaterialParameter& TextureParam,
+    int MaterialIndex)
+{
+  namespace cr = carla::rpc;
+  TArray<UStaticMeshComponent*> StaticMeshes;
+  Actor->GetComponents(StaticMeshes);
+  for (UStaticMeshComponent* Mesh : StaticMeshes)
+  {
+    for (int i = 0; i < Mesh->GetNumMaterials(); ++i)
+    {
+      UMaterialInterface* OriginalMaterial = Mesh->GetMaterial(i);
+      UMaterialInstanceDynamic* DynamicMaterial = Cast<UMaterialInstanceDynamic>(OriginalMaterial);
+      if(!DynamicMaterial)
+      {
+        DynamicMaterial = UMaterialInstanceDynamic::Create(OriginalMaterial, NULL);
+        Mesh->SetMaterial(i, DynamicMaterial);
+      }
+
+      switch(TextureParam)
+      {
+        case cr::MaterialParameter::Tex_BaseColor:
+          DynamicMaterial->SetTextureParameterValue("BaseColor", Texture);
+          DynamicMaterial->SetTextureParameterValue("Difuse", Texture);
+          DynamicMaterial->SetTextureParameterValue("Difuse 2", Texture);
+          DynamicMaterial->SetTextureParameterValue("Difuse 3", Texture);
+          DynamicMaterial->SetTextureParameterValue("Difuse 4", Texture);
+          break;
+        case cr::MaterialParameter::Tex_Normal:
+          DynamicMaterial->SetTextureParameterValue("Normal", Texture);
+          DynamicMaterial->SetTextureParameterValue("Normal 2", Texture);
+          DynamicMaterial->SetTextureParameterValue("Normal 3", Texture);
+          DynamicMaterial->SetTextureParameterValue("Normal 4", Texture);
+          break;
+        case cr::MaterialParameter::Tex_Emissive:
+          DynamicMaterial->SetTextureParameterValue("Emissive", Texture);
+          break;
+        case cr::MaterialParameter::Tex_Ao_Roughness_Metallic_Emissive:
+          DynamicMaterial->SetTextureParameterValue("AO / Roughness / Metallic / Emissive", Texture);
+          DynamicMaterial->SetTextureParameterValue("ORMH", Texture);
+          DynamicMaterial->SetTextureParameterValue("ORMH 2", Texture);
+          DynamicMaterial->SetTextureParameterValue("ORMH 3", Texture);
+          DynamicMaterial->SetTextureParameterValue("ORMH 4", Texture);
+          break;
+      }
+    }
+  }
 }
 
 void ACarlaGameModeBase::Tick(float DeltaSeconds)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -108,8 +108,7 @@ public:
   void ApplyTextureToActor(
       AActor* Actor,
       UTexture2D* Texture,
-      const carla::rpc::MaterialParameter& TextureParam,
-      int MaterialIndex);
+      const carla::rpc::MaterialParameter& TextureParam);
 
   TArray<FString> GetNamesOfAllActors();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.h
@@ -11,6 +11,8 @@
 
 #include <compiler/disable-ue4-macros.h>
 #include <boost/optional.hpp>
+#include <carla/rpc/Texture.h>
+#include <carla/rpc/MaterialParameter.h>
 #include <compiler/enable-ue4-macros.h>
 
 #include "Carla/Actor/CarlaActorFactory.h"
@@ -97,6 +99,19 @@ public:
   ALargeMapManager* GetLMManager() const {
     return LMManager;
   }
+
+  AActor* FindActorByName(const FString& ActorName);
+
+  UTexture2D* CreateUETexture(const carla::rpc::TextureColor& Texture);
+  UTexture2D* CreateUETexture(const carla::rpc::TextureFloatColor& Texture);
+
+  void ApplyTextureToActor(
+      AActor* Actor,
+      UTexture2D* Texture,
+      const carla::rpc::MaterialParameter& TextureParam,
+      int MaterialIndex);
+
+  TArray<FString> GetNamesOfAllActors();
 
 protected:
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -333,11 +333,10 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
-  BIND_SYNC(apply_color_texture_to_object) << [this](
-      const std::string &actor_name,
+  BIND_SYNC(apply_color_texture_to_objects) << [this](
+      const std::vector<std::string> &actors_name,
       const cr::MaterialParameter& parameter,
-      const cr::TextureColor& Texture,
-      int material_index) -> R<void>
+      const cr::TextureColor& Texture) -> R<void>
   {
     REQUIRE_CARLA_EPISODE();
     ACarlaGameModeBase* GameMode = UCarlaStatics::GetGameMode(Episode->GetWorld());
@@ -345,27 +344,37 @@ void FCarlaServer::FPimpl::BindActions()
     {
       RESPOND_ERROR("unable to find CARLA game mode");
     }
-    AActor* ActorToPaint = GameMode->FindActorByName(cr::ToFString(actor_name));
-    if(ActorToPaint == nullptr)
+    TArray<AActor*> ActorsToPaint;
+    for(const std::string& actor_name : actors_name)
+    {
+      AActor* ActorToPaint = GameMode->FindActorByName(cr::ToFString(actor_name));
+      if (ActorToPaint)
+      {
+        ActorsToPaint.Add(ActorToPaint);
+      }
+    }
+
+    if(!ActorsToPaint.Num())
     {
       RESPOND_ERROR("unable to find Actor to apply the texture");
     }
 
     UTexture2D* UETexture = GameMode->CreateUETexture(Texture);
 
-    GameMode->ApplyTextureToActor(
-        ActorToPaint,
-        UETexture,
-        parameter,
-        material_index);
+    for(AActor* ActorToPaint : ActorsToPaint)
+    {
+      GameMode->ApplyTextureToActor(
+          ActorToPaint,
+          UETexture,
+          parameter);
+    }
     return R<void>::Success();
   };
 
-  BIND_SYNC(apply_float_color_texture_to_object) << [this](
-      const std::string &actor_name,
+  BIND_SYNC(apply_float_color_texture_to_objects) << [this](
+      const std::vector<std::string> &actors_name,
       const cr::MaterialParameter& parameter,
-      const cr::TextureFloatColor& Texture,
-      int material_index) -> R<void>
+      const cr::TextureFloatColor& Texture) -> R<void>
   {
     REQUIRE_CARLA_EPISODE();
     ACarlaGameModeBase* GameMode = UCarlaStatics::GetGameMode(Episode->GetWorld());
@@ -373,19 +382,30 @@ void FCarlaServer::FPimpl::BindActions()
     {
       RESPOND_ERROR("unable to find CARLA game mode");
     }
-    AActor* ActorToPaint = GameMode->FindActorByName(cr::ToFString(actor_name));
-    if(ActorToPaint == nullptr)
+    TArray<AActor*> ActorsToPaint;
+    for(const std::string& actor_name : actors_name)
+    {
+      AActor* ActorToPaint = GameMode->FindActorByName(cr::ToFString(actor_name));
+      if (ActorToPaint)
+      {
+        ActorsToPaint.Add(ActorToPaint);
+      }
+    }
+
+    if(!ActorsToPaint.Num())
     {
       RESPOND_ERROR("unable to find Actor to apply the texture");
     }
 
     UTexture2D* UETexture = GameMode->CreateUETexture(Texture);
 
-    GameMode->ApplyTextureToActor(
-        ActorToPaint,
-        UETexture,
-        parameter,
-        material_index);
+    for(AActor* ActorToPaint : ActorsToPaint)
+    {
+      GameMode->ApplyTextureToActor(
+          ActorToPaint,
+          UETexture,
+          parameter);
+    }
     return R<void>::Success();
   };
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -10,6 +10,10 @@
 #include "Carla/Traffic/TrafficSignBase.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 
+#include <compiler/disable-ue4-macros.h>
+#include <carla/rpc/ObjectLabel.h>
+#include <compiler/enable-ue4-macros.h>
+
 #include "Components/CapsuleComponent.h"
 #include "GameFramework/Character.h"
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -9,6 +9,8 @@
 
 #include "Carla/Traffic/TrafficSignBase.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
+#include "Carla/Game/Tagger.h"
+#include "Carla/Traffic/TrafficLightBase.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/ObjectLabel.h>
@@ -16,6 +18,7 @@
 
 #include "Components/CapsuleComponent.h"
 #include "GameFramework/Character.h"
+#include "Components/BoxComponent.h"
 
 #include "Rendering/SkeletalMeshRenderData.h"
 #include "Engine/SkeletalMeshSocket.h"


### PR DESCRIPTION

#### Description

This pull request brings to CARLA the capability to change textures of objects in the scene in runtime.
Object are anything in the scene using textures, the following functions have been added to the `World` in order to manage texture updating:
`get_names_of_all_objects`: returns the names of all objects in the scene.
`apply_color_texture_to_object`: Applies an 8bit per channel, RGBA texture to an object (uint8 values).
`apply_float_color_texture_to_object`: Applies an 32bit per channel, RGBA texture to an object (float values).
`apply_textures_to_object`: Applies the full set of textures (Diffuse, Normal, Emissive, ARME) to an object.
The plural versions of these functions allow to apply the same texture to multiple items.

The new enum `MaterialParameter` defines what texture parameter in the material to modify (Diffuse, Normal, Emissive, ARME).

The new `TextureColor` and `TextureFloatColor` define the texture objects, they have height and width and pixels can be accessed and modified to define their values with the `get` and `set` functions. The pixel format is `Color` and `FloatColor` respectively.

The new `FloatColor` structure defines a color composed of float values.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4819)
<!-- Reviewable:end -->
