### PR TITLE
Added default values to carla.Client()

### DIFF
--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -187,7 +187,7 @@ void export_client() {
   ;
 
   class_<cc::Client>("Client",
-      init<std::string, uint16_t, size_t>((arg("host"), arg("port"), arg("worker_threads")=0u)))
+      init<std::string, uint16_t, size_t>((arg("host")="127.0.0.1", arg("port")=2000, arg("worker_threads")=0u)))
     .def("set_timeout", &::SetTimeout, (arg("seconds")))
     .def("get_client_version", &cc::Client::GetClientVersion)
     .def("get_server_version", CONST_CALL_WITHOUT_GIL(cc::Client, GetServerVersion))


### PR DESCRIPTION
### Description

Added default values to the *host* and *port* arguments of the carla.Client(), so that now it can initialized directly with 

```py
client = carla.Client()
```

instead of 

```py
client = carla.Client('127.0.0.1', 2000)
```

This now also matches the docs

![image](https://user-images.githubusercontent.com/58212725/234565443-432517b2-4999-4541-ae3a-382d3eb160bd.png)


### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6429)
<!-- Reviewable:end -->
