### PR TITLE
ROS2Native: Force fast-dds dependencies download to avoid build crash…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * Fixed bug in python agents when vehicle list was empty causing a check on all vehicles (BasicAgent.py) and detected pedestrians as vehicles if no pedestrains are present (BehaviourAgent.py) 
  * Added possibility to change gravity variable in imui sensor for the accelerometer
  * Fixed ROS2 native extension build error when ROS2 is installed in the system.
+ * ROS2Native: Force fast-dds dependencies download to avoid build crash when boost_asio and tinyxml2 are not installed in Linux.
 
 ## CARLA 0.9.15
 

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -960,7 +960,8 @@ if ${USE_ROS2} ; then
       -DCMAKE_INSTALL_PREFIX="${FASTDDS_INSTALL_DIR}" \
       -DCMAKE_CXX_FLAGS=-latomic \
       -DCMAKE_CXX_FLAGS_RELEASE="-D_GLIBCXX_USE_CXX11_ABI=0" \
-       \
+      -DTHIRDPARTY_Asio=FORCE \
+      -DTHIRDPARTY_TinyXML2=FORCE \
       ..
     ninja
     ninja install


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

ROS2Native: Force fast-dds dependencies download to avoid build crash when boost_asio and tinyxml2 are not installed in the system

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20204
  * **Python version(s):** .10
  * **Unreal Engine version(s):** 5.3
