### PR TITLE
Fixing spawn points height (from 3m to only 0.5m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added the speed limits for 100, 110 and 120 Km/h.
   * Fixing sensor destruction, now the stream and socket is succesfully destroyed.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.
+  * Changed the height of the automatic spawn points, from 3m to only 0.5m
   * Added multi-GPU feature. Now several servers (with dedicated GPU) can render sensors for the same simulation.
   * Fixed bug causing the `Vehicle.get_traffic_light_state()` function not notify about the green to yellow and yellow to red light state changes.
   * Fixed bug causing the `Vehicle.is_at_traffic_light()` function to return *false* if the traffic light was green.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -440,7 +440,7 @@ void ACarlaGameModeBase::GenerateSpawnPoints()
   {
     carla::geom::Transform CarlaTransform = Map->ComputeTransform(Pair.first);
     FTransform Transform(CarlaTransform);
-    Transform.AddToTranslation(FVector(0.f, 0.f, 300.0f));
+    Transform.AddToTranslation(FVector(0.f, 0.f, 50.0f));
     SpawnPointsTransforms.Add(Transform);
   }
 }


### PR DESCRIPTION
#### Description

When a map has no spawn points, automatically several are created (reading the information of the openDRIVE file), and those spawn points are placed at 3m over the road. Now we change that height to only 0.5m, avoiding problems of spawning vehicles over others below.

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5754)
<!-- Reviewable:end -->
