### PR TITLE
Fixed street lights at large maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug causing the scene lights to return an incorrect location at large maps.
   * Fixed bug causing the `world.ground_projection()` function to return an incorrect location at large maps.
   * Added failure state to vehicles, which can be retrieved by using `Vehicle.get_failure_state()`. Only Rollover failure state is currently supported.
   * Fixed bug causing the TM to block the simulation when another client teleported a vehicle with no physics.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
@@ -124,7 +124,14 @@ void UCarlaLight::SetLightState(carla::rpc::LightState LightState)
 
 FVector UCarlaLight::GetLocation() const
 {
-  return GetOwner()->GetActorLocation();
+  auto Location = GetOwner()->GetActorLocation();
+  ACarlaGameModeBase* GameMode = UCarlaStatics::GetGameMode(GetWorld());
+  ALargeMapManager* LargeMap = GameMode->GetLMManager();
+  if (LargeMap)
+  {
+    Location = LargeMap->LocalToGlobalLocation(Location);
+  }
+  return Location;
 }
 
 int UCarlaLight::GetId() const

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLightSubsystem.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Lights/CarlaLightSubsystem.cpp
@@ -32,6 +32,7 @@ void UCarlaLightSubsystem::RegisterLight(UCarlaLight* CarlaLight)
     }
     Lights.Add(LightId, CarlaLight);
   }
+  SetClientStatesdirty("");
 }
 
 void UCarlaLightSubsystem::UnregisterLight(UCarlaLight* CarlaLight)
@@ -40,6 +41,7 @@ void UCarlaLightSubsystem::UnregisterLight(UCarlaLight* CarlaLight)
   {
     Lights.Remove(CarlaLight->GetId());
   }
+  SetClientStatesdirty("");
 }
 
 bool UCarlaLightSubsystem::IsUpdatePending() const


### PR DESCRIPTION
### Description

The location of the street lights was incorrect for those that are part of large maps, as the large map transform was missing

EDIT: Additionally, updated the (un)registering of street lights to forcefully update the client, as without it, they were receiving outdated information 

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 4.26

### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5465)
<!-- Reviewable:end -->
