### PR TITLE
Implement UE5 ROS2 native build with dynamic linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,8 +390,6 @@ endif ()
 
 
 
-
-
 if (BUILD_OSM_WORLD_RENDERER)
 
     project (OsmMapRenderer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ option (
     OFF)
 
 option (
+    BUILD_LIBCARLA_ROS2_NATIVE
+    "Enable LibCarla-ROS2-native."
+    OFF)
+
+option (
     BUILD_PYTHON_API
     "Build the CARLA Python API."
     ON)
@@ -73,6 +78,7 @@ set (CARLA_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
 if (NOT CARLA_DEPENDENCIES_PATH)
     set (CARLA_DEPENDENCIES_PATH ${CMAKE_CURRENT_BINARY_DIR}/Dependencies)
 endif ()
+set(CARLA_INSTALL_PATH ${CARLA_WORKSPACE_PATH}/Install)
 
 configure_file (
     ${CARLA_WORKSPACE_PATH}/.clangd.in
@@ -381,6 +387,57 @@ if (BUILD_LIBCARLA_CLIENT)
     endforeach ()
 
 endif ()
+
+
+
+if (BUILD_LIBCARLA_ROS2_NATIVE)
+    project (carla-ros2-native)
+
+    file (
+        GLOB
+        LIBCARLA_ROS2_SOURCES
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.cpp
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.cpp
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.cpp
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.cpp
+    )
+
+    file (
+        GLOB
+        LIBCARLA_ROS2_HEADERS
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.h
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.h
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.h
+        ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.h
+    )
+
+    add_library (
+        carla-ros2-native STATIC
+        ${LIBCARLA_ROS2_HEADERS}
+        ${LIBCARLA_ROS2_SOURCES}
+    )
+
+    target_include_directories (
+        carla-ros2-native PUBLIC
+        ${LIBCARLA_SOURCE_PATH}
+        ${CARLA_INSTALL_PATH}/fast-dds-install/include
+    )
+
+    target_compile_definitions (
+        carla-ros2-native PUBLIC
+        ${CARLA_COMMON_DEFINITIONS}
+        WITH_ROS2
+        #_GLIBCXX_USE_CXX11_ABI=0
+    )
+
+    install (TARGETS carla-ros2-native DESTINATION lib)
+
+    #foreach (HEADER ${LIBCARLA_SERVER_HEADERS})
+    #    cmake_path (GET HEADER PARENT_PATH HEADER_PARENT)
+    #    cmake_path (RELATIVE_PATH HEADER_PARENT BASE_DIRECTORY ${LIBCARLA_SOURCE_PATH}/carla OUTPUT_VARIABLE HEADER_RELATIVE)
+    #    install (FILES ${HEADER} DESTINATION include/carla/${HEADER_RELATIVE})
+    #endforeach ()
+endif()
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,55 +390,6 @@ endif ()
 
 
 
-if (BUILD_LIBCARLA_ROS2_NATIVE)
-    project (carla-ros2-native)
-
-    file (
-        GLOB
-        LIBCARLA_ROS2_SOURCES
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.cpp
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.cpp
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.cpp
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.cpp
-    )
-
-    file (
-        GLOB
-        LIBCARLA_ROS2_HEADERS
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.h
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.h
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.h
-        ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.h
-    )
-
-    add_library (
-        carla-ros2-native STATIC
-        ${LIBCARLA_ROS2_HEADERS}
-        ${LIBCARLA_ROS2_SOURCES}
-    )
-
-    target_include_directories (
-        carla-ros2-native PUBLIC
-        ${LIBCARLA_SOURCE_PATH}
-        ${CARLA_INSTALL_PATH}/fast-dds-install/include
-    )
-
-    target_compile_definitions (
-        carla-ros2-native PUBLIC
-        ${CARLA_COMMON_DEFINITIONS}
-        WITH_ROS2
-        #_GLIBCXX_USE_CXX11_ABI=0
-    )
-
-    install (TARGETS carla-ros2-native DESTINATION lib)
-
-    #foreach (HEADER ${LIBCARLA_SERVER_HEADERS})
-    #    cmake_path (GET HEADER PARENT_PATH HEADER_PARENT)
-    #    cmake_path (RELATIVE_PATH HEADER_PARENT BASE_DIRECTORY ${LIBCARLA_SOURCE_PATH}/carla OUTPUT_VARIABLE HEADER_RELATIVE)
-    #    install (FILES ${HEADER} DESTINATION include/carla/${HEADER_RELATIVE})
-    #endforeach ()
-endif()
-
 
 
 if (BUILD_OSM_WORLD_RENDERER)

--- a/Configure.py
+++ b/Configure.py
@@ -1311,7 +1311,6 @@ def BuildDependencies(task_graph : TaskGraph):
       FOONATHAN_MEMORY_VENDOR_SOURCE_PATH,
       FOONATHAN_MEMORY_VENDOR_BUILD_PATH,
       '-DBUILD_SHARED_LIBS=ON',
-      #'-DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"',
       install_path=FOONATHAN_MEMORY_VENDOR_INSTALL_PATH))
     task_graph.Add(Task.CreateCMakeConfigureGxxABI(
       'fast-cdr-configure',
@@ -1409,10 +1408,7 @@ def BuildDependencies(task_graph : TaskGraph):
       [],
       FAST_DDS_SOURCE_PATH,
       FAST_DDS_BUILD_PATH,
-      #'-DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"',
       '-DCMAKE_CXX_FLAGS=-latomic',
-      #'-DCMAKE_CXX_FLAGS=-I{BOOST_INCLUDE_PATH} -latomic',
-      #f'-DAsio_INCLUDE_DIR={BOOST_INCLUDE_PATH}/boost',
       f'-DTHIRDPARTY_Asio=FORCE',
       f'-DTHIRDPARTY_TinyXML2=FORCE',
       f'-DCMAKE_LIBRARY_PATH={FAST_CDR_INSTALL_PATH}',

--- a/LibCarla/cmake/ros2-native/CMakeLists.txt
+++ b/LibCarla/cmake/ros2-native/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required (VERSION 3.20.0)
+
+project (carla-ros2-native)
+
+set (CARLA_WORKSPACE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+set (LIBCARLA_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../source)
+
+file (
+    GLOB
+    LIBCARLA_ROS2_SOURCES
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.cpp
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.cpp
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.cpp
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.cpp
+)
+
+file (
+    GLOB
+    LIBCARLA_ROS2_HEADERS
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/publishers/*.h
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/subscribers/*.h
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/listeners/*.h
+    ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.h
+)
+
+add_library (
+    carla-ros2-native SHARED
+    ${LIBCARLA_ROS2_HEADERS}
+    ${LIBCARLA_ROS2_SOURCES}
+)
+
+target_include_directories (
+    carla-ros2-native SYSTEM PRIVATE
+    ${LIBCARLA_SOURCE_PATH}
+    ${FASTDDS_INCLUDE_PATH}
+    ${BOOST_INCLUDE_PATH}
+)
+
+target_compile_definitions (
+    carla-ros2-native PUBLIC
+    BOOST_ASIO_ENABLE_BUFFER_DEBUGGING
+)
+
+install (TARGETS carla-ros2-native DESTINATION lib)
+
+#foreach (HEADER ${LIBCARLA_SERVER_HEADERS})
+#    cmake_path (GET HEADER PARENT_PATH HEADER_PARENT)
+#    cmake_path (RELATIVE_PATH HEADER_PARENT BASE_DIRECTORY ${LIBCARLA_SOURCE_PATH}/carla OUTPUT_VARIABLE HEADER_RELATIVE)
+#    install (FILES ${HEADER} DESTINATION include/carla/${HEADER_RELATIVE})
+#endforeach ()

--- a/LibCarla/cmake/ros2-native/CMakeLists.txt
+++ b/LibCarla/cmake/ros2-native/CMakeLists.txt
@@ -41,6 +41,8 @@ target_compile_definitions (
     BOOST_ASIO_ENABLE_BUFFER_DEBUGGING
 )
 
+target_link_libraries(carla-ros2-native /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastrtps.so /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastcdr.so)
+
 install (TARGETS carla-ros2-native DESTINATION lib)
 
 #foreach (HEADER ${LIBCARLA_SERVER_HEADERS})

--- a/LibCarla/cmake/ros2-native/CMakeLists.txt
+++ b/LibCarla/cmake/ros2-native/CMakeLists.txt
@@ -23,24 +23,22 @@ file (
     ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.h
 )
 
-add_library (
-    carla-ros2-native SHARED
+add_library (carla-ros2-native SHARED
     ${LIBCARLA_ROS2_HEADERS}
     ${LIBCARLA_ROS2_SOURCES}
 )
 
-target_include_directories (
-    carla-ros2-native SYSTEM PRIVATE
+target_include_directories (carla-ros2-native SYSTEM PRIVATE
     ${LIBCARLA_SOURCE_PATH}
     ${FASTDDS_INCLUDE_PATH}
     ${BOOST_INCLUDE_PATH}
 )
 
-target_compile_definitions (
-    carla-ros2-native PUBLIC
+target_compile_definitions (carla-ros2-native PUBLIC
     BOOST_ASIO_ENABLE_BUFFER_DEBUGGING
 )
 
-target_link_libraries(carla-ros2-native /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastrtps.so /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastcdr.so)
+target_link_libraries(carla-ros2-native
+    ${FASTDDS_LIBRARY_PATH}/libfastrtps.so)
 
 install (TARGETS carla-ros2-native DESTINATION lib)

--- a/LibCarla/cmake/ros2-native/CMakeLists.txt
+++ b/LibCarla/cmake/ros2-native/CMakeLists.txt
@@ -44,9 +44,3 @@ target_compile_definitions (
 target_link_libraries(carla-ros2-native /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastrtps.so /home/xsole/programing/carlaUE5/Install/fast-dds-install/lib/libfastcdr.so)
 
 install (TARGETS carla-ros2-native DESTINATION lib)
-
-#foreach (HEADER ${LIBCARLA_SERVER_HEADERS})
-#    cmake_path (GET HEADER PARENT_PATH HEADER_PARENT)
-#    cmake_path (RELATIVE_PATH HEADER_PARENT BASE_DIRECTORY ${LIBCARLA_SOURCE_PATH}/carla OUTPUT_VARIABLE HEADER_RELATIVE)
-#    install (FILES ${HEADER} DESTINATION include/carla/${HEADER_RELATIVE})
-#endforeach ()

--- a/LibCarla/source/carla/ros2/ROS2CallbackData.h
+++ b/LibCarla/source/carla/ros2/ROS2CallbackData.h
@@ -6,7 +6,16 @@
 
 #pragma once
 
-#include <variant>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4583)
+#pragma warning(disable:4582)
+#include <boost/variant2/variant.hpp>
+#pragma warning(pop)
+#else
+#include <boost/variant2/variant.hpp>
+#endif
+
 #include <functional>
 
 namespace carla {
@@ -23,7 +32,7 @@ namespace ros2 {
     bool    manual_gear_shift;
   };
 
-  using ROS2CallbackData = std::variant<VehicleControl>;
+  using ROS2CallbackData = boost::variant2::variant<VehicleControl>;
 
   using ActorCallback = std::function<void(void *actor, ROS2CallbackData data)>;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -211,7 +211,7 @@ FCarlaActor* UActorDispatcher::RegisterActor(
           {
             AActor *UEActor = reinterpret_cast<AActor *>(Actor);
             ActorROS2Handler Handler(UEActor, RosName);
-            std::visit(Handler, Data);
+            boost::variant2::visit(Handler, Data);
           });
         }
       }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -269,11 +269,14 @@ public class Carla :
 
     if (EnableRos2)
     {
-      AdditionalLibraries.Add(Path.Combine(LibCarlaLibPath, GetLibraryName("carla-ros2-native")));
+      AddDynamicLibrary(Path.Combine(LibCarlaLibPath, "carla-ros2-native"));
       string LibFastDDSPath = Path.Combine(CarlaInstallPath, "fast-dds-install");
       AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
       AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
       AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+      //AdditionalLibraries.Add("/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so");
+      //PublicIncludePaths.Add("/usr/include/c++/7");
+      //PublicAdditionalLibraries.Add("stdc++");
 
       //AddDynamicLibrary("/home/xsole/programing/UnrealEngine5_carla/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/aarch64-unknown-linux-gnueabi/lib/libstdc++.so.6");
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -269,22 +269,11 @@ public class Carla :
 
     if (EnableRos2)
     {
-      AdditionalLibraries.Add(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
-      RuntimeDependencies.Add(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
+      AddDynamicLibrary(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
       string LibFastDDSPath = Path.Combine(CarlaInstallPath, "fast-dds-install");
-      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
-      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
-      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
-      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
-      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
-      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
-
-      //AdditionalLibraries.Add("/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so");
-      //PublicIncludePaths.Add("/usr/include/c++/7");
-      //PublicAdditionalLibraries.Add("stdc++");
-      //AddDynamicLibrary(
-
-      //AddDynamicLibrary("/home/xsole/programing/UnrealEngine5_carla/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/aarch64-unknown-linux-gnueabi/lib/libstdc++.so.6");
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
     }
 
     PublicIncludePaths.AddRange(new string[]

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -269,14 +269,20 @@ public class Carla :
 
     if (EnableRos2)
     {
-      AddDynamicLibrary(Path.Combine(LibCarlaLibPath, "carla-ros2-native"));
+      AdditionalLibraries.Add(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
+      RuntimeDependencies.Add(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
       string LibFastDDSPath = Path.Combine(CarlaInstallPath, "fast-dds-install");
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
+      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
+      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
+      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
+      AdditionalLibraries.Add(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+      RuntimeDependencies.Add(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+
       //AdditionalLibraries.Add("/usr/lib/gcc/x86_64-linux-gnu/7/libstdc++.so");
       //PublicIncludePaths.Add("/usr/include/c++/7");
       //PublicAdditionalLibraries.Add("stdc++");
+      //AddDynamicLibrary(
 
       //AddDynamicLibrary("/home/xsole/programing/UnrealEngine5_carla/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/aarch64-unknown-linux-gnueabi/lib/libstdc++.so.6");
     }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -41,6 +41,7 @@ public class Carla :
     bool IsWindows = Target.Platform == UnrealTargetPlatform.Win64;
 
     EnableOSM2ODR = IsWindows;
+    EnableRos2 = !IsWindows;
 
     PrivatePCHHeaderFile = "Carla.h";
     bEnableExceptions = true;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -43,6 +43,7 @@ public class Carla :
       PublicAdditionalLibraries.Add(library);
       RuntimeDependencies.Add(library);
       PublicDelayLoadDLLs.Add(library);
+      Console.WriteLine("Dynamic Library Added: " + library);
     }
 
     bool IsWindows = Target.Platform == UnrealTargetPlatform.Win64;
@@ -269,11 +270,11 @@ public class Carla :
 
     if (EnableRos2)
     {
-      AddDynamicLibrary(Path.Combine(LibCarlaLibPath, "libcarla-ros2-native.so"));
-      string LibFastDDSPath = Path.Combine(CarlaInstallPath, "fast-dds-install");
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
-      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+      string LibRos2NativePath = Path.Combine(CarlaInstallPath, "LibRos2Native", "lib");
+      AddDynamicLibrary(Path.Combine(LibRos2NativePath, "libcarla-ros2-native.so"));
+      AddDynamicLibrary(Path.Combine(LibRos2NativePath, "libfoonathan_memory-0.7.3.so"));
+      AddDynamicLibrary(Path.Combine(LibRos2NativePath, "libfastcdr.so"));
+      AddDynamicLibrary(Path.Combine(LibRos2NativePath, "libfastrtps.so"));
     }
 
     PublicIncludePaths.AddRange(new string[]

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -38,6 +38,13 @@ public class Carla :
   public Carla(ReadOnlyTargetRules Target) :
   base(Target)
   {
+    void AddDynamicLibrary(string library)
+    {
+      PublicAdditionalLibraries.Add(library);
+      RuntimeDependencies.Add(library);
+      PublicDelayLoadDLLs.Add(library);
+    }
+
     bool IsWindows = Target.Platform == UnrealTargetPlatform.Win64;
 
     EnableOSM2ODR = IsWindows;
@@ -60,7 +67,7 @@ public class Carla :
         throw new DirectoryNotFoundException("Could not infer CARLA install directory.");
       Console.WriteLine("Using \"" + CarlaInstallPath + "\" as the CARLA install path.");
     }
-
+    
     if (CarlaDependenciesPath == null)
     {
       Console.WriteLine("\"-carla-dependencies-path\" was not specified, inferring...");
@@ -258,6 +265,17 @@ public class Carla :
         from Name in ChronoLibraryNames
         select FindLibraries(ChronoLibPath, GetLibraryName(Name))[0];
       AdditionalLibraries.AddRange(ChronoLibraries);
+    }
+
+    if (EnableRos2)
+    {
+      AdditionalLibraries.Add(Path.Combine(LibCarlaLibPath, GetLibraryName("carla-ros2-native")));
+      string LibFastDDSPath = Path.Combine(CarlaInstallPath, "fast-dds-install");
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfoonathan_memory-0.7.3.so"));
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastcdr.so"));
+      AddDynamicLibrary(Path.Combine(LibFastDDSPath, "lib", "libfastrtps.so"));
+
+      //AddDynamicLibrary("/home/xsole/programing/UnrealEngine5_carla/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/aarch64-unknown-linux-gnueabi/lib/libstdc++.so.6");
     }
 
     PublicIncludePaths.AddRange(new string[]


### PR DESCRIPTION
## Changes

### ROS2
- Implement ROS2 native build for UE5 Ubuntu.
- Changing ROS2 native build from static library to shared library to prevent mismatch between c++ library versions, as ROS2 is compiled with g++ old abi and Unreal is compiled with clang abi.
- ROS2 native library renamed from `libcarla_fastdds.a` to  `libcarla-ros2-native.so`.
- boost_asio and tinyXML libs are now downloaded and builded by fast-dds cmake internally.
- boost was reintroduced inside ROS2 native code to remove code from newer standards than C++11. Pending to see if it's possible to build ROS2 dependencies with a newer version of the standard.

### CARLA Configure.py
- Added log for source download step.