### PR TITLE
Updated install_gtest.bat

### DIFF
--- a/Util/InstallersWin/install_gtest.bat
+++ b/Util/InstallersWin/install_gtest.bat
@@ -86,7 +86,7 @@ if %errorlevel%  neq 0 goto error_cmake
 echo %FILE_N% Building...
 cmake --build . --config Release --target install
 
-if errorlevel  neq 0 goto error_install
+if %errorlevel% neq 0 goto error_install
 
 rem Remove the downloaded Google Test source because is no more needed
 if %DEL_SRC% == true (


### PR DESCRIPTION
#### Description

I updated the `install_gtest.bat` script to reflect what I believe to be the correct behavior. While installing Carla-0.9.15, I encountered a crash related to the Boost library installation (unrelated to this issue). Rerunning the `make PythonAPI` command resulted in the following error:

```
-[install_gtest]: [Batch params]: --build-dir "D:\Apps\carla\carla-dev\Build\" --generator "Visual Studio 16 2019"
The system cannot find the batch label specified - already_build
```

This issue is mentioned here:
- https://discord.com/channels/444206285647380482/445494135990779915/1232033672857780324
- https://github.com/carla-simulator/carla/issues/5088#issuecomment-1954561903

I resolved the issue by updating the errorlevel string to use the `%errorlevel%` variable.

#### Where has this been tested?

  * **Platform(s):** Tested on Windows 10
  * **Python version(s):** 3.8.10 (although I don't think this is required at this point)
  * **Unreal Engine version(s):** UE4.26 (again, I don't believe this is required here)

#### Possible Drawbacks

I don't anticipate any drawbacks, as this is a minor change that only affects the checks to ensure GTest is installed properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8258)
<!-- Reviewable:end -->
