### PR TITLE
Agent's `set_destination` needs update in their logic and fix broken tailgating, but how?

### DIFF
--- a/PythonAPI/carla/agents/navigation/basic_agent.py
+++ b/PythonAPI/carla/agents/navigation/basic_agent.py
@@ -139,30 +139,37 @@ class BasicAgent(object):
     def get_global_planner(self):
         """Get method for protected member local planner"""
         return self._global_planner
-
-    def set_destination(self, end_location, start_location=None):
+        
+    def set_destination(self, end_location, start_location=None, clean_queue=True):
+        # type: (carla.Location, carla.Location | None, bool) -> None
         """
         This method creates a list of waypoints between a starting and ending location,
         based on the route returned by the global router, and adds it to the local planner.
-        If no starting location is passed, the vehicle local planner's target location is chosen,
-        which corresponds (by default), to a location about 5 meters in front of the vehicle.
+        If no starting location is passed and `clean_queue` is True, the vehicle local planner's 
+        target location is chosen, which corresponds (by default), to a location about 5 meters 
+        in front of the vehicle.
+        If `clean_queue` is False the newly planned route will be appended to the current route.
 
             :param end_location (carla.Location): final location of the route
             :param start_location (carla.Location): starting location of the route
+            :param clean_queue (bool): Whether to clear or append to the currently planned route
         """
         if not start_location:
-            start_location = self._local_planner.target_waypoint.transform.location
-            clean_queue = True
-        else:
-            start_location = self._vehicle.get_location()
-            clean_queue = False
-
+            if clean_queue and self._local_planner.target_waypoint:
+                # Plan from the waypoint in front of the vehicle onwards
+                start_location = self._local_planner.target_waypoint.transform.location 
+            elif not clean_queue and self._local_planner._waypoints_queue:
+                # Append to the current plan
+                start_location = self._local_planner._waypoints_queue[-1][0].transform.location
+            else:
+                # no target_waypoint or _waypoints_queue empty, use vehicle location
+                start_location = self._vehicle.get_location() 
         start_waypoint = self._map.get_waypoint(start_location)
         end_waypoint = self._map.get_waypoint(end_location)
-
+        
         route_trace = self.trace_route(start_waypoint, end_waypoint)
         self._local_planner.set_global_plan(route_trace, clean_queue=clean_queue)
-
+        
     def set_global_plan(self, plan, stop_waypoint_creation=True, clean_queue=True):
         """
         Adds a specific plan to the agent.


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Addresses #7341:   
[`set_destination`](https://github.com/carla-simulator/carla/blob/cead6d1b05e89ad84df80984f62daba57bb50e55/PythonAPI/carla/agents/navigation/basic_agent.py#L141) does not really use the `start_location`, only for boolean evaluation instead of allowing users to pass a location.

In my experiments this sometimes creates troubles when passing a starting point, e.g. for [tailgating](https://github.com/carla-simulator/carla/blob/cead6d1b05e89ad84df80984f62daba57bb50e55/PythonAPI/carla/agents/navigation/behavior_agent.py#L119-L120) the agent performs U-Turns to an old way point.

#### Where has this been tested?

Note: Python code only

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.7, 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/7342)
<!-- Reviewable:end -->
