### PR TITLE
Added ApplyRolloverBehavior function

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -342,6 +342,9 @@ private:
   bool bAckermannControlActive = false;
   FAckermannController AckermannController;
 
+  float RolloverBehaviorForce = 0.35;
+  int RolloverBehaviorTracker = 0;
+
 public:
 
   /// Set the rotation of the car wheels indicated by the user
@@ -396,5 +399,12 @@ private:
 
   UPROPERTY(Category="CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
   TMap<UPrimitiveComponent*, UPhysicsConstraintComponent*> CollisionDisableConstraints;
+
+  /// Rollovers tend to have too much angular velocity, resulting in the vehicle doing a full 360º flip.
+  /// This function progressively reduces the vehicle's angular velocity so that it ends up upside down instead.
+  UFUNCTION(Category = "CARLA Wheeled Vehicle", BlueprintCallable)
+  void ApplyRolloverBehavior();
+
+  void CheckRollover(const float roll, const std::pair<float, float> threshold_roll);
 
 };


### PR DESCRIPTION
### Description

When vehicles rollover, they tend to have too much angular velocity, resulting in the vehicle doing a 360º flip, which allows them to resume their movements as if nothing happened. As such, vehicles hardly ever stays upside down, being unable to continue.

This PR adds a new function, `ApplyRolloverBehavior`, that progressively reduces the angular speed of a vehicle that is performing a rollover, resulting in it staying upside down. By default, none of the CARLA vehicles have this behavior, but it can be easily added by changing their blueprint

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 

### Possible Drawbacks

None as this is just an addition