### PR TITLE
Fix topology with ending lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.
   * Added new ConstantVelocityAgent
   * Added new parameter to the TrafficManager, `set_desired_speed`, to set a vehicle's speed.
   * Added 4 new attributes to all vehicles:

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -711,8 +711,18 @@ namespace road {
     for (const auto &pair : _data.GetRoads()) {
       const auto &road = pair.second;
       ForEachDrivableLane(road, [&](auto &&waypoint) {
-        for (auto &&successor : GetSuccessors(waypoint)) {
-          result.push_back({waypoint, successor});
+        auto successors = GetSuccessors(waypoint);
+        if (successors.size() == 0){
+          auto distance = static_cast<float>(GetDistanceAtEndOfLane(GetLane(waypoint)));
+          auto last_waypoint = GetWaypoint(waypoint.road_id, waypoint.lane_id, distance);
+          if (last_waypoint.has_value()){
+            result.push_back({waypoint, *last_waypoint});
+          }
+        }
+        else{
+          for (auto &&successor : GetSuccessors(waypoint)) {
+            result.push_back({waypoint, successor});
+          }
         }
       });
     }

--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -117,7 +117,7 @@ class GlobalRoutePlanner(object):
             else:
                 next_wps = wp1.next(self._sampling_resolution)
                 if len(next_wps) == 0:
-                    break
+                    continue
                 seg_dict['path'].append(next_wps[0])
             self._topology.append(seg_dict)
 

--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -110,9 +110,15 @@ class GlobalRoutePlanner(object):
                 w = wp1.next(self._sampling_resolution)[0]
                 while w.transform.location.distance(endloc) > self._sampling_resolution:
                     seg_dict['path'].append(w)
-                    w = w.next(self._sampling_resolution)[0]
+                    next_ws = w.next(self._sampling_resolution)
+                    if len(next_ws) == 0:
+                        break
+                    w = next_ws[0]
             else:
-                seg_dict['path'].append(wp1.next(self._sampling_resolution)[0])
+                next_wps = wp1.next(self._sampling_resolution)
+                if len(next_wps) == 0:
+                    break
+                seg_dict['path'].append(next_wps[0])
             self._topology.append(seg_dict)
 
     def _build_graph(self):


### PR DESCRIPTION
### Description

When using the `Map.get_topology`, there is an error that causes lanes with no successors to not be added. This resulted in something like the image below, where the red lines are the lanes part of the topology. As it can be seen, the topology is missing the lane on the left.

![image](https://user-images.githubusercontent.com/58212725/164386910-57aaae3c-a080-4019-a63b-be6a1927900a.png)

This is caused because the topology pairs the start of one lane with the start of the next ones. As such, if no successors are found, the lane's starting point isn't linked with anything. This has been changed and now, if no successors are found, the start of the lane is paired with the its end.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's

#### Possible Drawbacks

This changes the topology a bit, so there might be some cases where some logic is affected. I don't think this happens anywhere in CARLA though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5378)
<!-- Reviewable:end -->
