### PR TITLE
Introduce several helper macros and utilities for improved usability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Dist/
 out/
 
 CMakeSettings.json
+
+Help.md

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -134,18 +134,6 @@ carla_string_option (
   "/usr/bin/gcc-7"
 )
 
-carla_option (
-  CARLA_CMAKE_HELP
-  "Display additional information regarding the various options and targets."
-  OFF
-)
-
-carla_option (
-  CARLA_CMAKE_HELP_FILE
-  "Write the output of CARLA_CMAKE_HELP to ${CARLA_WORKSPACE_PATH}/Help.md"
-  OFF
-)
-
 
 
 # ================================

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -128,12 +128,6 @@ carla_string_option (
   "png"
 )
 
-carla_string_option (  
-  GCC_COMPILER
-  "gcc compiler used by some CARLA extensions."
-  "/usr/bin/gcc-7"
-)
-
 
 
 # ================================

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -125,13 +125,25 @@ carla_option (
 carla_string_option (
   LIBCARLA_IMAGE_SUPPORTED_FORMATS
   "Semicolon-separated list of supported image formats by LibCarla. Available formats: png, jpeg, tiff."
-  png
+  "png"
 )
 
 carla_string_option (  
   GCC_COMPILER
   "gcc compiler used by some CARLA extensions."
-  /usr/bin/gcc-7
+  "/usr/bin/gcc-7"
+)
+
+carla_option (
+  CARLA_CMAKE_HELP
+  "Display additional information regarding the various options and targets."
+  OFF
+)
+
+carla_option (
+  CARLA_CMAKE_HELP_FILE
+  "Write the output of CARLA_CMAKE_HELP to ${CARLA_WORKSPACE_PATH}/Help.md"
+  OFF
 )
 
 
@@ -192,7 +204,7 @@ if (${BUILD_CARLA_UNREAL} AND ${CARLA_HAS_UNREAL_ENGINE_PATH})
   )
 else ()
   carla_error (
-    "Could not add UE project to build since the carla_option CARLA_UNREAL_ENGINE_PATH"
+    "Could not add UE project to build since the carla_option CARLA_UNREAL_ENGINE_PATH "
     "is not set to a valid path (\"${CARLA_UNREAL_ENGINE_PATH}\")."
     "Please set it to point to the root path of your CARLA Unreal Engine installation."
   )

--- a/CMake/Util.cmake
+++ b/CMake/Util.cmake
@@ -1,12 +1,12 @@
 # Similar to configure_file, but also expands variables
 # that are set at generate time, like generator expressions.
-macro (carla_two_step_configure_file DESTINATION SOURCE)
+function (carla_two_step_configure_file DESTINATION SOURCE)
   carla_message ("Configuring file ${DESTINATION}")
   # Configure-time step; evaluate variables:
   configure_file (${SOURCE} ${DESTINATION} @ONLY)
   # Generate-time step; evaluate generator expressions:
   file (GENERATE OUTPUT ${DESTINATION} INPUT ${DESTINATION})
-endmacro ()
+endfunction ()
 
 
 
@@ -17,26 +17,104 @@ endfunction ()
 
 
 
-# message wrapper for warnings.
-macro (carla_warning)
+# message() wrapper for warnings.
+function (carla_warning)
   message (WARNING ${ARGN})
-endmacro ()
+endfunction ()
 
 
 
-# message wrapper for errors.
+# message() wrapper for errors.
 function (carla_error)
   message (FATAL_ERROR ${ARGN})
 endfunction ()
 
 
 
+function (carla_get_option_docs OUT_VAR)
+  get_property (DOCS GLOBAL PROPERTY CARLA_OPTION_DOCS)
+  set (${OUT_VAR} ${DOCS})
+  return (PROPAGATE ${OUT_VAR})
+endfunction ()
+
 macro (carla_option NAME DESCRIPTION VALUE)
   option (${NAME} ${DESCRIPTION} ${VALUE})
   carla_message ("(option) ${NAME} : ${VALUE}")
+  get_property (DOCS GLOBAL PROPERTY CARLA_OPTION_DOCS)
+  string (
+    APPEND
+    DOCS
+    "- ${NAME}\n"
+    "\t- Description: ${DESCRIPTION}\n"
+    "\t- Default: ${VALUE}\n"
+  )
+  set_property (GLOBAL PROPERTY CARLA_OPTION_DOCS ${DOCS})
 endmacro ()
+
+
 
 macro (carla_string_option NAME DESCRIPTION VALUE)
   set (${NAME} "${VALUE}")
   carla_message ("(option) ${NAME} : \"${VALUE}\"")
+  get_property (DOCS GLOBAL PROPERTY CARLA_OPTION_DOCS)
+  string (
+    APPEND
+    DOCS
+    "- ${NAME}\n"
+    "\t- Description: ${DESCRIPTION}\n"
+    "\t- Default: \"${VALUE}\"\n"
+  )
+  set_property (GLOBAL PROPERTY CARLA_OPTION_DOCS ${DOCS})
 endmacro ()
+
+
+
+function (carla_get_target_docs OUT_VAR)
+  get_property (DOCS GLOBAL PROPERTY CARLA_TARGET_DOCS)
+  set (${OUT_VAR} ${DOCS})
+  return (PROPAGATE ${OUT_VAR})
+endfunction ()
+
+
+function (carla_add_library NAME DESCRIPTION)
+  get_property (DOCS GLOBAL PROPERTY CARLA_TARGET_DOCS)
+  string (
+    APPEND
+    DOCS
+    "- ${NAME}\n"
+    "\t- Type: Library\n"
+    "\t- Description: ${DESCRIPTION}\n"
+  )
+  add_library (${NAME} ${ARGN})
+  set_property (GLOBAL PROPERTY CARLA_TARGET_DOCS ${DOCS})
+endfunction ()
+
+
+
+function (carla_add_executable NAME DESCRIPTION)
+  get_property (DOCS GLOBAL PROPERTY CARLA_TARGET_DOCS)
+  string (
+    APPEND
+    DOCS
+    "- ${NAME}\n"
+    "\t- Type: Executable\n"
+    "\t- Description: ${DESCRIPTION}\n"
+  )
+  add_executable (${NAME} ${ARGN})
+  set_property (GLOBAL PROPERTY CARLA_TARGET_DOCS ${DOCS})
+endfunction ()
+
+
+
+function (carla_add_custom_target NAME DESCRIPTION)
+  get_property (DOCS GLOBAL PROPERTY CARLA_TARGET_DOCS)
+  string (
+    APPEND
+    DOCS
+    "- ${NAME}\n"
+    "\t- Type: CustomTarget\n"
+    "\t- Description: ${DESCRIPTION}\n"
+  )
+  add_custom_target (${NAME} ${ARGN})
+  set_property (GLOBAL PROPERTY CARLA_TARGET_DOCS ${DOCS})
+endfunction ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,9 @@ endif ()
 if (CARLA_CMAKE_HELP)
   carla_get_option_docs (CARLA_OPTION_DOCS)
   carla_get_target_docs (CARLA_TARGET_DOCS)
-  set (
+  set (CARLA_CMAKE_HELP_MESSAGE)
+  string (
+    APPEND 
     CARLA_CMAKE_HELP_MESSAGE
     "# CARLA - CMake Help\n"
     "## CMake Targets\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,6 @@ include (${CARLA_WORKSPACE_PATH}/CMake/Options.cmake)
 include (${CARLA_WORKSPACE_PATH}/CMake/Common.cmake)
 include (${CARLA_WORKSPACE_PATH}/CMake/Dependencies.cmake)
 
-
-
 if (BUILD_CARLA_CLIENT OR BUILD_CARLA_SERVER)
   add_subdirectory (LibCarla)
 endif ()
@@ -98,4 +96,25 @@ endif ()
 
 if (BUILD_EXAMPLES)
   add_subdirectory (Examples)
+endif ()
+
+if (CARLA_CMAKE_HELP)
+  carla_get_option_docs (CARLA_OPTION_DOCS)
+  carla_get_target_docs (CARLA_TARGET_DOCS)
+  set (
+    CARLA_CMAKE_HELP_MESSAGE
+    "# CARLA - CMake Help\n"
+    "## CMake Targets\n"
+    "${CARLA_TARGET_DOCS}\n"
+    "## CMake Options\n"
+    "${CARLA_OPTION_DOCS}\n"
+  )
+  message ("${CARLA_CMAKE_HELP_MESSAGE}")
+  if (CARLA_CMAKE_HELP_FILE)
+    file (
+      WRITE
+      ${CARLA_WORKSPACE_PATH}/Help.md
+      ${CARLA_CMAKE_HELP_MESSAGE}
+    )
+  endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,25 +98,27 @@ if (BUILD_EXAMPLES)
   add_subdirectory (Examples)
 endif ()
 
-if (CARLA_CMAKE_HELP)
-  carla_get_option_docs (CARLA_OPTION_DOCS)
-  carla_get_target_docs (CARLA_TARGET_DOCS)
-  set (CARLA_CMAKE_HELP_MESSAGE)
-  string (
-    APPEND 
-    CARLA_CMAKE_HELP_MESSAGE
-    "# CARLA - CMake Help\n"
-    "## CMake Targets\n"
-    "${CARLA_TARGET_DOCS}\n"
-    "## CMake Options\n"
-    "${CARLA_OPTION_DOCS}\n"
-  )
-  message ("${CARLA_CMAKE_HELP_MESSAGE}")
-  if (CARLA_CMAKE_HELP_FILE)
-    file (
-      WRITE
-      ${CARLA_WORKSPACE_PATH}/Help.md
-      ${CARLA_CMAKE_HELP_MESSAGE}
-    )
-  endif ()
-endif ()
+carla_add_custom_target (
+  carla-help
+  "Display this message."
+  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_BINARY_DIR}/Help.md"
+)
+
+carla_get_option_docs (CARLA_OPTION_DOCS)
+carla_get_target_docs (CARLA_TARGET_DOCS)
+set (CARLA_CMAKE_HELP_MESSAGE)
+string (
+  APPEND 
+  CARLA_CMAKE_HELP_MESSAGE
+  "# CARLA - CMake Help\n"
+  "## CMake Targets\n"
+  "${CARLA_TARGET_DOCS}\n"
+  "## CMake Options\n"
+  "${CARLA_OPTION_DOCS}\n"
+)
+
+file (
+  WRITE
+  ${CMAKE_CURRENT_BINARY_DIR}/Help.md
+  ${CARLA_CMAKE_HELP_MESSAGE}
+)

--- a/Examples/CppClient/CMakeLists.txt
+++ b/Examples/CppClient/CMakeLists.txt
@@ -1,7 +1,8 @@
 project (carla-example-cpp-client)
 
-add_executable (
+carla_add_executable (
   carla-example-cpp-client
+  "Build the CARLA C++ client example."
   main.cpp
 )
 

--- a/LibCarla/CMakeLists.txt
+++ b/LibCarla/CMakeLists.txt
@@ -108,8 +108,9 @@ if (BUILD_CARLA_SERVER)
     ${LIBCARLA_THIRD_PARTY_SOURCE_PATH}/pugixml/*.hpp
   )
 
-  add_library (
+  carla_add_library (
     carla-server
+    "Build the CARLA server."
     ${LIBCARLA_SERVER_HEADERS}
     ${LIBCARLA_SERVER_SOURCES}
     ${LIBCARLA_SERVER_HEADERS_THIRD_PARTY}
@@ -264,8 +265,9 @@ if (BUILD_CARLA_CLIENT)
     ${LIBCARLA_THIRD_PARTY_SOURCE_PATH}/pugixml/*.cpp
   )
 
-  add_library (
+  carla_add_library (
     carla-client
+    "Build the CARLA client."
     ${LIBCARLA_CLIENT_HEADERS}
     ${LIBCARLA_CLIENT_SOURCES}
     ${LIBCARLA_CLIENT_HEADERS_THIRD_PARTY}
@@ -300,12 +302,3 @@ if (BUILD_CARLA_CLIENT)
   )
 
 endif ()
-
-add_custom_target (
-  carla-server-package
-)
-
-add_dependencies (
-  carla-server-package
-  carla-server
-)

--- a/PythonAPI/CMakeLists.txt
+++ b/PythonAPI/CMakeLists.txt
@@ -81,8 +81,9 @@ else ()
   )
 endif ()
 
-add_custom_target (
+carla_add_custom_target (
   carla-python-api
+  "Build the CARLA Python API."
   COMMAND
     ${CMAKE_COMMAND}
       -E copy
@@ -96,8 +97,9 @@ add_custom_target (
   USES_TERMINAL
 )
 
-add_custom_target (
+carla_add_custom_target (
   carla-python-api-install
+  "Build & install the CARLA Python API"
   COMMAND
     ${Python3_EXECUTABLE}
       -m pip install

--- a/Ros2Native/CMakeLists.txt
+++ b/Ros2Native/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.28.0)
 
-project(carla-ros2-native-project)
+project (carla-ros2-native-project)
 
 include (ExternalProject)
 
@@ -29,7 +29,7 @@ ExternalProject_add (
   DEPENDS foonathan_memory fastcdr
 )
 
-ExternalProject_Add(
+ExternalProject_Add (
   carla-ros2-native-lib
   DEPENDS fastdds
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/LibCarlaRos2Native
@@ -37,16 +37,20 @@ ExternalProject_Add(
 )
 
 set (CARLA_PLUGIN_BINARY_PATH ${CMAKE_SOURCE_DIR}/Unreal/CarlaUnreal/Plugins/Carla/Binaries/Linux)
-make_directory(${CARLA_PLUGIN_BINARY_PATH})
-add_custom_command(
-    TARGET carla-ros2-native-lib
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PROJECT_INSTALL_PATH}/lib/*.so*
-      ${CARLA_PLUGIN_BINARY_PATH}
+
+make_directory (${CARLA_PLUGIN_BINARY_PATH})
+
+add_custom_command (
+  TARGET carla-ros2-native-lib
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E copy
+    ${PROJECT_INSTALL_PATH}/lib/*.so*
+    ${CARLA_PLUGIN_BINARY_PATH}
 )
 
-add_custom_target (
+carla_add_custom_target (
   carla-ros2-native
+  "Build the ROS2-Native CARLA subproject."
   DEPENDS carla-ros2-native-lib
 )

--- a/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
+++ b/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
@@ -22,7 +22,10 @@ file (
     ${LIBCARLA_SOURCE_PATH}/carla/ros2/types/*.h
 )
 
-add_library (carla-ros2-native SHARED
+carla_add_library (
+    carla-ros2-native
+    "Build the CARLA ROS2-Native subproject."
+    SHARED
     ${LIBCARLA_ROS2_HEADERS}
     ${LIBCARLA_ROS2_SOURCES}
 )

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -8,7 +8,8 @@ project (
     "Open-source simulator for autonomous driving research."
 )
 
-option(ENABLE_DIRECTORY_CLEAN
+carla_option (
+  ENABLE_DIRECTORY_CLEAN
   "Enable ADDITIONAL_CLEAN_FILES on directory level"
   ON
 )
@@ -295,8 +296,9 @@ file (
 
 
 
-add_custom_target (
+carla_add_custom_target (
   carla-unreal
+  "Build the CarlaUnreal subproject."
   COMMAND
     ${CARLA_UE_BUILD_COMMAND_PREFIX} 
     CarlaUnreal
@@ -316,8 +318,9 @@ add_dependencies (
   ${UE_DEPENDENCIES_ORDER_ONLY}
 )
 
-add_custom_target (
+carla_add_custom_target (
   carla-unreal-editor
+  "Build the CarlaUnrealEditor subproject."
   COMMAND
     ${CARLA_UE_BUILD_COMMAND_PREFIX} 
     CarlaUnrealEditor
@@ -337,9 +340,11 @@ add_dependencies (
   ${UE_DEPENDENCIES_ORDER_ONLY}
 )
 
-function(add_carla_ue_package_target TARGET_NAME_SUFFIX UE_BUILD_CONFIGURATION)
-  add_custom_target (
+function (add_carla_ue_package_target PACKAGE_CONFIGURATION UE_BUILD_CONFIGURATION)
+  set (TARGET_NAME_SUFFIX -${PACKAGE_CONFIGURATION})
+  carla_add_custom_target (
     carla-unreal-package${TARGET_NAME_SUFFIX}
+    "Create a CARLA package in ${PACKAGE_CONFIGURATION} mode."
     COMMAND
       ${CARLA_UE_BUILD_COMMAND_PREFIX}
       CarlaUnreal
@@ -371,8 +376,8 @@ function(add_carla_ue_package_target TARGET_NAME_SUFFIX UE_BUILD_CONFIGURATION)
       VERBATIM
     )
 
-  set(CARLA_TARGET_PACKAGE_PATH ${CARLA_PACKAGE_PATH}/${UE_SYSTEM_NAME})
-  add_custom_command(
+  set (CARLA_TARGET_PACKAGE_PATH ${CARLA_PACKAGE_PATH}/${UE_SYSTEM_NAME})
+  add_custom_command (
     TARGET carla-unreal-package${TARGET_NAME_SUFFIX}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E echo "********** PACKAGE CREATING VERSION FILE UNREAL PACKAGE EXTRA FILES STARTED **********"
@@ -411,8 +416,9 @@ function(add_carla_ue_package_target TARGET_NAME_SUFFIX UE_BUILD_CONFIGURATION)
     ${UE_DEPENDENCIES_ORDER_ONLY}
   )
 
-  add_custom_target (
+  carla_add_custom_target (
     package${TARGET_NAME_SUFFIX}
+    "Create a CARLA package in ${PACKAGE_CONFIGURATION} mode."
   )
 
   add_dependencies (
@@ -424,11 +430,11 @@ endfunction()
 # Docs for UE5 build configurations:
 # https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/BuildConfigurations/
 add_carla_ue_package_target("" Shipping)
-add_carla_ue_package_target(-Shipping Shipping)
-add_carla_ue_package_target(-Debug Debug)
-add_carla_ue_package_target(-DebugGame DebugGame)
-add_carla_ue_package_target(-Development Development)
-add_carla_ue_package_target(-Test Test)
+add_carla_ue_package_target(Shipping Shipping)
+add_carla_ue_package_target(Debug Debug)
+add_carla_ue_package_target(DebugGame DebugGame)
+add_carla_ue_package_target(Development Development)
+add_carla_ue_package_target(Test Test)
 
 
 
@@ -445,8 +451,9 @@ set (
   VERBATIM
 )
 
-add_custom_target (
+carla_add_custom_target (
   launch
+  "Build and open CARLA in the Unreal Editor."
   ${CARLA_LAUNCH_TARGET_OPTIONS}
 )
 
@@ -462,8 +469,9 @@ else ()
   )
 endif ()
 
-add_custom_target (
-  prelaunch-content-check
+carla_add_custom_target (
+  check-unreal-content
+  "Perform some basic checks to ensure that the CARLA Unreal Editor will not open without its assets."
   COMMAND
     ${PRELAUNCH_CONTENT_CHECK_COMMAND}
   COMMENT
@@ -475,20 +483,22 @@ add_custom_target (
 add_dependencies (
   launch
   carla-unreal-editor
-  prelaunch-content-check
+  check-unreal-content
 )
 
-add_custom_target (
+carla_add_custom_target (
   launch-only
+  "Open CARLA in the Unreal Editor. This will not rebuild outdated targets."
   ${CARLA_LAUNCH_TARGET_OPTIONS}
 )
 
 add_dependencies (
   launch-only
-  prelaunch-content-check
+  check-unreal-content
 )
 
-set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES  
+set_property (
+  DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES  
   "${CARLA_UE_PATH}/Binaries" 
   "${CARLA_UE_PATH}/Intermediate"
   "${CARLA_UE_PATH}/Saved"
@@ -500,5 +510,5 @@ set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
   "${CARLA_UE_CARLA_PATH}/Saved"
   "${CARLA_BUILD_PATH}/Package"
   "${CARLA_BUILD_PATH}/PythonAPI/dist"
-  )
+)
 

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -341,7 +341,9 @@ add_dependencies (
 )
 
 function (add_carla_ue_package_target PACKAGE_CONFIGURATION UE_BUILD_CONFIGURATION)
-  set (TARGET_NAME_SUFFIX -${PACKAGE_CONFIGURATION})
+  if (NOT "${PACKAGE_CONFIGURATION}" STREQUAL "")
+    set (TARGET_NAME_SUFFIX -${PACKAGE_CONFIGURATION})
+  endif ()
   carla_add_custom_target (
     carla-unreal-package${TARGET_NAME_SUFFIX}
     "Create a CARLA package in ${PACKAGE_CONFIGURATION} mode."

--- a/osm-world-renderer/CMakeLists.txt
+++ b/osm-world-renderer/CMakeLists.txt
@@ -11,8 +11,9 @@ set (
   ${CARLA_WORKSPACE_PATH}/osm-world-renderer/OsmRenderer
 )
 
-add_library (
+carla_add_library (
   lib-osm-map-renderer
+  "Build OSM-Map-Renderer."
   ${OSM_RENDERER_SOURCE_PATH}/src/OsmRenderer.cpp
   ${OSM_RENDERER_SOURCE_PATH}/src/MapDrawer.cpp
   ${OSM_RENDERER_SOURCE_PATH}/src/MapRasterizer.cpp
@@ -32,8 +33,9 @@ target_include_directories (
   ${OSM_RENDERER_SOURCE_PATH}/include
 )
 
-add_executable (
+carla_add_executable (
   osm-world-renderer
+  "Build OSM-World-Renderer."
   ${OSM_RENDERER_SOURCE_PATH}/main.cpp
 )
 


### PR DESCRIPTION
This PR introduces the following helper macros:
 - carla_add_executable
 - carla_add_library
 - carla_add_custom_target
These all wrap the corresponding CMake commands, with the goal being to add extra documentation code in a similar fashion than seen in carla_option and carla_string_option.
This PR also adds two new options to print all relevant targets and options at configure time and to save it to /Help.md.