### PR TITLE
Fix TM hybrid respawn bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   * Fixed bug causing the scene lights to return an incorrect location at large maps.
   * Fixed bug causing the `world.ground_projection()` function to return an incorrect location at large maps.
   * Added failure state to vehicles, which can be retrieved by using `Vehicle.get_failure_state()`. Only Rollover failure state is currently supported.
-  * Fixed bug causing the TM to block the simulation when another client teleported a vehicle with no physics.
+  * Fixed bug causing the TM to block the simulation when a vehicle with no physics was teleported.
   * Fixed bug causing the TM to block the simulation when travelling through a short roads that looped on themselves.
   * Improved the TM's handling of non signalized junctions, resulting in a more fluid overall behavior.
   * Added check to avoid adding procedural trigger boxes inside intersections.


### PR DESCRIPTION
### Description

When the Traffic Manager has the `set_respawn_dormant_vehicles` `parameter activated, it will detected dormant actors and respawn them closer to the ego vehicle.

While this works fine, using this with hybrid mode was causing the simulation to run substantially slower. This is because the teleportation makes the TM bug out and think that the vehicle is moving extremely fast, resulting in a ridiculously long waypoint buffer. 

This PR makes the TM update the saved state of the teleported vehicle,  removing the aforementioned bug.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6049)
<!-- Reviewable:end -->
