### PR TITLE
Add fix for YieldSignComponent RoadInfoSignal incomplete type error

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -6,10 +6,12 @@
 
 #include "YieldSignComponent.h"
 #include "TrafficLightState.h"
+#include "Vehicle/CarlaWheeledVehicle.h"
 #include <queue>
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/road/element/RoadInfoSpeed.h>
+#include <carla/road/element/RoadInfoSignal.h>
 #include <compiler/enable-ue4-macros.h>
 
 void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -14,20 +14,23 @@
 #include <carla/road/element/RoadInfoSignal.h>
 #include <compiler/enable-ue4-macros.h>
 
+namespace cr = carla::road;
+namespace cre = carla::road::element;
+
 void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
 {
 
   const double epsilon = 0.00001;
 
-  auto References = GetAllReferencesToThisSignal(Map);
+  TArray<std::pair<cr::RoadId, const cre::RoadInfoSignal*>> References = GetAllReferencesToThisSignal(Map);
 
   for (auto& Reference : References)
   {
-    auto RoadId = Reference.first;
-    const auto* SignalReference = Reference.second;
+    cr::RoadId RoadId = Reference.first;
+    const cre::RoadInfoSignal* SignalReference = Reference.second;
     TSet<carla::road::RoadId> SignalPredecessors;
     // Yield box
-    for(auto &validity : SignalReference->GetValidities())
+    for(const carla::road::LaneValidity &validity : SignalReference->GetValidities())
     {
       for(auto lane : carla::geom::Math::GenerateRange(validity._from_lane, validity._to_lane))
       {


### PR DESCRIPTION

With the latest build tools, problems arise with YieldSignComponent for unknown reasons such as:
```
In file included from .../Unreal/CarlaUE4/Plugins/Carla/Intermediate/Build/Mac/x86_64/UE4Editor/Development/Carla/Module.Carla.3_of_3.cpp:3:
.../Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp:28:41: error: member access into incomplete type 'const carla::road::element::RoadInfoSignal'
    for(auto &validity : SignalReference->GetValidities())
```

which then leads to other syntax errors and nonsensical problems afterwards. The solution was to expliticly specify the includes for `RoadInfoSignal` and `CarlaWheeledVehicle` which were missing from `YieldSignComponent.[cpp,h]`

Fixes #5211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5217)
<!-- Reviewable:end -->
