### PR TITLE
Marcel/empty gbuffer fix

### DIFF
--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -2161,6 +2161,12 @@ Sensors compound a specific family of actors quite diverse and unique. They are 
 When <b>True</b> the sensor will be waiting for data.  
 
 ### Methods
+- <a name="carla.Sensor.is_listening"></a>**<font color="#7fb800">is_listening</font>**(<font color="#00a6ed">**self**</font>)  
+Returns whether the sensor is in a listening state.  
+- <a name="carla.Sensor.is_listening_gbuffer"></a>**<font color="#7fb800">is_listening_gbuffer</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**gbuffer_id**</font>)  
+Returns whether the sensor is in a listening state for a specific GBuffer texture.  
+    - **Parameters:**
+        - `gbuffer_id` (_[carla.GBufferTextureID](#carla.GBufferTextureID)_) - The ID of the target Unreal Engine GBuffer texture.  
 - <a name="carla.Sensor.listen"></a>**<font color="#7fb800">listen</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**callback**</font>)<button class="SnipetButton" id="carla.Sensor.listen-snipet_button">snippet &rarr;</button>  
 The function the sensor will be calling to every time a new measurement is received. This function needs for an argument containing an object type [carla.SensorData](#carla.SensorData) to work with.  
     - **Parameters:**
@@ -2168,7 +2174,7 @@ The function the sensor will be calling to every time a new measurement is recei
 - <a name="carla.Sensor.listen_to_gbuffer"></a>**<font color="#7fb800">listen_to_gbuffer</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**gbuffer_id**</font>, <font color="#00a6ed">**callback**</font>)  
 The function the sensor will be calling to every time the desired GBuffer texture is received.<br> This function needs for an argument containing an object type [carla.SensorData](#carla.SensorData) to work with.  
     - **Parameters:**
-        - `gbuffer_id` (_[carla.GBufferTextureID](#carla.GBufferTextureID)_) - The ID of the desired Unreal Engine GBuffer texture.  
+        - `gbuffer_id` (_[carla.GBufferTextureID](#carla.GBufferTextureID)_) - The ID of the target Unreal Engine GBuffer texture.  
         - `callback` (_function_) - The called function with one argument containing the received GBuffer texture.  
 - <a name="carla.Sensor.stop"></a>**<font color="#7fb800">stop</font>**(<font color="#00a6ed">**self**</font>)  
 Commands the sensor to stop listening for data.  

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -11,6 +11,8 @@
 
 #include <exception>
 
+constexpr size_t GBufferTextureCount = 13;
+
 namespace carla {
 namespace client {
 
@@ -23,7 +25,7 @@ namespace client {
     }
     if (IsListening() && GetEpisode().IsValid()) {
       try {
-        for (uint32_t i = 1; i != 13; ++i) {
+        for (uint32_t i = 1; i != GBufferTextureCount + 1; ++i) {
           if (listening_mask.test(i))
             StopGBuffer(i - 1);
         }
@@ -55,7 +57,7 @@ namespace client {
 
   void ServerSideSensor::ListenToGBuffer(uint32_t GBufferId, CallbackFunctionType callback) {
     log_debug(GetDisplayId(), ": subscribing to gbuffer stream");
-    RELEASE_ASSERT(GBufferId < 13);
+    RELEASE_ASSERT(GBufferId < GBufferTextureCount);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
       log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
@@ -68,7 +70,7 @@ namespace client {
 
   void ServerSideSensor::StopGBuffer(uint32_t GBufferId) {
     log_debug(GetDisplayId(), ": unsubscribing from gbuffer stream");
-    RELEASE_ASSERT(GBufferId < 13);
+    RELEASE_ASSERT(GBufferId < GBufferTextureCount);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
       log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
@@ -81,7 +83,7 @@ namespace client {
   bool ServerSideSensor::Destroy() {
     log_debug("calling sensor Destroy() ", GetDisplayId());
     if (IsListening()) {
-      for (uint32_t i = 1; i != 13; ++i) {
+      for (uint32_t i = 1; i != GBufferTextureCount + 1; ++i) {
         if (listening_mask.test(i)) {
           StopGBuffer(i - 1);
         }

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -24,9 +24,9 @@ namespace client {
     if (IsListening() && GetEpisode().IsValid()) {
       try {
         Stop();
-        for (uint32_t i = 1; i != 16; ++i) {
+        for (uint32_t i = 1; i != 13; ++i) {
           if (listening_mask.test(i))
-            StopGBuffer(i);
+            StopGBuffer(i - 1);
         }
       } catch (const std::exception &e) {
         log_error("exception trying to stop sensor:", GetDisplayId(), ':', e.what());
@@ -55,6 +55,7 @@ namespace client {
 
   void ServerSideSensor::ListenToGBuffer(uint32_t GBufferId, CallbackFunctionType callback) {
     log_debug(GetDisplayId(), ": subscribing to gbuffer stream");
+    RELEASE_ASSERT(GBufferId < 13);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
       log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
@@ -67,6 +68,7 @@ namespace client {
 
   void ServerSideSensor::StopGBuffer(uint32_t GBufferId) {
     log_debug(GetDisplayId(), ": unsubscribing from gbuffer stream");
+    RELEASE_ASSERT(GBufferId < 13);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
       log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
@@ -82,14 +84,13 @@ namespace client {
   bool ServerSideSensor::Destroy() {
     log_debug("calling sensor Destroy() ", GetDisplayId());
     if (IsListening()) {
-      for (uint32_t i = 1; i != 16; ++i) {
+      for (uint32_t i = 1; i != 13; ++i) {
         if (listening_mask.test(i)) {
-          StopGBuffer(i);
+          StopGBuffer(i - 1);
         }
       }
       Stop();
     }
-    listening_mask = {};
     return Actor::Destroy();
   }
 

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -23,11 +23,11 @@ namespace client {
     }
     if (IsListening() && GetEpisode().IsValid()) {
       try {
-        Stop();
         for (uint32_t i = 1; i != 13; ++i) {
           if (listening_mask.test(i))
             StopGBuffer(i - 1);
         }
+        Stop();
       } catch (const std::exception &e) {
         log_error("exception trying to stop sensor:", GetDisplayId(), ':', e.what());
       }
@@ -76,9 +76,6 @@ namespace client {
     }
     GetEpisode().Lock()->UnSubscribeFromGBuffer(*this, GBufferId);
     listening_mask.reset(GBufferId + 1);
-    if (listening_mask.count() == 1) {
-      listening_mask.reset(0);
-    }
   }
 
   bool ServerSideSensor::Destroy() {

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -60,7 +60,7 @@ namespace client {
     RELEASE_ASSERT(GBufferId < GBufferTextureCount);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
-      log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
+      log_warning("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
       return;
     }
     GetEpisode().Lock()->SubscribeToGBuffer(*this, GBufferId, std::move(callback));
@@ -73,7 +73,7 @@ namespace client {
     RELEASE_ASSERT(GBufferId < GBufferTextureCount);
     if (GetActorDescription().description.id != "sensor.camera.rgb")
     {
-      log_error("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
+      log_warning("GBuffer methods are not supported on non-RGB sensors (sensor.camera.rgb).");
       return;
     }
     GetEpisode().Lock()->UnSubscribeFromGBuffer(*this, GBufferId);

--- a/LibCarla/source/carla/client/ServerSideSensor.h
+++ b/LibCarla/source/carla/client/ServerSideSensor.h
@@ -54,7 +54,7 @@ namespace client {
 
   private:
 
-    std::bitset<32> listening_mask;
+    std::bitset<16> listening_mask;
 
   };
 

--- a/PythonAPI/carla/source/libcarla/Sensor.cpp
+++ b/PythonAPI/carla/source/libcarla/Sensor.cpp
@@ -28,6 +28,7 @@ void export_sensor() {
   class_<cc::Sensor, bases<cc::Actor>, boost::noncopyable, boost::shared_ptr<cc::Sensor>>("Sensor", no_init)
     .add_property("is_listening", &cc::Sensor::IsListening)
     .def("listen", &SubscribeToStream, (arg("callback")))
+    .def("is_listening", &cc::Sensor::IsListening)
     .def("stop", &cc::Sensor::Stop)
     .def(self_ns::str(self_ns::self))
   ;
@@ -35,6 +36,7 @@ void export_sensor() {
   class_<cc::ServerSideSensor, bases<cc::Sensor>, boost::noncopyable, boost::shared_ptr<cc::ServerSideSensor>>
       ("ServerSideSensor", no_init)
     .def("listen_to_gbuffer", &SubscribeToGBuffer, (arg("gbuffer_id"), arg("callback")))
+    .def("is_listening_gbuffer", &cc::ServerSideSensor::IsListeningGBuffer, (arg("gbuffer_id")))
     .def("stop_gbuffer", &cc::ServerSideSensor::StopGBuffer, (arg("gbuffer_id")))
     .def(self_ns::str(self_ns::self))
   ;

--- a/PythonAPI/docs/sensor.yml
+++ b/PythonAPI/docs/sensor.yml
@@ -41,6 +41,10 @@
       doc: >
         The function the sensor will be calling to every time a new measurement is received. This function needs for an argument containing an object type carla.SensorData to work with.
     # --------------------------------------
+    - def_name: is_listening
+      doc: >
+        Returns whether the sensor is in a listening state.
+    # --------------------------------------
     - def_name: stop
       doc: >
         Commands the sensor to stop listening for data.
@@ -50,7 +54,7 @@
       - param_name: gbuffer_id
         type: carla.GBufferTextureID
         doc: >
-          The ID of the desired Unreal Engine GBuffer texture.
+          The ID of the target Unreal Engine GBuffer texture.
       - param_name: callback
         type: function
         doc: >
@@ -58,6 +62,15 @@
       doc: >
         The function the sensor will be calling to every time the desired GBuffer texture is received.<br>
         This function needs for an argument containing an object type carla.SensorData to work with.
+    # --------------------------------------
+    - def_name: is_listening_gbuffer
+      params:
+      - param_name: gbuffer_id
+        type: carla.GBufferTextureID
+        doc: >
+          The ID of the target Unreal Engine GBuffer texture.
+      doc: >
+        Returns whether the sensor is in a listening state for a specific GBuffer texture.
     # --------------------------------------
     - def_name: stop_gbuffer
       params:

--- a/PythonAPI/examples/manual_control_gbuffer.py
+++ b/PythonAPI/examples/manual_control_gbuffer.py
@@ -1212,6 +1212,8 @@ class CameraManager(object):
             self.hud.notification('ERROR: Unsupported operation, see log for more info.')
             print('ERROR: GBuffer methods are not available for the current sensor type"%s". Only "sensor.camera.rgb" is currently supported.' % name)
             return False
+        if self.output_texture_id != 0:
+            self.sensor.stop_gbuffer(self.output_texture_id - 1)
         self.output_texture_id = index % len(gbuffer_names)
         adjusted_index = self.output_texture_id - 1
         if self.output_texture_id != 0:

--- a/PythonAPI/examples/manual_control_gbuffer.py
+++ b/PythonAPI/examples/manual_control_gbuffer.py
@@ -1205,8 +1205,6 @@ class CameraManager(object):
     def next_sensor(self):
         self.set_sensor(self.index + 1)
     
-    gbuffer_active_map = {}
-
     def set_gbuffer(self, index):
         weak_self = weakref.ref(self)
         name = self.sensors[self.index][0]
@@ -1217,8 +1215,7 @@ class CameraManager(object):
         self.output_texture_id = index % len(gbuffer_names)
         adjusted_index = self.output_texture_id - 1
         if self.output_texture_id != 0:
-            if not adjusted_index in self.gbuffer_active_map:
-                self.gbuffer_active_map[adjusted_index] = True
+            if not self.sensor.is_listening_gbuffer(adjusted_index):
                 self.sensor.listen_to_gbuffer(
                     adjusted_index,
                     lambda image, index = self.output_texture_id:

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -476,7 +476,7 @@ private:
         std::is_same<std::remove_reference_t<CameraGBufferT>, FCameraGBufferUint8>::value,
         FColor,
         FLinearColor>::type;
-      auto ViewSize = GBufferData.ViewRect.Size();
+      FIntPoint ViewSize;
       TArray<PixelType> Pixels;
       if (GBufferData.WaitForTextureTransfer(TextureID))
       {
@@ -490,6 +490,7 @@ private:
           SourcePitch,
           SourceExtent);
         auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
+        ViewSize = GBufferData.ViewRect.Size();
         Pixels.AddUninitialized(ViewSize.X * ViewSize.Y);
         FReadSurfaceDataFlags Flags = {};
         Flags.SetLinearToGamma(true);
@@ -505,6 +506,7 @@ private:
       }
       else
       {
+        ViewSize = GBufferData.ViewRect.Size();
         Pixels.SetNum(ViewSize.X * ViewSize.Y);
         for (auto& Pixel : Pixels)
           Pixel = PixelType::Black;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -484,7 +484,11 @@ private:
         void* PixelData;
         int32 SourcePitch;
         FIntPoint SourceExtent;
-        GBufferData.MapTextureData(TextureID, PixelData, SourcePitch, SourceExtent);
+        GBufferData.MapTextureData(
+          TextureID,
+          PixelData,
+          SourcePitch,
+          SourceExtent);
         auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
         Pixels.AddUninitialized(ViewSize.X * ViewSize.Y);
         FReadSurfaceDataFlags Flags = {};
@@ -501,11 +505,15 @@ private:
       }
       else
       {
-        Pixels.AddZeroed(ViewSize.X * ViewSize.Y);
+        Pixels.SetNum(ViewSize.X * ViewSize.Y);
+        for (auto& Pixel : Pixels)
+          Pixel = PixelType::Black;
       }
       auto GBufferStream = CameraGBuffer.GetDataStream(Self);
       auto Buffer = GBufferStream.PopBufferFromPool();
-      Buffer.copy_from(carla::sensor::SensorRegistry::get<CameraGBufferT*>::type::header_offset, Pixels);
+      Buffer.copy_from(
+        carla::sensor::SensorRegistry::get<CameraGBufferT*>::type::header_offset,
+        Pixels);
       if (Buffer.empty()) {
         return;
       }


### PR DESCRIPTION
This PR changes how unused GBuffer texture are handled by the Carla UE plugin. Previously, the user was expected to know whether a texture was available at the risk of crashing the client. Now, if a texture is not available, a black image is sent.
This PR also exposes the functions `carla.Sensor.is_listening` and `carla.Sensor.is_listening_gbuffer` to the PythonAPI, and it also fixes some minor issues with the GBuffer streams.


#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** Carla

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6013)
<!-- Reviewable:end -->
