### PR TITLE
Compute displacement direction when moving signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Improved algorithm to move signals out of the road by computing the desired displacement direction.
   * Added `TrafficManager.vehicle_lane_offset(actor, offset)` and `TrafficManager.global_lane_offset(offset)` methods.
   * Some of the warnings shown when building a map will now only be showing when debugging.
   * Fixed bug causing traffic signals at the end points of a road to sometimes create malformed waypoints.


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

When moving signals out of roads we now compute the desired displacement direction. Instead of moving signals always to the right we now check the right and left lane types.

The algorithm works in the following way:
1. If the right lane is of type `Driving` we move the signal to the left.
2. If the left lane is of type `Driving` we move the signal to the right.
3. If both lanes (right and left) are of type `Driving` we don't move the signal.
<!-- Please explain the changes you made here as detailed as possible. -->



#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3,7
  * **Unreal Engine version(s):** CARLA's

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5673)
<!-- Reviewable:end -->
