### PR TITLE
Fix Package.sh script

### DIFF
--- a/Util/BuildTools/Package.sh
+++ b/Util/BuildTools/Package.sh
@@ -276,55 +276,55 @@ for PACKAGE_NAME in "${PACKAGES[@]}" ; do if [[ ${PACKAGE_NAME} != "Carla" ]] ; 
 
   popd >/dev/null
 
-  if ${DO_TARBALL} ; then
+  pushd "${BUILD_FOLDER}" > /dev/null
 
-    pushd "${BUILD_FOLDER}" > /dev/null
+  SUBST_PATH="${BUILD_FOLDER}/CarlaUE4"
+  SUBST_FILE="${PACKAGE_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
 
-    SUBST_PATH="${BUILD_FOLDER}/CarlaUE4"
-    SUBST_FILE="${PACKAGE_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
+  # Copy the package config file to package
+  mkdir -p "$(dirname ${SUBST_FILE})" && cp "${PACKAGE_FILE}" "$_"
 
-    # Copy the package config file to package
-    mkdir -p "$(dirname ${SUBST_FILE})" && cp "${PACKAGE_FILE}" "$_"
+  # Copy the OpenDRIVE .xodr files to package
+  IFS='+' # set delimiter
+  # MAPS_TO_COOK is read into an array as tokens separated by IFS
+  read -ra ADDR <<< "$MAPS_TO_COOK"
+  for i in "${ADDR[@]}"; do # access each element of array
+    
+    XODR_FILE_PATH="${CARLAUE4_ROOT_FOLDER}/Content${i:5}"
+    MAP_NAME=${XODR_FILE_PATH##*/}
+    XODR_FILE=$(find "${CARLAUE4_ROOT_FOLDER}/Content" -name "${MAP_NAME}.xodr" -print -quit)
 
-    # Copy the OpenDRIVE .xodr files to package
-    IFS='+' # space is set as delimiter
-    # MAPS_TO_COOK is read into an array as tokens separated by IFS
-    read -ra ADDR <<< "$MAPS_TO_COOK"
-    for i in "${ADDR[@]}"; do # access each element of array
+    if [ -f "${XODR_FILE}" ] ; then
 
-      XODR_FILE_PATH="${CARLAUE4_ROOT_FOLDER}/Content${i:5}"
-      MAP_NAME=${XODR_FILE_PATH##*/}
-      XODR_FILE=$(find "${CARLAUE4_ROOT_FOLDER}/Content" -name "${MAP_NAME}.xodr" -print -quit)
+      SUBST_FILE="${XODR_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
 
-      if [ -f "${XODR_FILE}" ] ; then
+      # Copy the package config file to package
+      mkdir -p "$(dirname ${SUBST_FILE})" && cp "${XODR_FILE}" "$_"
 
-        SUBST_FILE="${XODR_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
+    fi
+
+    # binary files for navigation and traffic manager
+    BIN_FILE_PATH="${CARLAUE4_ROOT_FOLDER}/Content${i:5}"
+    MAP_NAME=${BIN_FILE_PATH##*/}
+    find "${CARLAUE4_ROOT_FOLDER}/Content" -name "${MAP_NAME}.bin" -print0 | while read -d $'\0' BIN_FILE
+    do
+      if [ -f "${BIN_FILE}" ] ; then
+
+        SUBST_FILE="${BIN_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
 
         # Copy the package config file to package
-        mkdir -p "$(dirname ${SUBST_FILE})" && cp "${XODR_FILE}" "$_"
-
-      fi
-
-      # binary files for navigation and traffic manager
-      BIN_FILE_PATH="${CARLAUE4_ROOT_FOLDER}/Content${i:5}"
-      MAP_NAME=${BIN_FILE_PATH##*/}
-      find "${CARLAUE4_ROOT_FOLDER}/Content" -name "${MAP_NAME}.bin" -print0 | while read -d $'\0' BIN_FILE
-      do
-        if [ -f "${BIN_FILE}" ] ; then
-
-          SUBST_FILE="${BIN_FILE/${CARLAUE4_ROOT_FOLDER}/${SUBST_PATH}}"
-
-          # Copy the package config file to package
-          mkdir -p "$(dirname ${SUBST_FILE})" && cp "${BIN_FILE}" "$_"
-      fi
-      done
+        mkdir -p "$(dirname ${SUBST_FILE})" && cp "${BIN_FILE}" "$_"
+    fi
     done
+  done
 
     rm -Rf "./CarlaUE4/Metadata"
     rm -Rf "./CarlaUE4/Plugins"
     rm -Rf "./CarlaUE4/Content/${PACKAGE_NAME}/Maps/${PROPS_MAP_NAME}"
     rm -f "./CarlaUE4/AssetRegistry.bin"
 
+  if ${DO_TARBALL} ; then
+  
     if ${SINGLE_PACKAGE} ; then
       tar -rf ${DESTINATION} *
     else


### PR DESCRIPTION
#### Description

Fix the Package.sh script that when you use the **--no-zip** option it won't copy the openDrive and binary files into the target package.

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5908)
<!-- Reviewable:end -->
