### PR TITLE
Disable PNG compression when using save_to_disk

### DIFF
--- a/LibCarla/source/carla/image/ImageIOConfig.h
+++ b/LibCarla/source/carla/image/ImageIOConfig.h
@@ -120,7 +120,9 @@ namespace detail {
 
     template <typename Str, typename ViewT>
     static void write_view(Str &&out_filename, const ViewT &view) {
-      boost::gil::write_view(std::forward<Str>(out_filename), view, boost::gil::png_tag());
+      boost::gil::image_write_info<boost::gil::png_tag> write_info;
+      write_info._compression_level = 0;
+      boost::gil::write_view(std::forward<Str>(out_filename), view, write_info);
     }
 
 #endif // LIBCARLA_IMAGE_WITH_PNG_SUPPORT


### PR DESCRIPTION
Description
Disable PNG compression when using save_to_disk function. Related to  #3895.

Where has this been tested?
Platform(s): Ubuntu 20
Python version(s): 3.7
Unreal Engine version(s): UE 4.26
Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5346)
<!-- Reviewable:end -->
