### PR TITLE
Add early support for Apple Silicon (M1) build

### DIFF
--- a/Docs/build_mac.md
+++ b/Docs/build_mac.md
@@ -1,0 +1,114 @@
+# Mac build
+
+This guide details how to build CARLA from source on MacOS Monterey (Apple Silicon). This work is mostly experimental and serves primarily as a proof-of-concept for those interested in building CARLA 0.9.13 on the Apple Silicon devices. 
+
+---
+## Prerequisites
+
+### System requirements
+
+* __MacOS 12__ This is for building on MacOS Monterey (12). The latest version this was tested on is 12.1 on my M1 Max.
+* __130 GB disk space.__ Carla will take around 31 GB and Unreal Engine will take around 91 GB so have about 130 GB free to account for both of these plus additional minor software installations. 
+* __An adequate GPU.__ The M1 GPU's are very capable, though it is still recommended to get the Pro/Max's since I've found the performance to scale nearly linearly with number of GPU cores. 
+* __Two TCP ports and good internet connection.__ 2000 and 2001 by default. Make sure that these ports are not blocked by firewalls or any other applications. 
+
+..warning::
+    __If you are upgrading from CARLA 0.9.12 to 0.9.13__: you must first upgrade the CARLA fork of the UE4 engine to the latest version. See the [__Unreal Engine__](#unreal-engine) section for details on upgrading UE4
+
+**WARNING**: UE4-carla does not build on MacOS 12 by default! See [this discussion](https://github.com/carla-simulator/carla/discussions/4848) for more details.
+
+
+### Software requirements
+
+CARLA requires many different kinds of software to run. Some are built during the CARLA build process itself, such as *Boost.Python*. Others are binaries that should be installed before starting the build (*cmake*, *clang*, different versions of *Python*, etc.). To install these requirements, run the following commands:
+
+```bash
+brew update && brew upgrade
+
+brew install --build-from-source mono
+
+brew install coreutils ninja wget autoconf automake curl libtool libpng aria2 libiconv
+```
+
+I recommend installing python through conda on mac:
+```bash
+conda create --name carla python=3.8
+conda activate carla
+conda install numpy distro wheel
+pip install setuptools==47.3.1 nose2
+```
+
+(Install xcode through the app store, I used the latest (at time of writing) 12.2.1)
+And then open up xcode and install the `xcode command line developer tools`
+```bash
+xcode-select --install
+sudo xcode-select -s /Applications/Xcode.app
+```
+
+Finally, you'll also need [Rosetta 2](https://support.apple.com/en-us/HT211861) for the translation between x86 (UE4 prerequisite) and arm64 (native Apple Silicon)
+
+---
+
+## Unreal Engine
+
+For now, refer to the Linux guide for how to build the engine, but note the [strange problem](https://github.com/carla-simulator/carla/discussions/4848) with building the Carla fork (not Vanilla 4.26.2) on Apple silicon.
+
+## Build CARLA 
+
+Note: This time, the build procedure is somewhat hacky and fragmanted by nature of using different architectures, but it still works reasonably well. The procedure is as follows:
+1. Build LibCarla in x86
+2. Build the UE4 carla game (also x86)
+3. Build LibCarla (AGAIN) in arm64
+4. Build the PythonAPI in arm64
+5. Add the arm64 Python arm .egg file to your PYTHONPATH
+6. Build the UE4 package in x86 (back to x86)
+
+
+This is because the python scripts work much better in `arm64` but the game itself (which depends on UE4) must be built for x86 and run on rosetta2.
+
+The way I recommend you go about this is as follows:
+```bash
+# git clone and enter mac branch
+./Update.sh # wait a while for the asset fetching to complete
+
+# go to Util/Buildtools/Environment.sh
+# make sure the ARCH (for IS_MAC) is set to "x86_64"
+
+make LibCarla # in x86
+...
+
+make launch # in x86 (uses UE4 build and xcode cmd line)
+...
+
+# go to Util/Buildtools/Environment.sh
+# make sure the ARCH (for IS_MAC) is set to "arm64"
+mv Build Build.x86 # denoting the current (x86) build as such
+
+make LibCarla # now in arm64!
+...
+
+make PythonAPI # now in arm64
+...
+
+make check # unit tests to verify everything works!
+...
+
+mv Build Build.arm64
+
+# now you can switch between (re)building arm64 and x86 by renaming
+# the Build.XYZ to just Build
+# example:
+
+mv Build.x86 Build
+
+make package
+...
+
+```
+
+Also, as an aside, since (almost) all the PythonAPI scripts look for a `'linux-x86_64'` `.egg` file, you'll not be able to find it unless you modify EVERY single file, since this is too much work, you can simply add this to your PYTHONPATH via:
+```bash
+export PYTHONPATH="${PYTHONPATH}:/PATH/TO/CARLA/PythonAPI/carla/dist/carla-0.9.13-py3.8-macosx-11.0-arm64.egg"
+# I simply put this in my .zshrc file
+```
+Then you should be able to quickly `import carla` without hassle!

--- a/LibCarla/source/carla/Buffer.h
+++ b/LibCarla/source/carla/Buffer.h
@@ -71,7 +71,7 @@ namespace carla {
         _data(std::make_unique<value_type[]>(size)) {}
 
     /// @copydoc Buffer(size_type)
-    explicit Buffer(uint64_t size)
+    explicit Buffer(size_t size)
       : Buffer([size]() {
           if (size > max_size()) {
             throw_exception(std::invalid_argument("message size too big"));
@@ -319,7 +319,7 @@ namespace carla {
     template <typename T>
     typename std::enable_if<boost::asio::is_const_buffer_sequence<T>::value>::type
     copy_from(size_type offset, const T &source) {
-      reset(boost::asio::buffer_size(source) + offset);
+      reset(static_cast<size_type>(boost::asio::buffer_size(source)) + offset);
       DEBUG_ASSERT(boost::asio::buffer_size(source) == size() - offset);
       DEBUG_ONLY(auto bytes_copied = )
       boost::asio::buffer_copy(buffer() + offset, source);

--- a/LibCarla/source/carla/MsgPack.h
+++ b/LibCarla/source/carla/MsgPack.h
@@ -20,7 +20,8 @@ namespace carla {
       namespace mp = ::clmdep_msgpack;
       mp::sbuffer sbuf;
       mp::pack(sbuf, obj);
-      return Buffer(reinterpret_cast<const unsigned char *>(sbuf.data()), sbuf.size());
+      return Buffer(reinterpret_cast<const unsigned char *>(sbuf.data()), 
+                    static_cast<Buffer::size_type>(sbuf.size()));
     }
 
     template <typename T>

--- a/LibCarla/source/carla/MsgPackAdaptors.h
+++ b/LibCarla/source/carla/MsgPackAdaptors.h
@@ -115,7 +115,7 @@ namespace adaptor {
       v = o.via.array.ptr[1].as<T>();
     }
 
-    template <uint64_t... Is>
+    template <size_t... Is>
     static void copy_to_variant(
         const uint64_t index,
         const clmdep_msgpack::object &o,

--- a/LibCarla/source/carla/road/element/Waypoint.cpp
+++ b/LibCarla/source/carla/road/element/Waypoint.cpp
@@ -13,12 +13,12 @@ namespace std {
   using WaypointHash = hash<carla::road::element::Waypoint>;
 
   WaypointHash::result_type WaypointHash::operator()(const argument_type &waypoint) const {
-    WaypointHash::result_type seed = 0u;
+    std::size_t seed = 0u;
     boost::hash_combine(seed, waypoint.road_id);
     boost::hash_combine(seed, waypoint.section_id);
     boost::hash_combine(seed, waypoint.lane_id);
     boost::hash_combine(seed, static_cast<float>(std::floor(waypoint.s * 200.0)));
-    return seed;
+    return static_cast<WaypointHash::result_type>(seed);
   }
 
 } // namespace std

--- a/LibCarla/source/carla/sensor/s11n/DVSEventArraySerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/DVSEventArraySerializer.h
@@ -55,7 +55,7 @@ namespace s11n {
     };
 
     /// Reset the output buffer
-    output.reset(sizeof(DVSHeader) + (events.size() * sizeof(data::DVSEvent)));
+    output.reset(static_cast<Buffer::size_type>(sizeof(DVSHeader) + (events.size() * sizeof(data::DVSEvent))));
 
     /// Pointer to data in buffer
     unsigned char *it = output.data();

--- a/LibCarla/source/test/common/test_buffer.cpp
+++ b/LibCarla/source/test/common/test_buffer.cpp
@@ -114,9 +114,9 @@ TEST(buffer, memcpy) {
 
 #ifndef LIBCARLA_NO_EXCEPTIONS
 TEST(buffer, message_too_big) {
-  ASSERT_THROW(Buffer(4294967296ul), std::invalid_argument);
+  ASSERT_THROW(Buffer(static_cast<size_t>(4294967296ul)), std::invalid_argument);
   Buffer buf;
-  ASSERT_THROW(buf.reset(4294967296ul), std::invalid_argument);
+  ASSERT_THROW(buf.reset(static_cast<uint64_t>(4294967296ul)), std::invalid_argument);
 }
 #endif // LIBCARLA_NO_EXCEPTIONS
 

--- a/LibCarla/source/test/common/test_streaming.cpp
+++ b/LibCarla/source/test/common/test_streaming.cpp
@@ -55,12 +55,12 @@ TEST(streaming, low_level_sending_strings) {
 
   io_context_running io;
 
-  Server<tcp::Server> srv(io.service, TESTING_PORT);
+  carla::streaming::low_level::Server<tcp::Server> srv(io.service, TESTING_PORT);
   srv.SetTimeout(1s);
 
   auto stream = srv.MakeStream();
 
-  Client<tcp::Client> c;
+  carla::streaming::low_level::Client<tcp::Client> c;
   c.Subscribe(io.service, stream.token(), [&](auto message) {
     ++message_count;
     ASSERT_EQ(message.size(), message_text.size());
@@ -90,10 +90,10 @@ TEST(streaming, low_level_unsubscribing) {
 
   io_context_running io;
 
-  Server<tcp::Server> srv(io.service, TESTING_PORT);
+  carla::streaming::low_level::Server<tcp::Server> srv(io.service, TESTING_PORT);
   srv.SetTimeout(1s);
 
-  Client<tcp::Client> c;
+  carla::streaming::low_level::Client<tcp::Client> c;
   for (auto n = 0u; n < 10u; ++n) {
     auto stream = srv.MakeStream();
     std::atomic_size_t message_count{0u};

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ include Util/BuildTools/Vars.mk
 ifeq ($(OS),Windows_NT)
 include Util/BuildTools/Windows.mk
 else
-include Util/BuildTools/Linux.mk
+include Util/BuildTools/Unix.mk
 endif

--- a/Unreal/CarlaUE4/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEngine.ini
@@ -57,6 +57,27 @@ OcclusionPlugin=
 +TargetedRHIs=SF_VULKAN_SM5
 +TargetedRHIs=GLSL_430
 
+[/Script/IOSRuntimeSettings.IOSRuntimeSettings]
+bSupportsPortraitOrientation=False
+bSupportsUpsideDownOrientation=False
+bSupportsLandscapeLeftOrientation=True
+PreferredLandscapeOrientation=LandscapeLeft
+
+[/Script/MacTargetPlatform.MacTargetSettings]
+-TargetedRHIs=SF_METAL_SM5
++TargetedRHIs=SF_METAL_SM5
+MaxShaderLanguageVersion=3
+UseFastIntrinsics=False
+EnableMathOptimisations=True
+AudioSampleRate=0
+AudioCallbackBufferFrameSize=0
+AudioNumBuffersToEnqueue=0
+AudioMaxChannels=0
+AudioNumSourceWorkers=0
+SpatializationPlugin=
+ReverbPlugin=
+OcclusionPlugin=
+
 [/Script/Engine.PhysicsSettings]
 DefaultGravityZ=-980.000000
 DefaultTerminalVelocity=4000.000000
@@ -110,3 +131,4 @@ DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel3,DefaultResponse=ECR_Overlap,bTraceType=True,bStaticObject=False,Name="OverlapChannel")
 +EditProfiles=(Name="BlockAll",CustomResponses=((Channel="SensorObject"),(Channel="SensorTrace")))
 +EditProfiles=(Name="OverlapAll",CustomResponses=((Channel="SensorObject",Response=ECR_Overlap),(Channel="SensorTrace",Response=ECR_Overlap)))
+

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/CarlaActor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/CarlaActor.h
@@ -166,13 +166,13 @@ public:
   template<typename T>
   T* GetActorData()
   {
-    return dynamic_cast<T*>(ActorData.Get());
+    return static_cast<T*>(ActorData.Get());
   }
 
   template<typename T>
   const T* GetActorData() const
   {
-    return dynamic_cast<T*>(ActorData.Get());
+    return static_cast<T*>(ActorData.Get());
   }
 
   // Actor function interface ----------------------

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -114,6 +114,12 @@ public class Carla : ModuleRules
     AddCarlaServerDependency(Target);
   }
 
+  private bool IsMac(ReadOnlyTargetRules Target)
+  {
+    return (Target.Platform == UnrealTargetPlatform.Mac);
+  }
+
+
   private bool UseDebugLibs(ReadOnlyTargetRules Target)
   {
     if (IsWindows(Target))
@@ -231,6 +237,7 @@ public class Carla : ModuleRules
     PublicDefinitions.Add("LIBCARLA_NO_EXCEPTIONS");
     PublicDefinitions.Add("PUGIXML_NO_EXCEPTIONS");
     PublicDefinitions.Add("BOOST_DISABLE_ABI_HEADERS");
+    PublicDefinitions.Add("MSGPACK_DISABLE_LEGACY_NIL");
     PublicDefinitions.Add("BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY");
   }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.cpp
@@ -277,7 +277,7 @@ static carla::Buffer FWorldObserver_Serialize(
   auto total_size = sizeof(Serializer::Header) + sizeof(ActorDynamicState) * Registry.Num();
   auto current_size = 0;
   // Set up buffer for writing.
-  buffer.reset(total_size);
+  buffer.reset(static_cast<carla::Buffer::size_type>(total_size));
   auto write_data = [&current_size, &buffer](const auto &data)
   {
     auto begin = buffer.begin() + current_size;

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -93,7 +93,11 @@ if ${HARD_CLEAN} ; then
 
   log "Doing a \"hard\" clean of the Unreal Engine project."
 
-  make CarlaUE4Editor ARGS=-clean
+  if ${MAC_OS}; then
+    xcodebuild -scheme CarlaUe4 clean
+  else
+    make CarlaUE4Editor ARGS=-clean
+  fi
 
 fi
 
@@ -113,6 +117,9 @@ if ${REMOVE_INTERMEDIATE} ; then
 
   popd >/dev/null
 
+  if ${MAC_OS}; then
+    rm -rf CarlaUE4.xcworkspace
+  fi
 fi
 
 # ==============================================================================
@@ -141,13 +148,23 @@ if ${BUILD_CARLAUE4} ; then
     # This command fails sometimes but normally we can continue anyway.
     set +e
     log "Generate Unreal project files."
-    ${UE4_ROOT}/GenerateProjectFiles.sh -project="${PWD}/CarlaUE4.uproject" -game -engine -makefiles
+    BUILD_TYPE=
+    if ${MAC_OS}; then
+      BUILD_TYPE=" -xcode"
+    else
+      BUILD_TYPE=" -makefiles"  
+    fi
+    ${UE4_ROOT}/GenerateProjectFiles.sh -project="${PWD}/CarlaUE4.uproject" -game -engine ${BUILD_TYPE}
     set -e
 
   fi
 
   log "Build CarlaUE4 project."
-  make CarlaUE4Editor
+  if ${MAC_OS}; then
+    xcodebuild -scheme CarlaUE4 -target CarlaUE4Editor -UseModernBuildSystem=YES
+  else
+    make CarlaUE4Editor
+  fi
 
   #Providing the user with the ExportedMaps folder
   EXPORTED_MAPS="${CARLAUE4_ROOT_FOLDER}/Content/Carla/ExportedMaps"
@@ -163,8 +180,11 @@ fi
 if ${LAUNCH_UE4_EDITOR} ; then
 
   log "Launching UE4Editor..."
-  ${GDB} ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${PWD}/CarlaUE4.uproject" ${RHI}
-
+  if ${MAC_OS}; then
+    /usr/bin/open -a "${UE4_ROOT}/Engine/Binaries/Mac/UE4Editor.app" "${PWD}/CarlaUE4.uproject"
+  else
+    ${GDB} ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${PWD}/CarlaUE4.uproject" ${RHI}
+  fi
 else
 
   log "Success!"

--- a/Util/BuildTools/BuildOSM2ODR.sh
+++ b/Util/BuildTools/BuildOSM2ODR.sh
@@ -89,8 +89,8 @@ if ${BUILD_OSM2ODR} ; then
   mkdir -p ${OSM2ODR_BUILD_FOLDER}
   cd ${OSM2ODR_BUILD_FOLDER}
   # define clang compiler
-  export CC=/usr/bin/clang-8
-  export CXX=/usr/bin/clang++-8
+  export CC=/usr/bin/clang
+  export CXX=/usr/bin/clang++
 
   cmake ${OSM2ODR_SOURCE_FOLDER} \
       -G "Eclipse CDT4 - Ninja" \

--- a/Util/BuildTools/BuildPythonAPI.sh
+++ b/Util/BuildTools/BuildPythonAPI.sh
@@ -50,8 +50,8 @@ done
 
 source $(dirname "$0")/Environment.sh
 
-export CC=clang-8
-export CXX=clang++-8
+export CC=clang
+export CXX=clang++
 
 if ! { ${REMOVE_INTERMEDIATE} || ${BUILD_PYTHONAPI} ; }; then
   fatal_error "Nothing selected to be done."

--- a/Util/BuildTools/BuildPythonAPI.sh
+++ b/Util/BuildTools/BuildPythonAPI.sh
@@ -89,7 +89,11 @@ if ${BUILD_PYTHONAPI} ; then
   # Add patchelf to the path. Auditwheel relies on patchelf to repair ELF files.
   export PATH="${LIBCARLA_INSTALL_CLIENT_FOLDER}/bin:${PATH}"
 
-  CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME)
+  if ${MAC_OS} ; then 
+    CODENAME="osx"
+  else
+    CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME)
+  fi
   if [[ ! -z ${TARGET_WHEEL_PLATFORM} ]] && [[ ${CODENAME#*=} != "bionic" ]] ; then
     log "A target platform has been specified but you are not using a compatible linux distribution. The wheel repair step will be skipped"
     TARGET_WHEEL_PLATFORM=

--- a/Util/BuildTools/Environment.sh
+++ b/Util/BuildTools/Environment.sh
@@ -8,6 +8,31 @@ CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 source $(dirname "$0")/Vars.mk
 unset CURDIR
 
+
+if [[ "$(uname)" == "Darwin" ]] ; then
+  export MAC_OS=true # automatically set to false on non-Mac builds
+else
+  export MAC_OS=false
+fi
+
+if ${MAC_OS}; then
+  ARCH="x86_64" # for building the UE4 package
+  # ARCH="arm64" # for building the PythonAPI
+  # for OSX apple silicon build (building x86 & using rosetta2)
+  # NOTE: UE4 wants use of macos 10.14, but 12.1 works fine
+  export ARCH_TARGET="-target ${ARCH}-apple-macos12.1"
+  export OS_FLAGS=" -nostdinc++" # for macos
+  export OS_STDLIB="-stdlib=libc++"
+  # for cmake -arch flag: https://cmake.org/cmake/help/latest/prop_tgt/OSX_ARCHITECTURES.html#prop_tgt:OSX_ARCHITECTURES
+  export CMAKE_OSX_ARCHITECTURES=${ARCH}
+  export TARGET_PLATFORM="Mac"
+else
+  export ARCH_TARGET="" # use default arch on linux
+  export OS_FLAGS="" 
+  export OS_STDLIB=""
+  export TARGET_PLATFORM="Linux"
+fi
+
 if [ -n "${CARLA_BUILD_NO_COLOR}" ]; then
 
   function log {

--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -112,12 +112,12 @@ if ${DO_CARLA_RELEASE} ; then
       -project="${PWD}/CarlaUE4.uproject" \
       -nocompileeditor -nop4 -cook -stage -archive -package -iterate \
       -clientconfig=${PACKAGE_CONFIG} -ue4exe=UE4Editor \
-      -prereqs -targetplatform=Linux -build -utf8output \
+      -prereqs -targetplatform=${TARGET_PLATFORM} -build -utf8output \
       -archivedirectory="${RELEASE_BUILD_FOLDER}"
 
   popd >/dev/null
 
-  if [[ ! -d ${RELEASE_BUILD_FOLDER}/LinuxNoEditor ]] ; then
+  if [[ ! -d ${RELEASE_BUILD_FOLDER}/${TARGET_PLATFORM}NoEditor ]] ; then
     fatal_error "Failed to cook the project!"
   fi
 
@@ -129,7 +129,7 @@ fi
 
 if ${DO_CARLA_RELEASE} ; then
 
-  DESTINATION=${RELEASE_BUILD_FOLDER}/LinuxNoEditor
+  DESTINATION=${RELEASE_BUILD_FOLDER}/${TARGET_PLATFORM}NoEditor
 
   log "Adding extra files to CARLA package."
 
@@ -145,7 +145,12 @@ if ${DO_CARLA_RELEASE} ; then
   copy_if_changed "./Docs/python_api.md" "${DESTINATION}/PythonAPI/python_api.md"
   copy_if_changed "./Util/Docker/Release.Dockerfile" "${DESTINATION}/Dockerfile"
   copy_if_changed "./Util/ImportAssets.sh" "${DESTINATION}/ImportAssets.sh"
-  copy_if_changed "./Util/DockerUtils/dist/RecastBuilder" "${DESTINATION}/Tools/"
+  if ${MAC_OS}; then 
+    RECAST_BIN="./Util/DockerUtils/dist/RecastBuilder.app/"
+  else
+    RECAST_BIN="./Util/DockerUtils/dist/RecastBuilder"
+  fi
+  copy_if_changed ${RECAST_BIN} "${DESTINATION}/Tools/"
 
   copy_if_changed "./PythonAPI/carla/dist/*.egg" "${DESTINATION}/PythonAPI/carla/dist/"
   copy_if_changed "./PythonAPI/carla/dist/*.whl" "${DESTINATION}/PythonAPI/carla/dist/"
@@ -181,14 +186,14 @@ fi
 if ${DO_CARLA_RELEASE} && ${DO_TARBALL} ; then
 
   DESTINATION=${RELEASE_PACKAGE_PATH}
-  SOURCE=${RELEASE_BUILD_FOLDER}/LinuxNoEditor
+  SOURCE=${RELEASE_BUILD_FOLDER}/${TARGET_PLATFORM}NoEditor
 
   pushd "${SOURCE}" >/dev/null
 
   log "Packaging CARLA release."
 
-  rm -f ./Manifest_NonUFSFiles_Linux.txt
-  rm -f ./Manifest_UFSFiles_Linux.txt
+  rm -f ./Manifest_NonUFSFiles_${TARGET_PLATFORM}.txt
+  rm -f ./Manifest_UFSFiles_${TARGET_PLATFORM}.txt
   rm -Rf ./CarlaUE4/Saved
   rm -Rf ./Engine/Saved
 
@@ -215,7 +220,7 @@ fi
 # ==============================================================================
 
 PACKAGE_PATH_FILE=${CARLAUE4_ROOT_FOLDER}/Content/PackagePath.txt
-MAP_LIST_FILE=${CARLAUE4_ROOT_FOLDER}/Content/MapPathsLinux.txt
+MAP_LIST_FILE=${CARLAUE4_ROOT_FOLDER}/Content/MapPaths${TARGET_PLATFORM}.txt
 
 for PACKAGE_NAME in "${PACKAGES[@]}" ; do if [[ ${PACKAGE_NAME} != "Carla" ]] ; then
 
@@ -238,15 +243,15 @@ for PACKAGE_NAME in "${PACKAGES[@]}" ; do if [[ ${PACKAGE_NAME} != "Carla" ]] ; 
   pushd "${CARLAUE4_ROOT_FOLDER}" > /dev/null
 
   # Prepare cooking of package
-  ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${CARLAUE4_ROOT_FOLDER}/CarlaUE4.uproject" \
+  ${UE4_ROOT}/Engine/Binaries/${TARGET_PLATFORM}/UE4Editor "${CARLAUE4_ROOT_FOLDER}/CarlaUE4.uproject" \
       -run=PrepareAssetsForCooking -PackageName=${PACKAGE_NAME} -OnlyPrepareMaps=false
 
   PACKAGE_FILE=$(<${PACKAGE_PATH_FILE})
   MAPS_TO_COOK=$(<${MAP_LIST_FILE})
 
   # Cook maps
-  ${UE4_ROOT}/Engine/Binaries/Linux/UE4Editor "${CARLAUE4_ROOT_FOLDER}/CarlaUE4.uproject" \
-      -run=cook -map="${MAPS_TO_COOK}" -cooksinglepackage -targetplatform="LinuxNoEditor" \
+  ${UE4_ROOT}/Engine/Binaries/${TARGET_PLATFORM}/UE4Editor "${CARLAUE4_ROOT_FOLDER}/CarlaUE4.uproject" \
+      -run=cook -map="${MAPS_TO_COOK}" -cooksinglepackage -targetplatform="${TARGET_PLATFORM}NoEditor" \
       -OutputDir="${BUILD_FOLDER}"
 
   PROP_MAP_FOLDER="${PACKAGE_PATH}/Maps/${PROPS_MAP_NAME}"

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -37,14 +37,14 @@ done
 # -- Set up environment --------------------------------------------------------
 # ==============================================================================
 
-command -v /usr/bin/clang++-8 >/dev/null 2>&1 || {
-  echo >&2 "clang 8 is required, but it's not installed.";
+command -v /usr/bin/clang++ >/dev/null 2>&1 || {
+  echo >&2 "clang is required, but it's not installed.";
   exit 1;
 }
 
 CXX_TAG=c8
-export CC=/usr/bin/clang-8
-export CXX=/usr/bin/clang++-8
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
 
 source $(dirname "$0")/Environment.sh
 
@@ -148,7 +148,7 @@ for PY_VERSION in ${PY_VERSION_LIST[@]} ; do
 
     pushd ${BOOST_BASENAME}-source >/dev/null
 
-    BOOST_TOOLSET="clang-8.0"
+    BOOST_TOOLSET="clang"
     BOOST_CFLAGS="-fPIC -std=c++14 -DBOOST_ERROR_CODE_HEADER_ONLY"
 
     py3="/usr/bin/env python${PY_VERSION}"

--- a/Util/BuildTools/Unix.mk
+++ b/Util/BuildTools/Unix.mk
@@ -1,0 +1,152 @@
+default: help
+
+help:
+	@less ${CARLA_BUILD_TOOLS_FOLDER}/Linux.mk.help
+
+launch: LibCarla.server.release
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --build --launch $(ARGS)
+
+launch-only:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --launch $(ARGS)
+
+import: CarlaUE4Editor PythonAPI
+	@${CARLA_BUILD_TOOLS_FOLDER}/Import.sh $(ARGS)
+
+package: CarlaUE4Editor PythonAPI
+	@${CARLA_BUILD_TOOLS_FOLDER}/Package.sh $(ARGS)
+
+package.rss: CarlaUE4Editor PythonAPI.rss.rebuild
+	@${CARLA_BUILD_TOOLS_FOLDER}/Package.sh $(ARGS)
+
+docs:
+	@doxygen
+	@echo "Documentation index at ./Doxygen/html/index.html"
+
+clean.LibCarla:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --clean
+clean.PythonAPI:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --clean
+clean.CarlaUE4Editor:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --clean
+clean.osm2odr:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.sh --clean
+clean: clean.CarlaUE4Editor clean.PythonAPI clean.LibCarla clean.osm2odr
+
+rebuild: setup
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --rebuild
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.sh --rebuild
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --rebuild $(ARGS)
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --rebuild $(ARGS)
+
+hard-clean:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --hard-clean
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.sh --clean
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --clean
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --clean
+	@echo "To force recompiling dependencies run: rm -Rf ${CARLA_BUILD_FOLDER}"
+
+check: LibCarla PythonAPI
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --all $(ARGS)
+
+check.LibCarla: LibCarla
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --libcarla-debug --libcarla-release $(ARGS)
+
+check.LibCarla.debug: LibCarla.debug
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --libcarla-debug $(ARGS)
+
+check.LibCarla.release: LibCarla.release
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --libcarla-release $(ARGS)
+
+check.PythonAPI: PythonAPI
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --python-api $(ARGS)
+
+check.PythonAPI.2: PythonAPI.2
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --python-api --python-version=2 $(ARGS)
+
+check.PythonAPI.3: PythonAPI.3
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --python-api --python-version=3 $(ARGS)
+
+benchmark: LibCarla.release
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --benchmark $(ARGS)
+	@cat profiler.csv
+
+smoke_tests:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Check.sh --smoke $(ARGS)
+
+examples:
+	@for D in ${CARLA_EXAMPLES_FOLDER}/*; do [ -d "$${D}" ] && make -C $${D} build; done
+
+run-examples:
+	@for D in ${CARLA_EXAMPLES_FOLDER}/*; do [ -d "$${D}" ] && make -C $${D} run.only; done
+
+CarlaUE4Editor: LibCarla.server.release
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildCarlaUE4.sh --build $(ARGS)
+
+.PHONY: PythonAPI
+PythonAPI: LibCarla.client.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh $(ARGS)
+
+PythonAPI.2: LibCarla.client.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --python-version=2
+
+PythonAPI.3: LibCarla.client.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --python-version=3
+
+PythonAPI.rebuild: LibCarla.client.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --rebuild $(ARGS)
+
+PythonAPI.rss: LibCarla.client.rss.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --rss $(ARGS)
+
+PythonAPI.rss.rebuild: LibCarla.client.rss.release osm2odr
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.sh --rebuild --rss $(ARGS)
+
+PythonAPI.docs:
+	@python PythonAPI/docs/doc_gen.py
+	@cd PythonAPI/docs && python3 bp_doc_gen.py
+
+.PHONY: LibCarla
+LibCarla: LibCarla.release LibCarla.debug
+
+LibCarla.debug: LibCarla.server.debug LibCarla.client.debug
+LibCarla.release: LibCarla.server.release LibCarla.client.release
+
+LibCarla.server: LibCarla.server.debug LibCarla.server.release
+LibCarla.server.debug: setup
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --server --debug
+LibCarla.server.release: setup
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --server --release
+
+LibCarla.client: LibCarla.client.debug LibCarla.client.release
+LibCarla.client.debug: setup
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --client --debug
+LibCarla.client.release: setup
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --client --release
+
+LibCarla.client.rss: LibCarla.client.rss.debug LibCarla.client.rss.release
+LibCarla.client.rss.debug: setup ad-rss
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --client --debug --rss
+LibCarla.client.rss.release: setup ad-rss
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.sh --client --release --rss
+
+.PHONY: Plugins
+plugins:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Plugins.sh $(ARGS)
+
+setup:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Setup.sh $(ARGS)
+
+ad-rss:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Ad-rss.sh $(ARGS)
+
+deploy:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Deploy.sh $(ARGS)
+
+pretty:
+	@${CARLA_BUILD_TOOLS_FOLDER}/Prettify.sh $(ARGS)
+
+build.utils: PythonAPI
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildUtilsDocker.sh
+
+osm2odr:
+	@${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.sh --build $(ARGS)

--- a/Util/BuildTools/Unix.mk.help
+++ b/Util/BuildTools/Unix.mk.help
@@ -1,0 +1,103 @@
+Welcome to CARLA Simulator!
+===========================
+
+This Makefile will help you building the different CARLA utilities.
+
+Use the following commands:
+
+    help:
+
+        Display this help message.
+
+    launch:
+
+        Compile CarlaUE4 project and launch it in Unreal Engine's Editor.
+
+    launch-only:
+
+        Launch CarlaUE4 project in Unreal Engine's Editor, but skip building
+        step (assume the project is already built).
+
+    import:
+
+        Import maps and assets that are located in "carla/Import" directly to Unreal,
+        so they will be ready to export.
+
+    package:
+
+        Makes a packaged version of CARLA ready for distribution. Used with
+        ARGS="--package=PackageNames" will create specific asset packages.
+
+    docs:
+
+        Build CARLA Doxygen documentation.
+
+    clean:
+
+        Remove intermediate build files.
+
+    rebuild:
+
+        Remove intermediate build files and rebuild the whole project.
+
+    hard-clean:
+
+        Remove intermediate build files and force a recompilation of Unreal
+        Engine's pre-compiled headers. Useful for fixing "version.h has been
+        modified since the precompiled header" errors. Beware, recompilation
+        takes a long time!
+
+
+There are also some lower level commands for building individual modules helpful
+for developers:
+
+    check:
+
+        Run unit test suites for LibCarla and PythonAPI.
+
+    check.LibCarla(.debug|.release):
+
+        Run unit test suites for LibCarla only.
+
+    check.PythonAPI(.2|.3):
+
+        Run unit test suites for PythonAPI only.
+
+    benchmark:
+
+        Run the benchmark tests for LibCarla.
+
+    (run-)examples:
+
+        Build (and run) the C++ client examples.
+
+    CarlaUE4Editor:
+
+        Build CarlaUE4 project, but do not launch the editor.
+
+    PythonAPI(.2|.3):
+
+        Build and package the Python API module for Python 2 and/or 3.
+
+    LibCarla(.server|.client)(.debug|.release):
+
+        Build LibCarla, "Server" and/or "Client" configurations.
+
+    clean.(LibCarla|PythonAPI|CarlaUE4Editor)
+
+        Remove intermediate build files for the specific module.
+
+    setup:
+
+        Run the setup step only.
+
+    deploy:
+
+        Upload nightly build.
+
+    pretty:
+
+        Prettify code files. Run uncrustify on C++ files or AutoPEP8 on Python
+        files. To prettify a single file, use: make pretty ARGS=-f/path/to/file.
+
+


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
There are several reasons why one might want to build CARLA on the M1 devices, not least of which is the incredible performance they house in a tiny form-factor. Here I present some changes that I needed to build CARLA on my M1 MAX machine. 

- Allow >clang-8 building
- Unified Linux and Mac `.sh` scripts as `Unix` build scripts
- Add necessary flags to `make LibCarla && make launch && make package` in `x86_64` Apple (Run on rosetta)
- Add necessary flags to `make LibCarla && make PythonAPI && make check` in `arm64` (runs natively)
- Does not change the Linux/Windows build
- Add documentation for Mac build (see Docs/build_mac.md)

Fixes #150 (but specifically for M1 devices)  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** MacOS 12.1, Linux (Ubuntu 21.04), Windows 10
  * **Python version(s):** Python3.8 - Anaconda
  * **Unreal Engine version(s):** 4.26-carla (modded by Carla)

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
- Unforeseen challenges with CARLA in multiple architectures
- Additional maintenance with CARLA for MacOS users
- Unable to build PythonAPI in `x86_64` mode
- Unable to build PythonAPI with `-ljpeg` and `-ltiff` for now
- Need to `make LibCarla` twice, once in `x86` mode and once in `arm64` mode
