### PR TITLE
Hack to fix ad_rss's import namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  * Synchronized actor BoundingBox between server and client
  * Add actor_id to bounding boxes
  * Fixed invisible terrain in instance segmentation
+ * carla.ad subpackages are now directly importable and are not directly importable anymore (e.g. import ad)
 
 ## CARLA 0.9.15
 

--- a/PythonAPI/carla/source/carla/__init__.py
+++ b/PythonAPI/carla/source/carla/__init__.py
@@ -6,3 +6,59 @@
 
 # pylint: disable=W0401,import-self
 from .libcarla import *
+
+def __fix_ad_namespaces():
+    """
+    When using PythonAPI.rss the ad_rss subpackage is imported, however
+    this package puts all its subpackages into sys.modules.
+    This creates ambiguous modules and a wrong hierarchy.
+    
+    This is a # HACK to fix this issue.
+    
+    When updating the RSS version, check if this is correct or ad_rss has fixed
+    the import behavior.
+    """
+    import sys
+    import inspect
+    ad_submodules = {}  # dict of modules
+    def get_submodules(mod, parent):
+       for v in vars(mod).values():
+            if (not inspect.ismodule(v)
+                or "." in v.__name__  # assume correct
+                or v.__name__ in sys.builtin_module_names  # Later ad versions may contain os or sys
+                # Make more robust with expected docstring
+                or (v.__doc__ and ("Python binding of" not in v.__doc__ or "C++ code" not in v.__doc__))
+            ):
+                # NOTE: Check when updating RSS version
+                #f inspect.ismodule(v):
+                #    print("Skipping", v)
+                continue
+            if v in ad_submodules:
+                # this could be problematic with sibling imports into subpackages
+                # e.g. ad.map vs ad.rss.map
+                # this should be fine for the current rss versions.
+                # NOTE: Check when updating RSS version
+                if v.__name__ != "map":
+                    print(v, "already imported. This might create a carla.ad import hierarchy")
+                continue
+            correct_path = parent+"."+v.__name__
+            ad_submodules[v] = correct_path
+            get_submodules(v, correct_path)
+    get_submodules(ad, "carla.ad")  # type: ignore
+    if ad is sys.modules["ad"]:  # type: ignore
+        sys.modules["carla.ad"] = sys.modules.pop("ad")
+    for mod, correct_name in ad_submodules.items():
+        # NOTE: Check when updating RSS version
+        #print("Correcting", mod.__name__, "to", correct_name)
+        sys.modules[correct_name] = sys.modules.pop(mod.__name__)
+        mod.__name__ = correct_name
+    
+# Only when using RSS build
+if "ad" in locals():
+    try:
+        __fix_ad_namespaces()
+    except Exception as e:
+        print("Could not clean ad_rss namespace due to", e, "Please report this bug")
+        pass
+
+del __fix_ad_namespaces

--- a/PythonAPI/carla/source/carla/__init__.py
+++ b/PythonAPI/carla/source/carla/__init__.py
@@ -39,14 +39,14 @@ def __fix_ad_namespaces():
                 # this should be fine for the current rss versions.
                 # NOTE: Check when updating RSS version
                 if v.__name__ != "map":
-                    print(v, "already imported. This might create a carla.ad import hierarchy")
+                    print(v, "already imported. This might create a wrong carla.ad import hierarchy")
                 continue
             correct_path = parent+"."+v.__name__
             ad_submodules[v] = correct_path
             get_submodules(v, correct_path)
-    get_submodules(ad, "carla.ad")  # type: ignore
-    if ad is sys.modules["ad"]:  # type: ignore
-        sys.modules["carla.ad"] = sys.modules.pop("ad")
+    get_submodules(ad, "carla.libcarla.ad")  # type: ignore
+    if ad.__name__ != "carla.libcarla.ad" and "ad" in sys.modules and ad is sys.modules["ad"] and "carla.libcarla.ad" not in sys.modules:  # type: ignore
+        sys.modules["carla.libcarla.ad"] = sys.modules.pop("ad")
     for mod, correct_name in ad_submodules.items():
         # NOTE: Check when updating RSS version
         #print("Correcting", mod.__name__, "to", correct_name)
@@ -59,6 +59,5 @@ if "ad" in locals():
         __fix_ad_namespaces()
     except Exception as e:
         print("Could not clean ad_rss namespace due to", e, "Please report this bug")
-        pass
 
 del __fix_ad_namespaces

--- a/PythonAPI/carla/source/libcarla/AdRss.cpp
+++ b/PythonAPI/carla/source/libcarla/AdRss.cpp
@@ -103,7 +103,7 @@ void export_ad() {
   using namespace boost::python;
 
   // create/import the ad module scope
-  object ad_module(handle<>(borrowed(PyImport_AddModule("ad"))));
+  object ad_module(handle<>(borrowed(PyImport_AddModule("carla.libcarla.ad"))));
   scope().attr("ad") = ad_module;
   scope submodule_scope = ad_module;
   scope().attr("__doc__") = "Python binding of ad namespace C++ code";


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #8093

This is a hack that fixes the messy import namespacing of the `ad_rss` library. Importing `carla` which in turns imports `ad_rss as ad` puts all its subpackages as top-level pckages/modules.

For example this is currently valid:

```py
import carla
import ad
import core # ad.rss.core
import world 
...
```

This raises an ImportError

```py
import carla.ad
```

Also it creates ambiguous import behavior where the order of imports matter, e.g. if I had a subpackage/module names like *any* of ad_rss subpackages the following code will also fail as it imports the wrong module

```py
# import world # <-- would import my local world.py
import carla  # assume with RSS
import world, core  # This imports ad subpackages instead of mine.

```

This is non-standard and confusing behavior.

See also: https://github.com/intel/ad-rss-lib/issues/258

---

**Note: This issue should actually be addressed by ad_rss lib or somewhere in the packaging process before creating the `.so` file**

**This PR manually adjust `sys.modules["ad..."]` to `sys.modules["carla.ad..."]` so that correct and normal import behavior is possible.**

---

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

- Code that relies on the strange import behavior needs updates.
- When the ad_rss requirement is updates the adjustments need to be checked again. I checked that it aligns with the currently latest master branch of https://github.com/intel/ad-rss-lib (4.5.3)
- This is only a hack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8152)
<!-- Reviewable:end -->
