### PR TITLE
Remove boost from ROS2 Native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ if (BUILD_OSM_WORLD_RENDERER)
 endif ()
 
 if (ENABLE_ROS2)
-  set (BOOST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/_deps/boost-src/libs)
   add_subdirectory (Ros2Native)
 endif()
 

--- a/LibCarla/source/carla/ros2/ROS2CallbackData.h
+++ b/LibCarla/source/carla/ros2/ROS2CallbackData.h
@@ -6,16 +6,6 @@
 
 #pragma once
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
-#include <boost/variant2/variant.hpp>
-#pragma warning(pop)
-#else
-#include <boost/variant2/variant.hpp>
-#endif
-
 #include <variant>
 #include <functional>
 
@@ -38,8 +28,8 @@ namespace ros2 {
     const char* message;
   };
 
-  using ROS2CallbackData = boost::variant2::variant<VehicleControl>;
-  using ROS2MessageCallbackData = boost::variant2::variant<MessageControl>;
+  using ROS2CallbackData = std::variant<VehicleControl>;
+  using ROS2MessageCallbackData = std::variant<MessageControl>;
 
   using ActorCallback = std::function<void(void *actor, ROS2CallbackData data)>;
   using ActorMessageCallback = std::function<void(void *actor, ROS2MessageCallbackData data)>;

--- a/Ros2Native/CMakeLists.txt
+++ b/Ros2Native/CMakeLists.txt
@@ -33,7 +33,7 @@ ExternalProject_Add (
   carla-ros2-native-lib
   DEPENDS fastdds
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/LibCarlaRos2Native
-  CMAKE_ARGS ${PROJECT_CMAKE_FLAGS} -DBOOST_INCLUDE_PATH=${BOOST_INCLUDE_PATH}
+  CMAKE_ARGS ${PROJECT_CMAKE_FLAGS}
 )
 
 set (CARLA_PLUGIN_BINARY_PATH ${CMAKE_SOURCE_DIR}/Unreal/CarlaUnreal/Plugins/Carla/Binaries/Linux)

--- a/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
+++ b/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
@@ -32,10 +32,6 @@ add_library (
 target_include_directories (carla-ros2-native SYSTEM PRIVATE
     ${LIBCARLA_SOURCE_PATH}
     ${CMAKE_INSTALL_PREFIX}/include
-    ${BOOST_INCLUDE_PATH}/variant2/include
-    ${BOOST_INCLUDE_PATH}/mp11/include
-    ${BOOST_INCLUDE_PATH}/assert/include
-    ${BOOST_INCLUDE_PATH}/config/include
 )
 
 target_compile_definitions (carla-ros2-native PUBLIC

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -20,6 +20,7 @@
   #include <compiler/disable-ue4-macros.h>
   #include "carla/ros2/ROS2.h"
   #include <compiler/enable-ue4-macros.h>
+  #include <variant>
 #endif
 
 void UActorDispatcher::Bind(FActorDefinition Definition, SpawnFunctionType Functor)
@@ -213,14 +214,14 @@ FCarlaActor* UActorDispatcher::RegisterActor(
           {
             AActor *UEActor = reinterpret_cast<AActor *>(Actor);
             ActorROS2Handler Handler(UEActor, RosName);
-            boost::variant2::visit(Handler, Data);
+            std::visit(Handler, Data);
           });
 
           ROS2->AddBasicSubscriberCallback(static_cast<void*>(&Actor), RosName, [RosName](void *Actor, carla::ros2::ROS2MessageCallbackData Data) -> void
           {
             AActor *UEActor = reinterpret_cast<AActor *>(Actor);
             ActorROS2Handler Handler(UEActor, RosName);
-            boost::variant2::visit(Handler, Data);
+            std::visit(Handler, Data);
           });
         }
       }


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

After building ROS2 Native with clang C++20, we remove Boost from ROS2 Native to reduce the dependencies.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.10
  * **Unreal Engine version(s):** 5.3
