### PR TITLE
Remove boost::numpy

### DIFF
--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -71,7 +71,6 @@ set (
   libsqlite3
   Boost::asio
   Boost::python
-  # Boost::numpy
   Boost::geometry
   Boost::gil
   Eigen3::Eigen

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -71,7 +71,7 @@ set (
   libsqlite3
   Boost::asio
   Boost::python
-  Boost::numpy
+  # Boost::numpy
   Boost::geometry
   Boost::gil
   Eigen3::Eigen


### PR DESCRIPTION
This PR removes boost numpy, as it is deprecated.
See https://github.com/ndarray/Boost.NumPy