### PR TITLE
Fix package generation command in Ubuntu

### DIFF
--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -343,19 +343,20 @@ add_custom_target (
   COMMAND
     ${CARLA_UE_UAT_COMMAND_PREFIX}
     BuildCookRun
-    -nocompileeditor
-    -TargetPlatform=${UE_SYSTEM_NAME}
-    -Platform=${UE_SYSTEM_NAME}
-    -installed
-    -nop4
     -project=${CARLA_UE_PROJECT_PATH}
+    -nocompileeditor
+    -nop4
     -cook
     -stage
-    -build
     -archive
-    -archivedirectory=${CARLA_PACKAGE_PATH}/Unreal
     -package
+    -iterate
     -clientconfig=Shipping
+    -TargetPlatform=${UE_SYSTEM_NAME}
+    -Platform=${UE_SYSTEM_NAME}
+    -prereqs
+    -build
+    -archivedirectory=${CARLA_PACKAGE_PATH}/Unreal
   DEPENDS
     ${CARLA_UNREAL_CONFIGURE_OUTPUTS}
     USES_TERMINAL


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Use same package generation command arguments than in CARLA UE4.
This fix package generation that was previously crashing.

#### Where has this been tested?

  * **Platform(s):**Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.3
