### PR TITLE
Fixed decals when importing a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Some of the warnings shown when building a map will now only be showing when debugging.
   * Fixed bug causing traffic signals at the end points of a road to sometimes create malformed waypoints.
+  * Fixed decals when importing maps. It was using other .json files found in other packages.
   * Added the speed limits for 100, 110 and 120 Km/h.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.
   * Fixed bug causing the `Vehicle.get_traffic_light_state()` function not notify about the green to yellow and yellow to red light state changes.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
@@ -329,7 +329,10 @@ void ULoadAssetMaterialsCommandlet::LoadAssetsMaterials(const FString &PackageNa
   MapObjectLibrary = UObjectLibrary::CreateLibrary(UWorld::StaticClass(), false, GIsEditor);
   const FString DefaultPath = TEXT("/Game/") + PackageName + TEXT("/Maps/");
   MapObjectLibrary->AddToRoot();
-  MapObjectLibrary->LoadAssetDataFromPath(*DefaultPath);
+  for (auto &&data : MapsPaths)
+  {
+    MapObjectLibrary->LoadAssetDataFromPath(*data.Path);
+  }
   MapObjectLibrary->LoadAssetsFromAssetData();
   MapObjectLibrary->GetAssetDataList(AssetDatas);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
@@ -121,7 +121,7 @@ ULoadAssetMaterialsCommandlet::ULoadAssetMaterialsCommandlet()
 
 #if WITH_EDITORONLY_DATA
 
-void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &LoadedMapName, bool IsInTiles)
+void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &LoadedMapName, const FString &PackageName, bool IsInTiles)
 {
   if (IsInTiles == true) {
 
@@ -143,7 +143,7 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
 
       // Acquire the TilesInfo.txt file for storing the tile data (offset and size)
       TArray<FString> FileList;
-      IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir()), *(FString("TilesInfo.txt")), true, false, false);
+      IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir() + "/" + PackageName), *(FString("TilesInfo.txt")), true, false, false);
 
       FString TxtFile;
       if (FFileHelper::LoadFileToString(TxtFile, *FileList[0]) == true) {
@@ -156,7 +156,6 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
         TileData.Size = (float) FCString::Atoi(*Out[2]);
       }
       else {
-
         UE_LOG(LogTemp, Warning, TEXT("Could not read TilesInfo.txt file"));
         return;
       }
@@ -169,21 +168,11 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
     // From the loaded map name (in style mymap_Tile_200_400) get the X and the Y (Tile_200_400 -> X = 200, Y = 400)
     int32 XIndex = FCString::Atoi(*StringArray[StringArray.Num() - 2]);
     int32 YIndex = FCString::Atoi(*StringArray[StringArray.Num() - 1]);
-
     FVector TilePosition;
     // This means it's the initial tile (mymap_Tile_0_0)
     // This is in RELATIVE coords
-    if(XIndex == 0 && YIndex == 0) {
-
-      TilePosition.X = TileData.FirstTileCenterX;
-      TilePosition.Y = TileData.FirstTileCenterY;
-    }
-    else {
-
-      TilePosition.X = TileData.FirstTileCenterX + (TileData.Size * (float)XIndex);
-      TilePosition.Y = TileData.FirstTileCenterY - (TileData.Size * (float)YIndex);
-    }
-
+    TilePosition.X = TileData.FirstTileCenterX + (TileData.Size * (float)XIndex);
+    TilePosition.Y = TileData.FirstTileCenterY - (TileData.Size * (float)YIndex);
     TilePosition.Z = 0.0f;
 
     float HalfSize = TileData.Size / 2.0f;
@@ -196,7 +185,7 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
 
     if (ReadConfigFile == true) {
 
-      DecalsProperties = ReadDecalsConfigurationFile();
+      DecalsProperties = ReadDecalsConfigurationFile(PackageName);
       ReadConfigFile = false;
     }
 
@@ -219,10 +208,11 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
         DecalLocation.x = FMath::RandRange(MinXSize, MaxXSize);
         DecalLocation.y = FMath::RandRange(MinYSize, MaxYSize);
         DecalLocation.z = 0.0f;
-
+  
         // Get the closest road waypoint from the random location calculated
         auto Wp = XODRMap->GetClosestWaypointOnRoad(DecalLocation);
-        FVector FinalLocation(XODRMap->ComputeTransform(Wp.get()).location);
+        carla::geom::Location RoadLocation = XODRMap->ComputeTransform(Wp.get()).location;
+        FVector FinalLocation(RoadLocation);
 
         // Check we don't exceed the map boundaries
         if (FinalLocation.X > MinXSizeCm && FinalLocation.X < MaxXSizeCm) {
@@ -268,13 +258,13 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
   }
 }
 
-FDecalsProperties ULoadAssetMaterialsCommandlet::ReadDecalsConfigurationFile() {
+FDecalsProperties ULoadAssetMaterialsCommandlet::ReadDecalsConfigurationFile(const FString &PackageName) {
 
   // Get road painter configuration file
   FString JsonConfigFile;
 
   TArray<FString> FileList;
-  IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir()),
+  IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir() + "/" + PackageName),
     *(FString("roadpainter_decals.json")), true, false, false);
 
   FDecalsProperties DecalConfiguration;
@@ -372,7 +362,7 @@ void ULoadAssetMaterialsCommandlet::LoadAssetsMaterials(const FString &PackageNa
         if (HasRoadMesh == true) {
 
           bool IsTiledMap = World->GetName().Contains("_Tile_", ESearchCase::Type::CaseSensitive);
-          ApplyRoadPainterMaterials(World->GetName(), IsTiledMap);
+          ApplyRoadPainterMaterials(World->GetName(), PackageName, IsTiledMap);
         }
 
 #if WITH_EDITOR

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.h
@@ -60,9 +60,9 @@ public:
 
   void LoadAssetsMaterials(const FString &PackageName, const TArray<FMapData> &MapsPaths);
 
-  void ApplyRoadPainterMaterials(const FString &LoadedMapName, bool IsInTiles = false);
+  void ApplyRoadPainterMaterials(const FString &LoadedMapName, const FString &PackageName, bool IsInTiles = false);
 
-  FDecalsProperties ReadDecalsConfigurationFile();
+  FDecalsProperties ReadDecalsConfigurationFile(const FString &PackageName);
 
   /// Main method and entry of the commandlet, taking as input parameters @a
   /// Params.


### PR DESCRIPTION
#### Description

When a map is imported, some decals are created over the road to add dirty. Those decals are configured through a .json file and also use the .xodr of the map. But in the import process those files were find in all the content of the project and not only on the content of the package created. That means that if other .json file or .xodr was found, that was used instead of the correct one.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5588)
<!-- Reviewable:end -->
