### PR TITLE
Fix extra bytes in DirectX textures (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Latest
+
+  * Fixed the extra data in Directx textures, so we need to copy row by row on Windows to remove extra bytes on images
+
 ## CARLA 0.9.14
 
   * Fixed bug in FrictionTrigger causing sometimes server segfault

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/AsyncDataStream.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/AsyncDataStream.h
@@ -66,7 +66,7 @@ public:
     {
       if (HeaderStr->frame != FrameNumber)
       {
-        carla::log_debug("Re-framing sensor type ", HeaderStr->sensor_type, " from ", HeaderStr->frame, " to ", FrameNumber);
+        carla::log_info("Re-framing sensor type ", HeaderStr->sensor_type, " from ", HeaderStr->frame, " to ", FrameNumber);
         HeaderStr->frame = FrameNumber;
       }
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -13,27 +13,6 @@
 #include "Runtime/ImageWriteQueue/Public/ImageWriteQueue.h"
 
 // =============================================================================
-// -- Local variables and types ------------------------------------------------
-// =============================================================================
-
-struct LockTexture
-{
-  LockTexture(FRHITexture2D *InTexture, uint32 &Stride)
-    : Texture(InTexture),
-      Source(reinterpret_cast<const uint8 *>(
-            RHILockTexture2D(Texture, 0, RLM_ReadOnly, Stride, false))) {}
-
-  ~LockTexture()
-  {
-    RHIUnlockTexture2D(Texture, 0, false);
-  }
-
-  FRHITexture2D *Texture;
-
-  const uint8 *Source;
-};
-
-// =============================================================================
 // -- FPixelReader -------------------------------------------------------------
 // =============================================================================
 
@@ -86,11 +65,12 @@ void FPixelReader::WritePixelsToBuffer(
     }
     
     FPixelFormatInfo PixelFormat = GPixelFormats[BackBufferPixelFormat];
+    uint32 ExpectedRowBytes = BackBufferSize.X * PixelFormat.BlockBytes;
     int32 Size = (BackBufferSize.Y * (PixelFormat.BlockBytes * BackBufferSize.X));
     void* LockedData = Readback->Lock(Size);
     if (LockedData)
     {
-      FuncForSending(LockedData, Size, Offset);
+      FuncForSending(LockedData, Size, Offset, ExpectedRowBytes);
     }
     Readback->Unlock();
     Readback.reset();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
@@ -10,6 +10,11 @@
 #include "Engine/TextureRenderTarget2D.h"
 #include "Runtime/ImageWriteQueue/Public/ImagePixelData.h"
 
+#ifdef PLATFORM_WINDOWS
+  #define WIN32_LEAN_AND_MEAN
+  #include <D3d12.h>
+#endif
+
 #include "Carla/Game/CarlaEngine.h"
 
 #include <compiler/disable-ue4-macros.h>
@@ -29,7 +34,7 @@ class FPixelReader
 {
 public:
 
-  using Payload = std::function<void(void *, uint32, uint32)>;
+  using Payload = std::function<void(void *, uint32, uint32, uint32)>;
 
   /// Copy the pixels in @a RenderTarget into @a BitMap.
   ///
@@ -111,7 +116,7 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
       if (!Sensor.IsPendingKill())
       {
         FPixelReader::Payload FuncForSending = 
-          [&Sensor, Frame = FCarlaEngine::GetFrameCounter(), Conversor = std::move(Conversor)](void *LockedData, uint32 Size, uint32 Offset)
+          [&Sensor, Frame = FCarlaEngine::GetFrameCounter(), Conversor = std::move(Conversor)](void *LockedData, uint32 Size, uint32 Offset, uint32 ExpectedRowBytes)
           {
             if (Sensor.IsPendingKill()) return;
 
@@ -129,11 +134,40 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
             auto Stream = Sensor.GetDataStream(Sensor);
             Stream.SetFrameNumber(Frame);
             auto Buffer = Stream.PopBufferFromPool();
+            
+            uint32 CurrentRowBytes = ExpectedRowBytes;
 
+#ifdef PLATFORM_WINDOWS
+            // DirectX uses additional bytes to align each row to 256 boundry, 
+            // so we need to remove that extra data
+            if (IsD3DPlatform(GMaxRHIShaderPlatform, false))
             {
+              CurrentRowBytes = Align(ExpectedRowBytes, D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
+              if (ExpectedRowBytes != CurrentRowBytes)
+              {
+                TRACE_CPUPROFILER_EVENT_SCOPE_STR("Buffer Copy (windows, row by row)");
+                Buffer.reset(Offset + Size);
+                auto DstRow = Buffer.begin() + Offset;
+                const uint8 *SrcRow = reinterpret_cast<uint8 *>(LockedData);
+                uint32 i = 0;
+                while (i < Size)
+                {
+                  FMemory::Memcpy(DstRow, SrcRow, ExpectedRowBytes);
+                  DstRow += ExpectedRowBytes;
+                  SrcRow += CurrentRowBytes;
+                  i += ExpectedRowBytes;
+                }
+              }
+            }
+#endif // PLATFORM_WINDOWS
+
+            if (ExpectedRowBytes == CurrentRowBytes)
+            {
+              check(ExpectedRowBytes == CurrentRowBytes);
               TRACE_CPUPROFILER_EVENT_SCOPE_STR("Buffer Copy");
               Buffer.copy_from(Offset, boost::asio::buffer(LockedData, Size));
             }
+
             {
               // send
               TRACE_CPUPROFILER_EVENT_SCOPE_STR("Sending buffer");


### PR DESCRIPTION
#### Description

Some extra data is added by DirectX to align pixel rows at the boundary of 256by (D3D12_TEXTURE_DATA_PITCH_ALIGNMENT).
In those cases where the size of the texture is not aligned to 256, then we need to copy row by row to remove the extra data, instead of doing just 1 copy of all the pixels.

Fixes # 6085

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Copy an image row by row instead of just a memcpy() is slower.
