### PR TITLE
Added the option to save SceneCapture images to disk on SensorSpawner.

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/SensorSpawnerActor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/SensorSpawnerActor.h
@@ -43,6 +43,8 @@ protected:
 	// Called when the game starts or when spawned.
 	virtual void BeginPlay() override;
 
+	virtual void Tick(float DeltaSeconds) override;
+
 	// Root
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Components")
 	USceneComponent* SceneComp;
@@ -67,6 +69,18 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Config")
 	FVector MinSpawnLocation {-120000.f, -110000.f, 9300.f};
 
+	// Enables that all SceneCaptures cameras save captures to /Saved/SensorSpawnerCaptures folder.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Config|SceneCapture")
+	bool bSaveCameraToDisk = false;
+
+	// How often ticking is done and a SceneCapture image is taken.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Config|SceneCapture")
+	float TickInterval = 1.f;
+
+	// Amount of time each camera takes captures.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta=(ClampMin=1.f), Category="Config|SceneCapture")
+	float CaptureTime = 30.f;
+	
 	
 private:
 	UFUNCTION()
@@ -74,13 +88,18 @@ private:
 
 	UFUNCTION()
 	void SpawnSensorsDelayed();
+
+	UFUNCTION()
+	void RemoveSceneCaptureCameras();
+
+	void StartSavingCapturesToDisk(const AActor* Actor);
 	
 	void GenerateSensorActorDescription(const FActorDefinition* Definition, FActorDescription& SensorDescription) const;
 
 	// Gets a transform with a random location between MaxSpawnLocation and MinSpawnLocation.
 	void GetRandomTransform(FTransform &Transform) const;
   
-	void SpawnSensorActor(const FActorDescription& SensorDescription) const;
+	void SpawnSensorActor(const FActorDescription& SensorDescription);
 
 	const FActorDefinition* GetActorDefinitionByClass(const TSubclassOf<AActor> ActorClass) const;
 
@@ -89,9 +108,15 @@ private:
 	UPROPERTY()
 	UCarlaEpisode* CarlaEpisode;
 
-	// Used for delayed spawn
+	// Used for delayed spawn.
 	FTimerHandle SpawnSensorsDelayedTimerHandle;
 	
-	// Used for delayed spawn
+	// Used for delayed spawn. Track cameras taking pictures on tick.
 	TArray<FSensorTuple> SensorsToSpawnCopy;
+	
+	// Track cameras saving pictures on tick.
+	TArray<const class ASceneCaptureCamera*> SceneCaptureCameras;
+	
+	// Path to the /Saved/SensorSpawnerCaptures project folder.
+	FString SaveImagePath;
 };


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

- If enabled in the SensorSpawnerActor configuration, spawned SceneCaptures will save images to disk.
- The images are to be saved in /Saved/SensorSpawnerCaptures folder.
- It is possible to modify the time SceneCaptureCameras are taking captures and how often they are taken.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows 11
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** UE 5.3

#### Possible Drawbacks

Not tested on Ubuntu.
