### PR TITLE
PythonAPI: Fix segfaults due to incorrect GIL locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Add keyword arguments for `carla.TrafficManager` Python API functions
   * Fixed bug causing the `FPixelReader::SavePixelsToDisk(PixelData, FilePath)` function to crash due to pixel array not set correctly.
   * Collisions detected by the CollisionSensor no longer generate more than one event per frame.
+  * Fixed crash in GetAvailableMaps (Python API) with Python 3.10.
 
 ## CARLA 0.9.14
 

--- a/PythonAPI/carla/source/libcarla/Client.cpp
+++ b/PythonAPI/carla/source/libcarla/Client.cpp
@@ -22,9 +22,13 @@ static void SetTimeout(carla::client::Client &client, double seconds) {
 }
 
 static auto GetAvailableMaps(const carla::client::Client &self) {
-  carla::PythonUtil::ReleaseGIL unlock;
   boost::python::list result;
-  for (const auto &str : self.GetAvailableMaps()) {
+  std::vector<std::string> maps;
+  {
+    carla::PythonUtil::ReleaseGIL unlock;
+    maps = self.GetAvailableMaps();
+  }
+  for (const auto &str : maps) {
     result.append(str);
   }
   return result;

--- a/PythonAPI/carla/source/libcarla/libcarla.cpp
+++ b/PythonAPI/carla/source/libcarla/libcarla.cpp
@@ -139,8 +139,8 @@ std::vector<T> PythonLitstToVector(boost::python::list &input) {
     }
 
 #define CALL_RETURNING_OPTIONAL_WITHOUT_GIL(cls, fn) +[](const cls &self) { \
-      carla::PythonUtil::ReleaseGIL unlock; \
-      auto optional = self.fn(); \
+      auto call = CONST_CALL_WITHOUT_GIL(cls, fn); \
+      auto optional = call(self); \
       return optional.has_value() ? boost::python::object(*optional) : boost::python::object(); \
     }
 


### PR DESCRIPTION
When using CARLA with Python 3.10, I'm getting a segfault in GetAvailableMaps. The problem disappears when PyList manipulation does not happen with GIL unlocked, as done in this commit.

The initial part of crash backtrace (from GDB) is below:

    Program terminated with signal SIGSEGV, Segmentation fault.

    warning: Section `.reg-xstate/49253' in core file too small.
    #0  _PyInterpreterState_GET () at ./Include/internal/pycore_pystate.h:117
    117	   return tstate->interp;
    [Current thread is 1 (Thread 0x7fe6fe48f740 (LWP 49253))]
    (gdb) bt
    #0  _PyInterpreterState_GET () at ./Include/internal/pycore_pystate.h:117
    #1  get_list_state () at Objects/listobject.c:26
    #2  PyList_New (size=0) at Objects/listobject.c:159
    #3  0x00007fe6fdc0dab0 in boost::python::detail::list_base::list_base() () from /nix/store/c95f3nrkz3sflvycihyw1c8q4nk47p4m-boost-1.79.0/lib/libboost_python310.so.1.79.0
    #4  0x00007fe6ef9ecfc4 in boost::python::list::list (this=0x7ffd8a8aae28) at include/boost/python/list.hpp:61
    #5  GetAvailableMaps (self=...) at source/libcarla/Client.cpp:26
    #6  0x00007fe6efb6a8fe in boost::python::detail::invoke<boost::python::to_python_value<boost::python::list const&>, boost::python::list (*)(carla::client::Client const&), boost::python::arg_from_python<carla::client::Client const&> > (rc=..., f=<optimized out>, ac0=...)
        at include/boost/python/detail/invoke.hpp:73
    #7  boost::python::detail::caller_arity<1u>::impl<boost::python::list (*)(carla::client::Client const&), boost::python::default_call_policies, boost::mpl::vector2<boost::python::list, carla::client::Client const&> >::operator() (args_=<optimized out>, this=<optimized out>)
        at include/boost/python/detail/caller.hpp:233
    #8  boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::python::list (*)(carla::client::Client const&), boost::python::default_call_policies, boost::mpl::vector2<boost::python::list, carla::client::Client const&> > >::operator() (
        this=<optimized out>, args=<optimized out>, kw=<optimized out>) at include/boost/python/object/py_function.hpp:38
    #9  0x00007fe6fdc1b4dd in boost::python::objects::function::call(_object*, _object*) const () from /nix/store/c95f3nrkz3sflvycihyw1c8q4nk47p4m-boost-1.79.0/lib/libboost_python310.so.1.79.0
    #10 0x00007fe6fdc1b6a8 in boost::detail::function::void_function_ref_invoker0<boost::python::objects::(anonymous namespace)::bind_return, void>::invoke(boost::detail::function::function_buffer&) ()
       from /nix/store/c95f3nrkz3sflvycihyw1c8q4nk47p4m-boost-1.79.0/lib/libboost_python310.so.1.79.0
    ...

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** default in 0.9.14

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6718)
<!-- Reviewable:end -->
