### PR TITLE
Updating wget when downloading fbxsdk

### DIFF
--- a/Util/BuildTools/BuildUtilsDocker.sh
+++ b/Util/BuildTools/BuildUtilsDocker.sh
@@ -17,7 +17,7 @@ FBXSDK_URL=https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/2020-0-1/${
 
 if [ ! -d "${FBX2OBJ_DEP_FOLDER}" ]; then
   log "Downloading FBX SDK..."
-  wget -c "${FBXSDK_URL}" -P "${CARLA_DOCKER_UTILS_FOLDER}"
+  wget -c "${FBXSDK_URL}" -P "${CARLA_DOCKER_UTILS_FOLDER}" --user-agent="Mozilla"
 
   echo "Unpacking..."
   mkdir -p "${FBX2OBJ_DEP_FOLDER}"


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [/] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [/] Code compiles correctly
  - [/] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

When trying to download fbxsdk in Util/BuildTools/BuildUtilsDocker.sh a 403 forbidden error was being raised. This was resolved with the following change.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):*Linux 18.04 LTS* ...
  * **Python version(s):*3.6.9* ...
  * **Unreal Engine version(s):*4.26* ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5631)
<!-- Reviewable:end -->
