### PR TITLE
Switch depth GBuffers to 32-bit float format

### DIFF
--- a/LibCarla/cmake/CMakeLists.txt
+++ b/LibCarla/cmake/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(libcarla)
 
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(LIBCARLA_BUILD_DEBUG "Build debug configuration" ON)
 option(LIBCARLA_BUILD_RELEASE "Build release configuration" ON)
 option(LIBCARLA_BUILD_TEST "Build unit tests" ON)

--- a/LibCarla/source/carla/sensor/data/Array.h
+++ b/LibCarla/source/carla/sensor/data/Array.h
@@ -20,7 +20,9 @@ namespace data {
 
   /// Base class for all the sensor data consisting of an array of items.
   template <typename T>
-  class Array : public SensorData {
+  class Array : public SensorData
+  {
+    using Super = SensorData;
   public:
 
     using value_type = T;
@@ -124,10 +126,11 @@ namespace data {
   protected:
 
     template <typename FuncT>
-    explicit Array(RawData &&data, FuncT get_offset)
-      : SensorData(data),
-        _data(std::move(data)),
-        _offset(get_offset(_data)) {
+    explicit Array(RawData &&data, FuncT&& get_offset)
+      : Super(data),
+        _offset(get_offset(_data)),
+        _data(std::move(data))
+    {
       DEBUG_ASSERT(_data.size() >= _offset);
       DEBUG_ASSERT((_data.size() - _offset) % sizeof(T) == 0u);
       DEBUG_ASSERT(begin() <= end());
@@ -142,9 +145,9 @@ namespace data {
 
   private:
 
+    const size_t _offset;
     RawData _data;
 
-    const size_t _offset;
   };
 
 } // namespace data

--- a/LibCarla/source/carla/streaming/detail/Stream.h
+++ b/LibCarla/source/carla/streaming/detail/Stream.h
@@ -54,9 +54,9 @@ namespace detail {
 
     /// Make a copy of @a data and flush it down the stream.
     template <typename T>
-    Stream &operator<<(const T &data) {
+    Stream &operator<<(T &&data) {
       auto buffer = MakeBuffer();
-      buffer.copy_from(data);
+      buffer.copy_from(std::forward<T>(data));
       Write(std::move(buffer));
       return *this;
     }

--- a/PythonAPI/carla/source/libcarla/SensorData.cpp
+++ b/PythonAPI/carla/source/libcarla/SensorData.cpp
@@ -44,6 +44,14 @@ namespace data {
     return out;
   }
 
+  std::ostream &operator<<(std::ostream &out, const FloatImage &image) {
+    out << "Image(frame=" << std::to_string(image.GetFrame())
+        << ", timestamp=" << std::to_string(image.GetTimestamp())
+        << ", size=" << std::to_string(image.GetWidth()) << 'x' << std::to_string(image.GetHeight())
+        << ')';
+    return out;
+  }
+
   std::ostream &operator<<(std::ostream &out, const OpticalFlowImage &image) {
     out << "OpticalFlowImage(frame=" << std::to_string(image.GetFrame())
         << ", timestamp=" << std::to_string(image.GetTimestamp())
@@ -435,6 +443,22 @@ void export_sensor_data() {
       return self.at(pos);
     })
     .def("__setitem__", +[](csd::OpticalFlowImage &self, size_t pos, csd::OpticalFlowPixel color) {
+      self.at(pos) = color;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::FloatImage, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::FloatImage>>("FloatImage", no_init)
+    .add_property("width", &csd::FloatImage::GetWidth)
+    .add_property("height", &csd::FloatImage::GetHeight)
+    .add_property("fov", &csd::FloatImage::GetFOVAngle)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::FloatImage>)
+    .def("__len__", &csd::FloatImage::size)
+    .def("__iter__", iterator<csd::FloatImage>())
+    .def("__getitem__", +[](const csd::FloatImage &self, size_t pos) -> cr::FloatColor {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::FloatImage &self, size_t pos, cr::FloatColor color) {
       self.at(pos) = color;
     })
     .def(self_ns::str(self_ns::self))

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -94,6 +94,7 @@ public class Carla : ModuleRules
         "CoreUObject",
         "Engine",
         "Foliage",
+        "Core",
         "ImageWriteQueue",
         "Json",
         "JsonUtilities",

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
@@ -12,13 +12,13 @@
 namespace ImageUtil
 {
   void DecodePixelsByFormat(
-      void* PixelData,
+      TArrayView<FLinearColor> Out,
+      TArrayView<uint8> PixelData,
       int32 SourcePitch,
       FIntPoint SourceExtent,
       FIntPoint DestinationExtent,
       EPixelFormat Format,
-      FReadSurfaceDataFlags Flags,
-      TArrayView<FLinearColor> Out)
+      FReadSurfaceDataFlags Flags)
   {
     SourcePitch *= GPixelFormats[Format].BlockBytes;
     auto OutPixelCount = DestinationExtent.X * DestinationExtent.Y;
@@ -28,46 +28,59 @@ namespace ImageUtil
     case PF_R16_UINT:
     case PF_R16_SINT:
       // Shadow maps
-      ConvertRawR16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_R8G8B8A8:
-      ConvertRawR8G8B8A8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR8G8B8A8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_B8G8R8A8:
-      ConvertRawB8G8R8A8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawB8G8R8A8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_A2B10G10R10:
-      ConvertRawA2B10G10R10DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawA2B10G10R10DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_FloatRGBA:
     case PF_R16G16B16A16_UNORM:
     case PF_R16G16B16A16_SNORM:
-      ConvertRawR16G16B16A16FDataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+      ConvertRawR16G16B16A16FDataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
     case PF_FloatR11G11B10:
-      ConvertRawRR11G11B10DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawRR11G11B10DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_A32B32G32R32F:
-      ConvertRawR32G32B32A32DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+      ConvertRawR32G32B32A32DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
     case PF_A16B16G16R16:
-      ConvertRawR16G16B16A16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16B16A16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_G16R16:
-      ConvertRawR16G16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
-    case PF_DepthStencil: // Depth / Stencil
-      ConvertRawD32S8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+    case PF_DepthStencil: // Depth Stencil
+      ConvertRawD32S8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
     case PF_X24_G8: // Depth Stencil
-      ConvertRawR24G8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+      ConvertRawR24G8DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
-    case PF_R32_FLOAT: // Depth Stencil
-      ConvertRawR32DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+    case PF_R32_FLOAT: // Depth
+      for (uint32 Y = 0; Y < (uint32)DestinationExtent.Y; Y++)
+      {
+        TArrayView<float> Row(
+          (float*)(&PixelData[0] + Y * SourcePitch),
+          DestinationExtent.X);
+        auto DestPtr = Out.GetData() + Y * DestinationExtent.X;
+        for (uint32 X = 0; X < (uint32)DestinationExtent.X; X++)
+        {
+          auto Depth = Row[X];
+          // Depth = FMath::Min(Flags.ComputeNormalizedDepth(Row[X]), 1.0f);
+          *DestPtr = FLinearColor(Depth, Depth, Depth);
+          ++DestPtr;
+        }
+      }
       break;
     case PF_R16G16B16A16_UINT:
     case PF_R16G16B16A16_SINT:
-      ConvertRawR16G16B16A16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16B16A16DataToFLinearColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     default:
       UE_LOG(LogCarla, Warning, TEXT("Unsupported format %llu"), (unsigned long long)Format);
@@ -77,13 +90,13 @@ namespace ImageUtil
   }
 
   void DecodePixelsByFormat(
-      void* PixelData,
+      TArrayView<FColor> Out,
+      TArrayView<uint8> PixelData,
       int32 SourcePitch,
       FIntPoint SourceExtent,
       FIntPoint DestinationExtent,
       EPixelFormat Format,
-      FReadSurfaceDataFlags Flags,
-      TArrayView<FColor> Out)
+      FReadSurfaceDataFlags Flags)
   {
     SourcePitch *= GPixelFormats[Format].BlockBytes;
     auto OutPixelCount = DestinationExtent.X * DestinationExtent.Y;
@@ -93,49 +106,62 @@ namespace ImageUtil
     case PF_R16_UINT:
     case PF_R16_SINT:
       // Shadow maps
-      ConvertRawR16DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_R8G8B8A8:
-      ConvertRawR8G8B8A8DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR8G8B8A8DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_B8G8R8A8:
-      ConvertRawB8G8R8A8DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawB8G8R8A8DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_A2B10G10R10:
-      ConvertRawR10G10B10A2DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR10G10B10A2DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_FloatRGBA:
     case PF_R16G16B16A16_UNORM:
     case PF_R16G16B16A16_SNORM:
-      ConvertRawR16G16B16A16FDataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), false);
+      ConvertRawR16G16B16A16FDataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), false);
       break;
     case PF_FloatR11G11B10:
-      ConvertRawR11G11B10DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), false);
+      ConvertRawR11G11B10DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), false);
       break;
     case PF_A32B32G32R32F:
-      ConvertRawR32G32B32A32DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), false);
+      ConvertRawR32G32B32A32DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), false);
       break;
     case PF_A16B16G16R16:
-      ConvertRawR16G16B16A16DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16B16A16DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_G16R16:
-      ConvertRawR16G16DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
-    case PF_DepthStencil: // Depth / Stencil
-      ConvertRawD32S8DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+    case PF_DepthStencil: // Depth Stencil
+      ConvertRawD32S8DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
-    case PF_X24_G8: // Depth / Stencil
-      ConvertRawR24G8DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+    case PF_X24_G8: // Depth Stencil
+      ConvertRawR24G8DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData(), Flags);
       break;
     case PF_R32_FLOAT: // Depth
-      ConvertRawR32DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+      for (uint32 Y = 0; Y < (uint32)DestinationExtent.Y; Y++)
+      {
+        TArrayView<float> Row(
+          (float*)(&PixelData[0] + Y * SourcePitch),
+          DestinationExtent.X);
+        auto DestPtr = Out.GetData() + Y * DestinationExtent.X;
+        for (uint32 X = 0; X < (uint32)DestinationExtent.X; X++)
+        {
+          auto Depth = Row[X];
+          // Depth = FMath::Min(Flags.ComputeNormalizedDepth(Row[X]), 1.0f);
+          *DestPtr = FLinearColor(Depth, Depth, Depth).ToFColor(Flags.GetLinearToGamma());
+          ++DestPtr;
+        }
+      }
       break;
     case PF_R16G16B16A16_UINT:
     case PF_R16G16B16A16_SINT:
-      ConvertRawR16G16B16A16DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR16G16B16A16DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     case PF_G8:
-      ConvertRawR8DataToFColor(DestinationExtent.X, DestinationExtent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
+      ConvertRawR8DataToFColor(DestinationExtent.X, DestinationExtent.Y, &PixelData[0], SourcePitch, Out.GetData());
       break;
     default:
       UE_LOG(LogCarla, Warning, TEXT("Unsupported format %llu"), (unsigned long long)Format);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ImageUtil.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/ImageUtil.h
@@ -14,20 +14,20 @@ class FRHIGPUTextureReadback;
 namespace ImageUtil
 {
   void DecodePixelsByFormat(
-      void* PixelData,
+      TArrayView<FColor> Out,
+      TArrayView<uint8> PixelData,
       int32 SourcePitch,
       FIntPoint SourceExtent,
       FIntPoint DestinationExtent,
       EPixelFormat Format,
-      FReadSurfaceDataFlags Flags,
-      TArrayView<FColor> Out);
+      FReadSurfaceDataFlags Flags);
 
   void DecodePixelsByFormat(
-      void* PixelData,
+      TArrayView<FLinearColor> Out,
+      TArrayView<uint8> PixelData,
       int32 SourcePitch,
       FIntPoint SourceExtent,
       FIntPoint DestinationExtent,
       EPixelFormat Format,
-      FReadSurfaceDataFlags Flags,
-      TArrayView<FLinearColor> Out);
+      FReadSurfaceDataFlags Flags);
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -11,10 +11,81 @@
 #include "Async/Async.h"
 #include "HighResScreenshot.h"
 #include "Runtime/ImageWriteQueue/Public/ImageWriteQueue.h"
+#include "HAL/LowLevelMemStats.h"
 
 // =============================================================================
 // -- FPixelReader -------------------------------------------------------------
 // =============================================================================
+
+DECLARE_LLM_MEMORY_STAT(TEXT("STAT_CARLA"), STAT_CARLA, STATGROUP_LLMFULL);
+
+static void InitTags()
+{
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_00, TEXT("CARLA_LLM_TAG_00"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_01, TEXT("CARLA_LLM_TAG_01"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_02, TEXT("CARLA_LLM_TAG_02"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_03, TEXT("CARLA_LLM_TAG_03"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_04, TEXT("CARLA_LLM_TAG_04"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_05, TEXT("CARLA_LLM_TAG_05"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_06, TEXT("CARLA_LLM_TAG_06"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_07, TEXT("CARLA_LLM_TAG_07"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_08, TEXT("CARLA_LLM_TAG_08"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_09, TEXT("CARLA_LLM_TAG_09"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_10, TEXT("CARLA_LLM_TAG_10"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_11, TEXT("CARLA_LLM_TAG_11"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_12, TEXT("CARLA_LLM_TAG_12"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_13, TEXT("CARLA_LLM_TAG_13"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_14, TEXT("CARLA_LLM_TAG_14"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_15, TEXT("CARLA_LLM_TAG_15"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_16, TEXT("CARLA_LLM_TAG_16"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_17, TEXT("CARLA_LLM_TAG_17"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_18, TEXT("CARLA_LLM_TAG_18"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_19, TEXT("CARLA_LLM_TAG_19"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_20, TEXT("CARLA_LLM_TAG_20"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_21, TEXT("CARLA_LLM_TAG_21"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_22, TEXT("CARLA_LLM_TAG_22"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_23, TEXT("CARLA_LLM_TAG_23"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_24, TEXT("CARLA_LLM_TAG_24"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_25, TEXT("CARLA_LLM_TAG_25"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_26, TEXT("CARLA_LLM_TAG_26"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_27, TEXT("CARLA_LLM_TAG_27"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_28, TEXT("CARLA_LLM_TAG_28"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_29, TEXT("CARLA_LLM_TAG_29"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_30, TEXT("CARLA_LLM_TAG_30"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_31, TEXT("CARLA_LLM_TAG_31"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_32, TEXT("CARLA_LLM_TAG_32"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_33, TEXT("CARLA_LLM_TAG_33"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_34, TEXT("CARLA_LLM_TAG_34"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_35, TEXT("CARLA_LLM_TAG_35"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_36, TEXT("CARLA_LLM_TAG_36"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_37, TEXT("CARLA_LLM_TAG_37"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_38, TEXT("CARLA_LLM_TAG_38"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_39, TEXT("CARLA_LLM_TAG_39"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_40, TEXT("CARLA_LLM_TAG_40"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_41, TEXT("CARLA_LLM_TAG_41"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_42, TEXT("CARLA_LLM_TAG_42"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_43, TEXT("CARLA_LLM_TAG_43"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_44, TEXT("CARLA_LLM_TAG_44"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_45, TEXT("CARLA_LLM_TAG_45"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_46, TEXT("CARLA_LLM_TAG_46"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_47, TEXT("CARLA_LLM_TAG_47"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_48, TEXT("CARLA_LLM_TAG_48"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_49, TEXT("CARLA_LLM_TAG_49"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_50, TEXT("CARLA_LLM_TAG_50"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_51, TEXT("CARLA_LLM_TAG_51"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_52, TEXT("CARLA_LLM_TAG_52"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_53, TEXT("CARLA_LLM_TAG_53"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_54, TEXT("CARLA_LLM_TAG_54"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_55, TEXT("CARLA_LLM_TAG_55"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_56, TEXT("CARLA_LLM_TAG_56"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_57, TEXT("CARLA_LLM_TAG_57"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_58, TEXT("CARLA_LLM_TAG_58"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_59, TEXT("CARLA_LLM_TAG_59"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_60, TEXT("CARLA_LLM_TAG_60"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_61, TEXT("CARLA_LLM_TAG_61"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_62, TEXT("CARLA_LLM_TAG_62"), GET_STATFNAME(STAT_CARLA), NAME_None));
+    LLM(FLowLevelMemTracker::Get().RegisterProjectTag((int32)ELLMTag::CARLA_LLM_TAG_63, TEXT("CARLA_LLM_TAG_63"), GET_STATFNAME(STAT_CARLA), NAME_None));
+}
 
 void FPixelReader::WritePixelsToBuffer(
     const UTextureRenderTarget2D &RenderTarget,
@@ -22,7 +93,10 @@ void FPixelReader::WritePixelsToBuffer(
     FRHICommandListImmediate &RHICmdList,
     FPixelReader::Payload FuncForSending)
 {
-    LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_05);
+    static std::once_flag once_flag;
+
+    std::call_once(once_flag, InitTags);
+
   TRACE_CPUPROFILER_EVENT_SCOPE_STR("WritePixelsToBuffer");
   check(IsInRenderingThread());
   
@@ -33,12 +107,7 @@ void FPixelReader::WritePixelsToBuffer(
     return;
   }
 
-  TUniquePtr<FRHIGPUTextureReadback> BackBufferReadback;
-
-  {
-      LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_04);
-      BackBufferReadback = MakeUnique<FRHIGPUTextureReadback>(TEXT("CameraBufferReadback"));
-  }
+  auto BackBufferReadback = MakeUnique<FRHIGPUTextureReadback>(TEXT("CameraBufferReadback"));
 
   FIntPoint BackBufferSize = Texture->GetSizeXY();
   EPixelFormat BackBufferPixelFormat = Texture->GetFormat();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -84,10 +84,6 @@ void FPixelReader::WritePixelsToBuffer(
         }
     }
     Readback->Unlock();
-    ENQUEUE_RENDER_COMMAND(FreeReadback)([Readback = MoveTemp(Readback)](FRHICommandList& CmdList) mutable
-    {
-        Readback.Reset();
-    });
   });  
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.cpp
@@ -62,8 +62,3 @@ void ASceneCaptureCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float
   );
   FPixelReader::SendPixelsInRenderThread<ASceneCaptureCamera, FColor>(*this);
 }
-
-void ASceneCaptureCamera::SendGBufferTextures(FGBufferRequest& GBuffer)
-{
-    SendGBufferTexturesInternal(*this, GBuffer);
-}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
@@ -27,8 +27,6 @@ public:
 
 protected:
 	
-  virtual void SendGBufferTextures(FGBufferRequest& GBuffer) override;
-
   void BeginPlay() override;
   void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
   void PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSeconds) override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.h
@@ -29,7 +29,6 @@ protected:
 	
   virtual void SendGBufferTextures(FGBufferRequest& GBuffer) override;
 
-
   void BeginPlay() override;
   void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
   void PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSeconds) override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -511,28 +511,18 @@ void ASceneCaptureSensor::CaptureSceneExtended()
   Prior = GBufferPtr->DesiredTexturesMask;
   GBufferPtr->OwningActor = CaptureComponent2D->GetViewOwner();
 
-#define CARLA_GBUFFER_DISABLE_TAA // Temporarily disable TAA to avoid jitter.
+  bool EnableTAA = false;
+  bool Prior = CaptureComponent2D->ShowFlags.TemporalAA;
 
-#ifdef CARLA_GBUFFER_DISABLE_TAA
-  bool bTAA = CaptureComponent2D->ShowFlags.TemporalAA;
-  if (bTAA) {
-    CaptureComponent2D->ShowFlags.TemporalAA = false;
-  }
-#endif
-
+  CaptureComponent2D->ShowFlags.TemporalAA = EnableTAA;
   CaptureComponent2D->CaptureSceneWithGBuffer(GBuffer);
-
-#ifdef CARLA_GBUFFER_DISABLE_TAA
-  if (bTAA) {
-    CaptureComponent2D->ShowFlags.TemporalAA = true;
-  }
-#undef CARLA_GBUFFER_DISABLE_TAA
-#endif
+  CaptureComponent2D->ShowFlags.TemporalAA = Prior;
 
   FlushRenderingCommands();
   AsyncTask(ENamedThreads::AnyHiPriThreadNormalTask, [this, GBuffer = MoveTemp(GBufferPtr)]() mutable
   {
     SendGBufferTextures(*GBuffer);
+    GBuffer.Reset();
   });
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -478,7 +478,7 @@ static void CheckGBufferStream(uint64_t& Mask, T& GBufferStreams)
       FGBufferRequest::MarkAsRequested(Mask, ID);
 }
 
-constexpr size_t MAX_CONCURRENT_GBUFFER_TRANSFERS = 64;
+constexpr size_t MAX_CONCURRENT_GBUFFER_TRANSFERS = 2;
 static std::atomic<size_t> active_gbuffer_transfer_count = { 0 };
 
 void ASceneCaptureSensor::CaptureSceneExtended()
@@ -505,8 +505,7 @@ void ASceneCaptureSensor::CaptureSceneExtended()
     return;
   }
 
-  auto count = active_gbuffer_transfer_count.fetch_add(1, std::memory_order_acquire);
-  if (active_gbuffer_transfer_count.fetch_add(1, std::memory_order_acquire) >= MAX_CONCURRENT_GBUFFER_TRANSFERS)
+  while (active_gbuffer_transfer_count.fetch_add(1, std::memory_order_acquire) >= MAX_CONCURRENT_GBUFFER_TRANSFERS)
   {
       (void)active_gbuffer_transfer_count.fetch_sub(1, std::memory_order_release);
       std::this_thread::yield();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -529,6 +529,7 @@ void ASceneCaptureSensor::CaptureSceneExtended()
 #undef CARLA_GBUFFER_DISABLE_TAA
 #endif
 
+  FlushRenderingCommands();
   AsyncTask(ENamedThreads::AnyHiPriThreadNormalTask, [this, GBuffer = MoveTemp(GBufferPtr)]() mutable
   {
     SendGBufferTextures(*GBuffer);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -478,6 +478,8 @@ private:
   template <EGBufferTextureID TextureID, typename SensorT>
   void SendGBuffer(SensorT& Sensor, FGBufferRequest& GBufferData)
   {
+      LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_08);
+
       auto& GBufferStream = std::get<(size_t)TextureID>(GBufferStreams);
 
       using CameraGBufferT = std::remove_reference_t<decltype(GBufferStream)>;
@@ -491,6 +493,8 @@ private:
 
       if (GBufferData.WaitForTextureTransfer(TextureID))
       {
+          LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_09);
+
         TRACE_CPUPROFILER_EVENT_SCOPE_STR("GBuffer Decode");
 
         FIntPoint SourceExtent = {};
@@ -499,6 +503,8 @@ private:
 
         if (GBufferData.MapTextureData(TextureID, PixelData, SourcePitch, SourceExtent))
         {
+            LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_10);
+
             auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
             ImageSize = GBufferData.ViewRect.Size();
             Pixels.AddUninitialized(ImageSize.X * ImageSize.Y);
@@ -551,6 +557,8 @@ private:
   template <typename SensorT>
   void SendGBufferTexturesInternal(SensorT& Sensor, FGBufferRequest& GBufferData)
   {
+      LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_07);
+
     if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SceneColor)) != 0)
         SendGBuffer<EGBufferTextureID::SceneColor>(Sensor, GBufferData);
     if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SceneDepth)) != 0)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -31,6 +31,7 @@ struct FCameraGBufferUint8
 {
   /// Prevent this sensor to be spawned by users.
   using not_spawnable = void;
+  using PixelType = FColor;
 
   void SetDataStream(FDataStream InStream)
   {
@@ -59,9 +60,10 @@ struct FCameraGBufferUint8
   ///
   /// You need to provide a reference to self, this is necessary for template
   /// deduction.
-  auto GetDataStream(const UCarlaEpisode& Episode)
+  template <typename SensorT>
+  auto GetDataStream(const SensorT& Self)
   {
-    return Stream.MakeAsyncDataStream(*this, Episode.GetElapsedGameTime());
+    return Stream.MakeAsyncDataStream(*this, Self.GetEpisode().GetElapsedGameTime());
   }
 
   mutable bool bIsUsed = false;
@@ -74,6 +76,7 @@ struct FCameraGBufferFloat
 {
   /// Prevent this sensor to be spawned by users.
   using not_spawnable = void;
+  using PixelType = FLinearColor;
 
   void SetDataStream(FDataStream InStream)
   {
@@ -101,9 +104,10 @@ struct FCameraGBufferFloat
   ///
   /// You need to provide a reference to self, this is necessary for template
   /// deduction.
-  auto GetDataStream(const UCarlaEpisode& Episode)
+  template <typename SensorT>
+  auto GetDataStream(const SensorT& Self)
   {
-    return Stream.MakeAsyncDataStream(*this, Episode.GetElapsedGameTime());
+    return Stream.MakeAsyncDataStream(*this, Self.GetEpisode().GetElapsedGameTime());
   }
   
   mutable bool bIsUsed = false;
@@ -421,9 +425,7 @@ public:
 
 protected:
     
-  void CaptureSceneExtended();
-
-  virtual void SendGBufferTextures(FGBufferRequest& GBuffer);
+  void EnqueueRenderSceneImmediateWithGBuffers(uint64 RequestedMask);
 
   virtual void BeginPlay() override;
 
@@ -460,131 +462,4 @@ protected:
   /// Whether to change render target format to PF_A16B16G16R16, offering 16bit / channel
   UPROPERTY(EditAnywhere)
   bool bEnable16BitFormat = false;
-  
-private:
-
-    template <typename PixelT>
-    static void SendGBufferFillEmptyTexture(
-        FGBufferRequest& GBufferData,
-        FIntPoint& ImageSize,
-        TArray<PixelT>& Pixels)
-    {
-        ImageSize = GBufferData.ViewRect.Size();
-        Pixels.AddUninitialized(ImageSize.X * ImageSize.Y);
-        for (auto& Pixel : Pixels)
-            Pixel = PixelT::Black;
-    }
-
-  template <EGBufferTextureID TextureID, typename SensorT>
-  void SendGBuffer(SensorT& Sensor, FGBufferRequest& GBufferData)
-  {
-      LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_08);
-
-      auto& GBufferStream = std::get<(size_t)TextureID>(GBufferStreams);
-
-      using CameraGBufferT = std::remove_reference_t<decltype(GBufferStream)>;
-      using PixelType = typename std::conditional<
-          std::is_same<CameraGBufferT, FCameraGBufferUint8>::value,
-          FColor,
-          FLinearColor>::type;
-
-      FIntPoint ImageSize;
-      TArray<PixelType> Pixels;
-
-      if (GBufferData.WaitForTextureTransfer(TextureID))
-      {
-          LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_09);
-
-        TRACE_CPUPROFILER_EVENT_SCOPE_STR("GBuffer Decode");
-
-        FIntPoint SourceExtent = {};
-        void* PixelData;
-        int32 SourcePitch;
-
-        if (GBufferData.MapTextureData(TextureID, PixelData, SourcePitch, SourceExtent))
-        {
-            LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_10);
-
-            auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
-            ImageSize = GBufferData.ViewRect.Size();
-            Pixels.AddUninitialized(ImageSize.X * ImageSize.Y);
-            FReadSurfaceDataFlags Flags = {};
-            Flags.SetLinearToGamma(true);
-            ImageUtil::DecodePixelsByFormat(
-                Pixels,
-                TArrayView<uint8>((uint8*)PixelData, SourcePitch * SourceExtent.Y),
-                SourcePitch,
-                SourceExtent,
-                ImageSize,
-                Format,
-                Flags);
-            GBufferData.UnmapTextureData(TextureID);
-        }
-        else
-        {
-            SendGBufferFillEmptyTexture(GBufferData, ImageSize, Pixels);
-        }
-      }
-      else
-      {
-          SendGBufferFillEmptyTexture(GBufferData, ImageSize, Pixels);
-      }
-
-      auto Stream = GBufferStream.GetDataStream(GetEpisode());
-      auto Buffer = Stream.PopBufferFromPool();
-
-      Buffer.copy_from(
-        carla::sensor::SensorRegistry::get<CameraGBufferT*>::type::header_offset,
-        boost::asio::buffer(&Pixels[0], Pixels.Num() * sizeof(PixelType)));
-
-      if (Buffer.empty()) {
-        return;
-      }
-
-      SCOPE_CYCLE_COUNTER(STAT_CarlaSensorStreamSend);
-      TRACE_CPUPROFILER_EVENT_SCOPE_STR("Stream Send");
-
-      Stream.Send(
-        GBufferStream,
-        std::move(Buffer),
-        ImageSize.X,
-        ImageSize.Y,
-        Sensor.GetFOVAngle());
-  }
-
- protected:
-
-  template <typename SensorT>
-  void SendGBufferTexturesInternal(SensorT& Sensor, FGBufferRequest& GBufferData)
-  {
-      LLM_SCOPE(ELLMTag::CARLA_LLM_TAG_07);
-
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SceneColor)) != 0)
-        SendGBuffer<EGBufferTextureID::SceneColor>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SceneDepth)) != 0)
-        SendGBuffer<EGBufferTextureID::SceneDepth>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SceneStencil)) != 0)
-        SendGBuffer<EGBufferTextureID::SceneStencil>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferA)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferA>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferB)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferB>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferC)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferC>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferD)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferD>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferE)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferE>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::GBufferF)) != 0)
-        SendGBuffer<EGBufferTextureID::GBufferF>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::Velocity)) != 0)
-        SendGBuffer<EGBufferTextureID::Velocity>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::SSAO)) != 0)
-        SendGBuffer<EGBufferTextureID::SSAO>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::CustomDepth)) != 0)
-        SendGBuffer<EGBufferTextureID::CustomDepth>(Sensor, GBufferData);
-    if ((GBufferData.DesiredTexturesMask & (1U << (uint8_t)EGBufferTextureID::CustomStencil)) != 0)
-        SendGBuffer<EGBufferTextureID::CustomStencil>(Sensor, GBufferData);
-  }
-
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/Sensor.h
@@ -16,6 +16,8 @@
 
 struct FActorDescription;
 
+class FGBufferRequest;
+
 /// Base class for sensors.
 UCLASS(Abstract, hidecategories = (Collision, Attachment, Actor))
 class CARLA_API ASensor : public AActor
@@ -63,7 +65,6 @@ public:
   // Small interface to notify sensors when no clients are listening
   virtual void OnLastClientDisconnected() {};
 
-  
   void PostPhysTickInternal(UWorld *World, ELevelTick TickType, float DeltaSeconds);
 
   UFUNCTION(BlueprintCallable)

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SensorFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SensorFactory.cpp
@@ -141,19 +141,19 @@ FActorSpawnResult ASensorFactory::SpawnActor(
     ASceneCaptureSensor * SceneCaptureSensor = Cast<ASceneCaptureSensor>(Sensor);
     if(SceneCaptureSensor)
     {
-      SceneCaptureSensor->CameraGBuffers.SceneColor.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.SceneDepth.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.SceneStencil.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferA.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferB.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferC.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferD.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferE.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.GBufferF.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.Velocity.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.SSAO.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.CustomDepth.SetDataStream(GameInstance->GetServer().OpenStream());
-      SceneCaptureSensor->CameraGBuffers.CustomStencil.SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SceneColor>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SceneDepth>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SceneStencil>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferA>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferB>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferC>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferD>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferE>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferF>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::Velocity>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SSAO>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::CustomDepth>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::CustomStencil>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
     }
   }
   UGameplayStatics::FinishSpawningActor(Sensor, Transform);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SensorFactory.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/SensorFactory.cpp
@@ -126,6 +126,7 @@ FActorSpawnResult ASensorFactory::SpawnActor(
       this,
       nullptr,
       ESpawnActorCollisionHandlingMethod::AlwaysSpawn);
+
   if (Sensor == nullptr)
   {
     UE_LOG(LogCarla, Error, TEXT("ASensorFactory: spawn sensor failed."));
@@ -138,22 +139,26 @@ FActorSpawnResult ASensorFactory::SpawnActor(
     Sensor->SetEpisode(*Episode);
     Sensor->Set(Description);
     Sensor->SetDataStream(GameInstance->GetServer().OpenStream());
-    ASceneCaptureSensor * SceneCaptureSensor = Cast<ASceneCaptureSensor>(Sensor);
+
+    auto SceneCaptureSensor = Cast<ASceneCaptureSensor>(Sensor);
+
     if(SceneCaptureSensor)
     {
-      std::get<(size_t)EGBufferTextureID::SceneColor>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::SceneDepth>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::SceneStencil>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferA>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferB>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferC>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferD>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferE>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::GBufferF>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::Velocity>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::SSAO>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::CustomDepth>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
-      std::get<(size_t)EGBufferTextureID::CustomStencil>(SceneCaptureSensor->GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      auto& GBufferStreams = SceneCaptureSensor->GBufferStreams;
+      // This should be thread-safe
+      std::get<(size_t)EGBufferTextureID::SceneColor>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SceneDepth>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SceneStencil>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferA>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferB>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferC>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferD>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferE>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::GBufferF>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::Velocity>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::SSAO>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::CustomDepth>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
+      std::get<(size_t)EGBufferTextureID::CustomStencil>(GBufferStreams).SetDataStream(GameInstance->GetServer().OpenStream());
     }
   }
   UGameplayStatics::FinishSpawningActor(Sensor, Transform);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/WorldObserver.h
@@ -39,7 +39,7 @@ public:
     bool PendingLightUpdate);
 
   /// Dummy. Required for compatibility with other sensors only.
-  FTransform GetActorTransform() const
+  inline FTransform GetActorTransform() const
   {
     return {};
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2083,67 +2083,67 @@ void FCarlaServer::FPimpl::BindActions()
     {
       case 0:
       {
-        const auto &Token = Sensor->CameraGBuffers.SceneColor.GetToken();
+        const auto &Token = std::get<0>(Sensor->GBufferStreams).GetToken();
         return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 1:
       {
-        const auto &Token = Sensor->CameraGBuffers.SceneDepth.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<1>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 2:
       {
-          const auto& Token = Sensor->CameraGBuffers.SceneStencil.GetToken();
+          const auto& Token = std::get<2>(Sensor->GBufferStreams).GetToken();
           return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 3:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferA.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<3>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 4:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferB.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<4>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 5:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferC.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<5>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 6:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferD.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<6>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 7:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferE.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<7>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 8:
       {
-        const auto &Token = Sensor->CameraGBuffers.GBufferF.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<8>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 9:
       {
-        const auto &Token = Sensor->CameraGBuffers.Velocity.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<9>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 10:
       {
-        const auto &Token = Sensor->CameraGBuffers.SSAO.GetToken();
-        return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
+          const auto& Token = std::get<0>(Sensor->GBufferStreams).GetToken();
+          return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 11:
       {
-          const auto& Token = Sensor->CameraGBuffers.CustomDepth.GetToken();
+          const auto& Token = std::get<1>(Sensor->GBufferStreams).GetToken();
           return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       case 12:
       {
-          const auto& Token = Sensor->CameraGBuffers.CustomStencil.GetToken();
+          const auto& Token = std::get<2>(Sensor->GBufferStreams).GetToken();
           return std::vector<unsigned char>(std::begin(Token.data), std::end(Token.data));
       }
       default:

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServerResponse.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServerResponse.h
@@ -24,4 +24,4 @@ enum class ECarlaServerResponse
   FunctionNotAvailiableWhenDormant
 };
 
-static FString GetStringError(ECarlaServerResponse Response);
+FString GetStringError(ECarlaServerResponse Response);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -3,6 +3,8 @@
 
 #include "Carla/Settings/CarlaSettings.h"
 
+#include "Carla/Game/CarlaGameInstance.h"
+
 #include "Async.h"
 #include "Components/StaticMeshComponent.h"
 #include "Engine/DirectionalLight.h"
@@ -15,6 +17,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Landscape.h"
 #include "Scalability.h"
+
 
 
 static constexpr float CARLA_SETTINGS_MAX_SCALE_SIZE = 50.0f;


### PR DESCRIPTION
#### Description

This PR changes the format of the SceneDepth and CustomDepth GBuffers. Client-side, they are now exposed as 4-channel, 32-bit float images. To do this, this PR improves support for the FloatImage type and adds some checks in manual_control_gbuffer.py to account for this image format.

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26-CARLA

#### Possible Drawbacks

The fact that depth formats are exposed as 4-channel images instead of single-channel is suboptimal.
There is also a hack now in ImageUtil to account for PF_R32_FLOAT images being converted to linear world units from within the renderer (in a shader).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6140)
<!-- Reviewable:end -->
