### PR TITLE
Fixing import script that can find a TilesInfo.txt from other existing map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Fixed bug causing the TM's unstuck logic to incorrectly remove the vehicles in some situations.
   * Fixed the extra data in Directx textures, so we need to copy row by row on Windows to remove extra bytes on images
+  * Fixed the import script, where could use any other TilesInfo.txt if the destination folder has many
   * Restored gamma value to 2.2 instead of 2.4
   * Added API function to avoid replaying the spectator
     * `Client.set_replayer_ignore_spectator(bool)`

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/LoadAssetMaterialsCommandlet.cpp
@@ -143,7 +143,7 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
 
       // Acquire the TilesInfo.txt file for storing the tile data (offset and size)
       TArray<FString> FileList;
-      IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir() + "/" + PackageName), *(FString("TilesInfo.txt")), true, false, false);
+      IFileManager::Get().FindFilesRecursive(FileList, *(FPaths::ProjectContentDir() + "/" + PackageName + "/Maps/" + MapName), *(FString("TilesInfo.txt")), true, false, false);
 
       FString TxtFile;
       if (FFileHelper::LoadFileToString(TxtFile, *FileList[0]) == true) {
@@ -198,8 +198,11 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
     float MaxYSizeCm = MaxYSize * 100.0f;
 
     float TileSizeCm = TileData.Size * 100.0f;
-    float TileWorldLocationX = TileData.FirstTileCenterX * 100.0f;
-    float TileWorldLocationY = TileData.FirstTileCenterY * 100.0f;
+    float FirstTileWorldLocationX = TileData.FirstTileCenterX * 100.0f;
+    float FirstTileWorldLocationY = TileData.FirstTileCenterY * 100.0f;
+
+    float CenterOfTileX = FirstTileWorldLocationX + (XIndex * TileSizeCm);
+    float CenterOfTileY = FirstTileWorldLocationY - (YIndex * TileSizeCm);
 
     for (int32 i = 0; i < DecalsProperties.DecalMaterials.Num(); ++i) {
 
@@ -224,8 +227,9 @@ void ULoadAssetMaterialsCommandlet::ApplyRoadPainterMaterials(const FString &Loa
             // Transform the location from world coords to tile coordinates.
             // The location we get is the location of the XODR waypoint, which is in WORLD coordinates
             // The Y coordinates are reversed! -Y = Y and Y = -Y
-            FinalLocation.X -= TileWorldLocationX + (XIndex * TileSizeCm);
-            FinalLocation.Y -= TileWorldLocationY - (YIndex * TileSizeCm);
+
+            FinalLocation.X -= CenterOfTileX;
+            FinalLocation.Y -= CenterOfTileY;
 
             FActorSpawnParameters SpawnParams;
             SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;


### PR DESCRIPTION
#### Description

When the import script runs to import a large map, it searches for a TilesInfo.txt file to know where the top,left cell has the center in the world. The problem is that in the destination folder can exist other large maps with that file, and the import script was searching recursively from the base folder (the package folder) and was taking the first TilesInfo.txt found, that could be from another existing map.

That has been fixed, and now the TilesInfo.txt file is searched only in the destination map folder, instead of the destination package folder.


#### Where has this been tested?

  * **Platform(s):** windows
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6289)
<!-- Reviewable:end -->
