### PR TITLE
Some sensors are forced to be always on the primary server in multi-g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Fixed bug causing traffic signals at the end points of a road to sometimes create malformed waypoints.
   * Fixed pedestrian skeleton frame, where sometimes it was draw displaced from the body
   * Fixed decals when importing maps. It was using other .json files found in other packages.
+  * In multi-GPU mode some sensors now are forced to be created on the primary server always (ex. collision sensor)
   * Added the speed limits for 100, 110 and 120 Km/h.
   * Fixing sensor destruction, now the stream and socket is succesfully destroyed.
   * Fixed bug at `Vehicle.get_traffic_light_state()` and `Vehicle.is_at_traffic_light()` causing vehicles to temporarily not lose the information of a traffic light if they moved away from it before it turned green.

--- a/PythonAPI/examples/tutorial_gbuffer.py
+++ b/PythonAPI/examples/tutorial_gbuffer.py
@@ -95,22 +95,22 @@ def main():
         # Here we will register the callbacks for each gbuffer texture.
         # The function "listen_to_gbuffer" behaves like the regular listen function,
         # but you must first pass it the ID of the desired gbuffer texture.
-        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneColor, lambda image: image.save_to_disk('_out/SceneColor-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneDepth, lambda image: image.save_to_disk('_out/SceneDepth-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneStencil, lambda image: image.save_to_disk('_out/SceneStencil-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferA, lambda image: image.save_to_disk('_out/GBufferA-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferB, lambda image: image.save_to_disk('_out/GBufferB-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferC, lambda image: image.save_to_disk('_out/GBufferC-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferD, lambda image: image.save_to_disk('_out/GBufferD-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneColor, lambda image: image.save_to_disk('_out/GBuffer-SceneColor-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneDepth, lambda image: image.save_to_disk('_out/GBuffer-SceneDepth-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.SceneStencil, lambda image: image.save_to_disk('_out/GBuffer-SceneStencil-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferA, lambda image: image.save_to_disk('_out/GBuffer-A-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferB, lambda image: image.save_to_disk('_out/GBuffer-B-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferC, lambda image: image.save_to_disk('_out/GBuffer-C-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferD, lambda image: image.save_to_disk('_out/GBuffer-D-%06d.png' % image.frame))
         # Note that some gbuffer textures may not be available for a particular scene.
         # For example, the textures E and F are likely unavailable in this example,
         # which will result in them being sent as black images.
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferE, lambda image: image.save_to_disk('_out/GBufferE-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferF, lambda image: image.save_to_disk('_out/GBufferF-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.Velocity, lambda image: image.save_to_disk('_out/Velocity-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.SSAO, lambda image: image.save_to_disk('_out/SSAO-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.CustomDepth, lambda image: image.save_to_disk('_out/CustomDepth-%06d.png' % image.frame))
-        camera.listen_to_gbuffer(carla.GBufferTextureID.CustomStencil, lambda image: image.save_to_disk('_out/CustomStencil-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferE, lambda image: image.save_to_disk('_out/GBuffer-E-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.GBufferF, lambda image: image.save_to_disk('_out/GBuffer-F-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.Velocity, lambda image: image.save_to_disk('_out/GBuffer-Velocity-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.SSAO, lambda image: image.save_to_disk('_out/GBuffer-SSAO-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.CustomDepth, lambda image: image.save_to_disk('_out/GBuffer-CustomDepth-%06d.png' % image.frame))
+        camera.listen_to_gbuffer(carla.GBufferTextureID.CustomStencil, lambda image: image.save_to_disk('_out/GBuffer-CustomStencil-%06d.png' % image.frame))
 
         time.sleep(10)
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
@@ -7,12 +7,19 @@
 #pragma once
 
 #include "Carla.h"
+#include "Carla/Actor/ActorData.h"
 #include "Carla/Actor/ActorRegistry.h"
 
 #include "Carla/Game/Tagger.h"
 #include "Carla/Traffic/TrafficLightBase.h"
 #include "Carla/Util/BoundingBoxCalculator.h"
 #include "Carla/Sensor/Sensor.h"
+
+#include <compiler/disable-ue4-macros.h>
+#include "carla/streaming/Token.h"
+#include "carla/streaming/detail/Token.h"
+#include <compiler/enable-ue4-macros.h>
+
 
 namespace crp = carla::rpc;
 
@@ -230,4 +237,22 @@ void FActorRegistry::WakeActorUp(FCarlaActor::IdType Id, UCarlaEpisode* CarlaEpi
   {
     WakeActorUp(ChildId, CarlaEpisode);
   }
+}
+
+FString FActorRegistry::GetDescriptionFromStream(carla::streaming::detail::stream_id_type Id)
+{
+  for (auto &Item : ActorDatabase)
+  {
+    // check for a sensor
+    ASensor *Sensor = Cast<ASensor>(Item.Value->GetActor());
+    if (Sensor == nullptr) continue;
+
+    carla::streaming::detail::token_type token(Sensor->GetToken());
+    if (token.get_stream_id() == Id)
+    {
+      const FActorInfo *Info = Item.Value->GetActorInfo();
+      return Info->Description.Id;
+    }
+  }
+  return FString("");
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorRegistry.h
@@ -19,15 +19,15 @@
 /// A registry of all the Carla actors.
 class FActorRegistry
 {
-private:
-
-  // using DatabaseType = std::unordered_map<FCarlaActor::IdType, FCarlaActor>;
-  using DatabaseType = TMap<FCarlaActor::IdType, TSharedPtr<FCarlaActor>>;
-
 public:
 
   using IdType = FCarlaActor::IdType;
   using ValueType = TSharedPtr<FCarlaActor>;
+
+private:
+
+  // using DatabaseType = std::unordered_map<IdType, FCarlaActor>;
+  using DatabaseType = TMap<IdType, TSharedPtr<FCarlaActor>>;
 
   // ===========================================================================
   /// @name Actor registry functions
@@ -90,10 +90,11 @@ public:
     return PtrToId ? FindCarlaActor(*PtrToId) : nullptr;
   }
 
+  FString GetDescriptionFromStream(carla::streaming::detail::stream_id_type Id);
 
-  void PutActorToSleep(FCarlaActor::IdType Id, UCarlaEpisode* CarlaEpisode);
+  void PutActorToSleep(IdType Id, UCarlaEpisode* CarlaEpisode);
 
-  void WakeActorUp(FCarlaActor::IdType Id, UCarlaEpisode* CarlaEpisode);
+  void WakeActorUp(IdType Id, UCarlaEpisode* CarlaEpisode);
 
   /// @}
   // ===========================================================================

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -183,6 +183,14 @@ public:
     return ActorDispatcher->GetActorRegistry().FindCarlaActor(Actor);
   }
 
+  /// Get the description of the Carla actor (sensor) using specific stream id.
+  ///
+  /// If the actor is not found returns an empty string
+  FString GetActorDescriptionFromStream(carla::streaming::detail::stream_id_type StreamId)
+  {
+    return ActorDispatcher->GetActorRegistry().GetDescriptionFromStream(StreamId);
+  }
+
   // ===========================================================================
   // -- Actor handling methods -------------------------------------------------
   // ===========================================================================


### PR DESCRIPTION
#### Description

In multi-GPU mode some sensors need to be always on the primary server, which is in charge of the physics calculation. So, the collision sensor needs to be created always on the primary server. Also, the same happens with the world observer, that needs to be always in the primary server.

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6042)
<!-- Reviewable:end -->
