### PR TITLE
Fixed tagged component ticks

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.cpp
@@ -18,6 +18,7 @@ UTaggedComponent::UTaggedComponent(const FObjectInitializer& ObjectInitializer) 
 
   TaggedMaterial = TaggedMaterialObject.Object;
   PrimaryComponentTick.bCanEverTick = true;
+  PrimaryComponentTick.bStartWithTickEnabled = false;
 }
 
 void UTaggedComponent::OnRegister()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.cpp
@@ -214,6 +214,7 @@ void ATagger::TagActor(const AActor &Actor, bool bTagForSemanticSegmentation)
 
     TaggedComponent->SetColor(Color);
     TaggedComponent->MarkRenderStateDirty();
+    TaggedComponent->SetComponentTickEnabled(true);
 
   }
 }


### PR DESCRIPTION
#### Description

This PR enables the ticks of the UTaggedComponent to those representing skeletal meshes. This should improve performace on maps with many static actors.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20
  * **Python version(s):** 3
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Instance semantic segmentation should be tested after this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6443)
<!-- Reviewable:end -->
