### PR TITLE
Multi-GPU synchronization of actors like TrafficLights

### DIFF
--- a/LibCarla/source/carla/multigpu/router.cpp
+++ b/LibCarla/source/carla/multigpu/router.cpp
@@ -70,6 +70,11 @@ void Router::SetCallbacks() {
   log_info("Listening at ", _endpoint);
 }
 
+void Router::SetNewConnectionCallback(std::function<void(void)> func)
+{
+  _callback = func;
+}
+
 void Router::AsyncRun(size_t worker_threads) {
   _pool.AsyncRun(worker_threads);
 }
@@ -83,6 +88,9 @@ void Router::ConnectSession(std::shared_ptr<Primary> session) {
   std::lock_guard<std::mutex> lock(_mutex);
   _sessions.emplace_back(std::move(session));
   log_info("Connected secondary servers:", _sessions.size());
+  // run external callback for new connections
+  if (_callback) 
+    _callback();
 }
 
 void Router::DisconnectSession(std::shared_ptr<Primary> session) {

--- a/LibCarla/source/carla/multigpu/router.h
+++ b/LibCarla/source/carla/multigpu/router.h
@@ -44,6 +44,8 @@ namespace multigpu {
     void Stop();
 
     void SetCallbacks();
+    void SetNewConnectionCallback(std::function<void(void)>);
+
     void AsyncRun(size_t worker_threads);
 
     boost::asio::ip::tcp::endpoint GetLocalEndpoint() const;
@@ -70,6 +72,7 @@ namespace multigpu {
     uint32_t                                _next;
     std::unordered_map<Primary *, std::shared_ptr<std::promise<SessionInfo>>>   _promises;
     PrimaryCommands                         _commander;
+    std::function<void(void)>               _callback;
   };
 
 } // namespace multigpu

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
@@ -170,6 +170,11 @@ void FCarlaEngine::NotifyInitGame(const UCarlaSettings &Settings)
       // we are primary server, starting server
       bIsPrimaryServer = true;
       SecondaryServer = Server.GetSecondaryServer();
+      SecondaryServer->SetNewConnectionCallback([this]()
+      { 
+        this->bNewConnection = true;
+        UE_LOG(LogCarla, Log, TEXT("New secondary connection detected"));
+      });
     }
   }
 
@@ -257,18 +262,19 @@ void FCarlaEngine::OnPreTick(UWorld *, ELevelTick TickType, float DeltaSeconds)
     // update frame counter
     UpdateFrameCounter();
 
-    if (CurrentEpisode != nullptr)
+    if (CurrentEpisode)
     {
       CurrentEpisode->TickTimers(DeltaSeconds);
-    }
-    if (!bIsPrimaryServer && GetCurrentEpisode())
-    {
-      if (FramesToProcess.size())
+
+      if (!bIsPrimaryServer)
       {
-        TRACE_CPUPROFILER_EVENT_SCOPE_STR("FramesToProcess.PlayFrameData");
-        std::lock_guard<std::mutex> Lock(FrameToProcessMutex);
-        FramesToProcess.front().PlayFrameData(GetCurrentEpisode(), MappedId);
-        FramesToProcess.erase(FramesToProcess.begin()); // remove first element
+        if (FramesToProcess.size())
+        {
+          TRACE_CPUPROFILER_EVENT_SCOPE_STR("FramesToProcess.PlayFrameData");
+          std::lock_guard<std::mutex> Lock(FrameToProcessMutex);
+          FramesToProcess.front().PlayFrameData(CurrentEpisode, MappedId);
+          FramesToProcess.erase(FramesToProcess.begin()); // remove first element
+        }
       }
     }
   }
@@ -284,10 +290,11 @@ void FCarlaEngine::OnPostTick(UWorld *World, ELevelTick TickType, float DeltaSec
     if (bIsPrimaryServer)
     {
       if (SecondaryServer->HasClientsConnected()) {
-        GetCurrentEpisode()->GetFrameData().GetFrameData(GetCurrentEpisode());
+        GetCurrentEpisode()->GetFrameData().GetFrameData(GetCurrentEpisode(), true, bNewConnection);
+        bNewConnection = false;
         std::ostringstream OutStream;
         GetCurrentEpisode()->GetFrameData().Write(OutStream);
-        
+
         // send frame data to secondary
         std::string Tmp(OutStream.str());
         SecondaryServer->GetCommander().SendFrameData(carla::Buffer(std::move((unsigned char *) Tmp.c_str()), (size_t) Tmp.size()));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
@@ -115,6 +115,7 @@ private:
   FDelegateHandle OnEpisodeSettingsChangeHandle;
 
   bool bIsPrimaryServer = true;
+  bool bNewConnection = false;
 
   std::unordered_map<uint32_t, uint32_t> MappedId;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.h
@@ -64,7 +64,7 @@ public:
 
   void SetEpisode(UCarlaEpisode* ThisEpisode) {Episode = ThisEpisode;}
 
-  void GetFrameData(UCarlaEpisode *ThisEpisode, bool bAdditionalData = false);
+  void GetFrameData(UCarlaEpisode *ThisEpisode, bool bAdditionalData = false, bool bIncludeActorsAgain = false);
 
   void PlayFrameData(UCarlaEpisode *ThisEpisode, std::unordered_map<uint32_t, uint32_t>& MappedId);
 
@@ -78,7 +78,8 @@ public:
       uint32_t DatabaseId,
       uint8_t Type,
       const FTransform &Transform,
-      FActorDescription ActorDescription);
+      FActorDescription ActorDescription,
+      bool bAddOtherRelatedInfo = true);
   void AddEvent(const CarlaRecorderEventAdd &Event);
   void AddEvent(const CarlaRecorderEventDel &Event);
   void AddEvent(const CarlaRecorderEventParent &Event);
@@ -107,12 +108,13 @@ private:
 
   void GetFrameCounter();
 
-  std::pair<int, FCarlaActor*> TryToCreateReplayerActor(
+  std::pair<int, FCarlaActor*> CreateOrReuseActor(
       FVector &Location,
       FVector &Rotation,
       FActorDescription &ActorDesc,
       uint32_t DesiredId,
-      bool SpawnSensors);
+      bool SpawnSensors,
+      std::unordered_map<uint32_t, uint32_t>& MappedId);
 
     // replay event for creating actor
   std::pair<int, uint32_t> ProcessReplayerEventAdd(
@@ -121,7 +123,8 @@ private:
       CarlaRecorderActorDescription Description,
       uint32_t DesiredId,
       bool bIgnoreHero,
-      bool ReplaySensors);
+      bool ReplaySensors,
+      std::unordered_map<uint32_t, uint32_t>& MappedId);
 
   // replay event for removing actor
   bool ProcessReplayerEventDel(uint32_t DatabaseId);
@@ -155,6 +158,8 @@ private:
   void SetFrameCounter();
 
   FCarlaActor* FindTrafficLightAt(FVector Location);
+
+  void AddExistingActors(void);
 
   UCarlaEpisode *Episode;
 };


### PR DESCRIPTION
#### Description

In multi-GPU, each time a new connection is done (secondary server connecting to the primary server), with the frame data we include all existing actors, so that way all the traffic lights and other actors are sent to all secondary servers (specially the new one).

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Will happen that we send actors that already exist on some secondary server. So if the actor with the Id is found, the actor is not created but reused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6058)
<!-- Reviewable:end -->
