### PR TITLE
Fix configure error when BUILD_CARLA_UNREAL=OFF

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -198,7 +198,8 @@ carla_string_option (
   "${CARLA_UNREAL_RHI_DEFAULT}"
 )
 
-if (${BUILD_CARLA_UNREAL} AND ${CARLA_HAS_UNREAL_ENGINE_PATH})
+if (${BUILD_CARLA_UNREAL})
+if (${CARLA_HAS_UNREAL_ENGINE_PATH})
   carla_message (
     "Carla UE project successfully added to build. (UE path: ${CARLA_UNREAL_ENGINE_PATH})"
   )
@@ -208,6 +209,7 @@ else ()
     "is not set to a valid path (\"${CARLA_UNREAL_ENGINE_PATH}\")."
     "Please set it to point to the root path of your CARLA Unreal Engine installation."
   )
+endif ()
 endif ()
 
 carla_string_option (


### PR DESCRIPTION
This PR fixes a configure-time error whenever BUILD_CARLA_UNREAL=OFF and the UE5 path is not set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/7875)
<!-- Reviewable:end -->
