### PR TITLE
Fixing replayer crash when running in multi gpu mode

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/FrameData.cpp
@@ -420,43 +420,37 @@ void FFrameData::AddVehicleWheelsAnimation(FCarlaActor *CarlaActor)
     return;
   if (CarlaActor->GetActorType() != FCarlaActor::ActorType::Vehicle)
     return;
+
   ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(CarlaActor->GetActor());
-  check(CarlaVehicle != nullptr)
+  if (CarlaVehicle == nullptr)
+    return;
+
   USkeletalMeshComponent* SkeletalMesh = CarlaVehicle->GetMesh();
-  check(SkeletalMesh != nullptr)
+  if (SkeletalMesh == nullptr)
+    return;
+
   UVehicleAnimInstance* VehicleAnim = Cast<UVehicleAnimInstance>(SkeletalMesh->GetAnimInstance());
-  check(VehicleAnim != nullptr)
+  if (VehicleAnim == nullptr)
+    return;
+
   const UWheeledVehicleMovementComponent* WheeledVehicleMovementComponent = VehicleAnim->GetWheeledVehicleMovementComponent();
-  check(WheeledVehicleMovementComponent != nullptr)
+  if (WheeledVehicleMovementComponent == nullptr)
+    return;
 
   CarlaRecorderAnimWheels Record;
   Record.DatabaseId = CarlaActor->GetActorId();
+  Record.WheelValues.reserve(WheeledVehicleMovementComponent->Wheels.Num());
 
-  WheelInfo FL;
-  FL.Location = EVehicleWheelLocation::FL_Wheel;
-  FL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FL.Location);
-  FL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FL.Location)]->GetRotationAngle();
-
-  WheelInfo FR;
-  FR.Location = EVehicleWheelLocation::FR_Wheel;
-  FR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(FR.Location);
-  FR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(FR.Location)]->GetRotationAngle();
-
-  WheelInfo BL;
-  BL.Location = EVehicleWheelLocation::BL_Wheel;
-  BL.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BL.Location);
-  BL.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BL.Location)]->GetRotationAngle();
-
-  WheelInfo BR;
-  BR.Location = EVehicleWheelLocation::BR_Wheel;
-  BR.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(BR.Location);
-  BR.TireRotation = WheeledVehicleMovementComponent->Wheels[static_cast<uint8>(BR.Location)]->GetRotationAngle();
-
-  Record.WheelValues.reserve(4);
-  Record.WheelValues.push_back(FL);
-  Record.WheelValues.push_back(FR);
-  Record.WheelValues.push_back(BL);
-  Record.WheelValues.push_back(BR);
+  uint8 i = 0;
+  for (auto Wheel : WheeledVehicleMovementComponent->Wheels)
+  {
+    WheelInfo Info;
+    Info.Location = static_cast<EVehicleWheelLocation>(i);
+    Info.SteeringAngle = CarlaVehicle->GetWheelSteerAngle(Info.Location);
+    Info.TireRotation = Wheel->GetRotationAngle();
+    Record.WheelValues.push_back(Info);
+    ++i;
+  }
 
   AddAnimVehicleWheels(Record);
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ x] Extended the README / documentation, if necessary
  - [ x] Code compiles correctly
  - [ x] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

When running Carla in multi gpu mode, a bug occurred when requesting the replayer to play a simulation. The code that caused this error has been updated in the AddVehicleWheelsAnimation function of the FrameData.cpp file, and the error has now been resolved.



Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6689)
<!-- Reviewable:end -->
