### PR TITLE
Revert upgrade patchelf version

### DIFF
--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -761,7 +761,7 @@ cp -p ${PROJ_SERVER_LIB} ${LIBCARLA_INSTALL_SERVER_FOLDER}/lib/
 # -- Get and compile patchelf --------------------------------------------------
 # ==============================================================================
 
-PATCHELF_VERSION=0.14
+PATCHELF_VERSION=0.12
 PATCHELF_REPO=https://github.com/NixOS/patchelf/archive/${PATCHELF_VERSION}.tar.gz
 
 PATCHELF_TAR=${PATCHELF_VERSION}.tar.gz


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Going back to `patchelf` `0.12`. `patchelf` `0.14` is using `c++17` which is no compatible with CARLA build system.

<!-- Please explain the changes you made here as detailed as possible. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
