### PR TITLE
Fix shared_ptr cycles in C++ carla::Client

### DIFF
--- a/LibCarla/source/carla/client/Light.cpp
+++ b/LibCarla/source/carla/client/Light.cpp
@@ -16,63 +16,75 @@ namespace client {
   using LightGroup = rpc::LightState::LightGroup;
 
 Color Light::GetColor() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->GetColor(_id);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->GetColor(_id);
 }
 
 float Light::GetIntensity() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->GetIntensity(_id);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->GetIntensity(_id);
 }
 
 LightGroup Light::GetLightGroup() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->GetLightGroup(_id);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->GetLightGroup(_id);
 }
 
 LightState Light::GetLightState() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->GetLightState(_id);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->GetLightState(_id);
 }
 
 bool Light::IsOn() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->IsActive(_id) == true;
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->IsActive(_id) == true;
 }
 
 bool Light::IsOff() const {
-  assert(_light_manager && "No light_manager");
-  return _light_manager->IsActive(_id) == false;
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  return light_manager->IsActive(_id) == false;
 }
 
 void Light::SetColor(Color color) {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetColor(_id, color);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetColor(_id, color);
 }
 
 void Light::SetIntensity(float intensity) {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetIntensity(_id, intensity);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetIntensity(_id, intensity);
 }
 
 void Light::SetLightGroup(LightGroup group) {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetLightGroup(_id, group);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetLightGroup(_id, group);
 }
 
 void Light::SetLightState(const LightState& state) {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetLightState(_id, state);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetLightState(_id, state);
 }
 
 void Light::TurnOn() {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetActive(_id, true);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetActive(_id, true);
 }
 
 void Light::TurnOff() {
-  assert(_light_manager && "No light_manager");
-  _light_manager->SetActive(_id, false);
+  auto light_manager = _light_manager.lock();
+  assert(light_manager && "No light_manager");
+  light_manager->SetActive(_id, false);
 }
 
 

--- a/LibCarla/source/carla/client/Light.h
+++ b/LibCarla/source/carla/client/Light.h
@@ -62,14 +62,14 @@ private:
 
   friend class LightManager;
 
-  Light(SharedPtr<LightManager> light_manager,
+  Light(WeakPtr<LightManager> light_manager,
     geom::Location location,
     LightId id)
   : _light_manager(light_manager),
     _location (location),
     _id (id) {}
 
-  SharedPtr<LightManager> _light_manager;
+  WeakPtr<LightManager> _light_manager;
   geom::Location _location;
 
   LightId _id;

--- a/LibCarla/source/carla/client/LightManager.cpp
+++ b/LibCarla/source/carla/client/LightManager.cpp
@@ -22,7 +22,7 @@ LightManager::~LightManager(){
   UpdateServerLightsState(true);
 }
 
-void LightManager::SetEpisode(detail::EpisodeProxy episode) {
+void LightManager::SetEpisode(detail::WeakEpisodeProxy episode) {
 
   _episode = episode;
 

--- a/LibCarla/source/carla/client/LightManager.h
+++ b/LibCarla/source/carla/client/LightManager.h
@@ -43,7 +43,7 @@ public:
     _dirty = other._dirty;
   }
 
-  void SetEpisode(detail::EpisodeProxy episode);
+  void SetEpisode(detail::WeakEpisodeProxy episode);
 
   std::vector<Light> GetAllLights(LightGroup type = LightGroup::None) const;
   // TODO: std::vector<Light> GetAllLightsInRoad(RoadId id, LightGroup type = LightGroup::None);
@@ -99,7 +99,7 @@ private:
   std::unordered_map<LightId, LightState> _lights_changes;
   std::unordered_map<LightId, Light> _lights;
 
-  detail::EpisodeProxy _episode;
+  detail::WeakEpisodeProxy _episode;
 
   std::mutex _mutex;
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -134,7 +134,7 @@ namespace detail {
       if (!GetEpisodeSettings().synchronous_mode) {
         WaitForTick(_client.GetTimeout());
       }
-      _light_manager->SetEpisode(EpisodeProxy{shared_from_this()});
+      _light_manager->SetEpisode(WeakEpisodeProxy{shared_from_this()});
     }
     return EpisodeProxy{shared_from_this()};
   }


### PR DESCRIPTION
carla::client::detail::Simulator had a strong reference from carla::client::LightManager, which meant that deleting the client-facing carla::Client did not actually delete the Simulator object, meaning that it remained connected. Fix that.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
