### PR TITLE
BasicAgent.set_destination parameter `start_location` is unused - How to improve?. Further reducing location->waypoint conversion

### DIFF
--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -179,12 +179,10 @@ class BasicAgent(object):
         """
         Calculates the shortest route between a starting and ending waypoint.
 
-            :param start_waypoint (carla.Waypoint): initial waypoint
-            :param end_waypoint (carla.Waypoint): final waypoint
+            :param start_waypoint (carla.Waypoint | carla.Location): initial waypoint
+            :param end_waypoint (carla.Waypoint | carla.Location): final waypoint
         """
-        start_location = start_waypoint.transform.location
-        end_location = end_waypoint.transform.location
-        return self._global_planner.trace_route(start_location, end_location)
+        return self._global_planner.trace_route(start_waypoint, end_waypoint)
 
     def run_step(self):
         """Execute one step of navigation."""

--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -145,7 +145,7 @@ class BasicAgent(object):
         If no starting location is passed, the vehicle local planner's target location is chosen,
         which corresponds (by default), to a location about 5 meters in front of the vehicle.
 
-            :param end_location (carla.Location): final location of the route
+            :param end_location (carla.Location | carla.Waypoint): final location of the route
             :param start_location (carla.Location): starting location of the route
         """
         if not start_location:
@@ -156,7 +156,7 @@ class BasicAgent(object):
             clean_queue = False
 
         start_waypoint = self._map.get_waypoint(start_location)
-        end_waypoint = self._map.get_waypoint(end_location)
+        end_waypoint = self._map.get_waypoint(end_location) if isinstance(end_location, carla.Location) else end_location
 
         route_trace = self.trace_route(start_waypoint, end_waypoint)
         self._local_planner.set_global_plan(route_trace, clean_queue=clean_queue)

--- a/PythonAPI/carla/agents/navigation/global_route_planner.py
+++ b/PythonAPI/carla/agents/navigation/global_route_planner.py
@@ -45,8 +45,15 @@ class GlobalRoutePlanner(object):
         """
         route_trace = []
         route = self._path_search(origin, destination)
-        current_waypoint = self._wmap.get_waypoint(origin)
-        destination_waypoint = self._wmap.get_waypoint(destination)
+        if not isinstance(origin, carla.Waypoint):
+            current_waypoint = self._wmap.get_waypoint(origin)
+        else:
+            current_waypoint = origin
+        if not isinstance(destination, carla.Waypoint):
+            destination_waypoint = self._wmap.get_waypoint(destination)
+        else:
+            destination_waypoint = destination
+            destination = destination_waypoint.transform.location
 
         for i in range(len(route) - 1):
             road_option = self._turn_decision(i, route)
@@ -267,7 +274,10 @@ class GlobalRoutePlanner(object):
         This function finds the road segment that a given location
         is part of, returning the edge it belongs to
         """
-        waypoint = self._wmap.get_waypoint(location)
+        if isinstance(location, carla.Location):
+            waypoint = self._wmap.get_waypoint(location)
+        else:
+            waypoint = location
         edge = None
         try:
             edge = self._road_id_to_edge[waypoint.road_id][waypoint.section_id][waypoint.lane_id]


### PR DESCRIPTION
* [ ] `start_location` parameter is unused. Signature and/or function should be updated.
* [x] Allow location and waypoint inputs removing 2 of 4 location -> Waypoint calculations

---

First, the BasicAgent.py `set_destination` function has a parameter `start_location : Location` but is unused in the code and always overwritten. I had a slight suspicion that `bool(start_location)` is False if it is the origin but that is also not the case.
The `set_destination` function needs some overhaul. 

Questions to be answered should be what to do with the `start_location` argument.

1. Discard it by turning it into a bool?
2. Keep it and allow to overwrite one option. But then what do with the discarded one, as they seem useful?
     a.  discard one option completely
     b.  allow for three possibilities. How should then the function signature look like. `start_location : True | None | False | Location`?

---

Secondly, the workflow of BasicAgent.py `set_destination` has IMO some unnecessary location -> waypoint -> location -> waypoint transformations in the functions underneath.
I replaced them with checks that allow for both types (so keeping current code working).

Downside: Projection to Driving road is not done.



