### PR TITLE
Fix the failure memory order argument to atomic_compare_exchange_strong explicit

### DIFF
--- a/LibCarla/source/carla/AtomicSharedPtr.h
+++ b/LibCarla/source/carla/AtomicSharedPtr.h
@@ -42,7 +42,7 @@ namespace carla {
           expected,
           desired,
           std::memory_order_acq_rel,
-          std::memory_order_acq_rel);
+          std::memory_order_acquire);
     }
 
     AtomicSharedPtr &operator=(std::shared_ptr<T> ptr) noexcept {


### PR DESCRIPTION
The failure memory order cannot be release or acq_rel. Clang since llvm/llvm-project@fed5644 diagnoses an invalid argument.