### PR TITLE
Fix lidar in replayer mode

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -202,7 +202,7 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
   }
 
   // check to ignore Hero or Spectator
-  if ((bIgnoreHero && IsHero) || 
+  if ((bIgnoreHero && IsHero) ||
       (bIgnoreSpectator && ActorDesc.Id.StartsWith("spectator")))
   {
     return std::make_pair(3, 0);
@@ -227,7 +227,11 @@ std::pair<int, uint32_t> CarlaReplayerHelper::ProcessReplayerEventAdd(
         // disable physics
         SetActorSimulatePhysics(result.second, false);
         // disable collisions
-        result.second->GetActor()->SetActorEnableCollision(false);
+        result.second->GetActor()->SetActorEnableCollision(true);
+        auto RootComponent = Cast<UPrimitiveComponent>(
+            result.second->GetActor()->GetRootComponent());
+        RootComponent->SetSimulatePhysics(false);
+        RootComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
         // disable autopilot for vehicles
         if (result.second->GetActorType() == FCarlaActor::ActorType::Vehicle)
           SetActorAutopilot(result.second, false, false);


### PR DESCRIPTION
Lidar was not working with vehicles and walkers in replayer mode.

Manually tested in Ubuntu 22

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/7733)
<!-- Reviewable:end -->
