### PR TITLE
Remove extra dash from -nullrhi in Multi-GPU docs

### DIFF
--- a/Docs/adv_multigpu.md
+++ b/Docs/adv_multigpu.md
@@ -12,13 +12,13 @@ The steps are: first, start the primary server without any render capability. Th
 Run the following from the command line:
 
 ```sh
-./CarlaUE4.sh --nullrhi
+./CarlaUE4.sh -nullrhi
 ```
 
 The primary server will use, by default, the port 2002 to listen for secondary servers. If you need to listen on another port, then you can change it with the port flag:
 
 ```sh
-./CarlaUE4.sh --nullrhi -carla-primary-port=3002
+./CarlaUE4.sh -nullrhi -carla-primary-port=3002
 ```
 
 ## Secondary servers


### PR DESCRIPTION
Minor typo in the Multi-GPU docs...
There should only be one dash before `-nullrhi` argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6113)
<!-- Reviewable:end -->
