### PR TITLE
Disable std::format unless ENABLE_STD_FORMAT is defined.

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -22,7 +22,8 @@
 
 #include <Carla/Vehicle/CarlaWheeledVehicle.h>
 
-#if __has_include(<format>)
+// Clang 16 does not support C++20's std::format
+#if defined(ENABLE_STD_FORMAT) && __has_include(<format>)
 #define HAS_FORMAT
 #include <format>
 #endif
@@ -32,7 +33,9 @@ requires (
   std::remove_reference_t<V>::Dim <= 3)
 static std::string FormatVectorLike(V&& v)
 {
+#ifndef HAS_FORMAT
   char buffer[256];
+#endif
   constexpr auto Dim = std::remove_reference_t<V>::Dim;
   if constexpr (Dim == 1)
   {


### PR DESCRIPTION
This PR removes std::format unless explicitly requested. This is because while <format> may exist, std::format may not be defined.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8178)
<!-- Reviewable:end -->
