### PR TITLE
Checking if path or extension is not empty

### DIFF
--- a/LibCarla/source/carla/FileSystem.cpp
+++ b/LibCarla/source/carla/FileSystem.cpp
@@ -17,7 +17,7 @@ namespace carla {
 
   void FileSystem::ValidateFilePath(std::string &filepath, const std::string &ext) {
     fs::path path(filepath);
-    if (path.extension() != ext)
+    if (!ext.empty() && path.extension() != ext)
       path.replace_extension(ext);
     auto parent = path.parent_path();
     if (!fs::exists(parent))

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -538,7 +538,7 @@ void FCarlaServer::FPimpl::BindActions()
     REQUIRE_CARLA_EPISODE();
 
     // Check that the path ends in a slash, add it otherwise
-    if (folder[folder.size() - 1] != '/' && folder[folder.size() - 1] != '\\') {
+    if (!folder.empty() && folder[folder.size() - 1] != '/' && folder[folder.size() - 1] != '\\') {
       folder += "/";
     }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Two issues:
- If a second argument is not passed to the ValidateFilePath(...), the extension is replaced by an empty string. For this reason I am checking now if it is empty or not. To avoid this replacement
- Same in CarlaServer but for the path. That it adds additional /.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** UE5 Carla

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
