### PR TITLE
Fix Unreal CMake typo. Add missing dependency.

### DIFF
--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -111,7 +111,7 @@ set (
 )
 
 set (
-  CARLA_UNREAL_DEFINITIONS_FILE_NAME
+  CARLA_UNREAL_OPTIONS_FILE_NAME
   Options.def
 )
 
@@ -371,6 +371,7 @@ carla_add_custom_target (
 
 add_dependencies (
   carla-unreal-editor
+  carla-unreal
   ${UE_DEPENDENCIES_ORDER_ONLY}
 )
 


### PR DESCRIPTION
This PR fixes an incorrect .def path and adds a missing dependency to carla-unreal-editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8215)
<!-- Reviewable:end -->
