### PR TITLE
Fixed raycasting functions at large maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug causing the `world.ground_projection()` function to return an incorrect location at large maps.
   * Added failure state to vehicles, which can be retrieved by using `Vehicle.get_failure_state()`. Only Rollover failure state is currently supported.
   * Fixed bug causing the TM to block the simulation when another client teleported a vehicle with no physics.
   * Fixed bug causing the TM to block the simulation when travelling through a short roads that looped on themselves.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/RayTracer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/RayTracer.cpp
@@ -30,7 +30,15 @@ std::vector<crp::LabelledPoint> URayTracer::CastRay(
     UPrimitiveComponent* Component = Hit.GetComponent();
     crp::CityObjectLabel ComponentTag =
         ATagger::GetTagOfTaggedComponent(*Component);
-    result.emplace_back(crp::LabelledPoint(Hit.Location, ComponentTag));
+
+    FVector UELocation = Hit.Location;
+    ACarlaGameModeBase* GameMode = UCarlaStatics::GetGameMode(World);
+    ALargeMapManager* LargeMap = GameMode->GetLMManager();
+    if (LargeMap)
+    {
+      UELocation = LargeMap->LocalToGlobalLocation(UELocation);
+    }
+    result.emplace_back(crp::LabelledPoint(UELocation, ComponentTag));
   }
   return result;
 }
@@ -52,7 +60,15 @@ std::pair<bool, crp::LabelledPoint> URayTracer::ProjectPoint(
     UPrimitiveComponent* Component = Hit.GetComponent();
     crp::CityObjectLabel ComponentTag =
         ATagger::GetTagOfTaggedComponent(*Component);
-    return std::make_pair(bDidHit, crp::LabelledPoint(Hit.Location, ComponentTag));
+
+    FVector UELocation = Hit.Location;
+    ACarlaGameModeBase* GameMode = UCarlaStatics::GetGameMode(World);
+    ALargeMapManager* LargeMap = GameMode->GetLMManager();
+    if (LargeMap)
+    {
+      UELocation = LargeMap->LocalToGlobalLocation(UELocation);
+    }
+    return std::make_pair(bDidHit, crp::LabelledPoint(UELocation, ComponentTag));
   }
   return std::make_pair(bDidHit, crp::LabelledPoint(FVector(0.0f,0.0f,0.0f), crp::CityObjectLabel::None));
 }


### PR DESCRIPTION
### Description

Fixed raycasting functions at large maps. While the points sent to these functions were indeed transformed from global to local coordinates (and as such the functions were correctly calculating the raycast hit), the resulting hit location wasn't being transformed back to global coordinates, so the API returned an incorrect location. This PR adds the missing transform.

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 4.26

### Possible Drawbacks

Theoretically none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5461)
<!-- Reviewable:end -->
