### PR TITLE
Fixed walker respawn in large maps

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorData.cpp
@@ -65,14 +65,7 @@ void FActorData::RestoreActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaE
   // we need to do it in the UCharacterMovementComponent.
   else if (Character != nullptr)
   {
-    auto CharacterMovement = Cast<UCharacterMovementComponent>(Character->GetCharacterMovement());
 
-    if(bSimulatePhysics) {
-      CharacterMovement->SetDefaultMovementMode();
-    }
-    else {
-      CharacterMovement->DisableMovement();
-    }
   }
   // In the rest of actors, the physics is controlled with the UPrimitiveComponent, so we use
   // that for disable it.
@@ -147,24 +140,27 @@ void FWalkerData::RecordActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaE
 {
   FActorData::RecordActorData(CarlaActor, CarlaEpisode);
   AActor* Actor = CarlaActor->GetActor();
-  auto Walker = Cast<APawn>(Actor);
+  auto Walker = Cast<AWalkerBase>(Actor);
   auto Controller = Walker != nullptr ? Cast<AWalkerController>(Walker->GetController()) : nullptr;
   if (Controller != nullptr)
   {
     WalkerControl = carla::rpc::WalkerControl{Controller->GetWalkerControl()};
   }
+  bAlive = Walker->bAlive;
 }
 
 void FWalkerData::RestoreActorData(FCarlaActor* CarlaActor, UCarlaEpisode* CarlaEpisode)
 {
   FActorData::RestoreActorData(CarlaActor, CarlaEpisode);
   AActor* Actor = CarlaActor->GetActor();
-  auto Walker = Cast<APawn>(Actor);
+  auto Walker = Cast<ACharacter>(Actor);
   auto Controller = Walker != nullptr ? Cast<AWalkerController>(Walker->GetController()) : nullptr;
   if (Controller != nullptr)
   {
     Controller->ApplyWalkerControl(WalkerControl);
   }
+  auto CharacterMovement = Cast<UCharacterMovementComponent>(Walker->GetCharacterMovement());
+  // TODO: Handle death timer
 }
 
 AActor* FTrafficSignData::RespawnActor(UCarlaEpisode* CarlaEpisode, const FActorInfo& Info)


### PR DESCRIPTION
#### Description

Fixes pedestrians being disabled when changing from dormant to active in large maps.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26
