### PR TITLE
Empty actor

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/UtilActorFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/UtilActorFactory.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "UtilActorFactory.h"
+
+#include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
+#include "Carla/Util/EmptyActor.h"
+#include "Carla/Game/CarlaEpisode.h"
+
+TArray<FActorDefinition> AUtilActorFactory::GetDefinitions()
+{
+  using ABFL = UActorBlueprintFunctionLibrary;
+  auto StaticMeshDefinition = ABFL::MakeGenericDefinition(
+      TEXT("util"),
+      TEXT("actor"),
+      TEXT("empty"));
+  StaticMeshDefinition.Class = AEmptyActor::StaticClass();
+  
+  return { StaticMeshDefinition };
+}
+
+FActorSpawnResult AUtilActorFactory::SpawnActor(
+    const FTransform &SpawnAtTransform,
+    const FActorDescription &ActorDescription)
+{
+  using ABFL = UActorBlueprintFunctionLibrary;
+  auto *World = GetWorld();
+  if (World == nullptr)
+  {
+    UE_LOG(LogCarla, Error, TEXT
+        ("AUtilActorFactory: cannot spawn mesh into an empty world."));
+    return {};
+  }
+
+  FActorSpawnParameters SpawnParameters;
+  SpawnParameters.SpawnCollisionHandlingOverride =
+      ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+  auto *StaticMeshActor = World->SpawnActor<AEmptyActor>(
+      ActorDescription.Class, SpawnAtTransform, SpawnParameters);
+
+  return FActorSpawnResult(StaticMeshActor);
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/UtilActorFactory.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/UtilActorFactory.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "Carla/Actor/ActorSpawnResult.h"
+#include "Carla/Actor/CarlaActorFactory.h"
+
+#include "UtilActorFactory.generated.h"
+
+/// Factory in charge of spawning static meshes. This factory is able to spawn
+/// any mesh in content.
+UCLASS()
+class CARLA_API AUtilActorFactory : public ACarlaActorFactory
+{
+  GENERATED_BODY()
+
+  /// Retrieve the definitions of the static mesh actor
+  TArray<FActorDefinition> GetDefinitions() final;
+
+  FActorSpawnResult SpawnActor(
+      const FTransform &SpawnAtTransform,
+      const FActorDescription &ActorDescription) final;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -174,7 +174,7 @@ void ALargeMapManager::OnActorSpawned(
 
   // LM_LOG(Warning, "ALargeMapManager::OnActorSpawned func %s %s", *Actor->GetName(), *Actor->GetTranslation().ToString());
 
-  if (Actor && CarlaActor.GetActorType() == FCarlaActor::ActorType::Vehicle)
+  if (Actor)
   { // Check if is hero vehicle
 
     assert(ActorInfo);
@@ -1076,24 +1076,11 @@ void ALargeMapManager::PrintMapInfo()
   int LastMsgIndex = TilesDistMsgIndex;
   GEngine->AddOnScreenDebugMessage(LastMsgIndex++, MsgTime, FColor::White,
     FString::Printf(TEXT("\nActor Global Position: %s km"), *(FDVector(CurrentActorPosition) / (1000.0 * 100.0)).ToString()) );
+  
+  FIntVector CurrentTile = GetTileVectorID(CurrentActorPosition);
+  GEngine->AddOnScreenDebugMessage(LastMsgIndex++, MsgTime, FColor::White,
+    FString::Printf(TEXT("\nActor Current Tile: %d_%d"), CurrentTile.X, CurrentTile.Y ));
 
-  GEngine->AddOnScreenDebugMessage(LastMsgIndex++, MsgTime, FColor::White, TEXT("Closest tiles - Distance:"));
-
-  for (const auto& TilePair : MapTiles)
-  {
-    const FCarlaMapTile& Tile = TilePair.Value;
-    const ULevelStreaming* Level = Tile.StreamingLevel;
-    FVector LevelLocation = Tile.Location;
-    float Distance = FDVector::Dist(LevelLocation, CurrentActorPosition);
-
-    FColor MsgColor = FColor::Green;
-    if (Distance < (TileSide * 2.0f))
-    {
-      GEngine->AddOnScreenDebugMessage(LastMsgIndex++, MsgTime, MsgColor,
-        FString::Printf(TEXT("%s       %.2f"), *Level->GetName(), Distance / (1000.0f * 100.0f)));
-    }
-    if (LastMsgIndex < MaxTilesDistMsgIndex) break;
-  }
   LastMsgIndex = ClientLocMsgIndex;
   GEngine->AddOnScreenDebugMessage(LastMsgIndex++, MsgTime, FColor::White,
     FString::Printf(TEXT("\nOrigin: %s km"), *(FDVector(CurrentOriginInt) / (1000.0 * 100.0)).ToString()) );


### PR DESCRIPTION
#### Description

Adds a new actor type: util.actor.empty. Which creates an actor with a transform that can be queried.
In addition, it can be used in large maps as the reference actor (the rolename should be set to `hero` or `ego_vehicle`).
This PR requires the content branch `axel/empty_actor`.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6136)
<!-- Reviewable:end -->
