### PR TITLE
Fixed Traffic Manager's unstuck logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Fixed bug causing the TM's unstuck logic to incorrectly remove the vehicles in some situations.
   * Fixed the extra data in Directx textures, so we need to copy row by row on Windows to remove extra bytes on images
   * Restored gamma value to 2.2 instead of 2.4
 

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -181,20 +181,19 @@ void ALSM::UpdateRegisteredActorsData(const bool hybrid_physics_mode, ALSM::Idle
     if (is_respawn_vehicles) {
       track_traffic.SetHeroLocation(hero_actor_info.second->GetTransform().location);
     }
-    UpdateData(hybrid_physics_mode, max_idle_time, hero_actor_info.second, hero_actor_present, physics_radius_square);
+    UpdateData(hybrid_physics_mode, hero_actor_info.second, hero_actor_present, physics_radius_square);
   }
   // Update information for all other registered vehicles.
   for (const Actor &vehicle : vehicle_list) {
     ActorId actor_id = vehicle->GetId();
     if (hero_actors.find(actor_id) == hero_actors.end()) {
-      UpdateData(hybrid_physics_mode, max_idle_time, vehicle, hero_actor_present, physics_radius_square);
+      UpdateData(hybrid_physics_mode, vehicle, hero_actor_present, physics_radius_square);
       UpdateIdleTime(max_idle_time, actor_id);
     }
   }
 }
 
-void ALSM::UpdateData(const bool hybrid_physics_mode,
-                      ALSM::IdleInfo &max_idle_time, const Actor &vehicle,
+void ALSM::UpdateData(const bool hybrid_physics_mode, const Actor &vehicle,
                       const bool hero_actor_present, const float physics_radius_square) {
 
   ActorId actor_id = vehicle->GetId();

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -188,6 +188,7 @@ void ALSM::UpdateRegisteredActorsData(const bool hybrid_physics_mode, ALSM::Idle
     ActorId actor_id = vehicle->GetId();
     if (hero_actors.find(actor_id) == hero_actors.end()) {
       UpdateData(hybrid_physics_mode, max_idle_time, vehicle, hero_actor_present, physics_radius_square);
+      UpdateIdleTime(max_idle_time, actor_id);
     }
   }
 }
@@ -264,9 +265,6 @@ void ALSM::UpdateData(const bool hybrid_physics_mode,
 
     simulation_state.AddActor(actor_id, kinematic_state, attributes, tl_state);
   }
-
-  // Updating idle time when necessary.
-  UpdateIdleTime(max_idle_time, actor_id);
 }
 
 
@@ -358,8 +356,9 @@ bool ALSM::IsVehicleStuck(const ActorId& actor_id) {
   if (idle_time.find(actor_id) != idle_time.end()) {
     double delta_idle_time = current_timestamp.elapsed_seconds - idle_time.at(actor_id);
     TrafficLightState tl_state = simulation_state.GetTLS(actor_id);
-    if ((!tl_state.at_traffic_light && tl_state.tl_state != TLS::Red && delta_idle_time >= BLOCKED_TIME_THRESHOLD)
-    || (delta_idle_time >= RED_TL_BLOCKED_TIME_THRESHOLD)) {
+    if ((delta_idle_time >= RED_TL_BLOCKED_TIME_THRESHOLD)
+    || (delta_idle_time >= BLOCKED_TIME_THRESHOLD && tl_state.tl_state != TLS::Red))
+    {
       return true;
     }
   }

--- a/LibCarla/source/carla/trafficmanager/ALSM.h
+++ b/LibCarla/source/carla/trafficmanager/ALSM.h
@@ -83,8 +83,7 @@ private:
   using IdleInfo = std::pair<ActorId, double>;
   void UpdateRegisteredActorsData(const bool hybrid_physics_mode, IdleInfo &max_idle_time);
 
-  void UpdateData(const bool hybrid_physics_mode,
-                  ALSM::IdleInfo &max_idle_time, const Actor &vehicle,
+  void UpdateData(const bool hybrid_physics_mode, const Actor &vehicle,
                   const bool hero_actor_present, const float physics_radius_square);
 
   void UpdateUnregisteredActorsData();


### PR DESCRIPTION
### Description

The Traffic Manager has a logic that checks there are no vehicles stuck, removing them after a certain amount of time has passed without them moving. This logic, however, is broken in two ways, which this PR fixes them.

1) When deciding which vehicle is the "most stuck" (aka the one that has been stopped the most time), the logic considered all hero vehicles, regardless of whether or not they were part of the TM. This breaks the logic if an unregistered hero is the one actually stuck.
2) The time needed to be considered stuck is increased for vehicles are red lights / stops, but the differentiation between this and the "normal" case is not done correctly. 

Fixes #6110

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6169)
<!-- Reviewable:end -->
