### PR TITLE
Fix invalid comparisions with string literals in RSS example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
  * Importing from carla.command is now possible
  * carla.ad subpackages are now directly importable and are not directly importable anymore (e.g. import ad)
  * Fixed segfault in traffic manager when trying to access not available vehicles
+ * Fixed invalid comparission in python examples/rss
 
 ## CARLA 0.9.15
 

--- a/PythonAPI/examples/rss/rss_sensor.py
+++ b/PythonAPI/examples/rss/rss_sensor.py
@@ -19,6 +19,7 @@ from carla import ad
 import math
 from rss_visualization import RssDebugVisualizer # pylint: disable=relative-import
 
+EVALUATOR_NONE_STATE = ad.rss.state.RssStateEvaluator.names["None"]
 
 # ==============================================================================
 # -- RssSensor -----------------------------------------------------------------
@@ -51,9 +52,9 @@ class RssStateInfo(object):
         self.longitudinal_margin = float(rss_state.longitudinalState.rssStateInformation.currentDistance - rss_state.longitudinalState.rssStateInformation.safeDistance)
         self.margin = max(0, self.longitudinal_margin)
         self.lateral_margin = None
-        if rss_state.lateralStateLeft.rssStateInformation.evaluator != "None":
+        if rss_state.lateralStateLeft.rssStateInformation.evaluator != EVALUATOR_NONE_STATE:
             self.lateral_margin = rss_state.lateralStateLeft.rssStateInformation.currentDistance - rss_state.lateralStateLeft.rssStateInformation.safeDistance
-        if rss_state.lateralStateRight.rssStateInformation.evaluator != "None":
+        if rss_state.lateralStateRight.rssStateInformation.evaluator != EVALUATOR_NONE_STATE:
             lateral_margin_right = rss_state.lateralStateRight.rssStateInformation.currentDistance - rss_state.lateralStateRight.rssStateInformation.safeDistance
             if self.lateral_margin is None or self.lateral_margin > lateral_margin_right:
                 self.lateral_margin = lateral_margin_right

--- a/PythonAPI/examples/rss/rss_visualization.py
+++ b/PythonAPI/examples/rss/rss_visualization.py
@@ -35,6 +35,9 @@ class Color:
     carla_green = carla.Color(0, 255, 0)
     carla_blue = carla.Color(0, 0, 255)
 
+RssStateEvaluator = ad.rss.state.RssStateEvaluator
+EVALUATOR_NONE_STATE = RssStateEvaluator.names["None"]
+
 class RssStateVisualizer(object):
 
     def __init__(self, display_dimensions, font, world):
@@ -89,27 +92,35 @@ class RssStateVisualizer(object):
             pygame.draw.circle(state_surface, color, (12, v_offset + 7), 5)
             xpos = 184
             if state.actor_calculation_mode == ad.rss.map.RssMode.Structured:
-                if not state.rss_state.longitudinalState.isSafe and ((state.rss_state.longitudinalState.rssStateInformation.evaluator == "LongitudinalDistanceSameDirectionOtherInFront") or (state.rss_state.longitudinalState.rssStateInformation.evaluator == "LongitudinalDistanceSameDirectionEgoFront")):
-                    pygame.draw.polygon(
-                        state_surface, (
-                            255, 255, 255), ((xpos + 1, v_offset + 1 + 4), (xpos + 6, v_offset + 1 + 0), (xpos + 11, v_offset + 1 + 4),
-                                             (xpos + 7, v_offset + 1 + 4), (xpos + 7, v_offset + 1 + 12), (xpos + 5, v_offset + 1 + 12), (xpos + 5, v_offset + 1 + 4)))
-                    xpos += 14
-
-                if not state.rss_state.longitudinalState.isSafe and ((state.rss_state.longitudinalState.rssStateInformation.evaluator == "LongitudinalDistanceOppositeDirectionEgoCorrectLane") or (state.rss_state.longitudinalState.rssStateInformation.evaluator == "LongitudinalDistanceOppositeDirection")):
-                    pygame.draw.polygon(
-                        state_surface, (
-                            255, 255, 255), ((xpos + 2, v_offset + 1 + 8), (xpos + 6, v_offset + 1 + 12), (xpos + 10, v_offset + 1 + 8),
-                                             (xpos + 7, v_offset + 1 + 8), (xpos + 7, v_offset + 1 + 0), (xpos + 5, v_offset + 1 + 0), (xpos + 5, v_offset + 1 + 8)))
-                    xpos += 14
-
-                if not state.rss_state.lateralStateRight.isSafe and not (state.rss_state.lateralStateRight.rssStateInformation.evaluator == "None"):
+                # Unsafe longitudinalState
+                if not state.rss_state.longitudinalState.isSafe:
+                    if (state.rss_state.longitudinalState.rssStateInformation.evaluator == RssStateEvaluator.LongitudinalDistanceSameDirectionOtherInFront
+                        or state.rss_state.longitudinalState.rssStateInformation.evaluator == RssStateEvaluator.LongitudinalDistanceSameDirectionEgoFront
+                    ):
+                        pygame.draw.polygon(
+                            state_surface, (
+                                255, 255, 255), ((xpos + 1, v_offset + 1 + 4), (xpos + 6, v_offset + 1 + 0), (xpos + 11, v_offset + 1 + 4),
+                                                (xpos + 7, v_offset + 1 + 4), (xpos + 7, v_offset + 1 + 12), (xpos + 5, v_offset + 1 + 12), (xpos + 5, v_offset + 1 + 4)))
+                        xpos += 14
+                    elif (state.rss_state.longitudinalState.rssStateInformation.evaluator == RssStateEvaluator.LongitudinalDistanceOppositeDirectionEgoCorrectLane
+                            or state.rss_state.longitudinalState.rssStateInformation.evaluator == RssStateEvaluator.LongitudinalDistanceOppositeDirection
+                    ):
+                        pygame.draw.polygon(
+                            state_surface, (
+                                255, 255, 255), ((xpos + 2, v_offset + 1 + 8), (xpos + 6, v_offset + 1 + 12), (xpos + 10, v_offset + 1 + 8),
+                                                (xpos + 7, v_offset + 1 + 8), (xpos + 7, v_offset + 1 + 0), (xpos + 5, v_offset + 1 + 0), (xpos + 5, v_offset + 1 + 8)))
+                        xpos += 14
+                        
+                # Unsafe Laterals: Draw Left/Right arrows
+                # Right
+                if not state.rss_state.lateralStateRight.isSafe and state.rss_state.lateralStateRight.rssStateInformation.evaluator is not EVALUATOR_NONE_STATE:
                     pygame.draw.polygon(
                         state_surface, (
                             255, 255, 255), ((xpos + 0, v_offset + 1 + 4), (xpos + 8, v_offset + 1 + 4), (xpos + 8, v_offset + 1 + 1),
                                              (xpos + 12, v_offset + 1 + 6), (xpos + 8, v_offset + 1 + 10), (xpos + 8, v_offset + 1 + 8), (xpos + 0, v_offset + 1 + 8)))
                     xpos += 14
-                if not state.rss_state.lateralStateLeft.isSafe and not (state.rss_state.lateralStateLeft.rssStateInformation.evaluator == "None"):
+                # Left
+                if not state.rss_state.lateralStateLeft.isSafe and state.rss_state.lateralStateLeft.rssStateInformation.evaluator is not EVALUATOR_NONE_STATE:
                     pygame.draw.polygon(
                         state_surface, (
                             255, 255, 255), ((xpos + 0, v_offset + 1 + 6), (xpos + 4, v_offset + 1 + 1), (xpos + 4, v_offset + 1 + 4),


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR addresses some string comparisons in the *rss_visualization.py* that are written like:  
`ad.rss.state.RssStateEvaluator.LongitudinalDistanceOppositeDirection == "LongitudinalDistanceOppositeDirection"` which is always `False` as the enum is an int and has no support for string comparison.

In the example some arrows on the HUD were therefore always or never printed.

---

For verification try this statement which **returns `False` but is intended to be `True`**.

```python
from carla import ad
print(ad.rss.state.RssStateEvaluator.LongitudinalDistanceOppositeDirection == "LongitudinalDistanceOppositeDirection")
# False
```

#### Where has this been tested?

  * **Python version(s):** Python 3.10

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8117)
<!-- Reviewable:end -->
