### PR TITLE
Adding a new function that loads a map only if it is different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Add keyword arguments for `carla.TrafficManager` Python API functions
   * Fixed bug causing the `FPixelReader::SavePixelsToDisk(PixelData, FilePath)` function to crash due to pixel array not set correctly.
   * Collisions detected by the CollisionSensor no longer generate more than one event per frame.
+  * Added API function to load a map only if it is different from the current one.
 
 ## CARLA 0.9.14
 

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -92,9 +92,7 @@ namespace client {
       std::string map_name_with_prefix = map_name_prefix + map_name;
       if(!(map_name_without_prefix == current_map_name) && !(map_name_with_prefix == current_map_name)){
         World World{_simulator->LoadEpisode(std::move(map_name), reset_settings, map_layers)};
-      }else{
-
-      }
+      }else{}
     }
     
     World GenerateOpenDriveWorld(

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -96,26 +96,6 @@ namespace client {
 
       }
     }
-
-/*
-    bool LoadWorldIfDifferent(
-        std::string map_name,
-        bool reset_settings = true,
-        rpc::MapLayer map_layers = rpc::MapLayer::All) const {
-        carla::client::World world = GetWorld();
-        carla::SharedPtr<carla::client::Map> current_map = world.GetMap();
-        std::string current_map_name = current_map->GetName();
-        std::string name_prefix = "Carla/Maps/";
-        std::string final_name = name_prefix + current_map_name;
-        if(!(current_map_name == map_name)){
-          World world = LoadWorld(map_name,reset_settings,map_layers);
-          return true;
-        }
-        else
-          return false;
-    }
-*/  
-
     
     World GenerateOpenDriveWorld(
         std::string opendrive,

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -8,6 +8,7 @@
 
 #include "carla/client/detail/Simulator.h"
 #include "carla/client/World.h"
+#include "carla/client/Map.h"
 #include "carla/PythonUtil.h"
 #include "carla/trafficmanager/TrafficManager.h"
 
@@ -77,6 +78,45 @@ namespace client {
       return World{_simulator->LoadEpisode(std::move(map_name), reset_settings, map_layers)};
     }
 
+    /// Return (and load) a new world (map) only when the requested map is different from the current one
+
+    void LoadWorldIfDifferent(
+        std::string map_name,
+        bool reset_settings = true,
+        rpc::MapLayer map_layers = rpc::MapLayer::All) const {
+      carla::client::World world = GetWorld();
+      carla::SharedPtr<carla::client::Map> current_map = world.GetMap();
+      std::string current_map_name = current_map->GetName();
+      std::string map_name_prefix = "Carla/Maps/";
+      std::string map_name_without_prefix = map_name;
+      std::string map_name_with_prefix = map_name_prefix + map_name;
+      if(!(map_name_without_prefix == current_map_name) && !(map_name_with_prefix == current_map_name)){
+        World World{_simulator->LoadEpisode(std::move(map_name), reset_settings, map_layers)};
+      }else{
+
+      }
+    }
+
+/*
+    bool LoadWorldIfDifferent(
+        std::string map_name,
+        bool reset_settings = true,
+        rpc::MapLayer map_layers = rpc::MapLayer::All) const {
+        carla::client::World world = GetWorld();
+        carla::SharedPtr<carla::client::Map> current_map = world.GetMap();
+        std::string current_map_name = current_map->GetName();
+        std::string name_prefix = "Carla/Maps/";
+        std::string final_name = name_prefix + current_map_name;
+        if(!(current_map_name == map_name)){
+          World world = LoadWorld(map_name,reset_settings,map_layers);
+          return true;
+        }
+        else
+          return false;
+    }
+*/  
+
+    
     World GenerateOpenDriveWorld(
         std::string opendrive,
         const rpc::OpendriveGenerationParameters & params,

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -198,6 +198,7 @@ void export_client() {
     .def("request_file", &cc::Client::RequestFile, (arg("name")))
     .def("reload_world", CONST_CALL_WITHOUT_GIL_1(cc::Client, ReloadWorld, bool), (arg("reset_settings")=true))
     .def("load_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, LoadWorld, std::string, bool, rpc::MapLayer), (arg("map_name"), arg("reset_settings")=true, arg("map_layers")=rpc::MapLayer::All))
+    .def("load_world_if_different", &cc::Client::LoadWorldIfDifferent, (arg("map_name"), arg("reset_settings")=true, arg("map_layers")=rpc::MapLayer::All))
     .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, GenerateOpenDriveWorld, std::string,
         rpc::OpendriveGenerationParameters, bool), (arg("opendrive"), arg("parameters")=rpc::OpendriveGenerationParameters(),
         arg("reset_settings")=true))

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
@@ -420,37 +420,43 @@ void FFrameData::AddVehicleWheelsAnimation(FCarlaActor *CarlaActor)
     return;
   if (CarlaActor->GetActorType() != FCarlaActor::ActorType::Vehicle)
     return;
-
   ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(CarlaActor->GetActor());
-  if (CarlaVehicle == nullptr)
-    return;
-
+  check(CarlaVehicle != nullptr)
   USkeletalMeshComponent* SkeletalMesh = CarlaVehicle->GetMesh();
-  if (SkeletalMesh == nullptr)
-    return;
-
+  check(SkeletalMesh != nullptr)
   UVehicleAnimInstance* VehicleAnim = Cast<UVehicleAnimInstance>(SkeletalMesh->GetAnimInstance());
-  if (VehicleAnim == nullptr)
-    return;
-
+  check(VehicleAnim != nullptr)
   const UWheeledVehicleMovementComponent* WheeledVehicleMovementComponent = VehicleAnim->GetWheeledVehicleMovementComponent();
-  if (WheeledVehicleMovementComponent == nullptr)
-    return;
+  check(WheeledVehicleMovementComponent != nullptr)
 
   CarlaRecorderAnimWheels Record;
   Record.DatabaseId = CarlaActor->GetActorId();
-  Record.WheelValues.reserve(WheeledVehicleMovementComponent->Wheels.Num());
 
-  uint8 i = 0;
-  for (auto Wheel : WheeledVehicleMovementComponent->Wheels)
-  {
-    WheelInfo Info;
-    Info.Location = static_cast<EVehicleWheelLocation>(i);
-    Info.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(Info.Location);
-    Info.TireRotation = Wheel->GetRotationAngle();
-    Record.WheelValues.push_back(Info);
-    ++i;
-  }
+  WheelInfo FL;
+  FL.Location = EVehicleWheelLocation::FL_Wheel;
+  FL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FL.Location);
+  FL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FL.Location)]->GetRotationAngle();
+
+  WheelInfo FR;
+  FR.Location = EVehicleWheelLocation::FR_Wheel;
+  FR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FR.Location);
+  FR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FR.Location)]->GetRotationAngle();
+
+  WheelInfo BL;
+  BL.Location = EVehicleWheelLocation::BL_Wheel;
+  BL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BL.Location);
+  BL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BL.Location)]->GetRotationAngle();
+
+  WheelInfo BR;
+  BR.Location = EVehicleWheelLocation::BR_Wheel;
+  BR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BR.Location);
+  BR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BR.Location)]->GetRotationAngle();
+
+  Record.WheelValues.reserve(4);
+  Record.WheelValues.push_back(FL);
+  Record.WheelValues.push_back(FR);
+  Record.WheelValues.push_back(BL);
+  Record.WheelValues.push_back(BR);
 
   AddAnimVehicleWheels(Record);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
@@ -420,43 +420,37 @@ void FFrameData::AddVehicleWheelsAnimation(FCarlaActor *CarlaActor)
     return;
   if (CarlaActor->GetActorType() != FCarlaActor::ActorType::Vehicle)
     return;
+
   ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(CarlaActor->GetActor());
-  check(CarlaVehicle != nullptr)
+  if (CarlaVehicle == nullptr)
+    return;
+
   USkeletalMeshComponent* SkeletalMesh = CarlaVehicle->GetMesh();
-  check(SkeletalMesh != nullptr)
+  if (SkeletalMesh == nullptr)
+    return;
+
   UVehicleAnimInstance* VehicleAnim = Cast<UVehicleAnimInstance>(SkeletalMesh->GetAnimInstance());
-  check(VehicleAnim != nullptr)
+  if (VehicleAnim == nullptr)
+    return;
+
   const UWheeledVehicleMovementComponent* WheeledVehicleMovementComponent = VehicleAnim->GetWheeledVehicleMovementComponent();
-  check(WheeledVehicleMovementComponent != nullptr)
+  if (WheeledVehicleMovementComponent == nullptr)
+    return;
 
   CarlaRecorderAnimWheels Record;
   Record.DatabaseId = CarlaActor->GetActorId();
+  Record.WheelValues.reserve(WheeledVehicleMovementComponent->Wheels.Num());
 
-  WheelInfo FL;
-  FL.Location = EVehicleWheelLocation::FL_Wheel;
-  FL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FL.Location);
-  FL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FL.Location)]->GetRotationAngle();
-
-  WheelInfo FR;
-  FR.Location = EVehicleWheelLocation::FR_Wheel;
-  FR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FR.Location);
-  FR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FR.Location)]->GetRotationAngle();
-
-  WheelInfo BL;
-  BL.Location = EVehicleWheelLocation::BL_Wheel;
-  BL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BL.Location);
-  BL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BL.Location)]->GetRotationAngle();
-
-  WheelInfo BR;
-  BR.Location = EVehicleWheelLocation::BR_Wheel;
-  BR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BR.Location);
-  BR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BR.Location)]->GetRotationAngle();
-
-  Record.WheelValues.reserve(4);
-  Record.WheelValues.push_back(FL);
-  Record.WheelValues.push_back(FR);
-  Record.WheelValues.push_back(BL);
-  Record.WheelValues.push_back(BR);
+  uint8 i = 0;
+  for (auto Wheel : WheeledVehicleMovementComponent->Wheels)
+  {
+    WheelInfo Info;
+    Info.Location = static_cast<EVehicleWheelLocation>(i);
+    Info.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(Info.Location);
+    Info.TireRotation = Wheel->GetRotationAngle();
+    Record.WheelValues.push_back(Info);
+    ++i;
+  }
 
   AddAnimVehicleWheels(Record);
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ x ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ x ] Code compiles correctly
  - [ x ] All tests passing with `make check` (only Linux)
  - [ x ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

A new function called load_world_if_different("map_name") has been added in /carla/PythonAPI/carla/source/libcarla/Client.cpp and /carla/LibCarla/source/carla/client/Client.h. This function loads a map only if the requested map is different from the current map and does nothing if the maps are the same.

By adding this new function, to be used from the PythonAPI, a user can load a map avoiding the reset of the session that occurs when loading a map that is the same as the one currently running (as happens with the function load_world). 

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04.6 LTS
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6651)
<!-- Reviewable:end -->
