### PR TITLE
Fixed bug at agent's vehicle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Python agents now have a function to lane change.
   * Python agents now detect vehicle in adjacent lanes if invaded due to the offset.
+  * Fixed bug causing the python agents to sometimes not detect a blocking actor if there were severral actors around it.
   * Improved Python agents performance for large maps.
   * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.
   * Added new ConstantVelocityAgent

--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -391,8 +391,6 @@ class BasicAgent(object):
                 if route_polygon.intersects(target_polygon):
                     return (True, target_vehicle, compute_distance(target_vehicle.get_location(), ego_location))
 
-                return (False, None, -1)
-
             # Simplified approach, using only the plan waypoints (similar to TM)
             else:
 


### PR DESCRIPTION
### Description

Removed a return at the basic agent's vehicle detection algorithm. This was causing the algorithm to prematurely stop after finding a close-by vehicle that wasn't an obstacle, failing to check the rest of the cloes-by vehicles.

### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5824)
<!-- Reviewable:end -->
