### PR TITLE
Fixing the retrieval of optional attributes

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/StaticMeshFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/StaticMeshFactory.cpp
@@ -45,7 +45,7 @@ FActorSpawnResult AStaticMeshFactory::SpawnActor(
     return {};
   }
 
-  float Scale = ABFL::ActorAttributeToFloat(ActorDescription.Variations["scale"], 1.0f);
+  float Scale = ABFL::RetrieveActorAttributeToFloat("scale", ActorDescription.Variations, 1.0f);
   FTransform ScaledTransform(SpawnAtTransform);
   ScaledTransform.SetScale3D(FVector(Scale));
 
@@ -73,7 +73,7 @@ FActorSpawnResult AStaticMeshFactory::SpawnActor(
 
       if (ActorDescription.Variations.Contains("mass"))
       {
-        float Mass = ABFL::ActorAttributeToFloat(ActorDescription.Variations["mass"], 0.0f);
+        float Mass = ABFL::RetrieveActorAttributeToFloat("mass", ActorDescription.Variations, 0.0f);
         if (Mass > 0)
         {
           StaticMeshComponent->SetMobility(EComponentMobility::Movable);


### PR DESCRIPTION
#### Description

The retrieval of optional attributes from the definition of the static mesh was wrong

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5982)
<!-- Reviewable:end -->
