### PR TITLE
Adding --ignore-spectator to the replayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * Fixed the extra data in Directx textures, so we need to copy row by row on Windows to remove extra bytes on images
   * Restored gamma value to 2.2 instead of 2.4
+  * Added API function to avoid replaying the spectator
+    * `Client.set_replayer_ignore_spectator(bool)`
+    * `start_replaying.py` using flag `--move-spectator`
 
 ## CARLA 0.9.14
 

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -137,6 +137,10 @@ namespace client {
       _simulator->SetReplayerIgnoreHero(ignore_hero);
     }
 
+    void SetReplayerIgnoreSpectator(bool ignore_spectator) {
+      _simulator->SetReplayerIgnoreSpectator(ignore_spectator);
+    }
+
     void ApplyBatch(
         std::vector<rpc::Command> commands,
         bool do_tick_cue = false) const {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -574,6 +574,10 @@ namespace detail {
     _pimpl->AsyncCall("set_replayer_ignore_hero", ignore_hero);
   }
 
+  void Client::SetReplayerIgnoreSpectator(bool ignore_spectator) {
+    _pimpl->AsyncCall("set_replayer_ignore_spectator", ignore_spectator);
+  }
+
   void Client::SubscribeToStream(
       const streaming::Token &token,
       std::function<void(Buffer)> callback) {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -362,6 +362,8 @@ namespace detail {
 
     void SetReplayerIgnoreHero(bool ignore_hero);
 
+    void SetReplayerIgnoreSpectator(bool ignore_spectator);
+
     void StopReplayer(bool keep_actors);
 
     void SubscribeToStream(

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -576,6 +576,10 @@ namespace detail {
       _client.SetReplayerIgnoreHero(ignore_hero);
     }
 
+    void SetReplayerIgnoreSpectator(bool ignore_spectator) {
+      _client.SetReplayerIgnoreSpectator(ignore_spectator);
+    }
+
     void StopReplayer(bool keep_actors) {
       _client.StopReplayer(keep_actors);
   }

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -210,6 +210,7 @@ void export_client() {
     .def("stop_replayer", &cc::Client::StopReplayer, (arg("keep_actors")))
     .def("set_replayer_time_factor", &cc::Client::SetReplayerTimeFactor, (arg("time_factor")))
     .def("set_replayer_ignore_hero", &cc::Client::SetReplayerIgnoreHero, (arg("ignore_hero")))
+    .def("set_replayer_ignore_spectator", &cc::Client::SetReplayerIgnoreSpectator, (arg("ignore_spectator")))
     .def("apply_batch", &ApplyBatchCommands, (arg("commands"), arg("do_tick")=false))
     .def("apply_batch_sync", &ApplyBatchCommandsSync, (arg("commands"), arg("do_tick")=false))
     .def("get_trafficmanager", CONST_CALL_WITHOUT_GIL_1(cc::Client, GetInstanceTM, uint16_t), (arg("port")=ctm::TM_DEFAULT_PORT))

--- a/PythonAPI/examples/start_replaying.py
+++ b/PythonAPI/examples/start_replaying.py
@@ -72,6 +72,10 @@ def main():
         action='store_true',
         help='ignore hero vehicles')
     argparser.add_argument(
+        '--move-spectator',
+        action='store_true',
+        help='move spectator camera')
+    argparser.add_argument(
         '--spawn-sensors',
         action='store_true',
         help='spawn sensors in the replayed world')
@@ -87,6 +91,9 @@ def main():
 
         # set to ignore the hero vehicles or not
         client.set_replayer_ignore_hero(args.ignore_hero)
+
+        # set to ignore the spectator camera or not
+        client.set_replayer_ignore_spectator(not args.move_spectator)
 
         # replay the session
         print(client.replay_file(args.recorder_filename, args.start, args.duration, args.camera, args.spawn_sensors))

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -73,6 +73,11 @@ void ACarlaRecorder::SetReplayerIgnoreHero(bool IgnoreHero)
   Replayer.SetIgnoreHero(IgnoreHero);
 }
 
+void ACarlaRecorder::SetReplayerIgnoreSpectator(bool IgnoreSpectator)
+{
+  Replayer.SetIgnoreSpectator(IgnoreSpectator);
+}
+
 void ACarlaRecorder::StopReplayer(bool KeepActors)
 {
   Replayer.Stop(KeepActors);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -166,6 +166,7 @@ public:
       uint32_t FollowId, bool ReplaySensors);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);
+  void SetReplayerIgnoreSpectator(bool IgnoreSpectator);
   void StopReplayer(bool KeepActors = false);
 
   void Ticking(float DeltaSeconds);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -86,6 +86,12 @@ public:
     IgnoreHero = InIgnoreHero;
   }
 
+  // set ignore spectator
+  void SetIgnoreSpectator(bool InIgnoreSpectator)
+  {
+    IgnoreSpectator = InIgnoreSpectator;
+  }
+
   // check if after a map is loaded, we need to replay
   void CheckPlayAfterMapLoaded(void);
 
@@ -119,6 +125,7 @@ private:
   double TimeFactor { 1.0 };
   // ignore hero vehicles
   bool IgnoreHero { false };
+  bool IgnoreSpectator { true };
   std::unordered_map<uint32_t, bool> IsHeroMap;
 
   // utils

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -179,6 +179,7 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
     CarlaRecorderActorDescription Description,
     uint32_t DesiredId,
     bool bIgnoreHero,
+    bool bIgnoreSpectator,
     bool ReplaySensors)
 {
   check(Episode != nullptr);
@@ -198,6 +199,13 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
     // check for hero
     if (Item.Id == "role_name" && Item.Value == "hero")
       IsHero = true;
+  }
+
+  // check to ignore Hero or Spectator
+  if ((bIgnoreHero && IsHero) || 
+      (bIgnoreSpectator && ActorDesc.Id.StartsWith("spectator")))
+  {
+    return std::make_pair(3, 0);
   }
 
   auto result = TryToCreateReplayerActor(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -38,6 +38,7 @@ public:
       CarlaRecorderActorDescription Description,
       uint32_t DesiredId,
       bool bIgnoreHero,
+      bool bIgnoreSpectator,
       bool ReplaySensors);
 
   // replay event for removing actor

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2232,6 +2232,13 @@ void FCarlaServer::FPimpl::BindActions()
     return R<void>::Success();
   };
 
+  BIND_SYNC(set_replayer_ignore_spectator) << [this](bool ignore_spectator) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    Episode->GetRecorder()->SetReplayerIgnoreSpectator(ignore_spectator);
+    return R<void>::Success();
+  };
+
   BIND_SYNC(stop_replayer) << [this](bool keep_actors) -> R<void>
   {
     REQUIRE_CARLA_EPISODE();


### PR DESCRIPTION
#### Description

When using a package to record and replay a simulation, the spectator can be replayed or not with this new API function/flag.
By default the spectator is ignored when replaying.

#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6166)
<!-- Reviewable:end -->
