### PR TITLE
Avoid notification of green-yellow state to TM vehicles

### DIFF
--- a/LibCarla/source/carla/trafficmanager/SimulationState.cpp
+++ b/LibCarla/source/carla/trafficmanager/SimulationState.cpp
@@ -43,6 +43,14 @@ void SimulationState::UpdateKinematicHybridEndLocation(ActorId actor_id, cg::Loc
 }
 
 void SimulationState::UpdateTrafficLightState(ActorId actor_id, TrafficLightState state) {
+  // The green-yellow state transition is not notified to the vehicle. This is done to avoid
+  // having vehicles stopped very near the intersection when only the rear part of the vehicle
+  // is colliding with the trigger volume of the traffic light.
+  auto previous_tl_state = GetTLS(actor_id);
+  if (previous_tl_state.at_traffic_light && previous_tl_state.tl_state == TLS::Green) {
+    state.tl_state = TLS::Green;
+  }
+
   tl_state_map.at(actor_id) = state;
 }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
This PR disables the notification of the green-yellow state transition to Traffic Manager vehicles. This is done to avoid having vehicles stopped very near the intersection when only the rear part of the vehicle is colliding with the trigger volume of the traffic light.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** CARLA

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5596)
<!-- Reviewable:end -->
