### PR TITLE
Extended Python agents initializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.
   * Added new ConstantVelocityAgent
   * Added new parameter to the TrafficManager, `set_desired_speed`, to set a vehicle's speed.

--- a/PythonAPI/carla/agents/navigation/behavior_agent.py
+++ b/PythonAPI/carla/agents/navigation/behavior_agent.py
@@ -30,7 +30,7 @@ class BehaviorAgent(BasicAgent):
     are encoded in the agent, from cautious to a more aggressive ones.
     """
 
-    def __init__(self, vehicle, behavior='normal', opt_dict={}):
+    def __init__(self, vehicle, behavior='normal', opt_dict={}, map_inst=None, grp_inst=None):
         """
         Constructor method.
 
@@ -38,7 +38,7 @@ class BehaviorAgent(BasicAgent):
             :param behavior: type of agent to apply
         """
 
-        super(BehaviorAgent, self).__init__(vehicle, opt_dict=opt_dict)
+        super().__init__(vehicle, opt_dict=opt_dict, map_inst=map_inst, grp_inst=grp_inst)
         self._look_ahead_steps = 0
 
         # Vehicle information

--- a/PythonAPI/carla/agents/navigation/constant_velocity_agent.py
+++ b/PythonAPI/carla/agents/navigation/constant_velocity_agent.py
@@ -22,7 +22,7 @@ class ConstantVelocityAgent(BasicAgent):
     wait for a bit, and then start again.
     """
 
-    def __init__(self, vehicle, target_speed=20, opt_dict={}):
+    def __init__(self, vehicle, target_speed=20, opt_dict={}, map_inst=None, grp_inst=None):
         """
         Initialization the agent parameters, the local and the global planner.
 
@@ -30,8 +30,10 @@ class ConstantVelocityAgent(BasicAgent):
             :param target_speed: speed (in Km/h) at which the vehicle will move
             :param opt_dict: dictionary in case some of its parameters want to be changed.
                 This also applies to parameters related to the LocalPlanner.
+            :param map_inst: carla.Map instance to avoid the expensive call of getting it.
+            :param grp_inst: GlobalRoutePlanner instance to avoid the expensive call of getting it.
         """
-        super(ConstantVelocityAgent, self).__init__(vehicle, target_speed, opt_dict=opt_dict)
+        super().__init__(vehicle, target_speed, opt_dict=opt_dict, map_inst=map_inst, grp_inst=grp_inst)
 
         self._use_basic_behavior = False  # Whether or not to use the BasicAgent behavior when the constant velocity is down
         self._target_speed = target_speed / 3.6  # [m/s]

--- a/PythonAPI/carla/agents/navigation/local_planner.py
+++ b/PythonAPI/carla/agents/navigation/local_planner.py
@@ -40,7 +40,7 @@ class LocalPlanner(object):
     unless a given global plan has already been specified.
     """
 
-    def __init__(self, vehicle, opt_dict={}):
+    def __init__(self, vehicle, opt_dict={}, map_inst=None):
         """
         :param vehicle: actor to apply to local planner logic onto
         :param opt_dict: dictionary of arguments with different parameters:
@@ -53,10 +53,18 @@ class LocalPlanner(object):
             max_brake: maximum brake applied to the vehicle
             max_steering: maximum steering applied to the vehicle
             offset: distance between the route waypoints and the center of the lane
+        :param map_inst: carla.Map instance to avoid the expensive call of getting it.
         """
         self._vehicle = vehicle
         self._world = self._vehicle.get_world()
-        self._map = self._world.get_map()
+        if map_inst:
+            if isinstance(map_inst, carla.Map):
+                self._map = map_inst
+            else:
+                print("Warning: Ignoring the given map as it is not a 'carla.Map'")
+                self._map = self._world.get_map()
+        else:
+            self._map = self._world.get_map()
 
         self._vehicle_controller = None
         self.target_waypoint = None


### PR DESCRIPTION
### Description

The Python API agents now have two additional optional inputs. *map_inst* is meant to be a **carla.Map** instance while *grp_inst* is an instance of the **GlobalRoutePlanner** class. 

Both of these classes are, by default, computed by the BasicAgent on initialization, but they are a **very expensive call for large maps** (up to several seconds). As these classes only depend on the static topology and, as such, won't be changed during the simulation, these new inputs can speed up the initialization of the agents

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's

### Possible Drawbacks

None? Nothing is removed and by default it still works the same as before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5402)
<!-- Reviewable:end -->
