### PR TITLE
Fixed numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ psutil
 requests
 scikit-build-core
 wheel
-numpy
+numpy==1.24.4
 setuptools==47.3.1
 build
 pygame


### PR DESCRIPTION
### Description

With the release of numpy 2.0, the numpy version now has to be fixed to avoid installing it, as it has conflict with some libraries such as boost

### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/7941)
<!-- Reviewable:end -->
