### PR TITLE
Fixed Agents bug for 0 distance lane change

### DIFF
--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -415,6 +415,9 @@ class BasicAgent(object):
         Use the different distances to fine-tune the maneuver.
         If the lane change is impossible, the returned path will be empty.
         """
+        distance_same_lane = max(distance_same_lane, 0.1)
+        distance_other_lane = max(distance_other_lane, 0.1)
+        lane_change_distance = max(lane_change_distance, 0.1)
 
         plan = []
         plan.append((waypoint, RoadOption.LANEFOLLOW))  # start position


### PR DESCRIPTION
### Description

The added lane change was breaking if any of its paramters was zero, as they were being used to do a `wp.next()`, so it can't be 0 now

### Where has this been tested?

  * **Platform(s):** Ubutnu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5610)
<!-- Reviewable:end -->
