### PR TITLE
Update build doc to Python 3.8

### DIFF
--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -44,7 +44,7 @@ In this section you will find details of system requirements, minor and major so
 * [__Git__](https://git-scm.com/downloads) is a version control system to manage CARLA repositories.  
 * [__Make__](http://gnuwin32.sourceforge.net/packages/make.htm) generates the executables. It is necessary to use __Make version 3.81__, otherwise the build may fail. If you have multiple versions of Make installed, check that you are using version 3.81 in your PATH when building CARLA. You can check your default version of Make by running `make --version`.
 * [__7Zip__](https://www.7-zip.org/) is a file compression software. This is required for automatic decompression of asset files and prevents errors during build time due to large files being extracted incorrectly or partially.
-* [__Python3 x64__](https://www.python.org/downloads/) is the main scripting language in CARLA. Having a x32 version installed may cause conflict, so it is highly advisable to have it uninstalled.
+* [__Python3.8 x64__](https://www.python.org/downloads/) is the main scripting language in CARLA. Having a x32 version installed may cause conflict, so it is highly advisable to have it uninstalled.
 
 !!! Important
     Be sure that the above programs are added to the [environment path](https://www.java.com/en/download/help/path.xml). Remember that the path added should correspond to the progam's `bin` directory.  


### PR DESCRIPTION
#### Description

Update "build carla for windows" documentation to specify the recommended python version to 3.8.
With this change we prevent compilation issues due incompatible python version.
