### PR TITLE
Switch to boost::variant2

### DIFF
--- a/LibCarla/source/carla/RecurrentSharedFuture.h
+++ b/LibCarla/source/carla/RecurrentSharedFuture.h
@@ -10,7 +10,15 @@
 #include "carla/Time.h"
 
 #include <boost/optional.hpp>
-#include <boost/variant.hpp>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 #include <condition_variable>
 #include <exception>
@@ -63,7 +71,7 @@ namespace detail {
 
     struct mapped_type {
       bool should_wait;
-      boost::variant<SharedException, T> value;
+      boost::variant2::variant<SharedException, T> value;
     };
 
     std::map<const char *, mapped_type> _map;
@@ -109,10 +117,10 @@ namespace detail {
     if (!_cv.wait_for(lock, timeout.to_chrono(), [&]() { return !r.should_wait; })) {
       return {};
     }
-    if (r.value.which() == 0) {
-      throw_exception(boost::get<SharedException>(r.value));
+    if (r.value.index() == 0) {
+      throw_exception(boost::variant2::get<SharedException>(r.value));
     }
-    return boost::get<T>(std::move(r.value));
+    return boost::variant2::get<T>(std::move(r.value));
   }
 
   template <typename T>

--- a/LibCarla/source/carla/client/detail/ActorVariant.cpp
+++ b/LibCarla/source/carla/client/detail/ActorVariant.cpp
@@ -16,7 +16,7 @@ namespace detail {
   void ActorVariant::MakeActor(EpisodeProxy episode) const {
     _value = detail::ActorFactory::MakeActor(
         episode,
-        boost::get<rpc::Actor>(std::move(_value)),
+        boost::variant2::get<rpc::Actor>(std::move(_value)),
         GarbageCollectionPolicy::Disabled);
   }
 

--- a/LibCarla/source/carla/client/detail/ActorVariant.h
+++ b/LibCarla/source/carla/client/detail/ActorVariant.h
@@ -12,7 +12,15 @@
 #include "carla/client/detail/EpisodeProxy.h"
 #include "carla/rpc/Actor.h"
 
-#include <boost/variant.hpp>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 namespace carla {
 namespace client {
@@ -39,15 +47,15 @@ namespace detail {
     }
 
     SharedPtr<client::Actor> Get(EpisodeProxy episode) const {
-      if (_value.which() == 0u) {
+      if (_value.index() == 0u) {
         MakeActor(episode);
       }
-      DEBUG_ASSERT(_value.which() == 1u);
-      return boost::get<SharedPtr<client::Actor>>(_value);
+      DEBUG_ASSERT(_value.index() == 1u);
+      return boost::variant2::get<SharedPtr<client::Actor>>(_value);
     }
 
     const rpc::Actor &Serialize() const {
-      return boost::apply_visitor(Visitor(), _value);
+      return boost::variant2::visit(Visitor(), _value);
     }
 
     ActorId GetId() const {
@@ -83,7 +91,7 @@ namespace detail {
 
     void MakeActor(EpisodeProxy episode) const;
 
-    mutable boost::variant<rpc::Actor, SharedPtr<client::Actor>> _value;
+    mutable boost::variant2::variant<rpc::Actor, SharedPtr<client::Actor>> _value;
   };
 
 } // namespace detail

--- a/LibCarla/source/carla/nav/WalkerEvent.h
+++ b/LibCarla/source/carla/nav/WalkerEvent.h
@@ -6,7 +6,15 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 #include "carla/rpc/ActorId.h"
 
@@ -40,7 +48,7 @@ namespace nav {
     };
 
     /// walker event variant
-    using WalkerEvent = boost::variant<WalkerEventIgnore, WalkerEventWait, WalkerEventStopAndCheck>;
+    using WalkerEvent = boost::variant2::variant<WalkerEventIgnore, WalkerEventWait, WalkerEventStopAndCheck>;
 
     /// visitor class
     class WalkerEventVisitor {

--- a/LibCarla/source/carla/nav/WalkerManager.cpp
+++ b/LibCarla/source/carla/nav/WalkerManager.cpp
@@ -254,7 +254,7 @@ namespace nav {
         // build the visitor structure
         WalkerEventVisitor visitor(this, id, delta);
         // run the event
-        return boost::apply_visitor(visitor, rp.event);
+        return boost::variant2::visit(visitor, rp.event);
     }
 
 

--- a/LibCarla/source/carla/rpc/Command.h
+++ b/LibCarla/source/carla/rpc/Command.h
@@ -11,13 +11,22 @@
 #include "carla/geom/Transform.h"
 #include "carla/rpc/ActorDescription.h"
 #include "carla/rpc/ActorId.h"
+#include "carla/rpc/TrafficLightState.h"
 #include "carla/rpc/VehicleAckermannControl.h"
 #include "carla/rpc/VehicleControl.h"
 #include "carla/rpc/VehiclePhysicsControl.h"
 #include "carla/rpc/VehicleLightState.h"
 #include "carla/rpc/WalkerControl.h"
 
-#include <boost/variant.hpp>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 namespace carla {
 
@@ -113,6 +122,16 @@ namespace rpc {
       ActorId actor;
       geom::Transform transform;
       MSGPACK_DEFINE_ARRAY(actor, transform);
+    };
+
+    struct ApplyLocation : CommandBase<ApplyLocation> {
+      ApplyLocation() = default;
+      ApplyLocation(ActorId id, const geom::Location &value)
+        : actor(id),
+          location(value) {}
+      ActorId actor;
+      geom::Location location;
+      MSGPACK_DEFINE_ARRAY(actor, location);
     };
 
     struct ApplyWalkerState : CommandBase<ApplyWalkerState> {
@@ -243,7 +262,26 @@ namespace rpc {
       MSGPACK_DEFINE_ARRAY(actor, light_state);
     };
 
-    using CommandType = boost::variant<
+    struct ConsoleCommand : CommandBase<ConsoleCommand> {
+      ConsoleCommand() = default;
+      ConsoleCommand(std::string cmd) : cmd(cmd) {}
+      std::string cmd;
+      MSGPACK_DEFINE_ARRAY(cmd);
+    };
+
+    struct SetTrafficLightState : CommandBase<SetTrafficLightState> {
+      SetTrafficLightState() = default;
+      SetTrafficLightState(
+          ActorId id,
+          rpc::TrafficLightState state)
+        : actor(id),
+          traffic_light_state(state) {}
+      ActorId actor;
+      rpc::TrafficLightState traffic_light_state;
+      MSGPACK_DEFINE_ARRAY(actor, traffic_light_state);
+    };
+
+    using CommandType = boost::variant2::variant<
         SpawnActor,
         DestroyActor,
         ApplyVehicleControl,
@@ -262,7 +300,10 @@ namespace rpc {
         SetEnableGravity,
         SetAutopilot,
         ShowDebugTelemetry,
-        SetVehicleLightState>;
+        SetVehicleLightState,
+        ApplyLocation,
+        ConsoleCommand,
+        SetTrafficLightState>;
 
     CommandType command;
 

--- a/LibCarla/source/carla/rpc/DebugShape.h
+++ b/LibCarla/source/carla/rpc/DebugShape.h
@@ -13,7 +13,15 @@
 #include "carla/geom/Rotation.h"
 #include "carla/rpc/Color.h"
 
-#include <boost/variant.hpp>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 namespace carla {
 namespace rpc {
@@ -54,7 +62,7 @@ namespace rpc {
       MSGPACK_DEFINE_ARRAY(location, text, draw_shadow);
     };
 
-    boost::variant<Point, Line, Arrow, Box, String> primitive;
+    boost::variant2::variant<Point, Line, Arrow, Box, String> primitive;
 
     Color color = {255u, 0u, 0u};
 

--- a/LibCarla/source/carla/rpc/Response.h
+++ b/LibCarla/source/carla/rpc/Response.h
@@ -10,7 +10,16 @@
 #include "carla/MsgPackAdaptors.h"
 
 #include <boost/optional.hpp>
-#include <boost/variant.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
 
 #include <string>
 
@@ -58,7 +67,7 @@ namespace rpc {
     }
 
     bool HasError() const {
-      return _data.which() == 0;
+      return _data.index() == 0;
     }
 
     template <typename... Ts>
@@ -68,17 +77,17 @@ namespace rpc {
 
     const error_type &GetError() const {
       DEBUG_ASSERT(HasError());
-      return boost::get<error_type>(_data);
+      return boost::variant2::get<error_type>(_data);
     }
 
     value_type &Get() {
       DEBUG_ASSERT(!HasError());
-      return boost::get<value_type>(_data);
+      return boost::variant2::get<value_type>(_data);
     }
 
     const value_type &Get() const {
       DEBUG_ASSERT(!HasError());
-      return boost::get<value_type>(_data);
+      return boost::variant2::get<value_type>(_data);
     }
 
     operator bool() const {
@@ -89,7 +98,7 @@ namespace rpc {
 
   private:
 
-    boost::variant<error_type, value_type> _data;
+    boost::variant2::variant<error_type, value_type> _data;
   };
 
   template <>

--- a/LibCarla/source/carla/trafficmanager/VehicleLightStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/VehicleLightStage.cpp
@@ -69,8 +69,8 @@ void VehicleLightStage::Update(const unsigned long index) {
 
   // Determine brake light state
   for (size_t cc = 0; cc < control_frame.size(); cc++) {
-    if (control_frame[cc].command.type() == typeid(carla::rpc::Command::ApplyVehicleControl)) {
-      carla::rpc::Command::ApplyVehicleControl& ctrl = boost::get<carla::rpc::Command::ApplyVehicleControl>(control_frame[cc].command);
+    if (auto* maybe_ctrl = boost::variant2::get_if<carla::rpc::Command::ApplyVehicleControl>(&control_frame[cc].command)) {
+      carla::rpc::Command::ApplyVehicleControl& ctrl = *maybe_ctrl;
       if (ctrl.actor == actor_id) {
         brake_lights = (ctrl.control.brake > 0.5); // hard braking, avoid blinking for throttle control
         break;

--- a/LibCarla/source/test/common/test_msgpack.cpp
+++ b/LibCarla/source/test/common/test_msgpack.cpp
@@ -74,22 +74,22 @@ TEST(msgpack, actor) {
 TEST(msgpack, variant) {
   using mp = carla::MsgPack;
 
-  boost::variant<bool, float, std::string> var;
+  boost::variant2::variant<bool, float, std::string> var;
 
   var = true;
   auto result = mp::UnPack<decltype(var)>(mp::Pack(var));
-  ASSERT_EQ(result.which(), 0);
-  ASSERT_EQ(boost::get<bool>(result), true);
+  ASSERT_EQ(result.index(), 0);
+  ASSERT_EQ(boost::variant2::get<bool>(result), true);
 
   var = 42.0f;
   result = mp::UnPack<decltype(var)>(mp::Pack(var));
-  ASSERT_EQ(result.which(), 1);
-  ASSERT_EQ(boost::get<float>(result), 42.0f);
+  ASSERT_EQ(result.index(), 1);
+  ASSERT_EQ(boost::variant2::get<float>(result), 42.0f);
 
   var = std::string("hola!");
   result = mp::UnPack<decltype(var)>(mp::Pack(var));
-  ASSERT_EQ(result.which(), 2);
-  ASSERT_EQ(boost::get<std::string>(result), "hola!");
+  ASSERT_EQ(result.index(), 2);
+  ASSERT_EQ(boost::variant2::get<std::string>(result), "hola!");
 }
 
 TEST(msgpack, optional) {

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -86,24 +86,22 @@ static auto ApplyBatchCommandsSync(
         bool autopilotValue = false;
 
         CommandType::CommandType& cmd_type = cmds[i].command;
-        const boost::typeindex::type_info& cmd_type_info = cmd_type.type();
 
         // check SpawnActor command
-        if (cmd_type_info == typeid(carla::rpc::Command::SpawnActor)) {
+        if (const auto *maybe_spawn_actor_cmd = boost::variant2::get_if<carla::rpc::Command::SpawnActor>(&cmd_type)) {
           // check inside 'do_after'
-          auto &spawn = boost::get<carla::rpc::Command::SpawnActor>(cmd_type);
-          for (auto &cmd : spawn.do_after) {
-            if (cmd.command.type() == typeid(carla::rpc::Command::SetAutopilot)) {
-              tm_port = boost::get<carla::rpc::Command::SetAutopilot>(cmd.command).tm_port;
-              autopilotValue = boost::get<carla::rpc::Command::SetAutopilot>(cmd.command).enabled;
+          for (auto &cmd : maybe_spawn_actor_cmd->do_after) {
+            if (const auto *maybe_set_autopilot_command = boost::variant2::get_if<carla::rpc::Command::SetAutopilot>(&cmd.command)) {
+              tm_port = maybe_set_autopilot_command->tm_port;
+              autopilotValue = maybe_set_autopilot_command->enabled;
               isAutopilot = true;
             }
           }
         }
         // check SetAutopilot command
-        else if (cmd_type_info == typeid(carla::rpc::Command::SetAutopilot)) {
-          tm_port = boost::get<carla::rpc::Command::SetAutopilot>(cmd_type).tm_port;
-          autopilotValue = boost::get<carla::rpc::Command::SetAutopilot>(cmd_type).enabled;
+        else if (const auto *maybe_set_autopilot_command = boost::variant2::get_if<carla::rpc::Command::SetAutopilot>(&cmd_type)) {
+          tm_port = maybe_set_autopilot_command->tm_port;
+          autopilotValue = maybe_set_autopilot_command->enabled;
           isAutopilot = true;
         }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -740,6 +740,21 @@ void FCarlaServer::FPimpl::BindActions()
     return true;
   };
 
+  BIND_SYNC(console_command) << [this](std::string cmd) -> R<bool>
+  {
+    REQUIRE_CARLA_EPISODE();
+    APlayerController* PController= UGameplayStatics::GetPlayerController(Episode->GetWorld(), 0);
+    if( PController )
+    {
+        auto result = PController->ConsoleCommand(UTF8_TO_TCHAR(cmd.c_str()), true);
+        return !(
+          result.Contains(FString(TEXT("Command not recognized"))) ||
+          result.Contains(FString(TEXT("Error")))
+        );
+    }
+    return GEngine->Exec(Episode->GetWorld(), UTF8_TO_TCHAR(cmd.c_str()));
+  };
+
   // ~~ Actor physics ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(set_actor_location) << [this](
@@ -2115,11 +2130,12 @@ void FCarlaServer::FPimpl::BindActions()
           ActorId id = result.Get().id;
           auto set_id = carla::Functional::MakeOverload(
               [](C::SpawnActor &) {},
+              [](C::ConsoleCommand &) {},
               [id](auto &s) { s.actor = id; });
           for (auto command : c.do_after)
           {
-            boost::apply_visitor(set_id, command.command);
-            boost::apply_visitor(self, command.command);
+            boost::variant2::visit(set_id, command.command);
+            boost::variant2::visit(self, command.command);
           }
           return id;
         }
@@ -2145,7 +2161,11 @@ void FCarlaServer::FPimpl::BindActions()
       [=](auto, const C::SetVehicleLightState &c) { MAKE_RESULT(set_vehicle_light_state(c.actor, c.light_state)); },
 //      [=](auto, const C::OpenVehicleDoor &c) {      MAKE_RESULT(open_vehicle_door(c.actor, c.door_idx)); },
 //      [=](auto, const C::CloseVehicleDoor &c) {     MAKE_RESULT(close_vehicle_door(c.actor, c.door_idx)); },
-      [=](auto, const C::ApplyWalkerState &c) {     MAKE_RESULT(set_walker_state(c.actor, c.transform, c.speed)); });
+      [=](auto, const C::ApplyWalkerState &c) {     MAKE_RESULT(set_walker_state(c.actor, c.transform, c.speed)); },
+      [=](auto, const C::ConsoleCommand& c) -> CR {       return console_command(c.cmd); },
+      [=](auto, const C::SetTrafficLightState& c) { MAKE_RESULT(set_traffic_light_state(c.actor, c.traffic_light_state)); },
+      [=](auto, const C::ApplyLocation& c)        { MAKE_RESULT(set_actor_location(c.actor, c.location)); }
+  );
 
 #undef MAKE_RESULT
 
@@ -2157,7 +2177,7 @@ void FCarlaServer::FPimpl::BindActions()
     result.reserve(commands.size());
     for (const auto &command : commands)
     {
-      result.emplace_back(boost::apply_visitor(command_visitor, command.command));
+      result.emplace_back(boost::variant2::visit(command_visitor, command.command));
     }
     if (do_tick_cue)
     {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/TriggerFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/TriggerFactory.cpp
@@ -12,6 +12,7 @@
 #include "Carla/Game/CarlaStatics.h"
 #include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
 #include "Carla/Trigger/FrictionTrigger.h"
+#include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
 
 // =============================================================================
 // -- ATriggerFactory -----------------------------------------------------------

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -5,6 +5,7 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "Carla.h"
+#include "Carla/Game/Tagger.h"
 #include "Carla/Util/BoundingBoxCalculator.h"
 
 #include "Carla/Traffic/TrafficSignBase.h"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -236,5 +236,5 @@ private:
 void FDebugShapeDrawer::Draw(const carla::rpc::DebugShape &Shape)
 {
   auto Visitor = FShapeVisitor(World, Shape.color, Shape.life_time, Shape.persistent_lines);
-  boost::apply_visitor(Visitor, Shape.primitive);
+  boost::variant2::visit(Visitor, Shape.primitive);
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Walker/WalkerController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Walker/WalkerController.cpp
@@ -14,8 +14,6 @@
 #include "GameFramework/CharacterMovementComponent.h"
 #include "GameFramework/Pawn.h"
 
-#include <boost/variant/apply_visitor.hpp>
-
 AWalkerController::AWalkerController(const FObjectInitializer &ObjectInitializer)
   : Super(ObjectInitializer)
 {
@@ -166,23 +164,18 @@ void AWalkerController::GetPoseFromAnimation()
   SkeletalMesh->SnapshotPose(WalkerAnim->Snap);
 }
 
-void AWalkerController::ControlTickVisitor::operator()(const FWalkerControl &WalkerControl)
-{
-  auto *Character = Controller->GetCharacter();
-  if (!Character) return;
-
-  Character->AddMovementInput(WalkerControl.Direction,
-        WalkerControl.Speed / Controller->GetMaximumWalkSpeed());
-  if (WalkerControl.Jump)
-  {
-    Character->Jump();
-  }
-}
-
 void AWalkerController::Tick(float DeltaSeconds)
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(AWalkerController::Tick);
   Super::Tick(DeltaSeconds);
-  AWalkerController::ControlTickVisitor ControlTickVisitor(this);
-  boost::apply_visitor(ControlTickVisitor, Control);
+
+  auto *Character = GetCharacter();
+  if (!Character) return;
+
+  Character->AddMovementInput(Control.Direction,
+        Control.Speed / GetMaximumWalkSpeed());
+  if (Control.Jump)
+  {
+    Character->Jump();
+  }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Walker/WalkerController.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Walker/WalkerController.h
@@ -15,7 +15,6 @@
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/WalkerBoneControlIn.h>
-#include <boost/variant.hpp>
 #include <compiler/enable-ue4-macros.h>
 
 #include "WalkerController.generated.h"
@@ -24,22 +23,6 @@ UCLASS()
 class CARLA_API AWalkerController : public AController
 {
   GENERATED_BODY()
-
-private:
-
-  class ControlTickVisitor : public boost::static_visitor<>
-  {
-  public:
-
-    ControlTickVisitor(AWalkerController *Controller)
-      : Controller(Controller) {}
-
-    void operator()(const FWalkerControl &WalkerControl);
-
-  private:
-
-    AWalkerController *Controller;
-  };
 
 public:
 
@@ -62,7 +45,7 @@ public:
   UFUNCTION(BlueprintCallable)
   const FWalkerControl GetWalkerControl() const
   {
-    return Control.which() == 0u ? boost::get<FWalkerControl>(Control) : FWalkerControl{};
+    return Control;
   }
 
   UFUNCTION(BlueprintCallable)
@@ -79,5 +62,5 @@ public:
 
 private:
 
-  boost::variant<FWalkerControl> Control;
+  FWalkerControl Control;
 };

--- a/Unreal/CarlaUE4/Source/CarlaUE4.Target.cs
+++ b/Unreal/CarlaUE4/Source/CarlaUE4.Target.cs
@@ -9,5 +9,6 @@ public class CarlaUE4Target : TargetRules
 	{
 		Type = TargetType.Game;
 		ExtraModuleNames.Add("CarlaUE4");
+		bUseLoggingInShipping = true;
 	}
 }


### PR DESCRIPTION
boost::variant only supports up to 20 types (MPL limit). boost::variant2
has no such limit; switch to it.

#### Where has this been tested?

  * **Platform(s):** Linux/ubuntu 18.04, Windows 10
  * **Python version(s):** 3.8 (windows and linux)
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None known.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5284)
<!-- Reviewable:end -->
