### PR TITLE
Recorder with skeleton bones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Fixing sensor destruction, now the stream and socket is succesfully destroyed.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.
   * Changed the height of the automatic spawn points, from 3m to only 0.5m
+  * Added pedestrian skeleton to the recorder, as additional data. They will replay with the exact pose.
   * Added multi-GPU feature. Now several servers (with dedicated GPU) can render sensors for the same simulation.
   * Fixed bug causing the `Vehicle.get_traffic_light_state()` function not notify about the green to yellow and yellow to red light state changes.
   * Fixed bug causing the `Vehicle.is_at_traffic_light()` function to return *false* if the traffic light was green.

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -24,6 +24,8 @@
 #include "GameFramework/SpectatorPawn.h"
 #include "GenericPlatform/GenericPlatformProcess.h"
 #include "Kismet/GameplayStatics.h"
+#include "Materials/MaterialParameterCollection.h"
+#include "Materials/MaterialParameterCollectionInstance.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 
@@ -324,6 +326,21 @@ void UCarlaEpisode::InitializeAtBeginPlay()
   {
     UE_LOG(LogCarla, Error, TEXT("Can't find spectator!"));
   }
+
+  // material parameters collection
+  UMaterialParameterCollection *Collection = LoadObject<UMaterialParameterCollection>(nullptr, TEXT("/Game/Carla/Blueprints/Game/CarlaParameters.CarlaParameters"), nullptr, LOAD_None, nullptr);
+	if (Collection != nullptr)
+  {
+    MaterialParameters = World->GetParameterCollectionInstance(Collection);
+    if (MaterialParameters == nullptr)
+    {
+      UE_LOG(LogCarla, Error, TEXT("Can't find CarlaParameters instance!"));
+    }
+  }
+  else
+	{
+    UE_LOG(LogCarla, Error, TEXT("Can't find CarlaParameters asset!"));
+	}
 
   for (TActorIterator<ATrafficSignBase> It(World); It; ++It)
   {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -17,6 +17,7 @@
 #include "Carla/Sensor/SensorManager.h"
 
 #include "GameFramework/Pawn.h"
+#include "Materials/MaterialParameterCollectionInstance.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/geom/BoundingBox.h>
@@ -97,6 +98,23 @@ public:
   double GetElapsedGameTime() const
   {
     return ElapsedGameTime;
+  }
+  
+  /// Visual game seconds
+  double GetVisualGameTime() const
+  {
+    return VisualGameTime;
+  }
+  
+  void SetVisualGameTime(double Time)
+  {
+    VisualGameTime = Time;
+
+    // update time in material parameters also
+    if (MaterialParameters)
+    {
+      MaterialParameters->SetScalarParameterValue(FName("VisualTime"), VisualGameTime);
+    }
   }
 
   /// Return the list of actor definitions that are available to be spawned this
@@ -327,11 +345,16 @@ private:
   void TickTimers(float DeltaSeconds)
   {
     ElapsedGameTime += DeltaSeconds;
+    SetVisualGameTime(VisualGameTime + DeltaSeconds);
   }
 
   const uint64 Id = 0u;
 
+  // simulation time
   double ElapsedGameTime = 0.0;
+  
+  // visual time (used by clounds and other FX that need to be deterministic)
+  double VisualGameTime = 0.0;
 
   UPROPERTY(VisibleAnywhere)
   FString MapName;
@@ -347,6 +370,9 @@ private:
 
   UPROPERTY(VisibleAnywhere)
   AWeather *Weather = nullptr;
+  
+  UPROPERTY(VisibleAnywhere)
+  UMaterialParameterCollectionInstance *MaterialParameters = nullptr;
 
   ACarlaRecorder *Recorder = nullptr;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -90,6 +90,8 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
   if (Enabled)
   {
     PlatformTime.UpdateTime();
+    VisualTime.SetTime(Episode->GetVisualGameTime());
+
     const FActorRegistry &Registry = Episode->GetActorRegistry();
 
     // through all actors in registry
@@ -122,6 +124,7 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
           if (bAdditionalData)
           {
             AddActorKinematics(View);
+            AddActorBones(View);
           }
           break;
 
@@ -318,6 +321,28 @@ void ACarlaRecorder::AddTrafficLightTime(const ATrafficLightBase& TrafficLight)
   }
 }
 
+void ACarlaRecorder::AddActorBones(FCarlaActor *CarlaActor)
+{
+  check(CarlaActor != nullptr);
+
+  // get the bones
+  FWalkerBoneControlOut Bones;
+  CarlaActor->GetBonesTransform(Bones);
+
+  CarlaRecorderWalkerBones Walker;
+  Walker.DatabaseId = CarlaActor->GetActorId();
+  for (auto &Bone : Bones.BoneTransforms) 
+  {
+    FString Name = Bone.Get<0>();
+    auto Transforms = Bone.Get<1>();
+    FVector Loc = Transforms.Relative.GetTranslation();
+    FVector Rot = Transforms.Relative.GetRotation().Euler();
+    CarlaRecorderWalkerBone Entry(Name, Loc, Rot);
+    Walker.Bones.push_back(Entry);
+  }
+  WalkersBones.Add(std::move(Walker));
+}
+
 std::string ACarlaRecorder::Start(std::string Name, FString MapName, bool AdditionalData)
 {
   // stop replayer if any in course
@@ -391,6 +416,7 @@ void ACarlaRecorder::Clear(void)
   TriggerVolumes.Clear();
   PhysicsControls.Clear();
   TrafficLightTimes.Clear();
+  WalkersBones.Clear();
 }
 
 void ACarlaRecorder::Write(double DeltaSeconds)
@@ -400,6 +426,7 @@ void ACarlaRecorder::Write(double DeltaSeconds)
 
   // start
   Frames.WriteStart(File);
+  VisualTime.Write(File);
 
   // events
   EventsAdd.Write(File);
@@ -426,6 +453,7 @@ void ACarlaRecorder::Write(double DeltaSeconds)
     PlatformTime.Write(File);
     PhysicsControls.Write(File);
     TrafficLightTimes.Write(File);
+    WalkersBones.Write(File);
   }
 
   // end

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -29,6 +29,8 @@
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderQuery.h"
 #include "CarlaRecorderState.h"
+#include "CarlaRecorderVisualTime.h"
+#include "CarlaRecorderWalkerBones.h"
 #include "CarlaReplayer.h"
 
 #include "CarlaRecorder.generated.h"
@@ -60,7 +62,9 @@ enum class CarlaRecorderPacketId : uint8_t
   PhysicsControl,
   TrafficLightTime,
   TriggerVolume,
-  FrameCounter
+  FrameCounter,
+  WalkerBones,
+  VisualTime
 };
 
 /// Recorder for the simulation
@@ -122,6 +126,8 @@ public:
   void AddPhysicsControl(const ACarlaWheeledVehicle& Vehicle);
 
   void AddTrafficLightTime(const ATrafficLightBase& TrafficLight);
+
+  void AddActorBones(FCarlaActor *CarlaActor);
 
   // set episode
   void SetEpisode(UCarlaEpisode *ThisEpisode)
@@ -189,7 +195,8 @@ private:
   CarlaRecorderPlatformTime PlatformTime;
   CarlaRecorderPhysicsControls PhysicsControls;
   CarlaRecorderTrafficLightTimes TrafficLightTimes;
-
+  CarlaRecorderWalkersBones WalkersBones;
+  CarlaRecorderVisualTime VisualTime;
 
   // replayer
   CarlaReplayer Replayer;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderHelpers.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderHelpers.cpp
@@ -42,10 +42,11 @@ void WriteFVector(std::ostream &OutFile, const FVector &InObj)
 }
 
 // write binary data from FTransform
-// void WriteFTransform(std::ostream &OutFile, const FTransform &InObj){
-// WriteFVector(OutFile, InObj.GetTranslation());
-// WriteFVector(OutFile, InObj.GetRotation().Euler());
-// }
+void WriteFTransform(std::ofstream &OutFile, const FTransform &InObj)
+{
+  WriteFVector(OutFile, InObj.GetTranslation());
+  WriteFVector(OutFile, InObj.GetRotation().Euler());
+}
 
 // write binary data from FString (length + text)
 void WriteFString(std::ostream &OutFile, const FString &InObj)
@@ -71,13 +72,14 @@ void ReadFVector(std::istream &InFile, FVector &OutObj)
 }
 
 // read binary data to FTransform
-// void ReadFTransform(std::istream &InFile, FTransform &OutObj){
-// FVector Vec;
-// ReadFVector(InFile, Vec);
-// OutObj.SetTranslation(Vec);
-// ReadFVector(InFile, Vec);
-// OutObj.GetRotation().MakeFromEuler(Vec);
-// }
+void ReadFTransform(std::ifstream &InFile, FTransform &OutObj)
+{
+  FVector Vec;
+  ReadFVector(InFile, Vec);
+  OutObj.SetTranslation(Vec);
+  ReadFVector(InFile, Vec);
+  OutObj.GetRotation().MakeFromEuler(Vec);
+}
 
 // read binary data to FString (length + text)
 void ReadFString(std::istream &InFile, FString &OutObj)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderHelpers.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderHelpers.h
@@ -47,7 +47,7 @@ void WriteTArray(std::ostream &OutFile, const TArray<T> &InVec)
 void WriteFVector(std::ostream &OutFile, const FVector &InObj);
 
 // write binary data from FTransform
-// void WriteFTransform(std::ostream &OutFile, const FTransform &InObj);
+void WriteFTransform(std::ofstream &OutFile, const FTransform &InObj);
 // write binary data from FString (length + text)
 void WriteFString(std::ostream &OutFile, const FString &InObj);
 
@@ -94,6 +94,6 @@ void ReadTArray(std::istream &InFile, TArray<T> &OutVec)
 void ReadFVector(std::istream &InFile, FVector &OutObj);
 
 // read binary data from FTransform
-// void ReadTransform(std::istream &InFile, FTransform &OutObj);
+void ReadTransform(std::ifstream &InFile, FTransform &OutObj);
 // read binary data from FString (length + text)
 void ReadFString(std::istream &InFile, FString &OutObj);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -86,7 +86,6 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
   // parse only frames
   while (File)
   {
-
     // get header
     if (!ReadHeader())
     {
@@ -517,7 +516,7 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
           SkipPacket();
         break;
 
-        case static_cast<char>(CarlaRecorderPacketId::TrafficLightTime):
+      case static_cast<char>(CarlaRecorderPacketId::TrafficLightTime):
         if (bShowAll)
         {
           ReadValue<uint16_t>(File, Total);
@@ -542,8 +541,37 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
           SkipPacket();
         break;
 
+      case static_cast<char>(CarlaRecorderPacketId::WalkerBones):
+        if (bShowAll)
+        {
+          ReadValue<uint16_t>(File, Total);
+          if (Total > 0 && !bFramePrinted)
+          {
+            PrintFrame(Info);
+            bFramePrinted = true;
+          }
+
+          Info << " Walkers Bones: " << Total << std::endl;
+          for (i = 0; i < Total; ++i)
+          {
+            WalkerBones.Clear();
+            WalkerBones.Read(File);
+            Info << "  Id: " << WalkerBones.DatabaseId << "\n";
+            for (const auto &Bone : WalkerBones.Bones)
+            {
+              Info << "     Bone: \"" << TCHAR_TO_UTF8(*Bone.Name) << "\" relative: " << "Loc("
+                   << Bone.Location.X << ", " << Bone.Location.Y << ", " << Bone.Location.Z << ") Rot(" 
+                   << Bone.Rotation.X << ", " << Bone.Rotation.Y << ", " << Bone.Rotation.Z << ")\n";
+            }
+          }
+          Info << std::endl;
+        }
+        else
+          SkipPacket();
+        break;
+
         // frame end
-        case static_cast<char>(CarlaRecorderPacketId::FrameEnd):
+      case static_cast<char>(CarlaRecorderPacketId::FrameEnd):
         // do nothing, it is empty
         break;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
@@ -24,6 +24,7 @@
 #include "CarlaRecorderInfo.h"
 #include "CarlaRecorderPosition.h"
 #include "CarlaRecorderState.h"
+#include "CarlaRecorderWalkerBones.h"
 
 class CarlaRecorderQuery
 {
@@ -66,6 +67,7 @@ private:
   CarlaRecorderPlatformTime PlatformTime;
   CarlaRecorderPhysicsControl PhysicsControl;
   CarlaRecorderTrafficLightTime TrafficLightTime;
+  CarlaRecorderWalkerBones WalkerBones;
 
   // read next header packet
   bool ReadHeader(void);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderVisualTime.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderVisualTime.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaRecorderVisualTime.h"
+#include "CarlaRecorder.h"
+#include "CarlaRecorderHelpers.h"
+
+void CarlaRecorderVisualTime::SetTime(double ThisTime)
+{
+  Time = ThisTime;
+}
+
+void CarlaRecorderVisualTime::Read(std::ifstream &InFile)
+{
+  ReadValue<double>(InFile, this->Time);
+}
+
+void CarlaRecorderVisualTime::Write(std::ofstream &OutFile)
+{
+  // write the packet id
+  WriteValue<char>(OutFile, static_cast<char>(CarlaRecorderPacketId::VisualTime));
+
+  // write packet size
+  uint32_t Total = sizeof(double);
+  WriteValue<uint32_t>(OutFile, Total);
+
+  WriteValue<double>(OutFile, this->Time);
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderVisualTime.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderVisualTime.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <fstream>
+#include <chrono>
+
+#pragma pack(push, 1)
+struct CarlaRecorderVisualTime
+{
+  double Time;
+
+  void SetTime(double ThisTime);
+
+  void Read(std::ifstream &InFile);
+
+  void Write(std::ofstream &OutFile);
+
+};
+#pragma pack(pop)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaRecorder.h"
+#include "CarlaRecorderWalkerBones.h"
+#include "CarlaRecorderHelpers.h"
+
+void CarlaRecorderWalkerBones::Write(std::ofstream &OutFile)
+{
+  // database id
+  WriteValue<uint32_t>(OutFile, this->DatabaseId);
+  
+  // write all bones
+  WriteValue<uint16_t>(OutFile, this->Bones.size());
+  for (const auto& Obj : this->Bones)
+  {
+    // name & transform
+    WriteFString(OutFile, Obj.Name);
+    WriteFVector(OutFile, Obj.Location);
+    WriteFVector(OutFile, Obj.Rotation);
+  }
+}
+
+void CarlaRecorderWalkerBones::Read(std::ifstream &InFile)
+{
+  // database id
+  ReadValue<uint32_t>(InFile, this->DatabaseId);
+
+  // read all bones
+  uint16_t Total;
+  ReadValue<uint16_t>(InFile, Total);
+  this->Bones.reserve(Total);
+  FString Name;
+  FVector Location, Rotation;
+  for (int i=0; i<Total; ++i)
+  {
+    // name & transform
+    ReadFString(InFile, Name);
+    ReadFVector(InFile, Location);
+    ReadFVector(InFile, Rotation);
+    // add to the vector of bones
+    this->Bones.emplace_back(Name, Location, Rotation);
+  }
+}
+
+void CarlaRecorderWalkerBones::Clear(void)
+{
+  Bones.clear();
+}
+
+// ---------------------------------------------
+
+void CarlaRecorderWalkersBones::Clear(void)
+{
+  Walkers.clear();
+}
+
+void CarlaRecorderWalkersBones::Add(const CarlaRecorderWalkerBones &Walker)
+{
+  Walkers.push_back(Walker);
+}
+
+void CarlaRecorderWalkersBones::Write(std::ofstream &OutFile)
+{
+  // write the packet id
+  WriteValue<char>(OutFile, static_cast<char>(CarlaRecorderPacketId::WalkerBones));
+
+  std::streampos PosStart = OutFile.tellp();
+
+  // write a dummy packet size
+  uint32_t Total = 0;
+  WriteValue<uint32_t>(OutFile, Total);
+
+  // write total records
+  Total = Walkers.size();
+  WriteValue<uint16_t>(OutFile, Total);
+
+  // write records
+  for (uint16_t i=0; i<Total; ++i)
+    Walkers[i].Write(OutFile);
+
+  // write the real packet size
+  std::streampos PosEnd = OutFile.tellp();
+  Total = PosEnd - PosStart - sizeof(uint32_t);
+  OutFile.seekp(PosStart, std::ios::beg);
+  WriteValue<uint32_t>(OutFile, Total);
+  OutFile.seekp(PosEnd, std::ios::beg);
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.h
@@ -16,7 +16,8 @@ struct CarlaRecorderWalkerBone
   FVector Location;
   FVector Rotation;
 
-  CarlaRecorderWalkerBone(FString &InName, FVector &InLocation, FVector &InRotation) : Name(InName), Location(InLocation), Rotation(InRotation) {}
+  CarlaRecorderWalkerBone(FString &InName, FVector &InLocation, FVector &InRotation) : 
+    Name(InName), Location(InLocation), Rotation(InRotation) {}
 };
 
 struct CarlaRecorderWalkerBones

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWalkerBones.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <fstream>
+#include <vector>
+
+#pragma pack(push, 1)
+struct CarlaRecorderWalkerBone
+{
+  FString Name;
+  FVector Location;
+  FVector Rotation;
+
+  CarlaRecorderWalkerBone(FString &InName, FVector &InLocation, FVector &InRotation) : Name(InName), Location(InLocation), Rotation(InRotation) {}
+};
+
+struct CarlaRecorderWalkerBones
+{
+  uint32_t DatabaseId;
+  std::vector<CarlaRecorderWalkerBone> Bones;
+  
+  void Read(std::ifstream &InFile);
+
+  void Write(std::ofstream &OutFile);
+
+  void Clear();
+
+};
+#pragma pack(pop)
+
+class CarlaRecorderWalkersBones
+{
+public:
+
+  void Add(const CarlaRecorderWalkerBones &InObj);
+
+  void Clear(void);
+
+  void Write(std::ofstream &OutFile);
+
+private:
+
+  std::vector<CarlaRecorderWalkerBones> Walkers;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -133,6 +133,8 @@ private:
   // processing packets
   void ProcessToTime(double Time, bool IsFirstTime = false);
 
+  void ProcessVisualTime(void);
+  
   void ProcessEventsAdd(void);
   void ProcessEventsDel(void);
   void ProcessEventsParent(void);
@@ -147,6 +149,8 @@ private:
   void ProcessLightVehicle(void);
   void ProcessLightScene(void);
 
+  void ProcessWalkerBones(void);
+  
   // positions
   void UpdatePositions(double Per, double DeltaTime);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -8,24 +8,24 @@
 #include "Carla/Recorder/CarlaReplayerHelper.h"
 
 #include "Carla/Actor/ActorDescription.h"
-#include "Carla/Actor/CarlaActor.h"
 #include "Carla/Actor/ActorRegistry.h"
-#include "Carla/Vehicle/WheeledVehicleAIController.h"
-#include "Carla/Walker/WalkerControl.h"
-#include "Carla/Walker/WalkerController.h"
+#include "Carla/Actor/ActorSpawnResult.h"
+#include "Carla/Actor/CarlaActor.h"
+#include "Carla/Game/CarlaEpisode.h"
+#include "Carla/Game/CarlaStatics.h"
 #include "Carla/Lights/CarlaLight.h"
 #include "Carla/Lights/CarlaLightSubsystem.h"
-#include "Carla/Actor/ActorSpawnResult.h"
-#include "Carla/Game/CarlaEpisode.h"
-#include "Carla/Traffic/TrafficSignBase.h"
+#include "Carla/MapGen/LargeMapManager.h"
 #include "Carla/Traffic/TrafficLightBase.h"
 #include "Carla/Traffic/TrafficLightController.h"
 #include "Carla/Traffic/TrafficLightGroup.h"
+#include "Carla/Traffic/TrafficSignBase.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
-#include "Engine/StaticMeshActor.h"
-#include "Carla/Game/CarlaStatics.h"
-#include "Carla/MapGen/LargeMapManager.h"
+#include "Carla/Vehicle/WheeledVehicleAIController.h"
+#include "Carla/Walker/WalkerControl.h"
+#include "Carla/Walker/WalkerController.h"
 #include "Components/BoxComponent.h"
+#include "Engine/StaticMeshActor.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/rpc/VehicleLightState.h>
@@ -417,6 +417,34 @@ void CarlaReplayerHelper::ProcessReplayerLightScene(CarlaRecorderLightScene Ligh
 void CarlaReplayerHelper::ProcessReplayerAnimWalker(CarlaRecorderAnimWalker Walker)
 {
   SetWalkerSpeed(Walker.DatabaseId, Walker.Speed);
+}
+
+// set walker bones
+void CarlaReplayerHelper::ProcessReplayerWalkerBones(const CarlaRecorderWalkerBones &WalkerBones)
+{
+  check(Episode != nullptr);
+  
+  FCarlaActor* CarlaActor = Episode->FindCarlaActor(WalkerBones.DatabaseId);
+  if (!CarlaActor) return;
+
+  AActor* Actor = CarlaActor->GetActor();
+  auto Walker = Cast<APawn>(Actor);
+  if (!Walker) return;
+
+  AWalkerController *Controller = Cast<AWalkerController>(Walker->GetController());
+  if (!Controller) return;
+
+  // build bones structure
+  FWalkerBoneControlIn BonesIn;
+  for (const auto &Bone : WalkerBones.Bones)
+  {
+    FTransform Trans(FRotator::MakeFromEuler(Bone.Rotation), Bone.Location, FVector(1, 1, 1));
+    BonesIn.BoneTransforms.Add(Bone.Name, Trans);
+  }
+  
+  // set the pose and blend
+  Controller->SetBonesTransform(BonesIn);
+  Controller->BlendPose(1.0f);
 }
 
 // replay finish

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -64,6 +64,9 @@ public:
   // set scene lights
   void ProcessReplayerLightScene(CarlaRecorderLightScene LightScene);
 
+  // set walker bones
+  void ProcessReplayerWalkerBones(const CarlaRecorderWalkerBones &Walker);
+
   // replay finish
   bool ProcessReplayerFinish(bool bApplyAutopilot, bool bIgnoreHero, std::unordered_map<uint32_t, bool> &IsHero);
 


### PR DESCRIPTION
#### Description

The recorder now can store the bone position of the pedestrian skeleton. We need to enable the additional data flag for the recorder. Then the replayer will pose the pedestrians at the exact pose each frame.

Fixes #4980, #4975

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Recorder files a bit bigger due to the increment of data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/5987)
<!-- Reviewable:end -->
