### PR TITLE
Retry download osm2odr

### DIFF
--- a/Util/BuildTools/BuildOSM2ODR.bat
+++ b/Util/BuildTools/BuildOSM2ODR.bat
@@ -93,9 +93,12 @@ if %REMOVE_INTERMEDIATE% == true (
 rem Build OSM2ODR
 if %BUILD_OSM2ODR% == true (
     cd "%OSM2ODR_SOURCE_PATH%"
-    curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/%CURRENT_OSM2ODR_COMMIT%.zip
-    tar -xf OSM2ODR.zip
-    cd sumo-%CURRENT_OSM2ODR_COMMIT%
+    if not exist "%OSM2ODR_SOURCE_PATH%" (
+        curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/%CURRENT_OSM2ODR_COMMIT%.zip
+        tar -xf OSM2ODR.zip
+        del OSM2ODR.zip
+        ren sumo-%CURRENT_OSM2ODR_COMMIT% %OSM2ODR_SOURCE_PATH%
+    )
 
     if not exist "%OSM2ODR_VSPROJECT_PATH%" mkdir "%OSM2ODR_VSPROJECT_PATH%"
     cd "%OSM2ODR_VSPROJECT_PATH%"

--- a/Util/BuildTools/BuildOSM2ODR.bat
+++ b/Util/BuildTools/BuildOSM2ODR.bat
@@ -92,13 +92,10 @@ if %REMOVE_INTERMEDIATE% == true (
 
 rem Build OSM2ODR
 if %BUILD_OSM2ODR% == true (
-
-    if  %GIT_PULL% == true (
-        if not exist "%OSM2ODR_SOURCE_PATH%" git clone -b %OSM2ODR_BRANCH% %OSM2ODR_REPO% %OSM2ODR_SOURCE_PATH%
-        cd "%OSM2ODR_SOURCE_PATH%"
-        git fetch
-        git checkout %CURRENT_OSM2ODR_COMMIT%
-    )
+    cd "%OSM2ODR_SOURCE_PATH%"
+    curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/%CURRENT_OSM2ODR_COMMIT%.zip
+    tar -xf OSM2ODR.zip
+    cd sumo-%CURRENT_OSM2ODR_COMMIT%
 
     if not exist "%OSM2ODR_VSPROJECT_PATH%" mkdir "%OSM2ODR_VSPROJECT_PATH%"
     cd "%OSM2ODR_VSPROJECT_PATH%"

--- a/Util/BuildTools/BuildOSM2ODR.sh
+++ b/Util/BuildTools/BuildOSM2ODR.sh
@@ -76,15 +76,10 @@ fi
 
 if ${BUILD_OSM2ODR} ; then
   log "Building OSM2ODR."
-  # [ ! -d ${OSM2ODR_BUILD_FOLDER} ] && mkdir ${OSM2ODR_BUILD_FOLDER}
-  if ${GIT_PULL} ; then
-    if [ ! -d ${OSM2ODR_SOURCE_FOLDER} ] ; then
-      git clone -b ${OSM2ODR_BRANCH} ${OSM2ODR_REPO} ${OSM2ODR_SOURCE_FOLDER}
-    fi
-    cd ${OSM2ODR_SOURCE_FOLDER}
-    git fetch
-    git checkout ${CURRENT_OSM2ODR_COMMIT}
-  fi
+  cd $OSM2ODR_SOURCE_PATH
+  curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/$CURRENT_OSM2ODR_COMMIT.zip
+  tar -xf OSM2ODR.zip
+  cd sumo-$CURRENT_OSM2ODR_COMMIT
 
   mkdir -p ${OSM2ODR_BUILD_FOLDER}
   cd ${OSM2ODR_BUILD_FOLDER}

--- a/Util/BuildTools/BuildOSM2ODR.sh
+++ b/Util/BuildTools/BuildOSM2ODR.sh
@@ -79,7 +79,7 @@ if ${BUILD_OSM2ODR} ; then
   if [ ! -d ${OSM2ODR_SOURCE_FOLDER} ] ; then
     cd ${CARLA_BUILD_FOLDER}
     curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/${CURRENT_OSM2ODR_COMMIT}.zip
-    unzip OSM2ODR.zip
+    unzip -qq OSM2ODR.zip
     rm -f OSM2ODR.zip
     mv sumo-${CURRENT_OSM2ODR_COMMIT} ${OSM2ODR_SOURCE_FOLDER}
   fi

--- a/Util/BuildTools/BuildOSM2ODR.sh
+++ b/Util/BuildTools/BuildOSM2ODR.sh
@@ -76,13 +76,17 @@ fi
 
 if ${BUILD_OSM2ODR} ; then
   log "Building OSM2ODR."
-  cd $OSM2ODR_SOURCE_PATH
-  curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/$CURRENT_OSM2ODR_COMMIT.zip
-  tar -xf OSM2ODR.zip
-  cd sumo-$CURRENT_OSM2ODR_COMMIT
+  if [ ! -d ${OSM2ODR_SOURCE_FOLDER} ] ; then
+    cd ${CARLA_BUILD_FOLDER}
+    curl --retry 5 --retry-max-time 120 -L -o OSM2ODR.zip https://github.com/carla-simulator/sumo/archive/${CURRENT_OSM2ODR_COMMIT}.zip
+    unzip OSM2ODR.zip
+    rm -f OSM2ODR.zip
+    mv sumo-${CURRENT_OSM2ODR_COMMIT} ${OSM2ODR_SOURCE_FOLDER}
+  fi
 
   mkdir -p ${OSM2ODR_BUILD_FOLDER}
   cd ${OSM2ODR_BUILD_FOLDER}
+
 
   export CC="$UE4_ROOT/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v17_clang-10.0.1-centos7/x86_64-unknown-linux-gnu/bin/clang"
   export CXX="$UE4_ROOT/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v17_clang-10.0.1-centos7/x86_64-unknown-linux-gnu/bin/clang++"


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Retry download when fails for osm2odr.

OSM2ODR was making the build fail randomly and this was causing Jenkins and some contributors to fail on building CARLA.

#### Where has this been tested?

  * **Platform(s):** Windows 10, Ubuntu 22.04
  * **Python version(s):** 3.10, 3.8
  * **Unreal Engine version(s):** 5.3