### PR TITLE
Disable multi process cooking

### DIFF
--- a/Unreal/CarlaUnreal/Config/DefaultEditor.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultEditor.ini
@@ -1,6 +1,0 @@
-[/Script/AdvancedPreviewScene.SharedProfiles]
-
-[CookSettings]
- 
-CookProcessCount=4
- 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Disable multiprocess cooking as is causing memory crash on Ubuntu.

Fixes #7429

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.3

