### PR TITLE
Fix tm ending lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * Collisions detected by the CollisionSensor no longer generate more than one event per frame.
   * Fixed segfaults in Python API due to incorrect GIL locking under Python 3.10.
   * Added API function to load a map only if it is different from the current one.
+  * Fixed a bug in the TrafficManager causing vehicles that reached an ending lane to have abnormal behavior while lane changing.
 
 ## CARLA 0.9.14
 

--- a/LibCarla/source/carla/trafficmanager/Constants.h
+++ b/LibCarla/source/carla/trafficmanager/Constants.h
@@ -105,6 +105,7 @@ static const float MAX_WPT_RADIANS = 0.087f;  // 5º
 static float const DELTA = 25.0f;
 static float const Z_DELTA = 500.0f;
 static float const STRAIGHT_DEG = 19.0f;
+static const double MIN_LANE_WIDTH = 1.0f;
 } // namespace Map
 
 namespace TrafficLight {


### PR DESCRIPTION
### Description

This PR solves a bug that caused the TrafficManager to abnormally control vehicles that where reaching an ending lane, such as when a road changes from 2 to 1 lane.

This was causes by a misslinkage in the TM's InMemoryMap, linking lanes that have no next one with themselves.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

### Possible Drawbacks

None?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6885)
<!-- Reviewable:end -->
