### PR TITLE
Multiple minor fixes related to build and docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ out/
 
 CMakeSettings.json
 
+.clangd
+
 Help.md

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -12,29 +12,37 @@ include (FetchContent)
 
 set (CARLA_DEPENDENCIES_PENDING)
 
+macro (carla_git_dependency_add NAME TAG ARCHIVE_URL GIT_URL)
+  carla_message ("Cloning ${NAME}...")
+  FetchContent_Declare (
+    ${NAME}
+    GIT_REPOSITORY ${GIT_URL}
+    GIT_TAG ${TAG}
+    GIT_SUBMODULES_RECURSE ON
+    GIT_SHALLOW ON
+    GIT_PROGRESS ON
+    OVERRIDE_FIND_PACKAGE
+    ${ARGN}
+  )
+  list (APPEND CARLA_DEPENDENCIES_PENDING ${NAME})
+endmacro ()
+
+macro (carla_download_dependency_add NAME TAG ARCHIVE_URL GIT_URL)
+  carla_message ("Downloading ${NAME}...")
+  FetchContent_Declare (
+    ${NAME}
+    URL ${ARCHIVE_URL}
+    OVERRIDE_FIND_PACKAGE
+    ${ARGN}
+  )
+  list (APPEND CARLA_DEPENDENCIES_PENDING ${NAME})
+endmacro ()
+
 macro (carla_dependency_add NAME TAG ARCHIVE_URL GIT_URL)
   if (PREFER_CLONE)
-    carla_message ("Cloning ${NAME}...")
-    FetchContent_Declare (
-      ${NAME}
-      GIT_REPOSITORY ${GIT_URL}
-      GIT_TAG ${TAG}
-      GIT_SUBMODULES_RECURSE ON
-      GIT_SHALLOW ON
-      GIT_PROGRESS ON
-      OVERRIDE_FIND_PACKAGE
-      ${ARGN}
-    )
-    list (APPEND CARLA_DEPENDENCIES_PENDING ${NAME})
+    carla_git_dependency_add (${NAME} ${TAG} ${ARCHIVE_URL} ${GIT_URL})
   else ()
-    carla_message ("Downloading ${NAME}...")
-    FetchContent_Declare (
-      ${NAME}
-      URL ${ARCHIVE_URL}
-      OVERRIDE_FIND_PACKAGE
-      ${ARGN}
-    )
-    list (APPEND CARLA_DEPENDENCIES_PENDING ${NAME})
+    carla_download_dependency_add (${NAME} ${TAG} ${ARCHIVE_URL} ${GIT_URL})
   endif ()
 endmacro ()
 

--- a/CMake/Util.cmake
+++ b/CMake/Util.cmake
@@ -39,7 +39,7 @@ endfunction ()
 
 macro (carla_option NAME DESCRIPTION VALUE)
   option (${NAME} ${DESCRIPTION} ${VALUE})
-  carla_message ("(option) ${NAME} : ${VALUE}")
+  carla_message ("(option) ${NAME} : ${${NAME}}")
   get_property (DOCS GLOBAL PROPERTY CARLA_OPTION_DOCS)
   string (
     APPEND
@@ -55,7 +55,7 @@ endmacro ()
 
 macro (carla_string_option NAME DESCRIPTION VALUE)
   set (${NAME} "${VALUE}")
-  carla_message ("(option) ${NAME} : \"${VALUE}\"")
+  carla_message ("(option) ${NAME} : \"${${NAME}}\"")
   get_property (DOCS GLOBAL PROPERTY CARLA_OPTION_DOCS)
   string (
     APPEND

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,11 @@
 {
-  "version": 8,
+  "version": 4,
+  "cmakeMinimumRequired":
+  {
+    "major": 3,
+    "minor": 27,
+    "patch": 2
+  },
   "configurePresets":
   [
     {

--- a/LibCarla/CMakeLists.txt
+++ b/LibCarla/CMakeLists.txt
@@ -1,3 +1,11 @@
+project (
+  libcarla
+  LANGUAGES
+    CXX
+  VERSION
+    ${CARLA_VERSION}
+)
+
 set (
   LIBCARLA_SOURCE_PATH
   ${CARLA_WORKSPACE_PATH}/LibCarla/source
@@ -14,14 +22,6 @@ carla_two_step_configure_file (
 )
 
 if (BUILD_CARLA_SERVER)
-
-  project (
-    carla-server
-    LANGUAGES
-      CXX
-    VERSION
-      ${CARLA_VERSION}
-  )
 
   file (
     GLOB
@@ -158,14 +158,6 @@ endif ()
 
 
 if (BUILD_CARLA_CLIENT)
-
-  project (
-    carla-client
-    LANGUAGES
-      CXX
-    VERSION
-      ${CARLA_VERSION}
-  )
 
   file (
     GLOB

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -357,10 +357,23 @@ add_dependencies (
   ${UE_DEPENDENCIES_ORDER_ONLY}
 )
 
-function (add_carla_ue_package_target PACKAGE_CONFIGURATION UE_BUILD_CONFIGURATION)
+function (
+  add_carla_ue_package_target
+  PACKAGE_CONFIGURATION
+  UE_BUILD_CONFIGURATION)
+
+  set (
+    CARLA_TARGET_PACKAGE_PATH
+    ${CARLA_PACKAGE_PATH}/${UE_SYSTEM_NAME}
+  )
+
   if (NOT "${PACKAGE_CONFIGURATION}" STREQUAL "")
     set (TARGET_NAME_SUFFIX -${PACKAGE_CONFIGURATION})
+    string (TOLOWER "${TARGET_NAME_SUFFIX}" TARGET_NAME_SUFFIX)
+  else ()
+    set (PACKAGE_CONFIGURATION "default (shipping)")
   endif ()
+
   carla_add_custom_target (
     carla-unreal-package${TARGET_NAME_SUFFIX}
     "Create a CARLA package in ${PACKAGE_CONFIGURATION} mode."
@@ -395,7 +408,6 @@ function (add_carla_ue_package_target PACKAGE_CONFIGURATION UE_BUILD_CONFIGURATI
       VERBATIM
     )
 
-  set (CARLA_TARGET_PACKAGE_PATH ${CARLA_PACKAGE_PATH}/${UE_SYSTEM_NAME})
   add_custom_command (
     TARGET carla-unreal-package${TARGET_NAME_SUFFIX}
     POST_BUILD


### PR DESCRIPTION
This PR applies the following changes:
- Rename the package targets to lower case for consistency. Example: from `package-DebugGame` to `package-debuggame`.
- Update top .gitignore to account for generated .clangd files.
- Fix the displayed option values of carla-help. Previously they were showing the default values instead of the ones being passed by the user.
- Remove multiple project statements from the libcarla CMakeLists.txt.
- Moves the body of the CMake macro carla_dependency_add into two functions: one for git clones and one for downloads. This will be useful for future refactors of how dependencies are handled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8132)
<!-- Reviewable:end -->
