### PR TITLE
Added extra functionality to the Procedural Building class

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
@@ -215,7 +215,7 @@ void AProceduralBuildingUtilities::CookProceduralMeshToMesh(
       SaveArgs);
 }
 
-void AProceduralBuildingUtilities::PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components, const FString& Name)
+void AProceduralBuildingUtilities::PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components)
 {
   //Security wall.
   if(Parent == nullptr) return;
@@ -231,7 +231,7 @@ void AProceduralBuildingUtilities::PlaceBuilding(AActor* Parent, TArray<UHierarc
     //Creates the component. The index is needed so every component has a unique name, if not, each iteration
     //will just override the previous one. 
     UHierarchicalInstancedStaticMeshComponent* NewComponent = 
-     NewObject<UHierarchicalInstancedStaticMeshComponent>(Parent, HSMClass, FName(Name + FString::FromInt(i)));
+      NewObject<UHierarchicalInstancedStaticMeshComponent>(Parent, HSMClass, FName(Components[i]->GetStaticMesh().GetName() + FString::FromInt(i)));
     
     //Sets static mesh
     NewComponent->SetStaticMesh(Components[i]->GetStaticMesh());

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
@@ -13,6 +13,7 @@
 #include "Materials/MaterialInstanceConstant.h"
 #include "MeshMergeModule.h"
 #include "ProceduralMeshComponent.h"
+#include "Components/HierarchicalInstancedStaticMeshComponent.h"
 #include "UObject/Class.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/SavePackage.h"
@@ -212,6 +213,44 @@ void AProceduralBuildingUtilities::CookProceduralMeshToMesh(
       StaticMesh,
       *FileName,
       SaveArgs);
+}
+
+void AProceduralBuildingUtilities::PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components, const FString& Name)
+{
+  //Security wall.
+  if(Parent == nullptr) return;
+
+  //We need to create a component. This line is just for readability purposes.
+  UClass* HSMClass = UHierarchicalInstancedStaticMeshComponent::StaticClass();
+
+  //For every hierarchichal component we passed in the function, set 
+  //In the parent actor a new hierarchichal component that copies 
+  //the instances of the passed one.
+  for(int i = 0; i < Components.Num(); i++)
+  {
+    //Creates the component. The index is needed so every component has a unique name, if not, each iteration
+    //will just override the previous one. 
+    UHierarchicalInstancedStaticMeshComponent* NewComponent = 
+     NewObject<UHierarchicalInstancedStaticMeshComponent>(Parent, HSMClass, FName(Name + FString::FromInt(i)));
+    
+    //Sets static mesh
+    NewComponent->SetStaticMesh(Components[i]->GetStaticMesh());
+
+    //Sets the instances transform.
+    for(int j = 0; j < Components[i]->GetInstanceCount(); j++)
+    {
+      FTransform InstanceTransform;
+      Components[i]->GetInstanceTransform(j, InstanceTransform, false);
+      NewComponent->AddInstance(InstanceTransform, false);
+    }
+
+    //Registers the component in the parent actor and makes it visible for the user.
+    NewComponent->RegisterComponent();
+    NewComponent->AttachToComponent(
+      Parent->GetRootComponent(),
+      FAttachmentTransformRules::SnapToTargetIncludingScale);
+    Parent->AddInstanceComponent(NewComponent);
+  }
 }
 
 UMaterialInstanceConstant* AProceduralBuildingUtilities::GenerateBuildingMaterialAsset(

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/ProceduralBuildingUtilities.h
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/ProceduralBuildingUtilities.h
@@ -8,6 +8,7 @@
 
 class USceneCaptureComponent2D;
 class UTexture2D;
+class UHierarchicalInstancedStaticMeshComponent;
 
 UENUM(BlueprintType)
 enum EBuildingCameraView
@@ -41,6 +42,9 @@ public:
 
   UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
   void CookProceduralBuildingToMesh(const FString& DestinationPath, const FString& FileName);
+
+  UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
+  void PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components, const FString& Name);
 
   UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
   void CookProceduralMeshToMesh(class UProceduralMeshComponent* Mesh, const FString& DestinationPath, const FString& FileName);

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/ProceduralBuildingUtilities.h
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/ProceduralBuildingUtilities.h
@@ -43,8 +43,10 @@ public:
   UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
   void CookProceduralBuildingToMesh(const FString& DestinationPath, const FString& FileName);
 
+  //Creates an actor with the current settings of the bp procedural building. Copying
+  //the hierarchical mesh components.
   UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
-  void PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components, const FString& Name);
+  void PlaceBuilding(AActor* Parent, TArray<UHierarchicalInstancedStaticMeshComponent*> Components);
 
   UFUNCTION(BlueprintCallable, Category="Procedural Building Utilities")
   void CookProceduralMeshToMesh(class UProceduralMeshComponent* Mesh, const FString& DestinationPath, const FString& FileName);


### PR DESCRIPTION
-Creates function that lets the user creates an actor with the hierarchichal meshes that are currently set in the BP_ProceduralBuilding.

-Function done because when moving the building it quickly updates, making it impossible to maintain a setting the user is happy with

-Function takes the name of the static mesh used by the passed Hierarchichal mesh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/7760)
<!-- Reviewable:end -->
