### PR TITLE
Spawn Foliage with distance filter

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.cpp
@@ -508,7 +508,7 @@ void AVegetationManager::SpawnSkeletalFoliages(TArray<FElementsToSpawn>& Element
       if (Element.TileMeshComponent->IndicesInUse.Contains(Index))
         continue;
       const float Distance = FMath::Abs(FVector::Dist(Transform.GetLocation(), HeroLocation));
-      if (Distance > (HideMaterialDistance * 2.0f))
+      if (Distance > (HideMaterialDistance * 3.0f))
         continue;
       bool Ok = EnableActorFromPool(Transform, Index, Element.TileMeshComponent, *Pool);
       if (Ok)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.h
@@ -90,7 +90,7 @@ public:
   bool DebugMaterials {false};
 
   UPROPERTY(Category = "CARLA Vegetation Spwaner", EditDefaultsOnly)
-  float HideMaterialDistance {500.0f};
+  float HideMaterialDistance {300.0f};
 
   //Filters for debug
   UPROPERTY(Category = "CARLA Vegetation Spwaner", EditDefaultsOnly)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vegetation/VegetationManager.h
@@ -109,7 +109,7 @@ public:
   float SpawnScale {1.0f};
 
   UPROPERTY(Category = "CARLA Vegetation Spwaner", EditDefaultsOnly)
-  int32 InitialPoolSize {10};
+  int32 InitialPoolSize {5};
 
   /// @}
   // ===========================================================================

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -224,7 +224,7 @@ void ACarlaWheeledVehicle::UpdateDetectionBox()
 const TArray<int32> ACarlaWheeledVehicle::GetFoliageInstancesCloseToVehicle(const UInstancedStaticMeshComponent* Component) const
 {  
   TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaWheeledVehicle::GetFoliageInstancesCloseToVehicle);
-  return Component->GetInstancesOverlappingSphere(FoliageBoundingBox.GetCenter(), DetectionSize, true);
+  return Component->GetInstancesOverlappingBox(FoliageBoundingBox);
 }
 
 FBox ACarlaWheeledVehicle::GetDetectionBox() const

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -224,7 +224,18 @@ void ACarlaWheeledVehicle::UpdateDetectionBox()
 const TArray<int32> ACarlaWheeledVehicle::GetFoliageInstancesCloseToVehicle(const UInstancedStaticMeshComponent* Component) const
 {  
   TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaWheeledVehicle::GetFoliageInstancesCloseToVehicle);
-  return Component->GetInstancesOverlappingBox(FoliageBoundingBox);
+  return Component->GetInstancesOverlappingSphere(FoliageBoundingBox.GetCenter(), DetectionSize, true);
+}
+
+FBox ACarlaWheeledVehicle::GetDetectionBox() const
+{  
+  TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaWheeledVehicle::GetDetectionBox);
+  return FoliageBoundingBox;
+}
+
+float ACarlaWheeledVehicle::GetDetectionSize() const
+{
+  return DetectionSize;
 }
 
 void ACarlaWheeledVehicle::DrawFoliageBoundingBox() const

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -354,7 +354,7 @@ private:
 
 public:
   UPROPERTY(Category = "CARLA Wheeled Vehicle", EditDefaultsOnly)
-  float DetectionSize { 750.0f };
+  float DetectionSize { 500.0f };
   
   UPROPERTY(Category = "CARLA Wheeled Vehicle", VisibleAnywhere, BlueprintReadOnly)
   FBox FoliageBoundingBox;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -363,6 +363,12 @@ public:
   UBoxComponent *VehicleBounds; 
 
   UFUNCTION()
+  FBox GetDetectionBox() const;
+
+  UFUNCTION()
+  float GetDetectionSize() const;
+
+  UFUNCTION()
   void UpdateDetectionBox();
 
   UFUNCTION()


### PR DESCRIPTION
The vegetation manager now spawns the elements closer to a distance.
This fixes the problem with the elements being spawned too far and destroyed instantly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5881)
<!-- Reviewable:end -->
