### PR TITLE
Added Python version requirements for installing Carla PythonAPI

### DIFF
--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -173,4 +173,5 @@ setup(
     url='https://github.com/carla-simulator/carla',
     author='The CARLA team',
     author_email='carla.simulator@gmail.com',
-    include_package_data=True)
+    include_package_data=True,
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<3.9')


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description


Inserted in setup.py the argument _python_requires_ for checking the Python version, which must be compatible with Python versions 2.7, 3.6, 3.7, and 3.8, according to the [documentation](https://carla.readthedocs.io/en/latest/start_quickstart/#install-client-library)


#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26


<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6284)
<!-- Reviewable:end -->
