### PR TITLE
Fix double dowload of boost backup due to wrong string comparision with sha256sum

### DIFF
--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -94,16 +94,16 @@ for PY_VERSION in ${PY_VERSION_LIST[@]} ; do
     log "Retrieving boost."
 
     start=$(date +%s)
-    wget "https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_PACKAGE_BASENAME}.tar.gz" || true
+    wget "https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_PACKAGE_BASENAME}.tar.gz" -O ${BOOST_PACKAGE_BASENAME}.tar.gz || true
     end=$(date +%s)
     echo "Elapsed Time downloading from boost webpage: $(($end-$start)) seconds"
 
     # try to use the backup boost we have in Jenkins
-    if [ ! -f "${BOOST_PACKAGE_BASENAME}.tar.gz" ] || [[ $(sha256sum "${BOOST_PACKAGE_BASENAME}.tar.gz") != "${BOOST_SHA256SUM}" ]] ; then
+    if [ ! -f "${BOOST_PACKAGE_BASENAME}.tar.gz" ] || [[ $(sha256sum "${BOOST_PACKAGE_BASENAME}.tar.gz" | cut -d " " -f 1 ) != "${BOOST_SHA256SUM}" ]] ; then
       log "Using boost backup"
 
       start=$(date +%s)
-      wget "https://carla-releases.s3.us-east-005.backblazeb2.com/Backup/${BOOST_PACKAGE_BASENAME}.tar.gz" || true
+      wget "https://carla-releases.s3.us-east-005.backblazeb2.com/Backup/${BOOST_PACKAGE_BASENAME}.tar.gz" -O ${BOOST_PACKAGE_BASENAME}.tar.gz || true
       end=$(date +%s)
       echo "Elapsed Time downloading from boost carla backup in backblaze: $(($end-$start)) seconds"
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes  #7633

The `sha256sum` check on the boost file returns a string in the format `<hash> <filename>` in the build script the string comparison fails because it only is checked against <hash>.

Applied solution and problem description see: https://unix.stackexchange.com/questions/265740/suppress-filename-from-output-of-sha512sum

Also prevents duplication of multiple boost tar files due to automatic renaming with numbers Credit to @MarcelPiNacy-CVC

---

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 22.04

#### Possible Drawbacks


