### PR TITLE
:sparkles: Issue #5902 Use UE4-Docker to build Carla fork of UE4

### DIFF
--- a/Util/BuildTools/Linux.mk
+++ b/Util/BuildTools/Linux.mk
@@ -12,7 +12,7 @@ launch-only:
 import: CarlaUE4Editor PythonAPI
 	@${CARLA_BUILD_TOOLS_FOLDER}/Import.sh $(ARGS)
 
-package: CarlaUE4Editor PythonAPI
+package: CarlaUE4Editor PythonAPI.rebuild
 	@${CARLA_BUILD_TOOLS_FOLDER}/Package.sh $(ARGS)
 
 package.rss: CarlaUE4Editor PythonAPI.rss.rebuild

--- a/Util/Docker/Carla.Dockerfile
+++ b/Util/Docker/Carla.Dockerfile
@@ -2,18 +2,17 @@ FROM carla-prerequisites:latest
 
 ARG GIT_BRANCH
 
-USER carla
-WORKDIR /home/carla
+USER ue4
 
-RUN cd /home/carla/ && \
+RUN cd /home/ue4 && \
   if [ -z ${GIT_BRANCH+x} ]; then git clone --depth 1 https://github.com/carla-simulator/carla.git; \
   else git clone --depth 1 --branch $GIT_BRANCH https://github.com/carla-simulator/carla.git; fi && \
-  cd /home/carla/carla && \
+  cd /home/ue4/carla && \
   ./Update.sh && \
   make CarlaUE4Editor && \
   make PythonAPI && \
   make build.utils && \
   make package && \
-  rm -r /home/carla/carla/Dist
+  rm -r /home/ue4/carla/Dist
 
-WORKDIR /home/carla/carla
+WORKDIR /home/ue4/carla

--- a/Util/Docker/Prerequisites.Dockerfile
+++ b/Util/Docker/Prerequisites.Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:18.04
+FROM adamrehn/ue4-source:custom
 
 USER root
 
-ARG EPIC_USER=user
-ARG EPIC_PASS=pass
-ENV DEBIAN_FRONTEND=noninteractive
+ENV UE4_ROOT /home/ue4/UnrealEngine
+
 RUN apt-get update ; \
   apt-get install -y wget software-properties-common && \
   add-apt-repository ppa:ubuntu-toolchain-r/test && \
@@ -34,24 +33,17 @@ RUN apt-get update ; \
     libtool \
     rsync \
     libxml2-dev \
-    git \
     aria2 && \
   pip3 install -Iv setuptools==47.3.1 && \
   pip3 install distro && \
   update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-8/bin/clang++ 180 && \
   update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-8/bin/clang 180
 
-RUN useradd -m carla
-COPY --chown=carla:carla . /home/carla
-USER carla
-WORKDIR /home/carla
-ENV UE4_ROOT /home/carla/UE4.26
-
-RUN git clone --depth 1 -b carla "https://${EPIC_USER}:${EPIC_PASS}@github.com/CarlaUnreal/UnrealEngine.git" ${UE4_ROOT}
+USER ue4
 
 RUN cd $UE4_ROOT && \
   ./Setup.sh && \
   ./GenerateProjectFiles.sh && \
   make
 
-WORKDIR /home/carla/
+WORKDIR /home/ue4

--- a/Util/Docker/README.md
+++ b/Util/Docker/README.md
@@ -1,6 +1,6 @@
 # Building Carla in a Docker
 
-_These instructions have been tested in **Ubuntu 16.04**._
+_These instructions have been tested in **Ubuntu 18.04**._
 
 This file is intended to explain how to build a Docker image that uses **Ubuntu 18.04** to compile Carla.
 
@@ -49,19 +49,26 @@ ue4-docker setup
 
 ## Building the Docker images
 
-Navigate to `carla/Util/Docker` and use the following commands, each one will take a long time.  
-First, let's create a Docker image containing a compiled version of Unreal Engine 4 version `24.3`. Change the version if needed.
+Navigate to `carla/Util/Docker` and use the following commands, each one will take a long time.
+
+### Image 1 - Unreal Engine 4
+First, let's create a Docker image containing a compiled version of Unreal Engine 4 version using the Carla forked repository and branch. Change the branch if needed.
+
+This will by default ask for the user Git credentials. You can also use -username my_user -password my_password
+Be aware that your password won't work has GitHub does not allow that for security reasons. Therefore, you should use a GitHub Authentification token with repository access. Cf: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
 ```
-ue4-docker build 4.24.3 --no-engine --no-minimal
+ue4-docker build --no-engine --linux --no-minimal custom -repo=https://github.com/CarlaUnreal/UnrealEngine.git -branch=carla
 ```
 
+### Image 2 - Prerequisites to build Carla
 Next, this will build the image with all the necessary requisites to build Carla in a **Ubuntu 18.04**
 
 ```
 docker build -t carla-prerequisites -f Prerequisites.Dockerfile .
 ```
 
+### Image 3 - Carla
 Finally create the actual Carla image, it will search for `carla-prerequisites:latest`:
 
 ```

--- a/Util/Docker/docker_tools.py
+++ b/Util/Docker/docker_tools.py
@@ -84,14 +84,14 @@ def main():
 
     args = parse_args()
     carla_image_name = "carla:latest"
-    inbox_assets_path = '/home/carla/carla/Import'
+    inbox_assets_path = '/home/ue4/carla/Import'
     client = docker.from_env()
 
     # All possible Docker arguments are here:
     # https://docker-py.readthedocs.io/en/stable/containers.html
     container_args = {
         "image": carla_image_name,
-        "user": 'carla',
+        "user": 'ue4',
         "auto_remove": True,
         "stdin_open": True,
         "tty": True,
@@ -114,24 +114,24 @@ def main():
             docker_utils.exec_command(
                 carla_container,
                 'make import',
-                user='carla', verbose=args.verbose, ignore_error=False)
+                user='ue4', verbose=args.verbose, ignore_error=False)
 
             docker_utils.exec_command(
                 carla_container,
                 'make package ARGS="--packages=' + str(args.packages) + '"',
-                user='carla', verbose=args.verbose, ignore_error=False)
+                user='ue4', verbose=args.verbose, ignore_error=False)
         else:
             # Just create a package of the whole project
             docker_utils.exec_command(
                 carla_container,
                 'make package',
-                user='carla', verbose=args.verbose, ignore_error=False)
+                user='ue4', verbose=args.verbose, ignore_error=False)
 
         # Get the files routes to export
         files_to_copy = docker_utils.get_file_paths(
             carla_container,
-            '/home/carla/carla/Dist/*.tar.gz',
-            user='carla', verbose=args.verbose)
+            '/home/ue4/carla/Dist/*.tar.gz',
+            user='ue4', verbose=args.verbose)
 
         # Copy these fles to the output folder
         docker_utils.extract_files(carla_container, files_to_copy, args.output)


### PR DESCRIPTION
#### Description

Fixes #5902 

#### Where has this been tested?

  * **Platform(s):** Linux Ubuntu 20.04
  * **Python version(s):** Python3.8
  * **Unreal Engine version(s):** 24.3.1 forked: https://github.com/CarlaUnreal/UnrealEngine a6fbc84 on Mar 31 2022 

#### Possible Drawbacks

- The use of `ue4-docker` package will add more abstraction (compare to using ubuntu18.08 image) but this is also why we do it, to not maintain the installation of UE4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5903)
<!-- Reviewable:end -->
