### PR TITLE
Add VS2022 and Ninja build support for Libcarla and OSM2ODR on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest
 
+  * Added build support for VS2022 and Ninja for LibCarla and osm2odr on Windows
   * Fixed bug causing the TM's unstuck logic to incorrectly remove the vehicles in some situations.
   * Fixed the extra data in Directx textures, so we need to copy row by row on Windows to remove extra bytes on images
   * Fixed sensors to check for the stream to be ready (race condition)

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -81,6 +81,9 @@ Get the 2019 version of Visual Studio from [here](https://developerinsider.co/do
 !!! Important
     Other Visual Studio versions may cause conflict. Even if these have been uninstalled, some registers may persist. To completely clean Visual Studio from the computer, go to `Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\layout` and run `.\InstallCleanup.exe -full`  
 
+!!! Note
+    It is also possible to use Visual Studio 2022 using the above steps and substituting the Windows 8.1 SDK for the Windows 11/10 SDK. To override the default Visual Studio 2019 Generator in CMake, specify GENERATOR="Visual Studio 17 2022" when using the makefile commands (see [table](build_windows.md#other-make-commands)). You may specify any generator that works with the build commands as specific in the build scripts, for a full list run `cmake -G` (Ninja has been tested to work for building LibCarla so far).
+
 ##### Unreal Engine
 
 Starting with version 0.9.12, CARLA uses a modified fork of Unreal Engine 4.26. This fork contains patches specific to CARLA.

--- a/Util/BuildTools/BuildOSM2ODR.bat
+++ b/Util/BuildTools/BuildOSM2ODR.bat
@@ -39,6 +39,10 @@ if not "%1"=="" (
     if "%1"=="--clean" (
         set REMOVE_INTERMEDIATE=true
     )
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     if "%1"=="-h" (
         echo %DOC_STRING%
         echo %USAGE_STRING%
@@ -72,6 +76,8 @@ set OSM2ODR_INSTALL_PATH=%ROOT_PATH:/=\%PythonAPI\carla\dependencies\
 set OSM2ODR__SERVER_INSTALL_PATH=%ROOT_PATH:/=\%Unreal\CarlaUE4\Plugins\Carla\CarlaDependencies
 set CARLA_DEPENDENCIES_FOLDER=%ROOT_PATH:/=\%Unreal\CarlaUE4\Plugins\Carla\CarlaDependencies\
 
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+
 if %REMOVE_INTERMEDIATE% == true (
     rem Remove directories
     for %%G in (
@@ -97,7 +103,13 @@ if %BUILD_OSM2ODR% == true (
     if not exist "%OSM2ODR_VSPROJECT_PATH%" mkdir "%OSM2ODR_VSPROJECT_PATH%"
     cd "%OSM2ODR_VSPROJECT_PATH%"
 
-    cmake -G "Visual Studio 16 2019" -A x64^
+    echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+        set PLATFORM=-A x64
+    ) || (
+        set PLATFORM=
+    )
+
+    cmake -G %GENERATOR% %PLATFORM%^
         -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
         -DCMAKE_INSTALL_PREFIX="%OSM2ODR_INSTALL_PATH:\=/%"^
         -DPROJ_INCLUDE_DIR=%INSTALLATION_DIR:/=\%\proj-install\include^
@@ -134,7 +146,7 @@ rem ============================================================================
 
 :error_install
     echo.
-    echo %FILE_N% [ERROR] An error ocurred while installing using Visual Studio 16 2019 Win64.
+    echo %FILE_N% [ERROR] An error ocurred while installing using %GENERATOR% Win64.
     echo           [ERROR] Possible causes:
     echo           [ERROR]  - Make sure you have Visual Studio installed.
     echo           [ERROR]  - Make sure you have the "x64 Visual C++ Toolset" in your path.

--- a/Util/BuildTools/Setup.bat
+++ b/Util/BuildTools/Setup.bat
@@ -44,18 +44,24 @@ if not "%1"=="" (
     if "%1"=="--chrono" (
         set USE_CHRONO=true
     )
+    if "%1" == "--generator" (
+        set GENERATOR=%2
+        shift
+    )
     if "%1"=="-h" (
         goto help
     )
     if "%1"=="--help" (
         goto help
     )
+    
     shift
     goto :arg-parse
 )
 
 rem If not defined, use Visual Studio 2019 as tool set
 if "%TOOLSET%" == "" set TOOLSET=msvc-14.2
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If is not set, set the number of parallel jobs to the number of CPU threads
 if "%NUMBER_OF_ASYNC_JOBS%" == "" set NUMBER_OF_ASYNC_JOBS=%NUMBER_OF_PROCESSORS%
@@ -68,6 +74,7 @@ set INSTALLATION_DIR=%INSTALLATION_DIR:/=\%
 
 echo %FILE_N% Asynchronous jobs:  %NUMBER_OF_ASYNC_JOBS%
 echo %FILE_N% Boost toolset:      %TOOLSET%
+echo %FILE_N% Generator:          %GENERATOR%
 echo %FILE_N% Install directory:  "%INSTALLATION_DIR%"
 
 if not exist "%CONTENT_DIR%" (
@@ -121,7 +128,8 @@ rem ============================================================================
 
 echo %FILE_N% Installing rpclib...
 call "%INSTALLERS_DIR%install_rpclib.bat"^
- --build-dir "%INSTALLATION_DIR%"
+ --build-dir "%INSTALLATION_DIR%"^
+ --generator %GENERATOR%
 
 if %errorlevel% neq 0 goto failed
 
@@ -136,7 +144,8 @@ rem ============================================================================
 
 echo %FILE_N% Installing Google Test...
 call "%INSTALLERS_DIR%install_gtest.bat"^
- --build-dir "%INSTALLATION_DIR%"
+ --build-dir "%INSTALLATION_DIR%"^
+ --generator %GENERATOR%
 
 if %errorlevel% neq 0 goto failed
 
@@ -152,7 +161,8 @@ rem ============================================================================
 
 echo %FILE_N% Installing "Recast & Detour"...
 call "%INSTALLERS_DIR%install_recast.bat"^
- --build-dir "%INSTALLATION_DIR%"
+ --build-dir "%INSTALLATION_DIR%"^
+ --generator %GENERATOR%
 
 if %errorlevel% neq 0 goto failed
 
@@ -188,7 +198,8 @@ rem ============================================================================
 
 echo %FILE_N% Installing Xercesc...
 call "%INSTALLERS_DIR%install_xercesc.bat"^
- --build-dir "%INSTALLATION_DIR%"
+ --build-dir "%INSTALLATION_DIR%"^
+ --generator %GENERATOR%
 copy %INSTALLATION_DIR%\xerces-c-3.2.3-install\lib\xerces-c_3.lib %CARLA_PYTHON_DEPENDENCIES%\lib
 copy %INSTALLATION_DIR%\xerces-c-3.2.3-install\lib\xerces-c_3.lib %CARLA_DEPENDENCIES_FOLDER%\lib
 
@@ -207,7 +218,8 @@ rem ============================================================================
 
 echo %FILE_N% Installing PROJ
 call "%INSTALLERS_DIR%install_proj.bat"^
- --build-dir "%INSTALLATION_DIR%"
+ --build-dir "%INSTALLATION_DIR%"^
+ --generator %GENERATOR%
 copy %INSTALLATION_DIR%\proj-install\lib\proj.lib %CARLA_PYTHON_DEPENDENCIES%\lib
 copy %INSTALLATION_DIR%\proj-install\lib\proj.lib %CARLA_DEPENDENCIES_FOLDER%\lib
 
@@ -227,7 +239,8 @@ rem ============================================================================
 if %USE_CHRONO% == true (
     echo %FILE_N% Installing Chrono...
     call "%INSTALLERS_DIR%install_chrono.bat"^
-     --build-dir "%INSTALLATION_DIR%"
+     --build-dir "%INSTALLATION_DIR%" ^
+     --generator %GENERATOR%
 
     if not exist "%CARLA_DEPENDENCIES_FOLDER%" (
         mkdir "%CARLA_DEPENDENCIES_FOLDER%"
@@ -349,6 +362,7 @@ rem ============================================================================
     echo                               Visual Studio 2015 -^> msvc-14.0
     echo                               Visual Studio 2017 -^> msvc-14.1
     echo                               Visual Studio 2019 -^> msvc-14.2 *
+    echo                               Visual Studio 2022 -^> msvc-14.3
     goto good_exit
 
 :error_cl

--- a/Util/BuildTools/Windows.mk
+++ b/Util/BuildTools/Windows.mk
@@ -62,17 +62,17 @@ PythonAPI: LibCarla osm2odr
 	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildPythonAPI.bat" --py3
 
 server: setup
-	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --server
+	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --server --generator "$(GENERATOR)"
 
 client: setup
-	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --client
+	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --client --generator "$(GENERATOR)"
 
 .PHONY: LibCarla
 LibCarla: setup
-	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --server --client
+	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildLibCarla.bat" --server --client --generator "$(GENERATOR)"
 
 setup:
-	@"${CARLA_BUILD_TOOLS_FOLDER}/Setup.bat" --boost-toolset msvc-14.2 $(ARGS)
+	@"${CARLA_BUILD_TOOLS_FOLDER}/Setup.bat" --boost-toolset msvc-14.2 --generator "$(GENERATOR)" $(ARGS)
 
 .PHONY: Plugins
 plugins:
@@ -82,7 +82,7 @@ deploy:
 	@"${CARLA_BUILD_TOOLS_FOLDER}/Deploy.bat" $(ARGS)
 
 osm2odr:
-	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.bat" --build $(ARGS)
+	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildOSM2ODR.bat" --generator "$(GENERATOR)" --build $(ARGS)
 
 osmrenderer:
 	@"${CARLA_BUILD_TOOLS_FOLDER}/BuildOSMRenderer.bat"

--- a/Util/InstallersWin/install_chrono.bat
+++ b/Util/InstallersWin/install_chrono.bat
@@ -27,6 +27,10 @@ if not "%1"=="" (
     if "%1"=="--help" (
         goto help
     )
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     shift
     goto :arg-parse
 )
@@ -34,6 +38,7 @@ if not "%1"=="" (
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem ============================================================================
 rem -- Get Eigen (Chrono dependency) -------------------------------------------
@@ -96,8 +101,14 @@ if not exist %CHRONO_INSTALL_DIR% (
 
     cd "%CHRONO_BUILD_DIR%"
 
+    echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+        set PLATFORM=-A x64
+    ) || (
+        set PLATFORM=
+    )
+
     echo %FILE_N% Compiling Chrono.
-    cmake -G "Visual Studio 16 2019" -A x64^
+    cmake -G %GENERATOR% %PLATFORM%^
         -DCMAKE_BUILD_TYPE=Release^
         -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
         -DEIGEN3_INCLUDE_DIR="%EIGEN_INCLUDE%"^

--- a/Util/InstallersWin/install_gtest.bat
+++ b/Util/InstallersWin/install_gtest.bat
@@ -23,14 +23,19 @@ if not "%1"=="" (
         set BUILD_DIR=%~dpn2
         shift
     )
-
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     if "%1"=="--delete-src" (
         set DEL_SRC=true
     )
-
+    
     shift
     goto :arg-parse
 )
+
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
@@ -64,7 +69,13 @@ if not exist "%GT_BUILD_DIR%" (
 cd "%GT_BUILD_DIR%"
 echo %FILE_N% Generating build...
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+    set PLATFORM=-A x64
+) || (
+    set PLATFORM=
+)
+
+cmake .. -G %GENERATOR% %PLATFORM%^
     -DCMAKE_BUILD_TYPE=Release^
     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
     -DCMAKE_INSTALL_PREFIX="%GT_INSTALL_DIR:\=/%"^
@@ -116,8 +127,8 @@ rem ============================================================================
 
 :error_install
     echo.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] An error ocurred while installing using Visual Studio 16 2019 Win64.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] Possible causes:
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] An error ocurred while installing using %GENERATOR% Win64.
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] Possible causes:
     echo %FILE_N%                - Make sure you have Visual Studio installed.
     echo %FILE_N%                - Make sure you have the "x64 Visual C++ Toolset" in your path.
     echo %FILE_N%                  For example using the "Visual Studio x64 Native Tools Command Prompt",

--- a/Util/InstallersWin/install_proj.bat
+++ b/Util/InstallersWin/install_proj.bat
@@ -27,9 +27,15 @@ if not "%1"=="" (
     if "%1"=="--help" (
         goto help
     )
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     shift
     goto :arg-parse
 )
+
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
@@ -73,7 +79,13 @@ move %BUILD_DIR%%PROJ_BASE_NAME% %PROJ_SRC_DIR%
 mkdir %PROJ_BUILD_DIR%
 cd %PROJ_BUILD_DIR%
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+    set PLATFORM=-A x64
+) || (
+    set PLATFORM=
+)
+
+cmake .. -G %GENERATOR% %PLATFORM%^
     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
     -DCMAKE_CXX_FLAGS="/MD /MP"^
     -DSQLITE3_INCLUDE_DIR=%SQLITE_INCLUDE_DIR% -DSQLITE3_LIBRARY=%SQLITE_LIB%^

--- a/Util/InstallersWin/install_recast.bat
+++ b/Util/InstallersWin/install_recast.bat
@@ -26,10 +26,15 @@ if not "%1"=="" (
     if "%1"=="--delete-src" (
         set DEL_SRC=true
     )
-
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     shift
     goto :arg-parse
 )
+
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
@@ -68,7 +73,13 @@ if not exist "%RECAST_BUILD_DIR%" (
 cd "%RECAST_BUILD_DIR%"
 echo %FILE_N% Generating build...
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+    set PLATFORM=-A x64
+) || (
+    set PLATFORM=
+)
+
+cmake .. -G %GENERATOR% %PLATFORM%^
     -DCMAKE_BUILD_TYPE=Release^
     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
     -DCMAKE_INSTALL_PREFIX="%RECAST_INSTALL_DIR:\=/%"^
@@ -120,8 +131,8 @@ rem ============================================================================
 
 :error_install
     echo.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] An error ocurred while installing using Visual Studio 16 2019 Win64.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] Possible causes:
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] An error ocurred while installing using %GENERATOR% Win64.
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] Possible causes:
     echo %FILE_N%                - Make sure you have Visual Studio installed.
     echo %FILE_N%                - Make sure you have the "x64 Visual C++ Toolset" in your path.
     echo %FILE_N%                  For example using the "Visual Studio x64 Native Tools Command Prompt",

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal 
 
 rem BAT script that downloads and installs a ready to use
 rem rpclib build for CARLA (carla.org).
@@ -19,18 +19,22 @@ set DEL_SRC=false
 
 :arg-parse
 if not "%1"=="" (
+
     if "%1"=="--build-dir" (
         set BUILD_DIR=%~dpn2
+    )
+    if "%1"=="--generator" (
+        set GENERATOR=%2
         shift
     )
-
     if "%1"=="--delete-src" (
         set DEL_SRC=true
     )
-
-    shift
+    shift  
     goto :arg-parse
 )
+
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
@@ -67,7 +71,14 @@ if not exist "%RPC_BUILD_DIR%" (
 cd "%RPC_BUILD_DIR%"
 echo %FILE_N% Generating build...
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+    set PLATFORM=-A x64
+) || (
+    set PLATFORM=
+)
+
+
+cmake .. -G %GENERATOR% %PLATFORM%^
         -DCMAKE_BUILD_TYPE=Release^
         -DRPCLIB_BUILD_EXAMPLES=OFF^
         -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
@@ -120,8 +131,8 @@ rem ============================================================================
 
 :error_install
     echo.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] An error ocurred while installing using Visual Studio 16 2019 Win64.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] Possible causes:
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] An error ocurred while installing using %GENERATOR% Win64.
+    echo %FILE_N% [%GENERATOR% Win64 ERROR] Possible causes:
     echo %FILE_N%                - Make sure you have Visual Studio installed.
     echo %FILE_N%                - Make sure you have the "x64 Visual C++ Toolset" in your path.
     echo %FILE_N%                  For example using the "Visual Studio x64 Native Tools Command Prompt",

--- a/Util/InstallersWin/install_xercesc.bat
+++ b/Util/InstallersWin/install_xercesc.bat
@@ -27,9 +27,15 @@ if not "%1"=="" (
     if "%1"=="--help" (
         goto help
     )
+    if "%1"=="--generator" (
+        set GENERATOR=%2
+        shift
+    )
     shift
     goto :arg-parse
 )
+
+if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
@@ -115,7 +121,13 @@ if not exist "%XERCESC_INSTALL_DIR%include" (
     mkdir "%XERCESC_INSTALL_DIR%include"
 )
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+echo.%GENERATOR% | findstr /C:"Visual Studio" >nul && (
+    set PLATFORM=-A x64
+) || (
+    set PLATFORM=
+)
+
+cmake .. -G %GENERATOR% %PLATFORM%^
   -DCMAKE_INSTALL_PREFIX="%XERCESC_INSTALL_DIR:\=/%"^
   -DBUILD_SHARED_LIBS=OFF^
   "%BUILD_DIR%%XERCESC_BASENAME%-%XERCESC_VERSION%-source"


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

The current Windows build system was hard-coded to only work with Visual Studio 2019. This change opens it up to using other visual studio versions and build systems such as Ninja which is already being used for the Linux build. Every build script has an extra "generator" flag that can override the default setting of Visual Studio 16 2019 which is still the default version used. Documentation has also been updated to reflect this. 

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** N/A

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I do not forsee any negative impacts since the default build method is still there (MSVC 2019), this change just makes it easier for others building libcarla to integrate it into their own cmake builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6778)
<!-- Reviewable:end -->
