### PR TITLE
Multi-GPU load map command

### DIFF
--- a/LibCarla/source/carla/multigpu/primaryCommands.cpp
+++ b/LibCarla/source/carla/multigpu/primaryCommands.cpp
@@ -31,9 +31,9 @@ void PrimaryCommands::SendFrameData(carla::Buffer buffer) {
 }
 
 // broadcast to all secondary servers the map to load
-void PrimaryCommands::SendLoadMap(std::string) {
-  // carla::Buffer buf((unsigned char *) map.c_str(), (size_t) map.size());
-  log_info("sending load map command");
+void PrimaryCommands::SendLoadMap(std::string map) {
+  carla::Buffer buf((unsigned char *) map.c_str(), (size_t) map.size() + 1);
+  _router->Write(MultiGPUCommand::LOAD_MAP, std::move(buf));
 }
 
 // send to who the router wants the request for a token

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
@@ -127,8 +127,11 @@ void FCarlaEngine::NotifyInitGame(const UCarlaSettings &Settings)
             break;
           }
           case carla::multigpu::MultiGPUCommand::LOAD_MAP:
+          {
+            FString FinalPath((char *) Data.data());
+            UGameplayStatics::OpenLevel(CurrentEpisode->GetWorld(), *FinalPath, true);
             break;
-          
+          }
           case carla::multigpu::MultiGPUCommand::GET_TOKEN:
           {
             // get the sensor id

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
@@ -77,6 +77,11 @@ public:
     FCarlaEngine::FrameCounter = Value;
   }
 
+  std::shared_ptr<carla::multigpu::Router> GetSecondaryServer()
+  {
+    return SecondaryServer;
+  }
+
 private:
 
   void OnPreTick(UWorld *World, ELevelTick TickType, float DeltaSeconds);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -103,6 +103,21 @@ bool UCarlaEpisode::LoadNewEpisode(const FString &MapString, bool ResetSettings)
     UGameplayStatics::OpenLevel(GetWorld(), *FinalPath, true);
     if (ResetSettings)
       ApplySettings(FEpisodeSettings{});
+    
+    // send 'LOAD_MAP' command to all secondary servers (if any)
+    if (bIsPrimaryServer)
+    {
+      UCarlaGameInstance *GameInstance = UCarlaStatics::GetGameInstance(GetWorld());
+      if(GameInstance)
+      {
+        FCarlaEngine *CarlaEngine = GameInstance->GetCarlaEngine();
+        auto SecondaryServer = CarlaEngine->GetSecondaryServer();
+        if (SecondaryServer->HasClientsConnected()) 
+        {
+          SecondaryServer->GetCommander().SendLoadMap(std::string(TCHAR_TO_UTF8(*FinalPath)));
+        }
+      }
+    }
   }
   return bIsFileFound;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameInstance.h
@@ -108,6 +108,11 @@ public:
     return CurrentMapLayer;
   }
 
+  FCarlaEngine* GetCarlaEngine()
+  {
+    return &CarlaEngine;
+  }
+
 private:
 
   UPROPERTY(Category = "CARLA Settings", EditAnywhere)


### PR DESCRIPTION
#### Description

Added the command LOAD_MAP for multi-GPU mode. Now, whenever the primary server loads a new map, the connected secondary servers will load the same map also.

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6014)
<!-- Reviewable:end -->
