### PR TITLE
Add temporary workaround for the memory blowup issue

### DIFF
--- a/.clangd.in
+++ b/.clangd.in
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: "@CMAKE_CURRENT_BINARY_DIR@"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ cmake_policy (SET CMP0091 NEW)
 cmake_policy (SET CMP0074 NEW)
 cmake_policy (SET CMP0077 NEW)
 cmake_policy (SET CMP0117 NEW)
+
 if (${CMAKE_MINOR_VERSION} GREATER_EQUAL 24)
   cmake_policy (SET CMP0135 NEW)
 endif ()
@@ -121,3 +122,10 @@ file (
   ${CMAKE_CURRENT_BINARY_DIR}/Help.md
   ${CARLA_CMAKE_HELP_MESSAGE}
 )
+
+if (CMAKE_EXPORT_COMPILE_COMMANDS)
+  configure_file (
+    ${CARLA_WORKSPACE_PATH}/.clangd.in
+    ${CARLA_WORKSPACE_PATH}/.clangd
+  )
+endif ()

--- a/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
@@ -15,7 +15,6 @@
 #include <boost/asio/connect.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
-#include <boost/asio/post.hpp>
 #include <boost/asio/bind_executor.hpp>
 
 #include <exception>
@@ -86,7 +85,6 @@ namespace tcp {
 
   void Client::Connect() {
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
       if (_done) {
         return;
       }
@@ -139,18 +137,15 @@ namespace tcp {
 
       log_debug("streaming client: connecting to", ep);
       _socket.async_connect(ep, boost::asio::bind_executor(_strand, handle_connect));
-    //});
   }
 
   void Client::Stop() {
     _connection_timer.cancel();
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
       _done = true;
       if (_socket.is_open()) {
         _socket.close();
       }
-    //});
   }
 
   void Client::Reconnect() {
@@ -165,7 +160,6 @@ namespace tcp {
 
   void Client::ReadData() {
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
       if (_done) {
         return;
       }
@@ -182,7 +176,6 @@ namespace tcp {
           // Move the buffer to the callback function and start reading the next
           // piece of data.
           // log_debug("streaming client: success reading data, calling the callback");
-          //boost::asio::post(_strand, [self, message]() { self->_callback(message->pop()); });
           _callback(message->pop());
           ReadData();
         } else {
@@ -201,23 +194,12 @@ namespace tcp {
           if (_done) {
             return;
           }
-
-//#define LIBCARLA_SEQUENTIAL_CALLBACKS // Temporary fix for memory usage blowup during save_to_disk
-#ifndef LIBCARLA_SEQUENTIAL_CALLBACKS
           // Now that we know the size of the coming buffer, we can allocate our
           // buffer and start putting data into it.
           boost::asio::async_read(
               _socket,
               message->buffer(),
-            boost::asio::bind_executor(_strand, handle_read_data));
-#else
-          boost::asio::read(
-              _socket,
-              message->buffer());
-          handle_read_data(
-            boost::system::error_code(),
-            message->size());
-#endif
+              boost::asio::bind_executor(_strand, handle_read_data));
         } else if (!_done) {
           log_debug("streaming client: failed to read header:", ec.message());
           DEBUG_ONLY(log_debug("size  = ", message->size()));
@@ -226,21 +208,11 @@ namespace tcp {
         }
       };
 
-#ifndef LIBCARLA_SEQUENTIAL_CALLBACKS
       // Read the size of the buffer that is coming.
       boost::asio::async_read(
           _socket,
           message->size_as_buffer(),
           boost::asio::bind_executor(_strand, handle_read_header));
-#else
-      boost::asio::read(
-          _socket,
-          message->size_as_buffer());
-      handle_read_header(
-        boost::system::error_code(),
-        sizeof(message_size_type));
-#endif
-    //});
   }
 
 } // namespace tcp

--- a/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/Client.cpp
@@ -86,7 +86,7 @@ namespace tcp {
 
   void Client::Connect() {
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
+    boost::asio::post(_strand, [this, self]() {
       if (_done) {
         return;
       }
@@ -139,18 +139,18 @@ namespace tcp {
 
       log_debug("streaming client: connecting to", ep);
       _socket.async_connect(ep, boost::asio::bind_executor(_strand, handle_connect));
-    //});
+    });
   }
 
   void Client::Stop() {
     _connection_timer.cancel();
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
+    boost::asio::post(_strand, [this, self]() {
       _done = true;
       if (_socket.is_open()) {
         _socket.close();
       }
-    //});
+    });
   }
 
   void Client::Reconnect() {
@@ -165,7 +165,7 @@ namespace tcp {
 
   void Client::ReadData() {
     auto self = shared_from_this();
-    //boost::asio::post(_strand, [this, self]() {
+    boost::asio::post(_strand, [this, self]() {
       if (_done) {
         return;
       }
@@ -182,8 +182,7 @@ namespace tcp {
           // Move the buffer to the callback function and start reading the next
           // piece of data.
           // log_debug("streaming client: success reading data, calling the callback");
-          //boost::asio::post(_strand, [self, message]() { self->_callback(message->pop()); });
-          _callback(message->pop());
+          boost::asio::post(_strand, [self, message]() { self->_callback(message->pop()); });
           ReadData();
         } else {
           // As usual, if anything fails start over from the very top.
@@ -201,23 +200,12 @@ namespace tcp {
           if (_done) {
             return;
           }
-
-//#define LIBCARLA_SEQUENTIAL_CALLBACKS // Temporary fix for memory usage blowup during save_to_disk
-#ifndef LIBCARLA_SEQUENTIAL_CALLBACKS
           // Now that we know the size of the coming buffer, we can allocate our
           // buffer and start putting data into it.
           boost::asio::async_read(
               _socket,
               message->buffer(),
-            boost::asio::bind_executor(_strand, handle_read_data));
-#else
-          boost::asio::read(
-              _socket,
-              message->buffer());
-          handle_read_data(
-            boost::system::error_code(),
-            message->size());
-#endif
+              boost::asio::bind_executor(_strand, handle_read_data));
         } else if (!_done) {
           log_debug("streaming client: failed to read header:", ec.message());
           DEBUG_ONLY(log_debug("size  = ", message->size()));
@@ -226,21 +214,12 @@ namespace tcp {
         }
       };
 
-#ifndef LIBCARLA_SEQUENTIAL_CALLBACKS
       // Read the size of the buffer that is coming.
       boost::asio::async_read(
           _socket,
           message->size_as_buffer(),
           boost::asio::bind_executor(_strand, handle_read_header));
-#else
-      boost::asio::read(
-          _socket,
-          message->size_as_buffer());
-      handle_read_header(
-        boost::system::error_code(),
-        sizeof(message_size_type));
-#endif
-    //});
+    });
   }
 
 } // namespace tcp

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -79,39 +79,43 @@ namespace tcp {
     DEBUG_ASSERT(message != nullptr);
     DEBUG_ASSERT(!message->empty());
     auto self = shared_from_this();
-    if (!_socket.is_open()) {
-      return;
-    }
-    if (_is_writing) {
-      if (_server.IsSynchronousMode()) {
-        // wait until previous message has been sent
-        while (_is_writing) {
-          std::this_thread::yield();
-        }
-      } else {
-        // ignore this message
-        log_debug("session", _session_id, ": connection too slow: message discarded");
+    boost::asio::post(_strand, [=]() {
+      if (!_socket.is_open()) {
         return;
       }
-    }
-    _is_writing = true;
-
-    auto handle_sent = [this, self, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
-      _is_writing = false;
-      if (ec) {
-        log_info("session", _session_id, ": error sending data :", ec.message());
-        CloseNow(ec);
-      } else {
-        DEBUG_ONLY(log_debug("session", _session_id, ": successfully sent", bytes, "bytes"));
-        DEBUG_ASSERT_EQ(bytes, sizeof(message_size_type) + message->size());
+      if (_is_writing) {
+        if (_server.IsSynchronousMode()) {
+          // wait until previous message has been sent
+          while (_is_writing) {
+            std::this_thread::yield();
+          }
+        } else {
+          // ignore this message
+          log_debug("session", _session_id, ": connection too slow: message discarded");
+          return;
+        }
       }
-    };
+      _is_writing = true;
 
-    log_debug("session", _session_id, ": sending message of", message->size(), "bytes");
+      auto handle_sent = [this, self, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
+        _is_writing = false;
+        if (ec) {
+          log_info("session", _session_id, ": error sending data :", ec.message());
+          CloseNow(ec);
+        } else {
+          DEBUG_ONLY(log_debug("session", _session_id, ": successfully sent", bytes, "bytes"));
+          DEBUG_ASSERT_EQ(bytes, sizeof(message_size_type) + message->size());
+        }
+      };
 
-    _deadline.expires_from_now(_timeout);
-    boost::asio::async_write(_socket, message->GetBufferSequence(), 
-      boost::asio::bind_executor(_strand, handle_sent));
+      log_debug("session", _session_id, ": sending message of", message->size(), "bytes");
+
+      _deadline.expires_from_now(_timeout);
+      boost::asio::async_write(
+          _socket,
+          message->GetBufferSequence(),
+          handle_sent);
+    });
   }
 
   void ServerSession::Close() {

--- a/PythonAPI/examples/.gitignore
+++ b/PythonAPI/examples/.gitignore
@@ -1,2 +1,1 @@
-carla.so
-carla.pyd
+_out/

--- a/PythonAPI/examples/.gitignore
+++ b/PythonAPI/examples/.gitignore
@@ -1,1 +1,2 @@
-_out/
+carla.so
+carla.pyd


### PR DESCRIPTION
This PR adds a workaround for the memory blowup issue when using save_to_disk within a listen callback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8098)
<!-- Reviewable:end -->
