### PR TITLE
Replace Travis build by GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: install
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-7 clang-8 ninja-build python3-pip libboost-python-dev libtiff5-dev libjpeg-dev libgeos-dev
+    - name: requirements
+      run: |
+        pip3 install -q --user setuptools
+        pip3 install -q --user -r PythonAPI/test/requirements.txt
+        pip3 install -q --user -r PythonAPI/carla/requirements.txt
+    - name: setup
+      run: make setup
+    - name: lib
+      run: make LibCarla
+    - name: python
+      run: make PythonAPI
+    - name: examples
+      run: make examples
+    - name: check
+      run: make check ARGS="--all --gtest_args=--gtest_filter=-*_mt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Added GitHub workflow, since the building on travis-ci.org is ceased. Updated the CI badge in the project readme.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.
   * Fixed bug causing the `Vehicle.get_traffic_light_state()` function not notify about the green to yellow and yellow to red light state changes.
   * Fixed bug causing the `Vehicle.is_at_traffic_light()` function to return *false* if the traffic light was green.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CARLA Simulator
 ===============
 
-[![Build Status](https://travis-ci.org/carla-simulator/carla.svg?branch=master)](https://travis-ci.org/carla-simulator/carla)
+[![Build Status](https://github.com/carla-simulator/carla/actions/workflows/ci.yml/badge.svg)](https://github.com/carla-simulator/carla/actions/workflows/ci.yml)
 [![Documentation](https://readthedocs.org/projects/carla/badge/?version=latest)](http://carla.readthedocs.io)
 
 [![carla.org](Docs/img/btn/web.png)](http://carla.org)


### PR DESCRIPTION
#### Description

Fixes broken Travis build https://travis-ci.org/carla-simulator/carla

> Since June 15th, 2021, the building on [travis-ci.org](http://www.travis-ci.org/) is ceased.

#### Where has this been tested?

  * https://github.com/PierrickKoch/carla/actions

#### Possible Drawbacks

* Missing pylint and docs build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5487)
<!-- Reviewable:end -->
