### PR TITLE
Bernat/sensor destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fixed bug causing traffic signals at the end points of a road to sometimes create malformed waypoints.
   * Fixed decals when importing maps. It was using other .json files found in other packages.
   * Added the speed limits for 100, 110 and 120 Km/h.
+  * Fixing sensor destruction, now the stream and socket is succesfully destroyed.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.
   * Added multi-GPU feature. Now several servers (with dedicated GPU) can render sensors for the same simulation.
   * Fixed bug causing the `Vehicle.get_traffic_light_state()` function not notify about the green to yellow and yellow to red light state changes.

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -31,14 +31,14 @@ namespace client {
   }
 
   void ServerSideSensor::Listen(CallbackFunctionType callback) {
-    log_warning("calling sensor Listen() ", GetDisplayId());
+    log_debug("calling sensor Listen() ", GetDisplayId());
     log_debug(GetDisplayId(), ": subscribing to stream");
     GetEpisode().Lock()->SubscribeToSensor(*this, std::move(callback));
     _is_listening = true;
   }
 
   void ServerSideSensor::Stop() {
-    log_warning("calling sensor Stop() ", GetDisplayId());
+    log_debug("calling sensor Stop() ", GetDisplayId());
     if (!_is_listening) {
       log_warning(
           "attempting to unsubscribe from stream but sensor wasn't listening:",
@@ -50,7 +50,7 @@ namespace client {
   }
 
   bool ServerSideSensor::Destroy() {
-    log_warning("calling sensor Destroy() ", GetDisplayId());
+    log_debug("calling sensor Destroy() ", GetDisplayId());
     if (IsListening()) {
       Stop();
     }

--- a/LibCarla/source/carla/streaming/Server.h
+++ b/LibCarla/source/carla/streaming/Server.h
@@ -53,6 +53,10 @@ namespace streaming {
       return _server.MakeStream();
     }
 
+    void CloseStream(carla::streaming::detail::stream_id_type id) {
+      return _server.CloseStream(id);
+    }
+
     void Run() {
       _pool.Run();
     }

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
@@ -62,8 +62,8 @@ namespace detail {
     log_debug("Calling CloseStream for ", id);
     auto search = _stream_map.find(id);
     if (search != _stream_map.end()) {
-      auto stream_state = search->second.lock();
-      if (stream_state != nullptr) {
+      auto stream_state = search->second;
+      if (stream_state) {
         log_debug("Disconnecting all sessions (stream ", id, ")");
         stream_state->ClearSessions();
       }
@@ -76,8 +76,8 @@ namespace detail {
     std::lock_guard<std::mutex> lock(_mutex);
     auto search = _stream_map.find(session->get_stream_id());
     if (search != _stream_map.end()) {
-      auto stream_state = search->second.lock();
-      if (stream_state != nullptr) {
+      auto stream_state = search->second;
+      if (stream_state) {
         log_debug("Connecting session (stream ", session->get_stream_id(), ")");
         stream_state->ConnectSession(std::move(session));
         log_debug("Current streams: ", _stream_map.size());
@@ -94,8 +94,8 @@ namespace detail {
     log_debug("Calling DeregisterSession for ", session->get_stream_id());
     auto search = _stream_map.find(session->get_stream_id());
     if (search != _stream_map.end()) {
-      auto stream_state = search->second.lock();
-      if (stream_state != nullptr) {
+      auto stream_state = search->second;
+      if (stream_state) {
         log_debug("Disconnecting session (stream ", session->get_stream_id(), ")");
         stream_state->DisconnectSession(session);
         log_debug("Current streams: ", _stream_map.size());

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
@@ -57,15 +57,32 @@ namespace detail {
     }
   }
 
+  void Dispatcher::CloseStream(carla::streaming::detail::stream_id_type id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    log_info("Calling CloseStream for ", id);
+    auto search = _stream_map.find(id);
+    if (search != _stream_map.end()) {
+      auto stream_state = search->second.lock();
+      if (stream_state != nullptr) {
+        log_info("Disconnecting all sessions (stream ", id, ")");
+        stream_state->ClearSessions();
+      }
+      _stream_map.erase(search);
+    }
+  }
+
   bool Dispatcher::RegisterSession(std::shared_ptr<Session> session) {
     DEBUG_ASSERT(session != nullptr);
     std::lock_guard<std::mutex> lock(_mutex);
     auto search = _stream_map.find(session->get_stream_id());
     if (search != _stream_map.end()) {
-      auto stream_state = search->second;
-      log_info("Connecting session (stream ", session->get_stream_id(), ")");
-      stream_state->ConnectSession(std::move(session));
-      return true;
+      auto stream_state = search->second.lock();
+      if (stream_state != nullptr) {
+        log_info("Connecting session (stream ", session->get_stream_id(), ")");
+        stream_state->ConnectSession(std::move(session));
+        log_info("Current streams: ", _stream_map.size());
+        return true;
+      }
     }
     log_error("Invalid session: no stream available with id", session->get_stream_id());
     return false;
@@ -74,14 +91,18 @@ namespace detail {
   void Dispatcher::DeregisterSession(std::shared_ptr<Session> session) {
     DEBUG_ASSERT(session != nullptr);
     std::lock_guard<std::mutex> lock(_mutex);
+    log_info("Calling DeregisterSession for ", session->get_stream_id());
     auto search = _stream_map.find(session->get_stream_id());
     if (search != _stream_map.end()) {
-      auto stream_state = search->second;
-      log_info("Disconnecting session (stream ", session->get_stream_id(), ")");
-      stream_state->DisconnectSession(session);
+      auto stream_state = search->second.lock();
+      if (stream_state != nullptr) {
+        log_info("Disconnecting session (stream ", session->get_stream_id(), ")");
+        stream_state->DisconnectSession(session);
+        log_info("Current streams: ", _stream_map.size());
+      }
     }
   }
-
+  
   token_type Dispatcher::GetToken(stream_id_type sensor_id) {
     std::lock_guard<std::mutex> lock(_mutex);
     log_info("Searching sensor id: ", sensor_id);

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.h
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.h
@@ -35,6 +35,8 @@ namespace detail {
 
     carla::streaming::Stream MakeStream();
 
+    void CloseStream(carla::streaming::detail::stream_id_type id);
+
     bool RegisterSession(std::shared_ptr<Session> session);
 
     void DeregisterSession(std::shared_ptr<Session> session);

--- a/LibCarla/source/carla/streaming/detail/MultiStreamState.h
+++ b/LibCarla/source/carla/streaming/detail/MultiStreamState.h
@@ -39,8 +39,7 @@ namespace detail {
       if (session != nullptr) {
         auto message = Session::MakeMessage(std::move(buffers)...);
         session->Write(std::move(message));
-        // log_info("sensor ", session->get_stream_id()," data sent ", message->size(), " by");        
-        log_info("sensor ", session->get_stream_id()," data sent");        
+        log_debug("sensor ", session->get_stream_id()," data sent");        
         // Return here, _session is only valid if we have a 
         // single session.
         return; 
@@ -53,8 +52,7 @@ namespace detail {
         for (auto &s : _sessions) {
           if (s != nullptr) {
             s->Write(message);
-            // log_info("sensor ", s->get_stream_id()," data sent ", message->size(), " by");
-            log_info("sensor ", s->get_stream_id()," data sent ");
+            log_debug("sensor ", s->get_stream_id()," data sent ");
          }
         }
       }
@@ -80,7 +78,7 @@ namespace detail {
     void DisconnectSession(std::shared_ptr<Session> session) final {
       DEBUG_ASSERT(session != nullptr);
       std::lock_guard<std::mutex> lock(_mutex);
-      log_info("Calling DisconnectSession for ", session->get_stream_id());
+      log_debug("Calling DisconnectSession for ", session->get_stream_id());
       if (_sessions.size() == 0) return;
       if (_sessions.size() == 1) {
         DEBUG_ASSERT(session == _session.load());

--- a/LibCarla/source/carla/streaming/detail/MultiStreamState.h
+++ b/LibCarla/source/carla/streaming/detail/MultiStreamState.h
@@ -39,6 +39,8 @@ namespace detail {
       if (session != nullptr) {
         auto message = Session::MakeMessage(std::move(buffers)...);
         session->Write(std::move(message));
+        // log_info("sensor ", session->get_stream_id()," data sent ", message->size(), " by");        
+        log_info("sensor ", session->get_stream_id()," data sent");        
         // Return here, _session is only valid if we have a 
         // single session.
         return; 
@@ -46,10 +48,14 @@ namespace detail {
 
       // try write multiple stream
       std::lock_guard<std::mutex> lock(_mutex);
-      auto message = Session::MakeMessage(std::move(buffers)...);
-      for (auto &s : _sessions) {
-        if (s != nullptr) {
-          s->Write(message);
+      if (_sessions.size() > 0) {
+        auto message = Session::MakeMessage(std::move(buffers)...);
+        for (auto &s : _sessions) {
+          if (s != nullptr) {
+            s->Write(message);
+            // log_info("sensor ", s->get_stream_id()," data sent ", message->size(), " by");
+            log_info("sensor ", s->get_stream_id()," data sent ");
+         }
         }
       }
     }
@@ -74,6 +80,7 @@ namespace detail {
     void DisconnectSession(std::shared_ptr<Session> session) final {
       DEBUG_ASSERT(session != nullptr);
       std::lock_guard<std::mutex> lock(_mutex);
+      log_info("Calling DisconnectSession for ", session->get_stream_id());
       if (_sessions.size() == 0) return;
       if (_sessions.size() == 1) {
         DEBUG_ASSERT(session == _session.load());
@@ -96,6 +103,11 @@ namespace detail {
 
     void ClearSessions() final {
       std::lock_guard<std::mutex> lock(_mutex);
+      for (auto &s : _sessions) {
+        if (s != nullptr) {
+          s->Close();
+        }
+      }
       _sessions.clear();
       _session.store(nullptr);
       log_debug("Disconnecting all multistream sessions");

--- a/LibCarla/source/carla/streaming/low_level/Server.h
+++ b/LibCarla/source/carla/streaming/low_level/Server.h
@@ -65,6 +65,10 @@ namespace low_level {
       return _dispatcher.MakeStream();
     }
 
+    void CloseStream(carla::streaming::detail::stream_id_type id) {
+      return _dispatcher.CloseStream(id);
+    }
+
     void SetSynchronousMode(bool is_synchro) {
       _server.SetSynchronousMode(is_synchro);
     }
@@ -82,6 +86,7 @@ namespace low_level {
         }
       };
       auto on_session_closed = [this](auto session) {
+        log_info("on_session_closed called");
         _dispatcher.DeregisterSession(session);
       };
       _server.Listen(on_session_opened, on_session_closed);

--- a/LibCarla/source/carla/streaming/low_level/Server.h
+++ b/LibCarla/source/carla/streaming/low_level/Server.h
@@ -86,7 +86,7 @@ namespace low_level {
         }
       };
       auto on_session_closed = [this](auto session) {
-        log_info("on_session_closed called");
+        log_debug("on_session_closed called");
         _dispatcher.DeregisterSession(session);
       };
       _server.Listen(on_session_opened, on_session_closed);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
@@ -45,6 +45,11 @@ public:
     return Server;
   }
 
+  FCarlaServer &GetServer()
+  {
+    return Server;
+  }
+
   UCarlaEpisode *GetCurrentEpisode()
   {
     return CurrentEpisode;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
@@ -79,6 +79,11 @@ public:
     return CarlaEngine.GetServer();
   }
 
+  FCarlaServer &GetServer()
+  {
+    return CarlaEngine.GetServer();
+  }
+
   void SetOpendriveGenerationParameters(
       const carla::rpc::OpendriveGenerationParameters & Parameters)
   {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
@@ -100,7 +100,10 @@ void ASensor::EndPlay(EEndPlayReason::Type EndPlayReason)
   Super::EndPlay(EndPlayReason);
   
   // close all sessions associated to the sensor stream
-  UCarlaStatics::GetGameInstance(GetEpisode().GetWorld())->GetServer().GetStreamingServer().CloseStream(carla::streaming::detail::token_type(Stream.GetToken()).get_stream_id());
+  auto *GameInstance = UCarlaStatics::GetGameInstance(GetEpisode().GetWorld());
+  auto &StreamingServer = GameInstance->GetServer().GetStreamingServer();
+  auto StreamId = carla::streaming::detail::token_type(Stream.GetToken()).get_stream_id();
+  StreamingServer.CloseStream(StreamId);
 
   Stream = FDataStream();
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.cpp
@@ -10,6 +10,7 @@
 
 #include "Carla/Actor/ActorDescription.h"
 #include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
+#include "Carla/Game/CarlaStatics.h"
 
 ASensor::ASensor(const FObjectInitializer &ObjectInitializer)
   : Super(ObjectInitializer)
@@ -97,6 +98,10 @@ void ASensor::PostActorCreated()
 void ASensor::EndPlay(EEndPlayReason::Type EndPlayReason)
 {
   Super::EndPlay(EndPlayReason);
+  
+  // close all sessions associated to the sensor stream
+  UCarlaStatics::GetGameInstance(GetEpisode().GetWorld())->GetServer().GetStreamingServer().CloseStream(carla::streaming::detail::token_type(Stream.GetToken()).get_stream_id());
+
   Stream = FDataStream();
 
   UCarlaEpisode* Episode = UCarlaStatics::GetCurrentEpisode(GetWorld());


### PR DESCRIPTION
#### Description

Sensors were destroyed but the stream and socket associated to them still alive in the system, eating system resources.
Now they are destroyed properly.

Fixes # 3197, 3994, 4861

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

We know that when a client disconnects the resources are not destroyed properly. We need to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5611)
<!-- Reviewable:end -->
