### PR TITLE
Add sensor type check.

### DIFF
--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -55,6 +55,11 @@ namespace client {
 
   void ServerSideSensor::ListenToGBuffer(uint32_t GBufferId, CallbackFunctionType callback) {
     log_debug(GetDisplayId(), ": subscribing to gbuffer stream");
+    if (GetActorDescription().description.id != "sensor.camera.rgb")
+    {
+      log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
+      return;
+    }
     GetEpisode().Lock()->SubscribeToGBuffer(*this, GBufferId, std::move(callback));
     listening_mask.set(0);
     listening_mask.set(GBufferId + 1);
@@ -62,6 +67,11 @@ namespace client {
 
   void ServerSideSensor::StopGBuffer(uint32_t GBufferId) {
     log_debug(GetDisplayId(), ": unsubscribing from gbuffer stream");
+    if (GetActorDescription().description.id != "sensor.camera.rgb")
+    {
+      log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
+      return;
+    }
     GetEpisode().Lock()->UnSubscribeFromGBuffer(*this, GBufferId);
     listening_mask.reset(GBufferId + 1);
     if (listening_mask.count() == 1) {

--- a/PythonAPI/examples/manual_control_gbuffer.py
+++ b/PythonAPI/examples/manual_control_gbuffer.py
@@ -1203,9 +1203,15 @@ class CameraManager(object):
 
     def next_sensor(self):
         self.set_sensor(self.index + 1)
+        self.output_texture_id = 0
 
     def next_gbuffer(self):
         weak_self = weakref.ref(self)
+        name = self.sensors[self.index][0]
+        if name != 'sensor.camera.rgb':
+            self.hud.notification('ERROR: Unsupported operation, see log for more info.')
+            print('ERROR: GBuffer methods are not available for the current sensor type"%s". Only "sensor.camera.rgb" is currently supported.' % name)
+            return
         if self.output_texture_id != 0:
             self.sensor.stop_gbuffer(self.output_texture_id - 1)
         self.output_texture_id = (self.output_texture_id + 1) % len(gbuffer_names)

--- a/PythonAPI/examples/manual_control_gbuffer.py
+++ b/PythonAPI/examples/manual_control_gbuffer.py
@@ -487,8 +487,13 @@ class KeyboardControl(object):
                         except Exception:
                             pass
                 elif event.key == K_u:
-                    world.camera_manager.next_gbuffer()
-                    world.hud.notification(gbuffer_names[world.camera_manager.output_texture_id])
+                    name = world.camera_manager.sensors[world.camera_manager.index][0]
+                    if name == 'sensor.camera.rgb':
+                        world.camera_manager.next_gbuffer()
+                        world.hud.notification(gbuffer_names[world.camera_manager.output_texture_id])
+                    else:
+                        world.hud.notification('ERROR: Unsupported operation, see log for more info.')
+                        print('ERROR: GBuffer methods are not available for the current sensor type"%s". Only "sensor.camera.rgb" is currently supported.' % name)
                 elif event.key > K_0 and event.key <= K_9:
                     index_ctrl = 0
                     if pygame.key.get_mods() & KMOD_CTRL:
@@ -1209,8 +1214,6 @@ class CameraManager(object):
         weak_self = weakref.ref(self)
         name = self.sensors[self.index][0]
         if name != 'sensor.camera.rgb':
-            self.hud.notification('ERROR: Unsupported operation, see log for more info.')
-            print('ERROR: GBuffer methods are not available for the current sensor type"%s". Only "sensor.camera.rgb" is currently supported.' % name)
             return
         if self.output_texture_id != 0:
             self.sensor.stop_gbuffer(self.output_texture_id - 1)


### PR DESCRIPTION
#### Description

This PR adds a type check when using the GBuffer API, to ensure that only sensors of type "sensor.camera.rgb" can use these methods.

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CarlaUnreal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6001)
<!-- Reviewable:end -->
