### PR TITLE
Fix incorrectly set ROS2 dependency tag.

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -409,7 +409,7 @@ carla_string_option (
 carla_string_option (
   CARLA_FASTCDR_VERSION
   "Target Fast-CDR version."
-  2.2.x
+  1.1.x
 )
 
 carla_string_option (


### PR DESCRIPTION
This PR sets the Fast-CDR back to its previous value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8172)
<!-- Reviewable:end -->
