### PR TITLE
Disable use less CPU in background

### DIFF
--- a/Unreal/CarlaUE4/Config/DefaultEditorSettings.ini
+++ b/Unreal/CarlaUE4/Config/DefaultEditorSettings.ini
@@ -1,0 +1,2 @@
+[/Script/UnrealEd.EditorPerformanceSettings]
+bThrottleCPUWhenNotForeground=False


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Desactivate "Use Less CPU when in Background" option to prevent the eidtor get frozen when launching manual control.

https://udn.unrealengine.com/s/question/0D5QP00000BmhxS0AR/is-it-possible-to-have-the-use-less-cpu-when-in-background-disabled-by-default 

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.3