### PR TITLE
Bernat/cache version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Added a RoadOption element in each SimpleWaypoint to specify which action will the vehicle perform if it follows that route.
   * Added the option for users to set a route using RoadOption elements to a vehicle controlled by the Traffic Manager.
   * Fixed keep_right_rule parameter.
+  * Cache now has an extra folder with current version of CARLA (so different cache per version)
   * Added new instance aware semantic segmentation sensor `sensor.camera.instance_segmentation`
   * Added new API classes: `MaterialParameter`, `TextureColor` and  `TextureFloatColor` to encode texture data and field (normal map, diffuse, etc)
   * Added new API functions: `apply_color_texture_to_object`, `apply_float_color_texture_to_object` and `apply_textures_to_object` to paint objects in runtime

--- a/LibCarla/source/carla/client/FIleTransfer.cpp
+++ b/LibCarla/source/carla/client/FIleTransfer.cpp
@@ -5,6 +5,7 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "FileTransfer.h"
+#include "carla/Version.h"
 
 namespace carla {
 namespace client {
@@ -33,11 +34,21 @@ namespace client {
   bool FileTransfer::FileExists(std::string file) {
     // Check if the file exists or not
     struct stat buffer;
-    return (stat((_filesBaseFolder + file).c_str(), &buffer) == 0);
+    std::string fullpath = _filesBaseFolder;
+    fullpath += "/";
+    fullpath += ::carla::version();
+    fullpath += "/";
+    fullpath += file;
+
+    return (stat(fullpath.c_str(), &buffer) == 0);
   }
 
   bool FileTransfer::WriteFile(std::string path, std::vector<uint8_t> content) {
-    std::string writePath = _filesBaseFolder + path;
+    std::string writePath = _filesBaseFolder;
+    writePath += "/";
+    writePath += ::carla::version();
+    writePath += "/";
+    writePath += path;
 
     // Validate and create the file path
     carla::FileSystem::ValidateFilePath(writePath);
@@ -56,8 +67,13 @@ namespace client {
   }
 
   std::vector<uint8_t> FileTransfer::ReadFile(std::string path) {
+    std::string fullpath = _filesBaseFolder;
+    fullpath += "/";
+    fullpath += ::carla::version();
+    fullpath += "/";
+    fullpath += path;
     // Read the binary file from the base folder
-    std::ifstream file(_filesBaseFolder + path, std::ios::binary);
+    std::ifstream file(fullpath, std::ios::binary);
     std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
     return content;
   }


### PR DESCRIPTION
#### Description

Add an extra folder with the CARLA version (like: 0.9.12 or 0.9.11-654-g62630cef0-dirty). This is needed to avoid problems with different binary formats that could arise with different versions of CARLA.

carlaCache\\**0.9.11-654-g62630cef0-dirty**\Carla\Maps\OpenDrive\

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Currently the cache never is cleaned. That means that with each different version of CARLA, the cache will grow, but currently the files are so small that is not a concern. Probably in the future we add more features to the cache, like an auto-cleaning function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4857)
<!-- Reviewable:end -->
