### PR TITLE
Fix the static mesh factory

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/StaticMeshFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/StaticMeshFactory.cpp
@@ -17,6 +17,18 @@ TArray<FActorDefinition> AStaticMeshFactory::GetDefinitions()
       TEXT("prop"),
       TEXT("mesh"));
   StaticMeshDefinition.Class = AStaticMeshActor::StaticClass();
+  StaticMeshDefinition.Variations.Emplace(FActorVariation{
+      TEXT("mesh_path"),
+      EActorAttributeType::String,
+      {""}, false});
+  StaticMeshDefinition.Variations.Emplace(FActorVariation{
+      TEXT("mass"),
+      EActorAttributeType::Float,
+      {""}, false});
+  StaticMeshDefinition.Variations.Emplace(FActorVariation{
+      TEXT("scale"),
+      EActorAttributeType::Float,
+      {"1.0f"}, false});
   return { StaticMeshDefinition };
 }
 
@@ -33,31 +45,43 @@ FActorSpawnResult AStaticMeshFactory::SpawnActor(
     return {};
   }
 
+  float Scale = ABFL::ActorAttributeToFloat(ActorDescription.Variations["scale"], 1.0f);
+  FTransform ScaledTransform(SpawnAtTransform);
+  ScaledTransform.SetScale3D(FVector(Scale));
+
   FActorSpawnParameters SpawnParameters;
   SpawnParameters.SpawnCollisionHandlingOverride =
       ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
   auto *StaticMeshActor = World->SpawnActor<AStaticMeshActor>(
-      ActorDescription.Class, SpawnAtTransform, SpawnParameters);
+      ActorDescription.Class, ScaledTransform, SpawnParameters);
 
   auto *StaticMeshComponent = Cast<UStaticMeshComponent>(
       StaticMeshActor->GetRootComponent());
+    
   if (StaticMeshComponent)
   {
-    if (ActorDescription.Variations.Contains("mesh_path") &&
-        ActorDescription.Variations.Contains("mass"))
+    if (ActorDescription.Variations.Contains("mesh_path"))
     {
       FString MeshPath = ABFL::ActorAttributeToString(
           ActorDescription.Variations["mesh_path"], "");
-      UObject* MeshObject = StaticLoadObject(UStaticMesh::StaticClass(),
-          nullptr,
-          *(MeshPath));
-      UStaticMesh *Mesh = Cast<UStaticMesh>(MeshObject);
+      
+      UStaticMesh *Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
       StaticMeshComponent->SetMobility(EComponentMobility::Movable);
-      StaticMeshComponent->SetStaticMesh(Mesh);
-      StaticMeshComponent->SetSimulatePhysics(true);
-      StaticMeshComponent->SetCollisionProfileName("PhysicsActor");
-      StaticMeshComponent->SetMassOverrideInKg("",
-         ABFL::ActorAttributeToFloat(ActorDescription.Variations["mass"], 1.0f));
+      if (!StaticMeshComponent->SetStaticMesh(Mesh))
+        UE_LOG(LogCarla, Warning, TEXT("Failed to set the mesh"));
+      StaticMeshComponent->SetMobility(EComponentMobility::Static);
+
+      if (ActorDescription.Variations.Contains("mass"))
+      {
+        float Mass = ABFL::ActorAttributeToFloat(ActorDescription.Variations["mass"], 0.0f);
+        if (Mass > 0)
+        {
+          StaticMeshComponent->SetMobility(EComponentMobility::Movable);
+          StaticMeshComponent->SetSimulatePhysics(true);
+          StaticMeshComponent->SetCollisionProfileName("PhysicsActor");
+          StaticMeshComponent->SetMassOverrideInKg("", Mass);
+        }
+      }
     }
   }
   return FActorSpawnResult(StaticMeshActor);


### PR DESCRIPTION
#### Description

Fix  the static mesh prop factory, that allow to load static meshes from resources in real time.
At the same time, we added attributes as **mass** and **scale**.
The attributes are:

- mesh_path: with the path to the resource, as "/Game/..."
- mass: if a mass different of 0 is defined, the asset will be setup as **movable** object, otherwise it will be **static**
- scale: scale for the mesh if any

A simple sniped of how to use it is:

```
client = carla.Client('localhost', 2000)
world = client.get_world()

# prepare the static mesh
bp = world.get_blueprint_library().find("static.prop.mesh")
bp.set_attribute('mesh_path', "/Game/Carla/Static/Vehicles/4Wheeled/ParkedVehicles/TeslaM3/SM_TeslaM3_parked.SM_TeslaM3_parked")
bp.set_attribute('mass', "1000")
bp.set_attribute('scale', "0.9")

# spawn the mesh
spawn_point = carla.Transform()
prop = world.spawn_actor(bp, spawn_point)
```
#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5723)
<!-- Reviewable:end -->
