### PR TITLE
Prevent adding trigger boxes inside the intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Added check to avoid adding procedural trigger boxes inside intersections.
   * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.
   * Added new ConstantVelocityAgent

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.cpp
@@ -100,6 +100,20 @@ UBoxComponent* USignComponent::GenerateTriggerBox(const FTransform &BoxTransform
   return BoxComponent;
 }
 
+UBoxComponent* USignComponent::GenerateTriggerBox(const FTransform &BoxTransform,
+    const FVector &BoxSize)
+{
+  AActor *ParentActor = GetOwner();
+  UBoxComponent *BoxComponent = NewObject<UBoxComponent>(ParentActor);
+  BoxComponent->RegisterComponent();
+  BoxComponent->AttachToComponent(
+      ParentActor->GetRootComponent(),
+      FAttachmentTransformRules::KeepRelativeTransform);
+  BoxComponent->SetWorldTransform(BoxTransform);
+  BoxComponent->SetBoxExtent(BoxSize, true);
+  return BoxComponent;
+}
+
 void USignComponent::AddEffectTriggerVolume(UBoxComponent* TriggerVolume)
 {
   EffectTriggerVolumes.Add(TriggerVolume);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/SignComponent.h
@@ -67,6 +67,9 @@ protected:
   UBoxComponent* GenerateTriggerBox(const FTransform &BoxTransform,
       float BoxSize);
 
+  UBoxComponent* GenerateTriggerBox(const FTransform &BoxTransform,
+      const FVector &BoxSize);
+
 private:
 
   UPROPERTY(Category = "Traffic Sign", EditAnywhere)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
@@ -43,9 +43,12 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
         auto box_waypoint = signal_waypoint;
         // Prevent adding the bounding box inside the intersection
         if (Map.IsJunction(RoadId)) {
-          auto previous_waypoints = Map.GetPrevious(signal_waypoint, 2.0);
-          if (previous_waypoints.size() == 1) {
-            box_waypoint = previous_waypoints.front();
+          auto predecessors = Map.GetPredecessors(box_waypoint);
+          if (predecessors.size() == 1) {
+            auto predecessor = predecessors.front();
+            if (!Map.IsJunction(predecessor.road_id)) {
+              box_waypoint = predecessor;
+            }
           }
         }
 
@@ -62,12 +65,12 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
         double LaneDistance = Map.GetLane(box_waypoint).GetDistance();
         if(lane < 0)
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s - BoxWidth,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s + BoxWidth,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(box_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.cpp
@@ -63,14 +63,16 @@ void UStopSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get min and max
         double LaneLength = Map.GetLane(box_waypoint).GetLength();
         double LaneDistance = Map.GetLane(box_waypoint).GetDistance();
+        // Safe distance to avoid overlapping the bounding box with the intersection
+        float AdditionalDistance = 1.5f;
         if(lane < 0)
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + 1.5f),
+          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + 1.5f),
+          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(box_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/StopSignComponent.h
@@ -23,7 +23,7 @@ public:
 private:
 
   void GenerateStopBox(const FTransform BoxTransform,
-      float BoxSize);
+      const FVector BoxSize);
 
   void GenerateCheckBox(const FTransform BoxTransform,
       float BoxSize);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -39,43 +39,53 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         auto signal_waypoint = Map.GetWaypoint(
             RoadId, lane, SignalReference->GetS()).get();
 
+        // Prevent adding the bounding box inside the intersection
+        if (Map.IsJunction(RoadId)) {
+          auto previous_waypoints = Map.GetPrevious(signal_waypoint, 2.0);
+          if (previous_waypoints.size() == 1) {
+            signal_waypoint = previous_waypoints.front();
+          }
+        }
+
         if(Map.GetLane(signal_waypoint).GetType() != cr::Lane::LaneType::Driving)
           continue;
 
-        // Get 90% of the half size of the width of the lane
-        float BoxSize = static_cast<float>(
-            0.9f*Map.GetLaneWidth(signal_waypoint)*0.5);
+        // Get 50% of the half size of the width of the lane
+        float BoxWidth = static_cast<float>(
+            0.5f*Map.GetLaneWidth(signal_waypoint)*0.5);
+        float BoxLength = 1.5f;
+        float BoxHeight = 1.0f;
+
         // Prevent a situation where the road width is 0,
         // this could happen in a lane that is just appearing
-        BoxSize = std::max(0.01f, BoxSize);
+        BoxWidth = std::max(0.01f, BoxWidth);
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
         if(lane < 0)
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - BoxSize,
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - BoxWidth,
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + BoxSize,
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + BoxWidth,
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
-        float UnrealBoxSize = 100*BoxSize;
         FTransform BoxTransform = Map.ComputeTransform(signal_waypoint);
         ALargeMapManager* LargeMapManager = UCarlaStatics::GetLargeMapManager(GetWorld());
         if (LargeMapManager)
         {
           BoxTransform = LargeMapManager->GlobalToLocalTransform(BoxTransform);
         }
-        GenerateTrafficLightBox(BoxTransform, UnrealBoxSize);
+        GenerateTrafficLightBox(BoxTransform, FVector(100*BoxLength, 100*BoxWidth, 100*BoxHeight));
       }
     }
   }
 }
 
 void UTrafficLightComponent::GenerateTrafficLightBox(const FTransform BoxTransform,
-    float BoxSize)
+    const FVector BoxSize)
 {
   UBoxComponent* BoxComponent = GenerateTriggerBox(BoxTransform, BoxSize);
   BoxComponent->OnComponentBeginOverlap.AddDynamic(this, &UTrafficLightComponent::OnOverlapTriggerBox);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -41,9 +41,12 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
 
         // Prevent adding the bounding box inside the intersection
         if (Map.IsJunction(RoadId)) {
-          auto previous_waypoints = Map.GetPrevious(signal_waypoint, 2.0);
-          if (previous_waypoints.size() == 1) {
-            signal_waypoint = previous_waypoints.front();
+          auto predecessors = Map.GetPredecessors(signal_waypoint);
+          if (predecessors.size() == 1) {
+            auto predecessor = predecessors.front();
+            if (!Map.IsJunction(predecessor.road_id)) {
+              signal_waypoint = predecessor;
+            }
           }
         }
 
@@ -64,12 +67,12 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
         if(lane < 0)
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - BoxWidth,
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + BoxWidth,
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(signal_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -65,14 +65,16 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         // Get min and max
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
+        // Safe distance to avoid overlapping the bounding box with the intersection
+        float AdditionalDistance = 1.5f;
         if(lane < 0)
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - (BoxLength + 1.5f),
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + (BoxLength + 1.5f),
+          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(signal_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
@@ -68,7 +68,7 @@ private:
 
   void GenerateTrafficLightBox(
       const FTransform BoxTransform,
-      float BoxSize);
+      const FVector BoxSize);
 
   UPROPERTY(Category = "Traffic Light", EditAnywhere)
   ETrafficLightState LightState;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -65,14 +65,16 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         // Get min and max
         double LaneLength = Map.GetLane(box_waypoint).GetLength();
         double LaneDistance = Map.GetLane(box_waypoint).GetDistance();
+        // Safe distance to avoid overlapping the bounding box with the intersection
+        float AdditionalDistance = 1.5f;
         if(lane < 0)
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + 1.5f),
+          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + 1.5f),
+          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(box_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -45,9 +45,12 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         auto box_waypoint = signal_waypoint;
         // Prevent adding the bounding box inside the intersection
         if (Map.IsJunction(RoadId)) {
-          auto previous_waypoints = Map.GetPrevious(signal_waypoint, 2.0);
-          if (previous_waypoints.size() == 1) {
-            box_waypoint = previous_waypoints.front();
+          auto predecessors = Map.GetPredecessors(box_waypoint);
+          if (predecessors.size() == 1) {
+            auto predecessor = predecessors.front();
+            if (!Map.IsJunction(predecessor.road_id)) {
+              box_waypoint = predecessor;
+            }
           }
         }
 
@@ -64,12 +67,12 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         double LaneDistance = Map.GetLane(box_waypoint).GetDistance();
         if(lane < 0)
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s - BoxWidth,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s - (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          box_waypoint.s = FMath::Clamp(box_waypoint.s + BoxWidth,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s + (BoxLength + 1.5f),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         FTransform BoxTransform = Map.ComputeTransform(box_waypoint);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.cpp
@@ -8,6 +8,8 @@
 #include "TrafficLightState.h"
 #include <queue>
 
+#include "Carla/Game/CarlaStatics.h"
+#include "Carla/MapGen/LargeMapManager.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 #include <compiler/disable-ue4-macros.h>
 #include <carla/road/element/RoadInfoSpeed.h>
@@ -40,27 +42,43 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
         if(Map.GetLane(signal_waypoint).GetType() != cr::Lane::LaneType::Driving)
           continue;
 
-        // Get 90% of the half size of the width of the lane
-        float BoxSize = static_cast<float>(
-            0.9*Map.GetLaneWidth(signal_waypoint)/2.0);
+        auto box_waypoint = signal_waypoint;
+        // Prevent adding the bounding box inside the intersection
+        if (Map.IsJunction(RoadId)) {
+          auto previous_waypoints = Map.GetPrevious(signal_waypoint, 2.0);
+          if (previous_waypoints.size() == 1) {
+            box_waypoint = previous_waypoints.front();
+          }
+        }
+
+        // Get 50% of the half size of the width of the lane
+        float BoxWidth = static_cast<float>(
+            0.5f*Map.GetLaneWidth(box_waypoint)*0.5);
+        float BoxLength = 1.5f;
+        float BoxHeight = 1.0f;
         // Prevent a situation where the road width is 0,
         // this could happen in a lane that is just appearing
-        BoxSize = std::max(0.01f, BoxSize);
+        BoxWidth = std::max(0.01f, BoxWidth);
         // Get min and max
-        double LaneLength = Map.GetLane(signal_waypoint).GetLength();
-        double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
+        double LaneLength = Map.GetLane(box_waypoint).GetLength();
+        double LaneDistance = Map.GetLane(box_waypoint).GetDistance();
         if(lane < 0)
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s - BoxSize,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s - BoxWidth,
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
         else
         {
-          signal_waypoint.s = FMath::Clamp(signal_waypoint.s + BoxSize,
+          box_waypoint.s = FMath::Clamp(box_waypoint.s + BoxWidth,
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);
         }
-        float UnrealBoxSize = 100*BoxSize;
-        GenerateYieldBox(Map.ComputeTransform(signal_waypoint), UnrealBoxSize);
+        FTransform BoxTransform = Map.ComputeTransform(box_waypoint);
+        ALargeMapManager* LargeMapManager = UCarlaStatics::GetLargeMapManager(GetWorld());
+        if (LargeMapManager)
+        {
+          BoxTransform = LargeMapManager->GlobalToLocalTransform(BoxTransform);
+        }
+        GenerateYieldBox(BoxTransform, FVector(100*BoxLength, 100*BoxWidth, 100*BoxHeight));
 
         auto Predecessors = Map.GetPredecessors(signal_waypoint);
         for(auto &Prev : Predecessors)
@@ -113,7 +131,15 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
             // this could happen in a lane that is just appearing
             BoxSize = std::max(0.01f, BoxSize);
             float UEBoxSize = 100*BoxSize;
-            GenerateCheckBox(Map.ComputeTransform(NextWaypoint), UEBoxSize);
+
+            FTransform BoxTransform = Map.ComputeTransform(NextWaypoint);
+            ALargeMapManager* LargeMapManager = UCarlaStatics::GetLargeMapManager(GetWorld());
+            if (LargeMapManager)
+            {
+              BoxTransform = LargeMapManager->GlobalToLocalTransform(BoxTransform);
+            }
+            GenerateCheckBox(BoxTransform, UEBoxSize);
+
             while (true)
             {
               auto Next = Map.GetNext(NextWaypoint, 2*BoxSize);
@@ -126,8 +152,13 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
               {
                 break;
               }
+              BoxTransform = Map.ComputeTransform(NextWaypoint);
+              if (LargeMapManager)
+              {
+                BoxTransform = LargeMapManager->GlobalToLocalTransform(BoxTransform);
+              }
+              GenerateCheckBox(BoxTransform, UEBoxSize);
 
-              GenerateCheckBox(Map.ComputeTransform(NextWaypoint), UEBoxSize);
             }
             // Cover the road before the junction
             // Hard coded anticipation time (boxes placed prior to the junction)
@@ -169,7 +200,7 @@ void UYieldSignComponent::InitializeSign(const carla::road::Map &Map)
 }
 
 void UYieldSignComponent::GenerateYieldBox(const FTransform BoxTransform,
-    float BoxSize)
+    const FVector BoxSize)
 {
   UBoxComponent* BoxComponent = GenerateTriggerBox(BoxTransform, BoxSize);
   BoxComponent->OnComponentBeginOverlap.AddDynamic(this, &UYieldSignComponent::OnOverlapBeginYieldEffectBox);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/YieldSignComponent.h
@@ -23,7 +23,7 @@ public:
 private:
 
   void GenerateYieldBox(const FTransform BoxTransform,
-      float BoxSize);
+      const FVector BoxSize);
 
   void GenerateCheckBox(const FTransform BoxTransform,
       float BoxSize);


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
<!-- Please explain the changes you made here as detailed as possible. -->

This PR modifies the location and shape of the trigger bounding boxes for the procedural traffic signs. It only affects to traffic lights, stops and yields.

The new algorithm prevents adding trigger boxes inside the intersection. It works in the following way:

1. If the landmark is not located inside an intersection, the center of the trigger box corresponds to the position of the landmark.
2. If the landmark is located inside an intersection it gets a previous waypoint (2m) and checks the number of predecessors. If there is only one possible predecessor we use this location as the center of the bounding box. Otherwise the landmark location is used. 

The shape of the trigger box has been also modified. Previously, the trigger box was a cube with dimension 90% of the lane width. To avoid collisions with oncoming traffic, the dimension of the bounding box has been changed to:
* Width: 50% lane width
* Length: 1.5m
* Heigh: 1m.

Also, large maps now supports stops and yields traffic signs.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks
Testing is required to verify that Town11 is not affected by these changes.

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5403)
<!-- Reviewable:end -->
