### PR TITLE
Fix GenerateLaneMarksForCenterLine problem

### DIFF
--- a/LibCarla/source/carla/road/MeshFactory.cpp
+++ b/LibCarla/source/carla/road/MeshFactory.cpp
@@ -930,8 +930,23 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             std::pair<geom::Vector3D, geom::Vector3D> edges =
               lane.GetCornerPositions(s_current, road_param.extra_lane_width);
 
-            geom::Vector3D director = edges.second - edges.first;
-            director /= director.Length();
+            geom::Vector3D director;
+            if (lane.GetWidth(s_current) != 0) {
+              director = edges.second - edges.first;
+              director /= director.Length(); 
+            } else {
+              const std::map<road::LaneId, road::Lane> & lanes = lane_section.GetLanes();
+              for (const auto& lane_pair : lanes) {
+                if (lane_pair.second.GetWidth(s_current) != 0) {
+                  std::pair<geom::Vector3D, geom::Vector3D> another_edge =
+                    lane_pair.second.GetCornerPositions(s_current, road_param.extra_lane_width);
+                  director = another_edge.second - another_edge.first;
+                  director /= director.Length();
+                  break;
+                }
+              }
+            }
+
             geom::Vector3D endmarking = edges.first + director * lane_mark_info.width;
 
             out_mesh.AddVertex(edges.first);
@@ -944,8 +959,22 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
 
-            director = edges.second - edges.first;
-            director /= director.Length();
+            if (lane.GetWidth(s_current) != 0) {
+              director = edges.second - edges.first;
+              director /= director.Length(); 
+            } else {
+              const std::map<road::LaneId, road::Lane> & lanes = lane_section.GetLanes();
+              for (const auto& lane_pair : lanes) {
+                if (lane_pair.second.GetWidth(s_current) != 0) {
+                  std::pair<geom::Vector3D, geom::Vector3D> another_edge =
+                    lane_pair.second.GetCornerPositions(s_current, road_param.extra_lane_width);
+                  director = another_edge.second - another_edge.first;
+                  director /= director.Length(); 
+                  break;
+                }
+              }
+            }
+            
             endmarking = edges.first + director * lane_mark_info.width;
 
             out_mesh.AddVertex(edges.first);


### PR DESCRIPTION
<!--


Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

When generating lanemarks with the digital twin tool, for broken lane lines with lane type None, the length of the unit vector director is 0 because the lane width is 0, resulting in endmarking values of (-nan, -nan, -nan).
Here, first determine whether the lane width is 0. If it is not 0, follow the original logic. If it is 0, use the other lane in the same lane_section to obtain the unit vector director.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** Python 3.7.16
  * **Unreal Engine version(s):** 4.26-carla

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/6995)
<!-- Reviewable:end -->
