### PR TITLE
Allow GetVehiclePhysicsControl to succeed when physics is off

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -459,17 +459,25 @@ FVehiclePhysicsControl ACarlaWheeledVehicle::GetVehiclePhysicsControl() const
     {
       FWheelPhysicsControl PhysicsWheel;
 
-      PxVehicleWheelData PWheelData = Vehicle4W->PVehicle->mWheelsSimData.getWheelData(i);
-      PhysicsWheel.DampingRate = Cm2ToM2(PWheelData.mDampingRate);
-      PhysicsWheel.MaxSteerAngle = FMath::RadiansToDegrees(PWheelData.mMaxSteer);
-      PhysicsWheel.Radius = PWheelData.mRadius;
-      PhysicsWheel.MaxBrakeTorque = Cm2ToM2(PWheelData.mMaxBrakeTorque);
-      PhysicsWheel.MaxHandBrakeTorque = Cm2ToM2(PWheelData.mMaxHandBrakeTorque);
+      if (bPhysicsEnabled) {
+        PxVehicleWheelData PWheelData = Vehicle4W->PVehicle->mWheelsSimData.getWheelData(i);
 
-      PxVehicleTireData PTireData = Vehicle4W->PVehicle->mWheelsSimData.getTireData(i);
-      PhysicsWheel.LatStiffMaxLoad = PTireData.mLatStiffX;
-      PhysicsWheel.LatStiffValue = PTireData.mLatStiffY;
-      PhysicsWheel.LongStiffValue = PTireData.mLongitudinalStiffnessPerUnitGravity;
+        PhysicsWheel.DampingRate = Cm2ToM2(PWheelData.mDampingRate);
+        PhysicsWheel.MaxSteerAngle = FMath::RadiansToDegrees(PWheelData.mMaxSteer);
+        PhysicsWheel.Radius = PWheelData.mRadius;
+        PhysicsWheel.MaxBrakeTorque = Cm2ToM2(PWheelData.mMaxBrakeTorque);
+        PhysicsWheel.MaxHandBrakeTorque = Cm2ToM2(PWheelData.mMaxHandBrakeTorque);
+
+        PxVehicleTireData PTireData = Vehicle4W->PVehicle->mWheelsSimData.getTireData(i);
+
+        PhysicsWheel.LatStiffMaxLoad = PTireData.mLatStiffX;
+        PhysicsWheel.LatStiffValue = PTireData.mLatStiffY;
+        PhysicsWheel.LongStiffValue = PTireData.mLongitudinalStiffnessPerUnitGravity;
+      } else {
+        if (i < LastPhysicsControl.Wheels.Num()) {
+          PhysicsWheel = LastPhysicsControl.Wheels[i];
+        }
+      }
 
       PhysicsWheel.TireFriction = Vehicle4W->Wheels[i]->TireConfig->GetFrictionScale();
       PhysicsWheel.Position = Vehicle4W->Wheels[i]->Location;
@@ -537,17 +545,23 @@ FVehiclePhysicsControl ACarlaWheeledVehicle::GetVehiclePhysicsControl() const
     {
       FWheelPhysicsControl PhysicsWheel;
 
-      PxVehicleWheelData PWheelData = VehicleNW->PVehicle->mWheelsSimData.getWheelData(i);
-      PhysicsWheel.DampingRate = Cm2ToM2(PWheelData.mDampingRate);
-      PhysicsWheel.MaxSteerAngle = FMath::RadiansToDegrees(PWheelData.mMaxSteer);
-      PhysicsWheel.Radius = PWheelData.mRadius;
-      PhysicsWheel.MaxBrakeTorque = Cm2ToM2(PWheelData.mMaxBrakeTorque);
-      PhysicsWheel.MaxHandBrakeTorque = Cm2ToM2(PWheelData.mMaxHandBrakeTorque);
+      if (bPhysicsEnabled) {
+        PxVehicleWheelData PWheelData = VehicleNW->PVehicle->mWheelsSimData.getWheelData(i);
+        PhysicsWheel.DampingRate = Cm2ToM2(PWheelData.mDampingRate);
+        PhysicsWheel.MaxSteerAngle = FMath::RadiansToDegrees(PWheelData.mMaxSteer);
+        PhysicsWheel.Radius = PWheelData.mRadius;
+        PhysicsWheel.MaxBrakeTorque = Cm2ToM2(PWheelData.mMaxBrakeTorque);
+        PhysicsWheel.MaxHandBrakeTorque = Cm2ToM2(PWheelData.mMaxHandBrakeTorque);
 
-      PxVehicleTireData PTireData = VehicleNW->PVehicle->mWheelsSimData.getTireData(i);
-      PhysicsWheel.LatStiffMaxLoad = PTireData.mLatStiffX;
-      PhysicsWheel.LatStiffValue = PTireData.mLatStiffY;
-      PhysicsWheel.LongStiffValue = PTireData.mLongitudinalStiffnessPerUnitGravity;
+        PxVehicleTireData PTireData = VehicleNW->PVehicle->mWheelsSimData.getTireData(i);
+        PhysicsWheel.LatStiffMaxLoad = PTireData.mLatStiffX;
+        PhysicsWheel.LatStiffValue = PTireData.mLatStiffY;
+        PhysicsWheel.LongStiffValue = PTireData.mLongitudinalStiffnessPerUnitGravity;
+      } else {
+        if (i < LastPhysicsControl.Wheels.Num()) {
+          PhysicsWheel = LastPhysicsControl.Wheels[i];
+        }
+      }
 
       PhysicsWheel.TireFriction = VehicleNW->Wheels[i]->TireConfig->GetFrictionScale();
       PhysicsWheel.Position = VehicleNW->Wheels[i]->Location;


### PR DESCRIPTION

#### Description

If physics is turned off (with set_simulate_physics) and you call get_physics_control, you previously got a crash (as the PhysXVehicle was destroyed). Fix it so it provides old data instead of crashing

```
~/tmp/c0.9.15/n$ ./CarlaUE4.sh -log
4.26.2-0+++UE4+Release-4.26 522 0
Disabling core dumps.
Signal 11 caught.
Malloc Size=65538 LargeMemoryPoolOffset=65554 
CommonUnixCrashHandler: Signal=11
Malloc Size=131160 LargeMemoryPoolOffset=196744 
Malloc Size=131160 LargeMemoryPoolOffset=327928 
Engine crash handling finished; re-raising signal 11 for the default handler. Good bye.
Segmentation fault
```

and 

```
>>> import carla
>>> c = carla.Client("127.0.0.1", 2000)
>>> w = c.get_world()
>>> m = w.get_map()
>>> bpl = w.get_blueprint_library()
>>> a = w.spawn_actor(bpl.filter("vehicle.toyota.prius")[0], m.get_spawn_points()[0])
>>> a
<carla.libcarla.Vehicle object at 0x7fe8a50f7150>
>>> a.set_simulate_physics(False)
>>> a.get_physics_control()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: time-out of 5000ms while waiting for the simulator, make sure the simulator is ready and connected to 127.0.0.1:2000
```
#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** 4.26.2

