### PR TITLE
Fix a typo in Client.set_timeout() documentation

### DIFF
--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -588,7 +588,7 @@ When used, the time speed of the reenacted simulation is modified at will. It ca
     - **Parameters:**
         - `time_factor` (_float_) - 1.0 means normal time speed. Greater than 1.0 means fast motion (2.0 would be double speed) and lesser means slow motion (0.5 would be half speed).  
 - <a name="carla.Client.set_timeout"></a>**<font color="#7fb800">set_timeout</font>**(<font color="#00a6ed">**self**</font>, <font color="#00a6ed">**seconds**</font>)  
-Sets the maxixum time a network call is allowed before blocking it and raising a timeout exceeded error.  
+Sets the maximum time a network call is allowed before blocking it and raising a timeout exceeded error.  
     - **Parameters:**
         - `seconds` (_float<small> - seconds</small>_) - New timeout value. Default is 5 seconds.  
 

--- a/PythonAPI/docs/client.yml
+++ b/PythonAPI/docs/client.yml
@@ -297,7 +297,7 @@
         doc: >
           New timeout value. Default is 5 seconds.
       doc: >
-        Sets the maxixum time a network call is allowed before blocking it and raising a timeout exceeded error.
+        Sets the maximum time a network call is allowed before blocking it and raising a timeout exceeded error.
      # --------------------------------------
     - def_name: set_replayer_ignore_hero
       params:


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

A typo with the word `maximum`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6440)
<!-- Reviewable:end -->
