### PR TITLE
Not tests V2X tick

### DIFF
--- a/PythonAPI/test/smoke/test_sensor_tick_time.py
+++ b/PythonAPI/test/smoke/test_sensor_tick_time.py
@@ -38,7 +38,9 @@ class TestSensorTickTime(SyncSmokeTest):
       "sensor.camera.semantic_segmentation",
       "sensor.camera.dvs",
       "sensor.other.obstacle",
-      "sensor.camera.instance_segmentation"
+      "sensor.camera.instance_segmentation",
+      "sensor.other.v2x",
+      "sensor.other.v2x_custom"
     }
     spawned_sensors = []
     sensor_tick = 1.0
@@ -64,5 +66,3 @@ class TestSensorTickTime(SyncSmokeTest):
       self.assertEqual(sensor.num_ticks, num_sensor_ticks,
         "\n\n {} does not match tick count".format(sensor.bp_sensor.id))
       sensor.destroy()
-
-


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [X] All tests passing with `make check` (only Linux)
  - [X] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
Not allow v2x sensor go through  tick tests. 
Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
