### PR TITLE
Correcting makefile typo to avoid override warning for target "downloadplugins"

### DIFF
--- a/Util/BuildTools/Linux.mk
+++ b/Util/BuildTools/Linux.mk
@@ -138,7 +138,7 @@ LibCarla.client.rss.release: setup ad-rss
 plugins:
 	@${CARLA_BUILD_TOOLS_FOLDER}/Plugins.sh $(ARGS)
 
-setup downloadplugins:
+setup: downloadplugins
 	@${CARLA_BUILD_TOOLS_FOLDER}/Setup.sh $(ARGS)
 
 ad-rss:


### PR DESCRIPTION
#### Description

A typo has been found on the Linux makefile, line 141: "setup" target is supposed to call "downloadplugins" target, but the column misplacement implies "downloadplugins" is the same target as "setup". However, "downloadplugins" target is already defined below (line 162). This leads to a warning:
```
Util/BuildTools/Linux.mk:162: warning: overriding commands for target « downloadplugins »
Util/BuildTools/Linux.mk:141: warning: ignoring old commands for target « downloadplugins »
```
This second definition overrides the first one, justifying the fact that the first one is a typo.

<!-- Please explain the changes you made here as detailed as possible. -->

Changed column location to avoid override warning and have a correct "setup" target.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

Nothing to my knowledge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8167)
<!-- Reviewable:end -->
