### PR TITLE
Add stdint library for declare unidentified type 'uint8_t'

### DIFF
--- a/LibCarla/source/carla/client/FileTransfer.h
+++ b/LibCarla/source/carla/client/FileTransfer.h
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <stdint.h>
 #include <sys/stat.h>
 
 namespace carla {


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [X] All tests passing with `make check` (only Linux)
  - [X] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Hello. I'm a junior developer who has been avidly using this project. I'm delighted to have the opportunity to contribute to this project.

During the process of running 'make PythonAPI' in CARLA 0.9.15.2 version, I encountered an error while building BuildLibCarla.sh.

The error log was as follows:

```
BuildLibCarla.sh: Building LibCarla "Client.Release" configuration.
CMake Deprecation Warning:
  Support for "Extra Generators" like

    Eclipse CDT4

  is deprecated and will be removed from a future version of CMake.  IDEs may
  use the cmake-file-api(7) to view CMake-generated project build trees.


-- The C compiler identification is Clang 10.0.1
-- The CXX compiler identification is Clang 10.0.1
-- Could not determine Eclipse version, assuming at least 3.6 (Helios). Adjust CMAKE_ECLIPSE_VERSION if this is wrong.
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/soda//UnrealEngine_4.26/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v17_clang-10.0.1-centos7/x86_64-unknown-linux-gnu/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/soda//UnrealEngine_4.26/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v17_clang-10.0.1-centos7/x86_64-unknown-linux-gnu/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Build debug:   OFF
-- Build release: ON
-- Build test:    ON
-- Configuring done (0.2s)
CMake Warning in CMakeLists.txt:
  The build directory is a subdirectory of the source directory.

  This is not supported well by Eclipse.  It is strongly recommended to use a
  build directory which is a sibling of the source directory.


-- Generating done (0.0s)
-- Build files have been written to: /home/soda/carla_dev/Build/libcarla-client-build.release
[2/134] Building CXX object LibCarla/c...source/carla/client/FIleTransfer.cpp.o
FAILED: LibCarla/cmake/client/CMakeFiles/carla_client.dir/__/__/source/carla/client/FIleTransfer.cpp.o 
/home/soda//UnrealEngine_4.26/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v17_clang-10.0.1-centos7/x86_64-unknown-linux-gnu/bin/clang++ -DBOOST_ERROR_CODE_HEADER_ONLY -DLIBCARLA_IMAGE_WITH_PNG_SUPPORT=true -DLIBCARLA_TEST_CONTENT_FOLDER=\"/home/soda/carla_dev/Build/test-content\" -I/home/soda/carla_dev/LibCarla/cmake/../source -I/home/soda/carla_dev/LibCarla/cmake/../source/third-party -isystem /home/soda/carla_dev/Build/boost-1.80.0-c10-install/include -isystem /home/soda/carla_dev/Build/rpclib-v2.2.1_c5-c10-libstdcxx-install/include -isystem /home/soda/carla_dev/Build/recast-c10-install/include -isystem /home/soda/carla_dev/Build/libpng-1.6.37-install/include -std=c++14 -pthread -fPIC -Wall -Wextra -Wpedantic -Wdeprecated -Wshadow -Wuninitialized -Wunreachable-code -Wpessimizing-move -Wold-style-cast -Wnull-dereference -Wduplicate-enum -Wnon-virtual-dtor -Wheader-hygiene -Wconversion -Wfloat-overflow-conversion -std=c++14 -pthread -fPIC -Wall -Wextra -Wpedantic -Wdeprecated -Wshadow -Wuninitialized -Wunreachable-code -Wpessimizing-move -Wold-style-cast -Wnull-dereference -Wduplicate-enum -Wnon-virtual-dtor -Wheader-hygiene -Wconversion -Wfloat-overflow-conversion  -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -std=c++14 -Wno-missing-braces -DBOOST_ERROR_CODE_HEADER_ONLY -MD -MT LibCarla/cmake/client/CMakeFiles/carla_client.dir/__/__/source/carla/client/FIleTransfer.cpp.o -MF LibCarla/cmake/client/CMakeFiles/carla_client.dir/__/__/source/carla/client/FIleTransfer.cpp.o.d -o LibCarla/cmake/client/CMakeFiles/carla_client.dir/__/__/source/carla/client/FIleTransfer.cpp.o -c /home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp
In file included from /home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp:7:
/home/soda/carla_dev/LibCarla/source/carla/client/FileTransfer.h:31:57: error: use of undeclared identifier 'uint8_t'
    static bool WriteFile(std::string path, std::vector<uint8_t> content);
                                                        ^
/home/soda/carla_dev/LibCarla/source/carla/client/FileTransfer.h:33:24: error: use of undeclared identifier 'uint8_t'
    static std::vector<uint8_t> ReadFile(std::string path);
                       ^
/home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp:46:62: error: use of undeclared identifier 'uint8_t'
  bool FileTransfer::WriteFile(std::string path, std::vector<uint8_t> content) {
                                                             ^
/home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp:69:15: error: use of undeclared identifier 'uint8_t'
  std::vector<uint8_t> FileTransfer::ReadFile(std::string path) {
              ^
/home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp:77:17: error: use of undeclared identifier 'uint8_t'
    std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
                ^
/home/soda/carla_dev/LibCarla/source/carla/client/FIleTransfer.cpp:77:26: error: C++ requires a type specifier for all declarations
    std::vector<uint8_t> content(std::istreambuf_iterator<char>(file), {});
                         ^
6 errors generated.
[27/134] Building CXX object LibCarla/...carla/client/detail/ActorFactory.cpp.o
ninja: build stopped: subcommand failed.
make: *** [Util/BuildTools/Linux.mk:129: LibCarla.client.release] Error 1
```

Upon encountering this error, my initial action was to search for issues related to the 'uint8_t' keyword in the issue section. However, I did not find any issues addressing the specific problem I was facing in my situation.

So, I searched for this error on Google, and I came across a solution at the following link, where the advice was to add the `#include <stdint.h>` header.
https://stackoverflow.com/questions/50346142/identifier-uint8-t-is-undefined-visual-studio-2017


Following this advice, I opened the specified file (`carla/LibCarla/source/carla/client/FileTransfer.h`) and added the mentioned header file. I then confirmed that the build process proceeded without any issues.
I had no issues building it before, and I'm also not sure why this problem occurred now.

In any case, since it seemed like a problem that needed to be resolved by directly modifying the library, regardless of the individual development environment, I decided to upload the information to the PR section instead of creating an issue.

If there are any aspects I may have overlooked, please feel free to point them out. 

#### Where has this been tested?

  * **Platform(s): Ubuntu 20.04** ...
  * **Python version(s): 3.8 (not anaconda)** ...
  * **Unreal Engine version(s): 4.26** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
- This modification can help reduce errors occurring during the LibCarla build process.
