### PR TITLE
Windows build error: Fix uninitalized varaible error on windows build

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1297,7 +1297,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       TArray<UActorComponent*> Components;
       CarlaActor->GetActor()->GetComponents(Components);
 
-      USceneComponent* Component;
+      USceneComponent* Component = nullptr;
       for(auto Cmp : Components)
       {
         if(USceneComponent* SCMP = Cast<USceneComponent>(Cmp))
@@ -1341,7 +1341,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       TArray<UActorComponent*> Components;
       CarlaActor->GetActor()->GetComponents(Components);
 
-      USceneComponent* Component;
+      USceneComponent* Component = nullptr;
       for(auto Cmp : Components)
       {
         if(USceneComponent* SCMP = Cast<USceneComponent>(Cmp))


### PR DESCRIPTION
Fix windows build broken due uninitialized variable error.