### PR TITLE
Fix pedestrian bones displaced from body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Added `TrafficManager.vehicle_lane_offset(actor, offset)` and `TrafficManager.global_lane_offset(offset)` methods.
   * Some of the warnings shown when building a map will now only be showing when debugging.
   * Fixed bug causing traffic signals at the end points of a road to sometimes create malformed waypoints.
+  * Fixed pedestrian skeleton frame, where sometimes it was draw displaced from the body
   * Fixed decals when importing maps. It was using other .json files found in other packages.
   * Added the speed limits for 100, 110 and 120 Km/h.
   * Fixing sensor destruction, now the stream and socket is succesfully destroyed.

--- a/LibCarla/source/carla/client/detail/Episode.cpp
+++ b/LibCarla/source/carla/client/detail/Episode.cpp
@@ -102,12 +102,6 @@ using namespace std::chrono_literals;
           // Notify waiting threads and do the callbacks.
           self->_snapshot.SetValue(next);
 
-          // Tick navigation.
-          auto navigation = self->_navigation.load();
-          if (navigation != nullptr) {
-            navigation->Tick(self);
-          }
-
           // Call user callbacks.
           self->_on_tick_callbacks.Call(next);
         }
@@ -164,6 +158,14 @@ using namespace std::chrono_literals;
       return true;
     }
     return false;
+  }
+
+  void Episode::NavigationTick() {
+    // tick pedestrian navigation
+    auto navigation = _navigation.load();
+    if (navigation != nullptr) {
+      navigation->Tick(shared_from_this());
+    }
   }
 
 } // namespace detail

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -114,6 +114,8 @@ namespace detail {
 
     bool HasMapChangedSinceLastCall();
 
+    void NavigationTick();
+
   private:
 
     Episode(Client &client, const rpc::EpisodeInfo &info);

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -199,6 +199,13 @@ namespace detail {
 
   WorldSnapshot Simulator::WaitForTick(time_duration timeout) {
     DEBUG_ASSERT(_episode != nullptr);
+
+    // tick pedestrian navigation
+    _episode->NavigationTick();
+    
+    // tick traffic manager
+    carla::traffic_manager::TrafficManager::Tick();
+
     auto result = _episode->WaitForState(timeout);
     if (!result.has_value()) {
       throw_exception(TimeoutException(_client.GetEndpoint(), timeout));

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -57,10 +57,6 @@ namespace detail {
         break;
       }
     }
-    if(result) {
-      carla::traffic_manager::TrafficManager::Tick();
-    }
-
     return result;
   }
 
@@ -212,7 +208,17 @@ namespace detail {
 
   uint64_t Simulator::Tick(time_duration timeout) {
     DEBUG_ASSERT(_episode != nullptr);
+    
+    // tick pedestrian navigation
+    _episode->NavigationTick();
+    
+    // tick traffic manager
+    carla::traffic_manager::TrafficManager::Tick();
+
+    // send tick command
     const auto frame = _client.SendTickCue();
+
+    // waits until new episode is received
     bool result = SynchronizeFrame(frame, *_episode, timeout);
     if (!result) {
       throw_exception(TimeoutException(_client.GetEndpoint(), timeout));

--- a/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
+++ b/LibCarla/source/carla/client/detail/WalkerNavigation.cpp
@@ -58,7 +58,7 @@ namespace detail {
       }
     }
 
-    _client.ApplyBatch(std::move(commands), false);
+    _client.ApplyBatchSync(std::move(commands), false);
   }
 
   void WalkerNavigation::CheckIfWalkerExist(std::vector<WalkerHandle> walkers, const EpisodeState &state) {

--- a/LibCarla/source/carla/nav/WalkerManager.cpp
+++ b/LibCarla/source/carla/nav/WalkerManager.cpp
@@ -62,9 +62,8 @@ namespace nav {
                         _nav->GetWalkerPosition(it.first, current);
                         // check distance to the target point
                         carla::geom::Vector3D dist(target.x - current.x, target.z - current.z, target.y - current.y);
-                        if (dist.SquaredLength() <= 4) {
+                        if (dist.SquaredLength() <= 1) {
                             info.state = WALKER_IN_EVENT;
-                            _nav->PauseAgent(it.first, true);
                         }
                     }
                     break;


### PR DESCRIPTION
#### Description

This is a fix for three different problems identified related to the skeleton of a pedestrian:

1. The skeleton of a pedestrian at some points was displaced from the body. That was caused by getting the bones of the pedestrian at the wrong moment. 

2. In function of the network congestion, could happen that the server start to build the frame before all the pedestrian position are updated from the client (pedestrian navigation is managed in the client side). That has been fixed using a synchronous call instead of an asynchronous call. So in synchronous mode now we are sure to update all pedestrian positions before do the tick.

3. When a pedestrian was reaching a point of the path for the route he is following, it was stop by 1 frame, and that was causing an interference of the animation because the speed was lower. The pause has been removed and now there are no glitches in the animation.

Fixes #  4980 (partially)

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5973)
<!-- Reviewable:end -->
