### PR TITLE
Propagate CMake generator to scikit-build-core.

### DIFF
--- a/PythonAPI/CMakeLists.txt
+++ b/PythonAPI/CMakeLists.txt
@@ -36,6 +36,18 @@ set (
   ${CMAKE_CURRENT_SOURCE_DIR}/carla
 )
 
+set (
+  CARLA_PYTHON_API_CMAKE_ARGS
+  "\t'-G${CMAKE_GENERATOR}'"
+)
+
+if (CMAKE_TOOLCHAIN_FILE)
+  set (
+    CARLA_PYTHON_API_CMAKE_ARGS
+    "${CARLA_PYTHON_API_CMAKE_ARGS},\n\'\t--toolchain=${CMAKE_TOOLCHAIN_FILE}\'"
+  )
+endif ()
+
 carla_two_step_configure_file (
   ${CARLA_PYTHON_API_CARLA_PATH}/pyproject.toml
   ${CARLA_PYTHON_API_CARLA_PATH}/pyproject.toml.in

--- a/PythonAPI/carla/pyproject.toml.in
+++ b/PythonAPI/carla/pyproject.toml.in
@@ -7,8 +7,10 @@ wheel.packages = ['carla']
 cmake.version = '>=@CMAKE_MAJOR_VERSION@.@CMAKE_MINOR_VERSION@'
 cmake.build-type = '@CMAKE_BUILD_TYPE@'
 cmake.args = [
-  '-DCMAKE_TOOLCHAIN_FILE=@CMAKE_TOOLCHAIN_FILE@'
+  @CARLA_PYTHON_API_CMAKE_ARGS@
 ]
+ninja.version=">=1.10"
+ninja.make-fallback=true
 
 [project]
 name = 'carla'


### PR DESCRIPTION
This PR adds a minor modification to the PythonAPI CMakeLists.txt to make scikit-build-core use the same generator as the invoking cmake instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8110)
<!-- Reviewable:end -->
