### PR TITLE
Remove duplicated instance variable `is_junction`

### DIFF
--- a/Docs/python_api.md
+++ b/Docs/python_api.md
@@ -3301,15 +3301,13 @@ OpenDRIVE road's id.
 - <a name="carla.Waypoint.section_id"></a>**<font color="#f8805a">section_id</font>** (_int_)  
 OpenDRIVE section's id, based on the order that they are originally defined.  
 - <a name="carla.Waypoint.is_junction"></a>**<font color="#f8805a">is_junction</font>** (_bool_)  
-True if the current Waypoint is on a junction as defined by OpenDRIVE.  
+<b>True</b> if the current Waypoint is on a junction as defined by OpenDRIVE.  
 - <a name="carla.Waypoint.junction_id"></a>**<font color="#f8805a">junction_id</font>** (_int_)  
 OpenDRIVE junction's id. For more information refer to OpenDRIVE [documentation](http://www.opendrive.org/docs/OpenDRIVEFormatSpecRev1.4H.pdf#page=20).  
 - <a name="carla.Waypoint.lane_id"></a>**<font color="#f8805a">lane_id</font>** (_int_)  
 OpenDRIVE lane's id, this value can be positive or negative which represents the direction of the current lane with respect to the road. For more information refer to OpenDRIVE [documentation](http://www.opendrive.org/docs/OpenDRIVEFormatSpecRev1.4H.pdf#page=20).  
 - <a name="carla.Waypoint.s"></a>**<font color="#f8805a">s</font>** (_float_)  
 OpenDRIVE <b>s</b> value of the current position.  
-- <a name="carla.Waypoint.is_junction"></a>**<font color="#f8805a">is_junction</font>** (_bool_)  
-<b>True</b> if the current Waypoint is on a junction as defined by OpenDRIVE.  
 - <a name="carla.Waypoint.lane_width"></a>**<font color="#f8805a">lane_width</font>** (_float_)  
 Horizontal size of the road at current <b>s</b>.  
 - <a name="carla.Waypoint.lane_change"></a>**<font color="#f8805a">lane_change</font>** (_[carla.LaneChange](#carla.LaneChange)_)  

--- a/PythonAPI/docs/map.yml
+++ b/PythonAPI/docs/map.yml
@@ -338,7 +338,7 @@
     - var_name: is_junction
       type: bool
       doc: >
-        True if the current Waypoint is on a junction as defined by OpenDRIVE.
+        <b>True</b> if the current Waypoint is on a junction as defined by OpenDRIVE.
     - var_name: junction_id
       type: int
       doc: >
@@ -352,10 +352,6 @@
       param_units: meters
       doc: >
         OpenDRIVE <b>s</b> value of the current position.
-    - var_name: is_junction
-      type: bool
-      doc: >
-        <b>True</b> if the current Waypoint is on a junction as defined by OpenDRIVE.
     - var_name: lane_width
       type: float
       param_units: meters


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Hi team, this pr is minor I think, but can be important for better documentation.

While I was reading the python api documentations, I just found a duplicated instance variable is written.
You may see the image below contains two `is_junction`s.

![image](https://github.com/carla-simulator/carla/assets/50267797/1fbb4c3f-7f10-4ecb-926e-4fb89393edcf)


#### Where has this been tested?

I just updated a document for python api.

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6702)
<!-- Reviewable:end -->
