### PR TITLE
TM determinism fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Latest
+
+  * Fixed bug causing the Traffic Manager to not be deterministic when using hybrid mode
+
 ## CARLA 0.9.13
 
   * Added new **instance aware semantic segmentation** sensor `sensor.camera.instance_segmentation`

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -405,7 +405,7 @@ namespace detail {
   }
 
   void Client::SetActorSimulatePhysics(rpc::ActorId actor, const bool enabled) {
-    _pimpl->AsyncCall("set_actor_simulate_physics", actor, enabled);
+    _pimpl->CallAndWait<void>("set_actor_simulate_physics", actor, enabled);
   }
 
   void Client::SetActorEnableGravity(rpc::ActorId actor, const bool enabled) {

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -225,7 +225,7 @@ void ALSM::UpdateData(const bool hybrid_physics_mode,
   bool enable_physics = hybrid_physics_mode ? in_range_of_hero_actor : true;
   if (!has_physics_enabled.count(actor_id) || has_physics_enabled[actor_id] != enable_physics) {
     if (hero_actors.find(actor_id) == hero_actors.end()) {
-      // vehicle->SetSimulatePhysics(enable_physics);
+      vehicle->SetSimulatePhysics(enable_physics);
       has_physics_enabled[actor_id] = enable_physics;
       if (enable_physics == true && simulation_state.ContainsActor(actor_id)) {
         vehicle->SetTargetVelocity(simulation_state.GetVelocity(actor_id));

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -225,7 +225,7 @@ void ALSM::UpdateData(const bool hybrid_physics_mode,
   bool enable_physics = hybrid_physics_mode ? in_range_of_hero_actor : true;
   if (!has_physics_enabled.count(actor_id) || has_physics_enabled[actor_id] != enable_physics) {
     if (hero_actors.find(actor_id) == hero_actors.end()) {
-      vehicle->SetSimulatePhysics(enable_physics);
+      // vehicle->SetSimulatePhysics(enable_physics);
       has_physics_enabled[actor_id] = enable_physics;
       if (enable_physics == true && simulation_state.ContainsActor(actor_id)) {
         vehicle->SetTargetVelocity(simulation_state.GetVelocity(actor_id));

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -27,8 +27,7 @@ ALSM::ALSM(
   CollisionStage &collision_stage,
   TrafficLightStage &traffic_light_stage,
   MotionPlanStage &motion_plan_stage,
-  VehicleLightStage &vehicle_light_stage,
-  RandomGeneratorMap &random_devices)
+  VehicleLightStage &vehicle_light_stage)
   : registered_vehicles(registered_vehicles),
     buffer_map(buffer_map),
     track_traffic(track_traffic),
@@ -41,8 +40,7 @@ ALSM::ALSM(
     collision_stage(collision_stage),
     traffic_light_stage(traffic_light_stage),
     motion_plan_stage(motion_plan_stage),
-    vehicle_light_stage(vehicle_light_stage),
-    random_devices(random_devices) {}
+    vehicle_light_stage(vehicle_light_stage) {}
 
 void ALSM::Update() {
 
@@ -375,7 +373,6 @@ void ALSM::RemoveActor(const ActorId actor_id, const bool registered_actor) {
     registered_vehicles.Remove({actor_id});
     buffer_map.erase(actor_id);
     idle_time.erase(actor_id);
-    random_devices.erase(actor_id);
     localization_stage.RemoveActor(actor_id);
     collision_stage.RemoveActor(actor_id);
     traffic_light_stage.RemoveActor(actor_id);

--- a/LibCarla/source/carla/trafficmanager/ALSM.h
+++ b/LibCarla/source/carla/trafficmanager/ALSM.h
@@ -64,8 +64,6 @@ private:
   // Time elapsed since last vehicle destruction due to being idle for too long.
   double elapsed_last_actor_destruction {0.0};
   cc::Timestamp current_timestamp;
-  // Random devices.
-  RandomGeneratorMap &random_devices;
   std::unordered_map<ActorId, bool> has_physics_enabled;
 
   // Updates the duration for which a registered vehicle is stuck at a location.
@@ -104,8 +102,7 @@ public:
        CollisionStage &collision_stage,
        TrafficLightStage &traffic_light_stage,
        MotionPlanStage &motion_plan_stage,
-       VehicleLightStage &vehicle_light_stage,
-       RandomGeneratorMap &random_devices);
+       VehicleLightStage &vehicle_light_stage);
 
   void Update();
 

--- a/LibCarla/source/carla/trafficmanager/AtomicActorSet.h
+++ b/LibCarla/source/carla/trafficmanager/AtomicActorSet.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <mutex>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "carla/client/Actor.h"
@@ -25,7 +25,7 @@ namespace traffic_manager {
   private:
 
     std::mutex modification_mutex;
-    std::unordered_map<ActorId, ActorPtr> actor_set;
+    std::map<ActorId, ActorPtr> actor_set;
     int state_counter;
 
   public:

--- a/LibCarla/source/carla/trafficmanager/CollisionStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/CollisionStage.cpp
@@ -22,14 +22,14 @@ CollisionStage::CollisionStage(
   const TrackTraffic &track_traffic,
   const Parameters &parameters,
   CollisionFrame &output_array,
-  RandomGeneratorMap &random_devices)
+  RandomGenerator &random_device)
   : vehicle_id_list(vehicle_id_list),
     simulation_state(simulation_state),
     buffer_map(buffer_map),
     track_traffic(track_traffic),
     parameters(parameters),
     output_array(output_array),
-    random_devices(random_devices) {}
+    random_device(random_device) {}
 
 void CollisionStage::Update(const unsigned long index) {
   ActorId obstacle_id = 0u;
@@ -91,9 +91,9 @@ void CollisionStage::Update(const unsigned long index) {
                                                                        look_ahead_index);
         if (negotiation_result.first) {
           if ((other_actor_type == ActorType::Vehicle
-               && parameters.GetPercentageIgnoreVehicles(ego_actor_id) <= random_devices.at(ego_actor_id).next())
+               && parameters.GetPercentageIgnoreVehicles(ego_actor_id) <= random_device.next())
               || (other_actor_type == ActorType::Pedestrian
-                  && parameters.GetPercentageIgnoreWalkers(ego_actor_id) <= random_devices.at(ego_actor_id).next())) {
+                  && parameters.GetPercentageIgnoreWalkers(ego_actor_id) <= random_device.next())) {
             collision_hazard = true;
             obstacle_id = other_actor_id;
             available_distance_margin = negotiation_result.second;

--- a/LibCarla/source/carla/trafficmanager/CollisionStage.h
+++ b/LibCarla/source/carla/trafficmanager/CollisionStage.h
@@ -57,7 +57,7 @@ private:
   // to avoid repeated computation within a cycle.
   GeometryComparisonMap geometry_cache;
   GeodesicBoundaryMap geodesic_boundary_map;
-  RandomGeneratorMap &random_devices;
+  RandomGenerator &random_device;
 
   // Method to determine if a vehicle is on a collision path to another.
   std::pair<bool, float> NegotiateCollision(const ActorId reference_vehicle_id,
@@ -90,7 +90,7 @@ public:
                  const TrackTraffic &track_traffic,
                  const Parameters &parameters,
                  CollisionFrame &output_array,
-                 RandomGeneratorMap &random_devices);
+                 RandomGenerator &random_device);
 
   void Update (const unsigned long index) override;
 

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -22,7 +22,7 @@ LocalizationStage::LocalizationStage(
   Parameters &parameters,
   std::vector<ActorId>& marked_for_removal,
   LocalizationFrame &output_array,
-  RandomGeneratorMap &random_devices)
+  RandomGenerator &random_device)
     : vehicle_id_list(vehicle_id_list),
     buffer_map(buffer_map),
     simulation_state(simulation_state),
@@ -31,7 +31,7 @@ LocalizationStage::LocalizationStage(
     parameters(parameters),
     marked_for_removal(marked_for_removal),
     output_array(output_array),
-    random_devices(random_devices){}
+    random_device(random_device){}
 
 void LocalizationStage::Update(const unsigned long index) {
 
@@ -120,9 +120,9 @@ void LocalizationStage::Update(const unsigned long index) {
     const float perc_keep_right = parameters.GetKeepRightPercentage(actor_id);
     const float perc_random_leftlanechange = parameters.GetRandomLeftLaneChangePercentage(actor_id);
     const float perc_random_rightlanechange = parameters.GetRandomRightLaneChangePercentage(actor_id);
-    const bool is_keep_right = perc_keep_right > random_devices.at(actor_id).next();
-    const bool is_random_left_change = perc_random_leftlanechange >= random_devices.at(actor_id).next();
-    const bool is_random_right_change = perc_random_rightlanechange >= random_devices.at(actor_id).next();
+    const bool is_keep_right = perc_keep_right > random_device.next();
+    const bool is_random_left_change = perc_random_leftlanechange >= random_device.next();
+    const bool is_random_right_change = perc_random_rightlanechange >= random_device.next();
 
     // Determine which of the parameters we should apply.
     if (is_keep_right || is_random_right_change) {
@@ -135,7 +135,7 @@ void LocalizationStage::Update(const unsigned long index) {
         lane_change_direction = false;
       } else {
         // Both a left and right lane changes are forced. Choose between one of them.
-        lane_change_direction = FIFTYPERC > random_devices.at(actor_id).next();
+        lane_change_direction = FIFTYPERC > random_device.next();
       }
     }
   }
@@ -194,7 +194,7 @@ void LocalizationStage::Update(const unsigned long index) {
       uint64_t selection_index = 0u;
       // Pseudo-randomized path selection if found more than one choice.
       if (next_waypoints.size() > 1) {
-        double r_sample = random_devices.at(actor_id).next();
+        double r_sample = random_device.next();
         selection_index = static_cast<uint64_t>(r_sample*next_waypoints.size()*0.01);
       } else if (next_waypoints.size() == 0) {
         if (!parameters.GetOSMMode()) {

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.h
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.h
@@ -44,7 +44,7 @@ private:
   ActorIdSet vehicles_at_junction;
   using SimpleWaypointPair = std::pair<SimpleWaypointPtr, SimpleWaypointPtr>;
   std::unordered_map<ActorId, SimpleWaypointPair> vehicles_at_junction_entrance;
-  RandomGeneratorMap &random_devices;
+  RandomGenerator &random_device;
 
   SimpleWaypointPtr AssignLaneChange(const ActorId actor_id,
                                      const cg::Location vehicle_location,
@@ -74,7 +74,7 @@ public:
                     Parameters &parameters,
                     std::vector<ActorId>& marked_for_removal,
                     LocalizationFrame &output_array,
-                    RandomGeneratorMap &random_devices);
+                    RandomGenerator &random_device);
 
   void Update(const unsigned long index) override;
 

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -84,15 +84,6 @@ void MotionPlanStage::Update(const unsigned long index) {
   current_timestamp = world.GetSnapshot().GetTimestamp();
   StateEntry current_state;
 
-  // std::cout << index << std::endl;
-  // std::cout << " Location: " << vehicle_location.x << " " << vehicle_location.y << " " << vehicle_location.z << std::endl;
-  // std::cout << " Rotation: " << vehicle_rotation.roll << " " << vehicle_rotation.pitch << " " << vehicle_rotation.yaw << std::endl;
-  // std::cout << " Velocity: " << vehicle_velocity.x << " " << vehicle_velocity.y << " " << vehicle_velocity.z << std::endl;
-  // std::cout << " Speed: " << vehicle_speed << std::endl;
-  // std::cout << " Heading: " << vehicle_heading.x << " " << vehicle_heading.y << " " << vehicle_heading.z << std::endl;
-  // std::cout << " Physics: " << vehicle_physics_enabled << std::endl;
-
-
   // Instanciating teleportation transform as current vehicle transform.
   cg::Transform teleportation_transform = cg::Transform(vehicle_location, vehicle_rotation);
 
@@ -224,8 +215,6 @@ void MotionPlanStage::Update(const unsigned long index) {
       current_state.steer = actuation_signal.steer;
       StateEntry &state = pid_state_map.at(actor_id);
       state = current_state;
-
-      // std::cout << " Control: " << vehicle_control.throttle << " " << vehicle_control.brake << " " << vehicle_control.steer << " " << std::endl;
     }
     // For physics-less vehicles, determine position and orientation for teleportation.
     else {
@@ -268,8 +257,6 @@ void MotionPlanStage::Update(const unsigned long index) {
       }
       // Constructing the actuation signal.
       output_array.at(index) = carla::rpc::Command::ApplyTransform(actor_id, teleportation_transform);
-
-      // std::cout << " Teleport transform: " << teleportation_transform.location.x << " " << teleportation_transform.location.y << " " << teleportation_transform.location.z << " " << teleportation_transform.rotation.roll << " " << teleportation_transform.rotation.pitch << " " << teleportation_transform.rotation.yaw << std::endl;
     }
   }
 }

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -84,6 +84,15 @@ void MotionPlanStage::Update(const unsigned long index) {
   current_timestamp = world.GetSnapshot().GetTimestamp();
   StateEntry current_state;
 
+  // std::cout << index << std::endl;
+  // std::cout << " Location: " << vehicle_location.x << " " << vehicle_location.y << " " << vehicle_location.z << std::endl;
+  // std::cout << " Rotation: " << vehicle_rotation.roll << " " << vehicle_rotation.pitch << " " << vehicle_rotation.yaw << std::endl;
+  // std::cout << " Velocity: " << vehicle_velocity.x << " " << vehicle_velocity.y << " " << vehicle_velocity.z << std::endl;
+  // std::cout << " Speed: " << vehicle_speed << std::endl;
+  // std::cout << " Heading: " << vehicle_heading.x << " " << vehicle_heading.y << " " << vehicle_heading.z << std::endl;
+  // std::cout << " Physics: " << vehicle_physics_enabled << std::endl;
+
+
   // Instanciating teleportation transform as current vehicle transform.
   cg::Transform teleportation_transform = cg::Transform(vehicle_location, vehicle_rotation);
 
@@ -216,6 +225,7 @@ void MotionPlanStage::Update(const unsigned long index) {
       StateEntry &state = pid_state_map.at(actor_id);
       state = current_state;
 
+      // std::cout << " Control: " << vehicle_control.throttle << " " << vehicle_control.brake << " " << vehicle_control.steer << " " << std::endl;
     }
     // For physics-less vehicles, determine position and orientation for teleportation.
     else {
@@ -258,6 +268,8 @@ void MotionPlanStage::Update(const unsigned long index) {
       }
       // Constructing the actuation signal.
       output_array.at(index) = carla::rpc::Command::ApplyTransform(actor_id, teleportation_transform);
+
+      // std::cout << " Teleport transform: " << teleportation_transform.location.x << " " << teleportation_transform.location.y << " " << teleportation_transform.location.z << " " << teleportation_transform.rotation.roll << " " << teleportation_transform.rotation.pitch << " " << teleportation_transform.rotation.yaw << std::endl;
     }
   }
 }

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -41,7 +41,7 @@ MotionPlanStage::MotionPlanStage(
   const TLFrame &tl_frame,
   const cc::World &world,
   ControlFrame &output_array,
-  RandomGeneratorMap &random_devices,
+  RandomGenerator &random_device,
   const LocalMapPtr &local_map)
     : vehicle_id_list(vehicle_id_list),
     simulation_state(simulation_state),
@@ -57,7 +57,7 @@ MotionPlanStage::MotionPlanStage(
     tl_frame(tl_frame),
     world(world),
     output_array(output_array),
-    random_devices(random_devices),
+    random_device(random_device),
     local_map(local_map) {
 
       // Adding structure to avoid retrieving traffic lights when checking for landmarks.
@@ -111,7 +111,7 @@ void MotionPlanStage::Update(const unsigned long index) {
     double elapsed_time = current_timestamp.elapsed_seconds - teleportation_instance.at(actor_id).elapsed_seconds;
 
     if (parameters.GetSynchronousMode() || elapsed_time > HYBRID_MODE_DT) {
-      float random_sample = (static_cast<float>(random_devices.at(actor_id).next())*dilate_factor) + lower_bound;
+      float random_sample = (static_cast<float>(random_device.next())*dilate_factor) + lower_bound;
       NodeList teleport_waypoint_list = local_map->GetWaypointsInDelta(hero_location, ATTEMPTS_TO_TELEPORT, random_sample);
       if (!teleport_waypoint_list.empty()) {
         for (auto &teleport_waypoint : teleport_waypoint_list) {

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
@@ -42,7 +42,7 @@ private:
   std::unordered_map<ActorId, cc::Timestamp> teleportation_instance;
   ControlFrame &output_array;
   cc::Timestamp current_timestamp;
-  RandomGeneratorMap &random_devices;
+  RandomGenerator &random_device;
   const LocalMapPtr &local_map;
   TLMap tl_map;
 
@@ -83,7 +83,7 @@ public:
                   const TLFrame &tl_frame,
                   const cc::World &world,
                   ControlFrame &output_array,
-                  RandomGeneratorMap &random_devices,
+                  RandomGenerator &random_device,
                   const LocalMapPtr &local_map);
 
   void Update(const unsigned long index);

--- a/LibCarla/source/carla/trafficmanager/RandomGenerator.h
+++ b/LibCarla/source/carla/trafficmanager/RandomGenerator.h
@@ -18,7 +18,5 @@ private:
     std::uniform_real_distribution<double> dist;
 };
 
-using RandomGeneratorMap = std::unordered_map<carla::rpc::ActorId, RandomGenerator>;
-
 } // namespace traffic_manager
 } // namespace carla

--- a/LibCarla/source/carla/trafficmanager/TrafficLightStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficLightStage.cpp
@@ -17,14 +17,14 @@ TrafficLightStage::TrafficLightStage(
   const Parameters &parameters,
   const cc::World &world,
   TLFrame &output_array,
-  RandomGeneratorMap &random_devices)
+  RandomGenerator &random_device)
   : vehicle_id_list(vehicle_id_list),
     simulation_state(simulation_state),
     buffer_map(buffer_map),
     parameters(parameters),
     world(world),
     output_array(output_array),
-    random_devices(random_devices) {}
+    random_device(random_device) {}
 
 void TrafficLightStage::Update(const unsigned long index) {
   bool traffic_light_hazard = false;
@@ -46,7 +46,7 @@ void TrafficLightStage::Update(const unsigned long index) {
     if (is_at_traffic_light &&
         traffic_light_state != TLS::Green &&
         traffic_light_state != TLS::Off &&
-        parameters.GetPercentageRunningLight(ego_actor_id) <= random_devices.at(ego_actor_id).next()) {
+        parameters.GetPercentageRunningLight(ego_actor_id) <= random_device.next()) {
 
       traffic_light_hazard = true;
     }
@@ -55,7 +55,7 @@ void TrafficLightStage::Update(const unsigned long index) {
             !is_at_traffic_light &&
             traffic_light_state != TLS::Green &&
             traffic_light_state != TLS::Off &&
-            parameters.GetPercentageRunningSign(ego_actor_id) <= random_devices.at(ego_actor_id).next()) {
+            parameters.GetPercentageRunningSign(ego_actor_id) <= random_device.next()) {
 
       traffic_light_hazard = HandleNonSignalisedJunction(ego_actor_id, junction_id, current_timestamp);
     }

--- a/LibCarla/source/carla/trafficmanager/TrafficLightStage.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficLightStage.h
@@ -26,7 +26,7 @@ private:
   /// Map containing the previous junction visited by a vehicle.
   std::unordered_map<ActorId, JunctionID> vehicle_last_junction;
   TLFrame &output_array;
-  RandomGeneratorMap &random_devices;
+  RandomGenerator &random_device;
   cc::Timestamp current_timestamp;
 
   bool HandleNonSignalisedJunction(const ActorId ego_actor_id, const JunctionID junction_id,
@@ -39,7 +39,7 @@ public:
                     const Parameters &parameters,
                     const cc::World &world,
                     TLFrame &output_array,
-                    RandomGeneratorMap &random_devices);
+                    RandomGenerator &random_device);
 
   void Update(const unsigned long index) override;
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -227,7 +227,6 @@ void TrafficManagerLocal::Run() {
     }
     collision_stage.ClearCycleCache();
     vehicle_light_stage.UpdateWorldInfo();
-    // std::cout << "New Frame" << std::endl;
     for (unsigned long index = 0u; index < vehicle_id_list.size(); ++index) {
       traffic_light_stage.Update(index);
       motion_plan_stage.Update(index);

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -189,11 +189,7 @@ void TrafficManagerLocal::Run() {
     int current_registered_vehicles_state = registered_vehicles.GetState();
     unsigned long number_of_vehicles = vehicle_id_list.size();
     if (registered_vehicles_state != current_registered_vehicles_state || number_of_vehicles != registered_vehicles.Size()) {
-
       vehicle_id_list = registered_vehicles.GetIDList();
-
-      std::sort(vehicle_id_list.begin(), vehicle_id_list.end());
-
       number_of_vehicles = vehicle_id_list.size();
 
       // Reserve more space if needed.
@@ -323,8 +319,10 @@ void TrafficManagerLocal::Reset() {
 
 void TrafficManagerLocal::RegisterVehicles(const std::vector<ActorPtr> &vehicle_list) {
   std::lock_guard<std::mutex> registration_lock(registration_mutex);
-  registered_vehicles.Insert(vehicle_list);
-  for (const ActorPtr &vehicle: vehicle_list) {
+  std::vector<ActorPtr> sorted_vehicle_list = vehicle_list;
+  std::sort(sorted_vehicle_list.begin(), sorted_vehicle_list.end(), [](ActorPtr &a, ActorPtr &b) {return a->GetId() > b->GetId(); });
+  registered_vehicles.Insert(sorted_vehicle_list);
+  for (const ActorPtr &vehicle: sorted_vehicle_list) {
     if (!is_custom_seed) {
       seed = vehicle->GetId() + seed;
     } else {

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -42,7 +42,7 @@ TrafficManagerLocal::TrafficManagerLocal(
                                          parameters,
                                          marked_for_removal,
                                          localization_frame,
-                                         random_devices)),
+                                         random_device)),
 
     collision_stage(CollisionStage(vehicle_id_list,
                                    simulation_state,
@@ -50,7 +50,7 @@ TrafficManagerLocal::TrafficManagerLocal(
                                    track_traffic,
                                    parameters,
                                    collision_frame,
-                                   random_devices)),
+                                   random_device)),
 
     traffic_light_stage(TrafficLightStage(vehicle_id_list,
                                           simulation_state,
@@ -58,7 +58,7 @@ TrafficManagerLocal::TrafficManagerLocal(
                                           parameters,
                                           world,
                                           tl_frame,
-                                          random_devices)),
+                                          random_device)),
 
     motion_plan_stage(MotionPlanStage(vehicle_id_list,
                                       simulation_state,
@@ -74,7 +74,7 @@ TrafficManagerLocal::TrafficManagerLocal(
                                       tl_frame,
                                       world,
                                       control_frame,
-                                      random_devices,
+                                      random_device,
                                       local_map)),
 
     vehicle_light_stage(VehicleLightStage(vehicle_id_list,
@@ -95,8 +95,7 @@ TrafficManagerLocal::TrafficManagerLocal(
               collision_stage,
               traffic_light_stage,
               motion_plan_stage,
-              vehicle_light_stage,
-              random_devices)),
+              vehicle_light_stage)),
 
     server(TrafficManagerServer(RPCportTM, static_cast<carla::traffic_manager::TrafficManagerBase *>(this))) {
 
@@ -190,6 +189,7 @@ void TrafficManagerLocal::Run() {
     unsigned long number_of_vehicles = vehicle_id_list.size();
     if (registered_vehicles_state != current_registered_vehicles_state || number_of_vehicles != registered_vehicles.Size()) {
       vehicle_id_list = registered_vehicles.GetIDList();
+      std::sort(vehicle_id_list.begin(), vehicle_id_list.end());
       number_of_vehicles = vehicle_id_list.size();
 
       // Reserve more space if needed.
@@ -282,7 +282,6 @@ void TrafficManagerLocal::Stop() {
   track_traffic.Clear();
   previous_update_instance = chr::system_clock::now();
   current_reserved_capacity = 0u;
-  random_devices.clear();
 
   simulation_state.Reset();
   localization_stage.Reset();
@@ -322,14 +321,6 @@ void TrafficManagerLocal::RegisterVehicles(const std::vector<ActorPtr> &vehicle_
   std::vector<ActorPtr> sorted_vehicle_list = vehicle_list;
   std::sort(sorted_vehicle_list.begin(), sorted_vehicle_list.end(), [](ActorPtr &a, ActorPtr &b) {return a->GetId() > b->GetId(); });
   registered_vehicles.Insert(sorted_vehicle_list);
-  for (const ActorPtr &vehicle: sorted_vehicle_list) {
-    if (!is_custom_seed) {
-      seed = vehicle->GetId() + seed;
-    } else {
-      seed = 1 + seed;
-    }
-    random_devices.insert({vehicle->GetId(), RandomGenerator(seed)});
-  }
 }
 
 void TrafficManagerLocal::UnregisterVehicles(const std::vector<ActorPtr> &actor_list) {
@@ -490,6 +481,8 @@ std::vector<ActorId> TrafficManagerLocal::GetRegisteredVehiclesIDs() {
 void TrafficManagerLocal::SetRandomDeviceSeed(const uint64_t _seed) {
   seed = _seed;
   is_custom_seed = true;
+  random_device = RandomGenerator(seed);
+  std::cout << random_device.next() << std::endl;
   world.ResetAllTrafficLights();
 }
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.cpp
@@ -183,13 +183,11 @@ void TrafficManagerLocal::Run() {
     // Updating simulation state, actor life cycle and performing necessary cleanup.
     alsm.Update();
 
-
     // Re-allocating inter-stage communication frames based on changed number of registered vehicles.
     int current_registered_vehicles_state = registered_vehicles.GetState();
     unsigned long number_of_vehicles = vehicle_id_list.size();
     if (registered_vehicles_state != current_registered_vehicles_state || number_of_vehicles != registered_vehicles.Size()) {
       vehicle_id_list = registered_vehicles.GetIDList();
-      std::sort(vehicle_id_list.begin(), vehicle_id_list.end());
       number_of_vehicles = vehicle_id_list.size();
 
       // Reserve more space if needed.
@@ -229,6 +227,7 @@ void TrafficManagerLocal::Run() {
     }
     collision_stage.ClearCycleCache();
     vehicle_light_stage.UpdateWorldInfo();
+    // std::cout << "New Frame" << std::endl;
     for (unsigned long index = 0u; index < vehicle_id_list.size(); ++index) {
       traffic_light_stage.Update(index);
       motion_plan_stage.Update(index);
@@ -308,7 +307,6 @@ void TrafficManagerLocal::Release() {
 }
 
 void TrafficManagerLocal::Reset() {
-
   Release();
   episode_proxy = episode_proxy.Lock()->GetCurrentEpisode();
   world = cc::World(episode_proxy);
@@ -318,9 +316,7 @@ void TrafficManagerLocal::Reset() {
 
 void TrafficManagerLocal::RegisterVehicles(const std::vector<ActorPtr> &vehicle_list) {
   std::lock_guard<std::mutex> registration_lock(registration_mutex);
-  std::vector<ActorPtr> sorted_vehicle_list = vehicle_list;
-  std::sort(sorted_vehicle_list.begin(), sorted_vehicle_list.end(), [](ActorPtr &a, ActorPtr &b) {return a->GetId() > b->GetId(); });
-  registered_vehicles.Insert(sorted_vehicle_list);
+  registered_vehicles.Insert(vehicle_list);
 }
 
 void TrafficManagerLocal::UnregisterVehicles(const std::vector<ActorPtr> &actor_list) {
@@ -480,9 +476,7 @@ std::vector<ActorId> TrafficManagerLocal::GetRegisteredVehiclesIDs() {
 
 void TrafficManagerLocal::SetRandomDeviceSeed(const uint64_t _seed) {
   seed = _seed;
-  is_custom_seed = true;
   random_device = RandomGenerator(seed);
-  std::cout << random_device.next() << std::endl;
   world.ResetAllTrafficLights();
 }
 

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
@@ -109,11 +109,11 @@ private:
   std::condition_variable step_end_trigger;
   /// Single worker thread for sequential execution of sub-components.
   std::unique_ptr<std::thread> worker_thread;
-  /// Structure holding random devices per vehicle.
-  RandomGeneratorMap random_devices;
   /// Randomization seed.
   uint64_t seed {static_cast<uint64_t>(time(NULL))};
   bool is_custom_seed {false};
+  /// Structure holding random devices per vehicle.
+  RandomGenerator random_device = RandomGenerator(seed);
   std::vector<ActorId> marked_for_removal;
   /// Mutex to prevent vehicle registration during frame array re-allocation.
   std::mutex registration_mutex;

--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
@@ -111,7 +111,6 @@ private:
   std::unique_ptr<std::thread> worker_thread;
   /// Randomization seed.
   uint64_t seed {static_cast<uint64_t>(time(NULL))};
-  bool is_custom_seed {false};
   /// Structure holding random devices per vehicle.
   RandomGenerator random_device = RandomGenerator(seed);
   std::vector<ActorId> marked_for_removal;

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -156,10 +156,17 @@ static auto ApplyBatchCommandsSync(
   vehicles_to_enable.shrink_to_fit();
   vehicles_to_disable.shrink_to_fit();
 
+  // Ensure the TM always receives the same vector by sorting the elements
+  std::vector<carla::traffic_manager::ActorPtr> sorted_vehicle_to_enable = vehicles_to_enable;
+  std::sort(sorted_vehicle_to_enable.begin(), sorted_vehicle_to_enable.end(), [](carla::traffic_manager::ActorPtr &a, carla::traffic_manager::ActorPtr &b) {return a->GetId() < b->GetId(); });
+
+  std::vector<carla::traffic_manager::ActorPtr> sorted_vehicle_to_disable = vehicles_to_disable;
+  std::sort(sorted_vehicle_to_disable.begin(), sorted_vehicle_to_disable.end(), [](carla::traffic_manager::ActorPtr &a, carla::traffic_manager::ActorPtr &b) {return a->GetId() < b->GetId(); });
+
   // check if any autopilot command was sent
-  if (vehicles_to_enable.size() || vehicles_to_disable.size()) {
-    self.GetInstanceTM(tm_port).RegisterVehicles(vehicles_to_enable);
-    self.GetInstanceTM(tm_port).UnregisterVehicles(vehicles_to_disable);
+  if (sorted_vehicle_to_enable.size() || sorted_vehicle_to_disable.size()) {
+    self.GetInstanceTM(tm_port).RegisterVehicles(sorted_vehicle_to_enable);
+    self.GetInstanceTM(tm_port).UnregisterVehicles(sorted_vehicle_to_disable);
   }
 
   return result;


### PR DESCRIPTION
### Description

This PR fixes some non-deterministic behaviors that were introduced after 0.9.11. These includes:
- Sorting the vehicles at the *ApplyBatchSync* so that the TM always registers them in the same order, avoiding the need to sort them 
- Changed one variable from *unordered map* to *map*, avoiding having to sort it when looping through its keys.
- TM now uses one global seed for all vehicles, instead of one per vehicle.
- Changing a vehicle's physics is now a synchronous call. Due to its high interaction with other commands, as well as its expensive computations, the async nature of the call was causing other commands called after this one, to sometimes finish earlier, breaking determinism and creating unexpected behaviors 
- Updated the determinism smoke test to also use the hybrid mode

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA fork

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/4989)
<!-- Reviewable:end -->
