### PR TITLE
Prevent from segfault OnTriggerEndOverlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug in FrictionTrigger causing sometimes server segfault
   * Added attachment type "SpringArmGhost" for cinematic cameras but without doing the collision test.
   * Improved algorithm to move signals out of the road by computing the desired displacement direction.
   * Added `TrafficManager.vehicle_lane_offset(actor, offset)` and `TrafficManager.global_lane_offset(offset)` methods.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/FrictionTrigger.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Trigger/FrictionTrigger.cpp
@@ -71,6 +71,9 @@ void AFrictionTrigger::OnTriggerEndOverlap(
   UpdateWheelsFriction(OtherActor, OldFrictionValues);
 
   ACarlaWheeledVehicle *Vehicle = Cast<ACarlaWheeledVehicle>(OtherActor);
+  if(Vehicle == nullptr)
+    return;
+
   TArray<float> CurrFriction = Vehicle->GetWheelsFrictionScale();
 }
 


### PR DESCRIPTION
In case the OtherActor is not a Vehicle just return

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ -] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [X] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ... Ubuntu 20.04
  * **Python version(s):** ... 3.7
  * **Unreal Engine version(s):** ... 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5838)
<!-- Reviewable:end -->
