### PR TITLE
Exposed Python agents' offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   * Python agents now accept a carla.Map and GlobalRoutePlanner instances as inputs, avoiding the need to recompute them.
   * Python agents now have a function to lane change.
   * Python agents now detect vehicle in adjacent lanes if invaded due to the offset.
+  * Python agents now have the offset exposed.
   * Fixed bug causing the python agents to sometimes not detect a blocking actor if there were severral actors around it.
   * Improved Python agents performance for large maps.
   * Fix a bug at `Map.get_topology()`, causing lanes with no successors to not be part of it.

--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -229,6 +229,10 @@ class BasicAgent(object):
         """(De)activates the checks for stop signs"""
         self._ignore_vehicles = active
 
+    def set_offset(self, offset):
+        """Sets an offset for the vehicle"""
+        self._local_planner.set_offset(offset)
+
     def lane_change(self, direction, same_lane_time=0, other_lane_time=0, lane_change_time=2):
         """
         Changes the path so that the vehicle performs a lane change.

--- a/PythonAPI/carla/agents/navigation/controller.py
+++ b/PythonAPI/carla/agents/navigation/controller.py
@@ -100,6 +100,10 @@ class VehiclePIDController():
         """Changes the parameters of the PIDLongitudinalController"""
         self._lon_controller.change_parameters(**args_lateral)
 
+    def set_offset(self, offset):
+        """Changes the offset"""
+        self._lat_controller.set_offset(offset)
+
 
 class PIDLongitudinalController():
     """
@@ -203,6 +207,10 @@ class PIDLateralController():
             +1 maximum steering to right
         """
         return self._pid_control(waypoint, self._vehicle.get_transform())
+
+    def set_offset(self, offset):
+        """Changes the offset"""
+        self._offset = offset
 
     def _pid_control(self, waypoint, vehicle_transform):
         """

--- a/PythonAPI/carla/agents/navigation/local_planner.py
+++ b/PythonAPI/carla/agents/navigation/local_planner.py
@@ -216,6 +216,10 @@ class LocalPlanner(object):
 
         self._stop_waypoint_creation = stop_waypoint_creation
 
+    def set_offset(self, offset):
+        """Sets an offset for the vehicle"""
+        self._vehicle_controller.set_offset(offset)
+
     def run_step(self, debug=False):
         """
         Execute one step of local planning which involves running the longitudinal and lateral PID controllers to


### PR DESCRIPTION
### Description

While the Python agents could have an offset, this value wasn't exposed so it couldn't be changed in runtime. Well, not anymore

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6005)
<!-- Reviewable:end -->
