### PR TITLE
Correct "libcarla.command" namespace and allow `from carla.command import ...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  * Synchronized actor BoundingBox between server and client
  * Add actor_id to bounding boxes
  * Fixed invisible terrain in instance segmentation
+ * Importing from carla.command is now possible
 
 ## CARLA 0.9.15
 

--- a/PythonAPI/carla/source/carla/__init__.py
+++ b/PythonAPI/carla/source/carla/__init__.py
@@ -6,3 +6,8 @@
 
 # pylint: disable=W0401,import-self
 from .libcarla import *
+
+# Allow from carla.command import ...
+import sys
+sys.modules["carla.command"] = command
+del sys

--- a/PythonAPI/carla/source/carla/command.py
+++ b/PythonAPI/carla/source/carla/command.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma de
-# Barcelona (UAB).
-#
-# This work is licensed under the terms of the MIT license.
-# For a copy, see <https://opensource.org/licenses/MIT>.
-
-# pylint: disable=W0401
-from .libcarla.command import *

--- a/PythonAPI/carla/source/libcarla/Commands.cpp
+++ b/PythonAPI/carla/source/libcarla/Commands.cpp
@@ -52,7 +52,7 @@ void export_commands() {
 
   using ActorPtr = carla::SharedPtr<cc::Actor>;
 
-  object command_module(handle<>(borrowed(PyImport_AddModule("libcarla.command"))));
+  object command_module(handle<>(borrowed(PyImport_AddModule("carla.libcarla.command"))));
   scope().attr("command") = command_module;
   scope submodule_scope = command_module;
 


### PR DESCRIPTION
Fixes  #6414  

Currently `import carla.command` or `from carla.command import ...` is not possible.

This will raise:
```python
# command.py
      7 # pylint: disable=W0401
----> 8 from .libcarla.command import *

ModuleNotFoundError: No module named 'carla.libcarla.command'
```

This is because the `command` module is registered as `libcarla.command` in `sys.modules`. This is not really correct.

---

This PR adjusts this:
- renames the module to `carla.libcarla.command` 
- provides a duplicate `carla.command` that can be imported.

Note / Up to discussion:
This PR deletes `command.py` as otherwise `carla.command is not carla.libcarla.command`. Both modules would be equivalent but not the same. I think this is the cleaner option.

### Alternatives

This PR:
- PRO: Compatibility is granted and extended to be more user friendly
- CON: Duplicate module in sys.modules

1) Instead of putting `command` into `libcarla` we could put it into `carla` directly without creating a duplicate `carla.libcarla.command`.
   - PRO: More user friendly, no duplication of the module in `sys.modules`.
   - CON: Not part of `libcarla`
2) Do not allow `import carla.command` and only `from carla import command`
   - PRO: No duplication in `sys.modules`
   - CON: Less user friendly

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.10
  * **Unreal Engine version(s):** 4.26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8161)
<!-- Reviewable:end -->
