### PR TITLE
Cmake migrate FetchContent from git clone to zip download

### DIFF
--- a/CMake/CarlaDependencies.cmake
+++ b/CMake/CarlaDependencies.cmake
@@ -107,11 +107,16 @@ if (BUILD_PYTHON_API)
   set (BOOST_ENABLE_PYTHON ${BUILD_PYTHON_API})
 endif ()
 
-carla_dependency_add (
+set (BOOST_VERSION 1.84.0)
+FetchContent_Declare(
   boost
-  https://github.com/boostorg/boost.git
-  ${CARLA_BOOST_TAG}
+  GIT_SUBMODULES_RECURSE ON
+  GIT_SHALLOW ON
+  GIT_PROGRESS ON
+  URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.zip
+  OVERRIDE_FIND_PACKAGE
 )
+list (APPEND CARLA_DEPENDENCIES boost)
 
 set (EIGEN_BUILD_PKGCONFIG OFF)
 set (BUILD_TESTING OFF)

--- a/CMake/CarlaDependencies.cmake
+++ b/CMake/CarlaDependencies.cmake
@@ -10,17 +10,50 @@ if (LINUX)
   find_package (Threads REQUIRED)
 endif ()
 
+set (CARLA_DEPENDENCIES)
 
+macro (carla_dependency_add_git NAME URL TAG)
+  message ("Fetching ${NAME}...")
+  FetchContent_Declare(
+    ${NAME}
+    GIT_SUBMODULES_RECURSE ON
+    GIT_SHALLOW ON
+    GIT_PROGRESS ON
+    GIT_REPOSITORY ${URL}
+    GIT_TAG ${TAG}
+    OVERRIDE_FIND_PACKAGE
+  )
+  list (APPEND CARLA_DEPENDENCIES ${NAME})
+endmacro ()
+
+macro (carla_dependency_add_zip NAME URL)
+  FetchContent_Declare(
+    ${NAME}
+    URL ${URL}
+    OVERRIDE_FIND_PACKAGE
+  )
+  list (APPEND CARLA_DEPENDENCIES ${NAME})
+endmacro ()
+
+macro (carla_dependencies_make_available)
+  FetchContent_MakeAvailable (
+    ${CARLA_DEPENDENCIES})
+  set (CARLA_DEPENDENCIES)
+endmacro ()
+
+macro (carla_fetchcontent_option NAME VALUE)
+  set (${NAME} ${VALUE} CACHE INTERNAL "")
+endmacro ()
 
 set (CARLA_DEPENDENCIES_INSTALL_PATH)
 
 string (REPLACE "." "" CARLA_SQLITE_TAG ${CARLA_SQLITE_VERSION})
 
-FetchContent_Declare (
+carla_dependency_add_zip (
   sqlite3
-  URL https://www.sqlite.org/2024/sqlite-amalgamation-${CARLA_SQLITE_TAG}.zip
+  https://www.sqlite.org/2024/sqlite-amalgamation-${CARLA_SQLITE_TAG}.zip
 )
-FetchContent_MakeAvailable (sqlite3)
+carla_dependencies_make_available ()
 
 add_library (
   libsqlite3 STATIC
@@ -43,41 +76,10 @@ target_link_libraries (
   libsqlite3
 )
 
-
-
-set (CARLA_DEPENDENCIES)
-
-macro (carla_dependency_add NAME URL TAG)
-  message ("Fetching ${NAME}...")
-  FetchContent_Declare(
-    ${NAME}
-    GIT_SUBMODULES_RECURSE ON
-    GIT_SHALLOW ON
-    GIT_PROGRESS ON
-    GIT_REPOSITORY ${URL}
-    GIT_TAG ${TAG}
-    OVERRIDE_FIND_PACKAGE
-  )
-  list (APPEND CARLA_DEPENDENCIES ${NAME})
-endmacro ()
-
-macro (carla_dependencies_make_available)
-  FetchContent_MakeAvailable (
-    ${CARLA_DEPENDENCIES})
-  set (CARLA_DEPENDENCIES)
-endmacro ()
-
-macro (carla_fetchcontent_option NAME VALUE)
-  set (${NAME} ${VALUE} CACHE INTERNAL "")
-endmacro ()
-
-
-
 set (ZLIB_BUILD_EXAMPLES OFF)
-carla_dependency_add (
+carla_dependency_add_zip (
   zlib
-  https://github.com/madler/zlib.git
-  ${CARLA_ZLIB_TAG}
+  https://github.com/madler/zlib/archive/refs/tags/${CARLA_ZLIB_TAG}.zip
 )
 carla_dependencies_make_available ()
 include_directories (${zlib_SOURCE_DIR} ${zlib_BINARY_DIR}) # HACK
@@ -93,10 +95,9 @@ else ()
 endif ()
 set (ZLIB_INCLUDE_DIRS ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
 set (ZLIB_LIBRARIES ${ZLIB_LIBRARY})
-carla_dependency_add (
+carla_dependency_add_zip (
   libpng
-  https://github.com/glennrp/libpng.git
-  ${CARLA_LIBPNG_TAG}
+  https://github.com/pnggroup/libpng/archive/refs/tags/${CARLA_LIBPNG_TAG}.zip
 )
 carla_dependencies_make_available ()
 include_directories (${libpng_SOURCE_DIR} ${libpng_BINARY_DIR}) # HACK
@@ -107,36 +108,27 @@ if (BUILD_PYTHON_API)
   set (BOOST_ENABLE_PYTHON ${BUILD_PYTHON_API})
 endif ()
 
-set (BOOST_VERSION 1.84.0)
-FetchContent_Declare(
+carla_dependency_add_zip(
   boost
-  GIT_SUBMODULES_RECURSE ON
-  GIT_SHALLOW ON
-  GIT_PROGRESS ON
-  URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.zip
-  OVERRIDE_FIND_PACKAGE
+  https://github.com/boostorg/boost/releases/download/${CARLA_BOOST_TAG}/${CARLA_BOOST_TAG}.zip
 )
-list (APPEND CARLA_DEPENDENCIES boost)
 
 set (EIGEN_BUILD_PKGCONFIG OFF)
 set (BUILD_TESTING OFF)
 set (EIGEN_BUILD_DOC OFF)
-carla_dependency_add (
+carla_dependency_add_zip (
   eigen
-  https://gitlab.com/libeigen/eigen.git
-  ${CARLA_EIGEN_TAG}
+  https://gitlab.com/libeigen/eigen/-/archive/${CARLA_EIGEN_TAG}/eigen-${CARLA_EIGEN_TAG}.tar.gz
 )
 
-carla_dependency_add (
+carla_dependency_add_zip (
   rpclib
-  https://github.com/carla-simulator/rpclib.git
-  ${CARLA_RPCLIB_TAG}
+  https://github.com/carla-simulator/rpclib/archive/refs/heads/${CARLA_RPCLIB_TAG}.zip
 )
 
-carla_dependency_add (
+carla_dependency_add_zip (
   recastnavigation
-  https://github.com/carla-simulator/recastnavigation.git
-  ${CARLA_RECAST_TAG}
+  https://github.com/carla-simulator/recastnavigation/archive/refs/heads/${CARLA_RECAST_TAG}.zip
 )
 
 if (ENABLE_OSM2ODR)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Changed the way how FetchContent is downloading the source code. Previously was using git clone and now is downloading zip an uncompresing.

#### Benefit
- Performance of download improved and cmake configuration step time was reduced 30% as result in average with a 1GB of download internet connection (speedup will be higher with slower connections).
- Theoretically reduced the number of build errors produced due git clone connection failures. Downloading just one file have less chance of error.

#### Where has this been tested?

  * **Platform(s):*Ubuntu 22.04* ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):*5* ...

