### PR TITLE
Fix the compilation error related to encoding format in Windows11 platform

### DIFF
--- a/CMake/Common.cmake
+++ b/CMake/Common.cmake
@@ -39,6 +39,7 @@ endif ()
 
 if (WIN32)
   add_compile_definitions (_CRT_SECURE_NO_WARNINGS)
+  add_compile_options (/utf-8)
 endif ()
 
 set (CARLA_COMMON_DEFINITIONS)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fix the compilation error related to encoding format in Windows11 platform

Related issue: #7907

#### Where has this been tested?

  * **Platform(s):** Windows11
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 5.3.2

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8032)
<!-- Reviewable:end -->
