### PR TITLE
Improved TM's non signalized junctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Latest
 
   * Fixed bug causing the TM to block the simulation when another client teleported a vehicle with no physics.
+  * Fixed bug causing the TM to block the simulation when travelling through a short roads that looped on themselves.
+  * Improved the TM's handling of non signalized junctions, resulting in a more fluid overall behavior.
   * Added check to avoid adding procedural trigger boxes inside intersections.
   * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Python agents now have a function to lane change.

--- a/LibCarla/source/carla/trafficmanager/Constants.h
+++ b/LibCarla/source/carla/trafficmanager/Constants.h
@@ -108,8 +108,8 @@ static float const STRAIGHT_DEG = 19.0f;
 } // namespace Map
 
 namespace TrafficLight {
-static const uint64_t NO_SIGNAL_PASSTHROUGH_INTERVAL = 5u;
-static const double DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL = 5.0;
+static const double MINIMUM_STOP_TIME = 2.0;
+static const double EXIT_JUNCTION_THRESHOLD = 0;  // Dot product of 90º
 } // namespace TrafficLight
 
 namespace MotionPlan {

--- a/LibCarla/source/carla/trafficmanager/DataStructures.h
+++ b/LibCarla/source/carla/trafficmanager/DataStructures.h
@@ -27,6 +27,7 @@ namespace cg = carla::geom;
 using ActorId = carla::ActorId;
 using ActorPtr = carla::SharedPtr<cc::Actor>;
 using JunctionID = carla::road::JuncId;
+using Junction = carla::SharedPtr<carla::client::Junction>;
 using SimpleWaypointPtr = std::shared_ptr<SimpleWaypoint>;
 using Buffer = std::deque<SimpleWaypointPtr>;
 using BufferMap = std::unordered_map<carla::ActorId, Buffer>;

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -206,6 +206,10 @@ void LocalizationStage::Update(const unsigned long index) {
       }
       SimpleWaypointPtr next_wp_selection = next_waypoints.at(selection_index);
       PushWaypoint(actor_id, track_traffic, waypoint_buffer, next_wp_selection);
+      if (next_wp_selection->GetId() == waypoint_buffer.front()->GetId()){
+        // Found a loop, stop. Don't use zero distance as there can be two waypoints at the same location
+        break;
+      }
     }
   }
   ExtendAndFindSafeSpace(actor_id, is_at_junction_entrance, waypoint_buffer);

--- a/LibCarla/source/carla/trafficmanager/TrafficLightStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/TrafficLightStage.cpp
@@ -7,8 +7,10 @@
 namespace carla {
 namespace traffic_manager {
 
-using constants::TrafficLight::DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL;
+using constants::TrafficLight::EXIT_JUNCTION_THRESHOLD;
+using constants::TrafficLight::MINIMUM_STOP_TIME;
 using constants::WaypointSelection::JUNCTION_LOOK_AHEAD;
+using constants::MotionPlan::EPSILON_RELATIVE_SPEED;
 
 TrafficLightStage::TrafficLightStage(
   const std::vector<ActorId> &vehicle_id_list,
@@ -34,15 +36,14 @@ void TrafficLightStage::Update(const unsigned long index) {
     const Buffer &waypoint_buffer = buffer_map.at(ego_actor_id);
     const SimpleWaypointPtr look_ahead_point = GetTargetWaypoint(waypoint_buffer, JUNCTION_LOOK_AHEAD).first;
 
-    const JunctionID junction_id = look_ahead_point->GetWaypoint()->GetJunctionId();
+    const Junction junction = look_ahead_point->GetWaypoint()->GetJunction();
     current_timestamp = world.GetSnapshot().GetTimestamp();
 
     const TrafficLightState tl_state = simulation_state.GetTLS(ego_actor_id);
     const TLS traffic_light_state = tl_state.tl_state;
     const bool is_at_traffic_light = tl_state.at_traffic_light;
 
-    // We determine to stop if the current position of the vehicle is not a
-    // junction and there is a red or yellow light.
+    // We determine to stop if the vehicle found a traffic light in yellow / red.
     if (is_at_traffic_light &&
         traffic_light_state != TLS::Green &&
         traffic_light_state != TLS::Off &&
@@ -50,75 +51,103 @@ void TrafficLightStage::Update(const unsigned long index) {
 
       traffic_light_hazard = true;
     }
-    // Handle entry negotiation at non-signalised junction.
+    // The vehicle is currently at a non signalized junction, so handle its priorities.
+    // Don't use the next condition as bounding boxes might switch to green
+    else if (vehicle_last_junction.find(ego_actor_id) != vehicle_last_junction.end()){
+
+      if (!look_ahead_point->CheckJunction()) {
+        // Very close to the junction exit, forget about it.
+        RemoveActor(ego_actor_id);
+      }
+      else {
+        auto junction_id = junction->GetId();
+        auto& exiting_vehicles = exiting_vehicles_map.at(junction_id);
+        if (std::find(exiting_vehicles.begin(), exiting_vehicles.end(), ego_actor_id) != exiting_vehicles.end()) {
+          // The vehicle is exitting the junction.
+          traffic_light_hazard =  false;
+        }
+        else {
+          // Vehicle entering the junction, handle it
+          traffic_light_hazard = HandleNonSignalisedJunction(ego_actor_id, junction, waypoint_buffer, current_timestamp);
+        }
+      }
+    }
     else if (look_ahead_point->CheckJunction() &&
             !is_at_traffic_light &&
             traffic_light_state != TLS::Green &&
-            traffic_light_state != TLS::Off &&
             parameters.GetPercentageRunningSign(ego_actor_id) <= random_device.next()) {
 
-      traffic_light_hazard = HandleNonSignalisedJunction(ego_actor_id, junction_id, current_timestamp);
+      AddActorToNonSignalisedJunction(ego_actor_id, junction);
+      traffic_light_hazard = true;
     }
   }
   output_array.at(index) = traffic_light_hazard;
 }
 
-bool TrafficLightStage::HandleNonSignalisedJunction(const ActorId ego_actor_id, const JunctionID junction_id,
-                                                    cc::Timestamp timestamp) {
+void TrafficLightStage::AddActorToNonSignalisedJunction(const ActorId ego_actor_id, const Junction junction) {
+
+  auto junction_id = junction->GetId();
+
+  if (entering_vehicles_map.find(junction_id) == entering_vehicles_map.end()) {
+    // Initializing new map entry for the junction with an empty actor deque.
+    std::deque<ActorId> entry_deque;
+    std::deque<ActorId> exit_deque;
+    entering_vehicles_map.insert({junction_id, entry_deque});
+    exiting_vehicles_map.insert({junction_id, exit_deque});
+  }
+
+  auto& entering_vehicles = entering_vehicles_map.at(junction_id);
+  if (std::find(entering_vehicles.begin(), entering_vehicles.end(), ego_actor_id) == entering_vehicles.end()){
+    // Initializing new actor entry to the junction maps.
+    entering_vehicles.push_back(ego_actor_id);
+    if (vehicle_last_junction.find(ego_actor_id) != vehicle_last_junction.end()) {
+      // The actor was entering another junction, so remove all of its stored data
+      RemoveActor(ego_actor_id);
+    }
+    vehicle_last_junction.insert({ego_actor_id, junction_id});
+  }
+}
+
+
+bool TrafficLightStage::HandleNonSignalisedJunction(const ActorId ego_actor_id, const Junction junction,
+                                                    const Buffer &waypoint_buffer, cc::Timestamp timestamp) {
 
   bool traffic_light_hazard = false;
+  auto junction_id = junction->GetId();
 
-  if (vehicle_last_junction.find(ego_actor_id) == vehicle_last_junction.end()) {
-    // Initializing new map entry for the actor with  an arbitrary and different junction id.
-    vehicle_last_junction.insert({ego_actor_id, junction_id + 1});
+  auto& entering_vehicles = entering_vehicles_map.at(junction_id);
+  auto& exiting_vehicles = exiting_vehicles_map.at(junction_id);
+
+  if (vehicle_stop_time.find(ego_actor_id) == vehicle_stop_time.end()) {
+    // Ensure the vehicle stops before doing anything else
+    if (simulation_state.GetVelocity(ego_actor_id).Length() < EPSILON_RELATIVE_SPEED) {
+      vehicle_stop_time.insert({ego_actor_id, timestamp});
+    }
+    traffic_light_hazard = true;
   }
 
-  if (vehicle_last_junction.at(ego_actor_id) != junction_id) {
-    vehicle_last_junction.at(ego_actor_id) = junction_id;
+  else if (entering_vehicles.front() == ego_actor_id) {
+    auto entry_elapsed_seconds = vehicle_stop_time.at(ego_actor_id).elapsed_seconds;
+    if (timestamp.elapsed_seconds - entry_elapsed_seconds < MINIMUM_STOP_TIME) {
+      // Wait at least the minimum amount of time before entering the junction
+      traffic_light_hazard = true;
+    }
+    else {
+      // Track the first actor until it has passed the mid-point
+      cg::Transform actor_transform = waypoint_buffer.front()->GetTransform();
+      cg::Vector3D forward_vec = actor_transform.GetForwardVector();
+      cg::Vector3D to_center_vec = junction->GetBoundingBox().location - actor_transform.location;
 
-    // Check if the vehicle has an outdated ticket or needs a new one.
-    bool need_to_issue_new_ticket = false;
-    if (vehicle_last_ticket.find(ego_actor_id) == vehicle_last_ticket.end()) {
-
-      need_to_issue_new_ticket = true;
-    } else {
-
-      const cc::Timestamp &previous_ticket = vehicle_last_ticket.at(ego_actor_id);
-      const double diff = timestamp.elapsed_seconds - previous_ticket.elapsed_seconds;
-      if (diff > DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL) {
-        need_to_issue_new_ticket = true;
+      if (cg::Math::Dot(forward_vec, to_center_vec) < EXIT_JUNCTION_THRESHOLD) {
+        // Remove it from the entry data, letting the next one enter it
+        entering_vehicles.pop_front();
+        vehicle_stop_time.erase(ego_actor_id);
+        exiting_vehicles.push_back(ego_actor_id);
       }
     }
 
-    // If new ticket is needed for the vehicle, then query the junction
-    // ticket map and update the map value to the new ticket value.
-    if (need_to_issue_new_ticket) {
-      if (junction_last_ticket.find(junction_id) != junction_last_ticket.end()) {
-
-        cc::Timestamp &last_ticket = junction_last_ticket.at(junction_id);
-        const double diff = timestamp.elapsed_seconds - last_ticket.elapsed_seconds;
-        if (diff > 0.0) {
-          last_ticket.elapsed_seconds = timestamp.elapsed_seconds + DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL;
-        } else {
-          last_ticket.elapsed_seconds += DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL;
-        }
-      } else {
-        cc::Timestamp &new_ticket = timestamp;
-        new_ticket.elapsed_seconds += DOUBLE_NO_SIGNAL_PASSTHROUGH_INTERVAL;
-        junction_last_ticket.insert({junction_id, new_ticket});
-      }
-      if (vehicle_last_ticket.find(ego_actor_id) != vehicle_last_ticket.end()) {
-        vehicle_last_ticket.at(ego_actor_id) = junction_last_ticket.at(junction_id);
-      } else {
-        vehicle_last_ticket.insert({ego_actor_id, junction_last_ticket.at(junction_id)});
-      }
-    }
-  }
-
-  // If current time is behind ticket time, then do not enter junction.
-  const cc::Timestamp current_ticket = vehicle_last_ticket.at(ego_actor_id);
-  const double diff = current_ticket.elapsed_seconds - timestamp.elapsed_seconds;
-  if (diff > 0.0) {
+  } else {
+    // Only one vehicle can be entering the junction, so stop the rest.
     traffic_light_hazard = true;
   }
 
@@ -126,14 +155,34 @@ bool TrafficLightStage::HandleNonSignalisedJunction(const ActorId ego_actor_id, 
 }
 
 void TrafficLightStage::RemoveActor(const ActorId actor_id) {
-  vehicle_last_ticket.erase(actor_id);
-  vehicle_last_junction.erase(actor_id);
+  if (vehicle_last_junction.find(actor_id) != vehicle_last_junction.end()) {
+    auto junction_id = vehicle_last_junction.at(actor_id);
+
+    auto& entering_vehicles = entering_vehicles_map.at(junction_id);
+    auto ent_index = std::find(entering_vehicles.begin(), entering_vehicles.end(), actor_id);
+    if (ent_index != entering_vehicles.end()) {
+      entering_vehicles.erase(ent_index);
+    }
+
+    auto& exiting_vehicles = exiting_vehicles_map.at(junction_id);
+    auto ext_index = std::find(exiting_vehicles.begin(), exiting_vehicles.end(), actor_id);
+    if (ext_index != exiting_vehicles.end()) {
+      exiting_vehicles.erase(ext_index);
+    }
+
+    if (vehicle_stop_time.find(actor_id) != vehicle_stop_time.end()) {
+      vehicle_stop_time.erase(actor_id);
+    }
+
+    vehicle_last_junction.erase(actor_id);
+  }
 }
 
 void TrafficLightStage::Reset() {
-  vehicle_last_ticket.clear();
+  entering_vehicles_map.clear();
+  exiting_vehicles_map.clear();
   vehicle_last_junction.clear();
-  junction_last_ticket.clear();
+  vehicle_stop_time.clear();
 }
 
 } // namespace traffic_manager

--- a/LibCarla/source/carla/trafficmanager/TrafficLightStage.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficLightStage.h
@@ -19,18 +19,29 @@ private:
   const BufferMap &buffer_map;
   const Parameters &parameters;
   const cc::World &world;
-  /// Map containing the time ticket issued for vehicles.
-  std::unordered_map<ActorId, cc::Timestamp> vehicle_last_ticket;
-  /// Map containing the previous time ticket issued for junctions.
-  std::unordered_map<JunctionID, cc::Timestamp> junction_last_ticket;
-  /// Map containing the previous junction visited by a vehicle.
+
+  /// Variables used to handle non signalized junctions
+
+  /// Map containing the vehicles entering a specific junction, ordered by time of arrival.
+  std::unordered_map<JunctionID, std::deque<ActorId>> entering_vehicles_map;
+  /// Map containing the vehicles exiting a specific junction.
+  std::unordered_map<JunctionID, std::deque<ActorId>> exiting_vehicles_map;
+  /// Map linking the vehicles with their current junction. Used for easy access to the previous two maps.
   std::unordered_map<ActorId, JunctionID> vehicle_last_junction;
+  /// Map containing the timestamp at which the actor first stopped at a stop sign.
+  std::unordered_map<ActorId, cc::Timestamp> vehicle_stop_time;
   TLFrame &output_array;
   RandomGenerator &random_device;
   cc::Timestamp current_timestamp;
 
-  bool HandleNonSignalisedJunction(const ActorId ego_actor_id, const JunctionID junction_id,
-                                   cc::Timestamp timestamp);
+  /// This controls all vehicle's interactions at non signalized junctions. Priorities are done by order of arrival
+  /// and no two vehicle will enter the junction at the same time. Only once it is exiting can the next one enter.
+  /// Additionally, all vehicles will always brake at the stop sign for a set amount of time.
+  bool HandleNonSignalisedJunction(const ActorId ego_actor_id, const Junction junction,
+                                   const Buffer &waypoint_buffer, cc::Timestamp timestamp);
+
+  /// Initialized the vehicle to the non-signalized junction maps
+  void AddActorToNonSignalisedJunction(const ActorId ego_actor_id, const Junction junction);
 
 public:
   TrafficLightStage(const std::vector<ActorId> &vehicle_id_list,


### PR DESCRIPTION
### Description

Improved how the TM vehicles handle the non signalized intersections, resulting in an overall more fluid traffic.

Previously, a series of tickets where issued according to their time of arrival, which dictated the order of the vehicles. However, this approach had some minor bugs that caused vehicles to wait, even though the junction was empty, and overall, their behavior wasn't that intuitive.

The new approach creates a list of all entering vehicles according to their order of arrival. From there, lane priority is given to the first vehicle that arrived, and once its maneuver ends, the next one starts entering the junction. To have a smoother traffic, the maneuver ends when the vehicle has left the center of the intersection behind, and not once it has exited the junction. Note that while this might not work for 100% of junction configurations, this priorty is "just" for the TrafficLightStage, and it is later followed by the CollisionStage, which will handle possible collisions between the entering and exiting vehicles. Additionally, all vehicles will break when entering the junction and wait at the stop sign for a minimum amount of time, even if no vehicles are inside it

Additionally, a TM bug has been fixed that was causing the TM to block the simulation when trying to calculate the waypoint buffer of a vehicle that was traversing a very short road that looped onto itself.

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 4.26

### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5443)
<!-- Reviewable:end -->
