### PR TITLE
Ros2: Prevent memory vendor crash when ros2 is installed in the system

### DIFF
--- a/Configure.py
+++ b/Configure.py
@@ -1314,6 +1314,12 @@ def BuildDependencies(task_graph : TaskGraph):
       XERCESC_INSTALL_PATH))
   
   if ENABLE_ROS2:
+    #HACK: Prevent find_package() detect foonathan-memory-vendor library when ros2 is installed in the system.
+    #      foonathan-memory-vendor does not build if is already installed in the system and there are no cmake arguments to prvent this behavioud in foonathan-memory-vendor.
+    def is_ros_system_install_path(path):
+      return any(ros_folder in path for ros_folder in ['/ros/', '/ros2/'])
+    os.environ['PATH'] = ':'.join([path for path in os.environ['PATH'].split(':') if not is_ros_system_install_path(path)])
+    
     task_graph.Add(Task.CreateCMakeConfigureGxxABI(
       'foonathan-memory-vendor-configure',
       [],


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

ROS2 build fails when ROS2 is already installed on the system due memory vendor library cmake avoids to build when detecting is already present on the system. This causes memory `libfoonathan_memory-0.7.3.so` to not be built and installed.

Fixes #51

#### Where has this been tested?

  * **Platform(s):*Ubuntu 22.04 and 20.04* ...
  * **Python version(s):*3.10* ...
  * **Unreal Engine version(s):*5.3* ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
