### PR TITLE
Solve the issue that the digital twin tool only generates one map tile

### DIFF
--- a/Unreal/CarlaUE4/Plugins/CarlaTools/Source/CarlaTools/Private/OpenDriveToMap.cpp
+++ b/Unreal/CarlaUE4/Plugins/CarlaTools/Source/CarlaTools/Private/OpenDriveToMap.cpp
@@ -363,7 +363,7 @@ void UOpenDriveToMap::GenerateTile(){
 
     UEditorLoadingAndSavingUtils::SaveDirtyPackages(true, true);
     UEditorLevelLibrary::SaveCurrentLevel();
-    RemoveFromRoot();
+	// RemoveFromRoot();
   }
 }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Removing the statement that cleans up the `FilePath` variable can solve the problem that only one tile is generated for the large map. If it is not commented, the `FilePath` memory value pointing to the xodr file is garbled when the tile is generated for the second time.

Fixes #6913

#### Where has this been tested?

  * **Platform(s):** windows 10
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26
![twin](https://github.com/carla-simulator/carla/assets/7724320/1f6a1f42-ccd0-4825-9f5d-4ee14b85dc80)

#### Possible Drawbacks
Whether Ubuntu works normally.
<!-- What are the possible side-effects or negative impacts of the code change? -->
