### PR TITLE
Fix TM blocking the simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug causing the TM to block the simulation when another client teleported a vehicle with no physics.
   * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.
   * Added new ConstantVelocityAgent

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -28,7 +28,7 @@ using constants::Collision::EPSILON;
 
 MotionPlanStage::MotionPlanStage(
   const std::vector<ActorId> &vehicle_id_list,
-  const SimulationState &simulation_state,
+  SimulationState &simulation_state,
   const Parameters &parameters,
   const BufferMap &buffer_map,
   TrackTraffic &track_traffic,
@@ -257,6 +257,7 @@ void MotionPlanStage::Update(const unsigned long index) {
       }
       // Constructing the actuation signal.
       output_array.at(index) = carla::rpc::Command::ApplyTransform(actor_id, teleportation_transform);
+      simulation_state.UpdateKinematicHybridEndLocation(actor_id, teleportation_transform.location);
     }
   }
 }

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
@@ -22,7 +22,7 @@ using TLMap = std::unordered_map<std::string, SharedPtr<client::Actor>>;
 class MotionPlanStage: Stage {
 private:
   const std::vector<ActorId> &vehicle_id_list;
-  const SimulationState &simulation_state;
+  SimulationState &simulation_state;
   const Parameters &parameters;
   const BufferMap &buffer_map;
   TrackTraffic &track_traffic;
@@ -70,7 +70,7 @@ private:
 
 public:
   MotionPlanStage(const std::vector<ActorId> &vehicle_id_list,
-                  const SimulationState &simulation_state,
+                  SimulationState &simulation_state,
                   const Parameters &parameters,
                   const BufferMap &buffer_map,
                   TrackTraffic &track_traffic,

--- a/LibCarla/source/carla/trafficmanager/SimulationState.cpp
+++ b/LibCarla/source/carla/trafficmanager/SimulationState.cpp
@@ -38,12 +38,20 @@ void SimulationState::UpdateKinematicState(ActorId actor_id, KinematicState stat
   kinematic_state_map.at(actor_id) = state;
 }
 
+void SimulationState::UpdateKinematicHybridEndLocation(ActorId actor_id, cg::Location location) {
+  kinematic_state_map.at(actor_id).hybrid_end_location = location;
+}
+
 void SimulationState::UpdateTrafficLightState(ActorId actor_id, TrafficLightState state) {
   tl_state_map.at(actor_id) = state;
 }
 
 cg::Location SimulationState::GetLocation(ActorId actor_id) const {
   return kinematic_state_map.at(actor_id).location;
+}
+
+cg::Location SimulationState::GetHybridEndLocation(ActorId actor_id) const {
+  return kinematic_state_map.at(actor_id).hybrid_end_location;
 }
 
 cg::Rotation SimulationState::GetRotation(ActorId actor_id) const {

--- a/LibCarla/source/carla/trafficmanager/SimulationState.h
+++ b/LibCarla/source/carla/trafficmanager/SimulationState.h
@@ -21,6 +21,7 @@ struct KinematicState {
   float speed_limit;
   bool physics_enabled;
   bool is_dormant;
+  cg::Location hybrid_end_location;
 };
 using KinematicStateMap = std::unordered_map<ActorId, KinematicState>;
 
@@ -71,9 +72,13 @@ public :
 
   void UpdateKinematicState(ActorId actor_id, KinematicState state);
 
+  void UpdateKinematicHybridEndLocation(ActorId actor_id, cg::Location location);
+
   void UpdateTrafficLightState(ActorId actor_id, TrafficLightState state);
 
   cg::Location GetLocation(const ActorId actor_id) const;
+
+  cg::Location GetHybridEndLocation(const ActorId actor_id) const;
 
   cg::Rotation GetRotation(const ActorId actor_id) const;
 


### PR DESCRIPTION
### Description

Fixed a bug that caused the TM to sometimes calculate a vehicle's speed as a ridiculously high number.

The TM calculates the speed of physicsless vehicles as the position difference between ticks. However, this fails if another client teleports the vehicle, creating an insanely high spee , and generally causing the LocalizationStage to try to create a larger waypoint buffer than the map, blocking the simulation.

As such, a new `hybrid_end_location` has been added, which is the location that the TM calculates for that vehicle at the end of its execution, and it's that position, and not the one gottetn by the server, the one that's used to calcualte the speed. For all other purposes, the "normal" position is used.  

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's

### Possible Drawbacks

Some corner cases might have been changed, such as when the TM doesn't have the actor's information saved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5407)
<!-- Reviewable:end -->
