### PR TITLE
Upgrade CARLA code to work with UE5.5

### DIFF
--- a/CMake/Common.cmake
+++ b/CMake/Common.cmake
@@ -106,9 +106,30 @@ endif ()
 #   RTTI Definitions
 # ================================
 
+if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC" AND
+    NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if (ENABLE_RTTI)
+    set (RTTI_FLAG /GR)
+  else ()
+    set (RTTI_FLAG /GR-)
+  endif ()
+else ()
+  if (ENABLE_RTTI)
+    set (RTTI_FLAG -frtti)
+  else ()
+    set (RTTI_FLAG -fno-rtti)
+  endif ()
+endif ()
+
+carla_message ("Checking for ${RTTI_FLAG} support")
+check_cxx_compiler_flag (${RTTI_FLAG} HAS_RTTI_FLAG)
+if (HAS_RTTI_FLAG)
+  add_compile_options (${RTTI_FLAG})
+endif ()
+
 set (CARLA_RTTI_DEFINITIONS)
 
-if (CARLA_RTTI_DEFINITIONS)
+if (ENABLE_RTTI)
   # Nothing
 else ()
   list (APPEND CARLA_RTTI_DEFINITIONS BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY)

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -258,7 +258,7 @@ endif ()
 
 
 
-if (BUILD_CARLA_UNREAL)
+if (BUILD_CARLA_UNREAL AND ENABLE_STREETMAP)
   # ==== STREETMAP ====
   carla_dependency_add (
     StreetMap

--- a/CMake/LinuxToolchain.cmake
+++ b/CMake/LinuxToolchain.cmake
@@ -33,9 +33,29 @@ elseif (${ARCH} STREQUAL "aarch64")
 	set (TARGET_TRIPLE "aarch64-unknown-linux-gnueabi" CACHE STRING "")
 endif()
 
+file (
+	GLOB
+	UE_SYSROOT_CANDIDATES
+	${UE_ROOT}/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v*_clang-*.*.*-*/${TARGET_TRIPLE}
+	LIST_DIRECTORIES TRUE
+	FOLLOW_SYMLINKS
+)
+
+set (UE_SYSROOT_CANDIDATE)
+foreach (CANDIDATE ${UE_SYSROOT_CANDIDATES})
+	if (IS_DIRECTORY ${CANDIDATE})
+		set (UE_SYSROOT_CANDIDATE ${CANDIDATE})
+		break ()
+	endif ()
+endforeach ()
+
+if (NOT UE_SYSROOT_CANDIDATE)
+	message (FATAL_ERROR "Could not find Unreal Engine clang sysroot.")
+endif ()
+
 set (
 	UE_SYSROOT
-	${UE_ROOT}/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/${TARGET_TRIPLE}
+	${UE_SYSROOT_CANDIDATE}
 	CACHE PATH ""
 )
 

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -89,7 +89,7 @@ carla_option (
 carla_option (
   ENABLE_RTTI
   "Enable C++ RTTI."
-  OFF
+  ON
 )
 
 carla_option (
@@ -143,6 +143,12 @@ carla_string_option (
 carla_option (
   VERBOSE_CONFIGURE
   "Whether to emit extra messages during CMake configure."
+  OFF
+)
+
+carla_option (
+  ENABLE_STREETMAP
+  "Whether to download the Streetmap UE plugin."
   OFF
 )
 

--- a/LibCarla/CMakeLists.txt
+++ b/LibCarla/CMakeLists.txt
@@ -117,7 +117,7 @@ if (BUILD_CARLA_SERVER)
   )
 
   target_link_libraries (
-    carla-server PUBLIC
+    carla-server PUBLIC SYSTEM
     Boost::asio
     Boost::geometry
     Boost::algorithm

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ environmental conditions.
 [![CARLA Video](Docs/img/carla_ue5_readme_img.webp)](https://www.youtube.com/watch?v=q4V9GYjA1pE)
 
 >[!NOTE]
-> This is the development branch `ue5-dev` for the **Unreal Engine 5.3 version of CARLA**. This branch exists in parallel with the Unreal Engine 4.26 version of CARLA, in the `ue4-dev` branch. Please be sure that this version of CARLA is suitable for your needs as there are significant differences between the UE 5.3 and UE 4.26 versions of CARLA. 
+> This is the development branch `ue5-dev` for the **Unreal Engine 5.5 version of CARLA**. This branch exists in parallel with the Unreal Engine 4.26 version of CARLA, in the `ue4-dev` branch. Please be sure that this version of CARLA is suitable for your needs as there are significant differences between the UE 5.5 and UE 4.26 versions of CARLA. 
 
 ### Recommended system
 
@@ -27,7 +27,7 @@ environmental conditions.
 * Ubuntu 22.04
 
  >[!NOTE]
-> Ubuntu version 22.04 is required, the Unreal Engine 5.3 version of CARLA will not work on Ubuntu 20.04 or lower. 
+> Ubuntu version 22.04 is required, the Unreal Engine 5.5 version of CARLA will not work on Ubuntu 20.04 or lower. 
 
 ## Documentation
 
@@ -77,7 +77,7 @@ Felipe Codevilla, Antonio Lopez, Vladlen Koltun; PMLR 78:1-16
 }
 ```
 
-Building CARLA with Unreal Engine 5.3
+Building CARLA with Unreal Engine 5.5
 --------------
 
 Clone this repository locally from GitHub:
@@ -102,7 +102,7 @@ cd CarlaUE5
 Setup.bat
 ```
 
-This will download and install Unreal Engine 5.3, install the prerequisite requirements and build and launch CARLA. It may take some time to complete and use a significant amount of disk space. For further instructions on building in Linux can be found [here][buildlinuxlink] and the instructions for building in Windows can be found [here][buildwindowslink].
+This will download and install Unreal Engine 5.5, install the prerequisite requirements and build and launch CARLA. It may take some time to complete and use a significant amount of disk space. For further instructions on building in Linux can be found [here][buildlinuxlink] and the instructions for building in Windows can be found [here][buildwindowslink].
 
 [buildlinuxlink]: https://carla.readthedocs.io/en/latest/build_linux_ue5/
 [buildwindowslink]: https://carla.readthedocs.io/en/latest/build_windows_ue5/

--- a/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
+++ b/Ros2Native/LibCarlaRos2Native/CMakeLists.txt
@@ -51,7 +51,7 @@ target_compile_definitions (
 )
 
 target_link_libraries (
-  carla-ros2-native
+  carla-ros2-native PUBLIC SYSTEM
   ${CMAKE_INSTALL_PREFIX}/lib/libfastrtps.so
 )
 

--- a/Unreal/CarlaUnreal/CarlaUnreal.uproject
+++ b/Unreal/CarlaUnreal/CarlaUnreal.uproject
@@ -54,10 +54,6 @@
 			"Enabled": true
 		},
 		{
-			"Name": "StreetMap",
-			"Enabled": true
-		},
-		{
 			"Name": "ModelingToolsEditorMode",
 			"Enabled": true,
 			"TargetAllowList": [

--- a/Unreal/CarlaUnreal/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultEngine.ini
@@ -19,8 +19,7 @@ GlobalDefaultServerGameMode=/Game/Carla/Blueprints/Game/CarlaGameMode.CarlaGameM
 
 [/Script/Engine.RendererSettings]
 r.DefaultFeature.MotionBlur=True
-r.BasePassOutputsVelocity=True
-r.BasePassForceOutputsVelocity=False
+r.VelocityOutputPass=True
 r.AllowStaticLighting=True
 r.DiscardUnusedQuality=True
 r.DefaultFeature.Bloom=False

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/MapGenFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/MapGenFunctionLibrary.cpp
@@ -14,6 +14,7 @@
 #include "PhysicsEngine/BodySetup.h"
 #include "Engine/StaticMeshActor.h"
 #include "Carla/Actor/LevelActor/InstancedStaticMeshActor.h"
+#include "UObject/SavePackage.h"
 #if WITH_EDITOR
 #include "Editor/EditorEngine.h"
 #include "Editor/Transactor.h"
@@ -185,7 +186,26 @@ UStaticMesh* UMapGenFunctionLibrary::CreateMesh(
 
     // Notify asset registry of new asset
     FAssetRegistryModule::AssetCreated(Mesh);
-    //UPackage::SavePackage(Package, Mesh, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone, *(MeshName.ToString()), GError, nullptr, true, true, SAVE_NoError);
+
+    /*
+
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags =
+      EObjectFlags::RF_Public |
+      EObjectFlags::RF_Standalone;
+    SaveArgs.Error = GError;
+    SaveArgs.bForceByteSwapping = true;
+    SaveArgs.bWarnOfLongFilename = true;
+    SaveArgs.SaveFlags = SAVE_NoError;
+
+    UPackage::SavePackage(
+      Package, 
+      Mesh,
+      *(MeshName.ToString()),
+      SaveArgs);
+
+    */
+
     Package->MarkPackageDirty();
     return Mesh;
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -39,6 +39,7 @@ public class Carla :
 
     PrivatePCHHeaderFile = "Carla.h";
     bEnableExceptions = true;
+    bUseRTTI = true;
     
     void AddDynamicLibrary(string library)
     {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
@@ -60,7 +60,7 @@ ACityMapGenerator::~ACityMapGenerator() {}
 // -- Overriden from UObject ---------------------------------------------------
 // =============================================================================
 
-void ACityMapGenerator::PreSave(const ITargetPlatform *TargetPlatform)
+void ACityMapGenerator::PreSave(FObjectPreSaveContext ObjectSaveContext)
 {
 #if WITH_EDITOR
   if (bGenerateRoadMapOnSave) {
@@ -73,7 +73,7 @@ void ACityMapGenerator::PreSave(const ITargetPlatform *TargetPlatform)
   }
 #endif // WITH_EDITOR
 
-  Super::PreSave(TargetPlatform);
+  Super::PreSave(ObjectSaveContext);
 }
 
 // =============================================================================

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/CityMapGenerator.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/CityMapGenerator.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include "MapGen/CityMapMeshHolder.h"
-
 #include "MapGen/DoublyConnectedEdgeList.h"
 #include "MapGen/GraphParser.h"
+
+#include "UObject/ObjectSaveContext.h"
 
 #include "CityMapGenerator.generated.h"
 
@@ -40,7 +41,7 @@ public:
   /// @{
 public:
 
-  virtual void PreSave(const ITargetPlatform *TargetPlatform) override;
+  virtual void PreSave(FObjectPreSaveContext ObjectSaveContext) override;
 
   /// @}
   // ===========================================================================

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -20,6 +20,7 @@
 #include "UObject/ConstructorHelpers.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Carla/MapGen/LargeMapManager.h"
+#include "UObject/Package.h"
 
 static bool ValidateStaticMesh(UStaticMesh *Mesh)
 {
@@ -334,7 +335,7 @@ bool UPrepareAssetsForCookingCommandlet::SaveWorld(
 {
   // Create Package to save
   UPackage *Package = AssetData.GetPackage();
-  Package->SetFolderName(*WorldName);
+  // Package->SetFolderName(*WorldName); @TODO
   Package->FullyLoad();
   Package->MarkPackageDirty();
   FAssetRegistryModule::AssetCreated(World);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -20,6 +20,7 @@
 #include "UObject/ConstructorHelpers.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Carla/MapGen/LargeMapManager.h"
+#include "UObject/SavePackage.h"
 #include "UObject/Package.h"
 
 static bool ValidateStaticMesh(UStaticMesh *Mesh)
@@ -475,16 +476,20 @@ bool UPrepareAssetsForCookingCommandlet::SavePackage(const FString &PackagePath,
     return false;
   }
 
+  FSavePackageArgs SaveArgs;
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
+  SaveArgs.Error = GError;
+  SaveArgs.bForceByteSwapping = true;
+  SaveArgs.bWarnOfLongFilename = true;
+  SaveArgs.SaveFlags = SAVE_NoError;
+
   return UPackage::SavePackage(
       Package,
       World,
-      EObjectFlags::RF_Public | EObjectFlags::RF_Standalone,
       *PackageFileName,
-      GError,
-      nullptr,
-      true,
-      true,
-      SAVE_NoError);
+      SaveArgs);
 }
 
 void UPrepareAssetsForCookingCommandlet::GenerateMapPathsFile(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -335,7 +335,6 @@ bool UPrepareAssetsForCookingCommandlet::SaveWorld(
 {
   // Create Package to save
   UPackage *Package = AssetData.GetPackage();
-  // Package->SetFolderName(*WorldName); @TODO
   Package->FullyLoad();
   Package->MarkPackageDirty();
   FAssetRegistryModule::AssetCreated(World);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -286,7 +286,7 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureColor& 
     }
   }
   UTexture2D* UETexture = UTexture2D::CreateTransient(Texture.GetWidth(), Texture.GetHeight(), EPixelFormat::PF_B8G8R8A8);
-  FTexture2DMipMap& Mip = UETexture->PlatformData->Mips[0];
+  FTexture2DMipMap& Mip = UETexture->GetPlatformData()->Mips[0];
   void* Data = Mip.BulkData.Lock( LOCK_READ_WRITE );
   FMemory::Memcpy( Data,
       &Colors[0],
@@ -309,7 +309,7 @@ UTexture2D* ACarlaGameModeBase::CreateUETexture(const carla::rpc::TextureFloatCo
     }
   }
   UTexture2D* UETexture = UTexture2D::CreateTransient(Texture.GetWidth(), Texture.GetHeight(), EPixelFormat::PF_FloatRGBA);
-  FTexture2DMipMap& Mip = UETexture->PlatformData->Mips[0];
+  FTexture2DMipMap& Mip = UETexture->GetPlatformData()->Mips[0];
   void* Data = Mip.BulkData.Lock( LOCK_READ_WRITE );
   FMemory::Memcpy( Data,
       &Colors[0],

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/CityMapMeshHolder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/CityMapMeshHolder.cpp
@@ -58,7 +58,7 @@ void ACityMapMeshHolder::PostInitializeComponents()
 {
   Super::PostInitializeComponents();
 
-  if (IsValid(GetLevel()) && !GetLevel()->IsPendingKill())
+  if (IsValid(GetLevel()) && IsValidChecked(GetLevel()))
   {
 	 TArray<AActor*> roadpieces;
      GetAttachedActors(roadpieces);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/CityMapMeshTag.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/CityMapMeshTag.cpp
@@ -23,8 +23,6 @@ uint32 CityMapMeshTag::GetRoadIntersectionSize()
 
 FString CityMapMeshTag::ToString(ECityMapMeshTag Tag)
 {
-  const UEnum* ptr = FindObject<UEnum>(ANY_PACKAGE, TEXT("ECityMapMeshTag"), true);
-  if(!ptr)
-    return FString("Invalid");
-  return ptr->GetNameStringByIndex(static_cast<int32>(Tag));
+  static_assert(TIsEnumClass<ECityMapMeshTag>::Value);
+  return StaticEnum<ECityMapMeshTag>()->GetNameStringByValue((int64)Tag);
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -677,12 +677,12 @@ FCarlaMapTile& ALargeMapManager::LoadCarlaMapTile(FString TileMapPath, TileID Ti
   StreamingLevel->LevelTransform = FTransform(TileLocation);
   StreamingLevel->PackageNameToLoad = *FullName;
 
-  if (!FPackageName::DoesPackageExist(FullName, NULL, &PackageFileName))
+  if (!FPackageName::DoesPackageExist(FullName, &PackageFileName))
   {
     LM_LOG(Error, "Level does not exist in package with FullName variable -> %s", *FullName);
   }
 
-  if (!FPackageName::DoesPackageExist(LongLevelPackageName, NULL, &PackageFileName))
+  if (!FPackageName::DoesPackageExist(LongLevelPackageName, &PackageFileName))
   {
     LM_LOG(Error, "Level does not exist in package with LongLevelPackageName variable -> %s", *LongLevelPackageName);
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
@@ -169,11 +169,23 @@ UOpenDriveMap *UOpenDrive::LoadOpenDriveMap(const FString &MapName)
 
 UOpenDriveMap *UOpenDrive::LoadCurrentOpenDriveMap(const UObject *WorldContextObject)
 {
-  UWorld *World = nullptr;
 #if WITH_EDITOR
-  GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+
+  if (WorldContextObject == nullptr)
+    return nullptr;
+
+  auto World = GEngine->GetWorldFromContextObject(
+    WorldContextObject,
+    EGetWorldErrorMode::LogAndReturnNull);
+
+  if (World == nullptr)
+    return nullptr;
+
+  return LoadOpenDriveMap(World->GetMapName());
+  
+#else
+
+  return nullptr;
+
 #endif
-  return World != nullptr ?
-      LoadOpenDriveMap(World->GetMapName()) :
-      nullptr;
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
@@ -131,7 +131,7 @@ void ADVSCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTim
   TRACE_CPUPROFILER_EVENT_SCOPE(ADVSCamera::PostPhysTick);
   Super::PostPhysTick(World, TickType, DeltaTime);
   check(CaptureRenderTarget != nullptr);
-  if (!HasActorBegunPlay() || IsPendingKill())
+  if (!HasActorBegunPlay() || IsValid(this))
   {
     return;
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
@@ -38,56 +38,14 @@ namespace ImageUtil
     TArrayView<FLinearColor> Out)
   {
     SourcePitch *= GPixelFormats[Format].BlockBytes;
-    auto OutPixelCount = Extent.X * Extent.Y;
-    switch (Format)
-    {
-    case PF_G16:
-    case PF_R16_UINT:
-    case PF_R16_SINT:
-      // Shadow maps
-      ConvertRawR16DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_R8G8B8A8:
-      ConvertRawR8G8B8A8DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_B8G8R8A8:
-      ConvertRawB8G8R8A8DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_A2B10G10R10:
-      ConvertRawA2B10G10R10DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_FloatRGBA:
-    case PF_R16G16B16A16_UNORM:
-    case PF_R16G16B16A16_SNORM:
-      ConvertRawR16G16B16A16FDataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
-      break;
-    case PF_FloatR11G11B10:
-      ConvertRawRR11G11B10DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_A32B32G32R32F:
-      ConvertRawR32G32B32A32DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
-      break;
-    case PF_A16B16G16R16:
-      ConvertRawR16G16B16A16DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_G16R16:
-      ConvertRawR16G16DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    case PF_X24_G8: // Depth Stencil
-      ConvertRawR24G8DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
-      break;
-    case PF_R32_FLOAT: // Depth Stencil
-      ConvertRawR32DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
-      break;
-    case PF_R16G16B16A16_UINT:
-    case PF_R16G16B16A16_SINT:
-      ConvertRawR16G16B16A16DataToFLinearColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData());
-      break;
-    default:
-      UE_LOG(LogCarla, Warning, TEXT("Unsupported format %llu"), (unsigned long long)Format);
-      return false;
-    }
-    return true;
+    return ConvertRAWSurfaceDataToFLinearColor(
+      Format,
+      Extent.X,
+      Extent.Y,
+      (uint8*)PixelData,
+      SourcePitch,
+      Out.GetData(),
+      Flags);
   }
 
 
@@ -143,7 +101,17 @@ namespace ImageUtil
       ConvertRawR24G8DataToFColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
       break;
     case PF_R32_FLOAT: // Depth
-      ConvertRawR32DataToFColor(Extent.X, Extent.Y, (uint8*)PixelData, SourcePitch, Out.GetData(), Flags);
+		  for (uint32 Y = 0; Y < Extent.Y; Y++)
+		  {
+		  	auto SrcPtr = (float*)((uint8*)PixelData + Y * SourcePitch);
+		  	auto DestPtr = Out.GetData() + Y * Extent.X;
+		  	for (uint32 X = 0; X < Extent.X; X++)
+		  	{
+		  		*DestPtr = FLinearColor(SrcPtr[0], 0.f, 0.f, 1.f).QuantizeRound();
+		  		++SrcPtr;
+		  		++DestPtr;
+		  	}
+		  }
       break;
     case PF_R16G16B16A16_UINT:
     case PF_R16G16B16A16_SINT:
@@ -244,7 +212,7 @@ namespace ImageUtil
 
     auto& CmdList = FRHICommandListImmediate::Get();
     auto Resource = static_cast<FTextureRenderTarget2DResource*>(
-      RenderTarget.Resource);
+      RenderTarget.GetResource());
     auto Texture = Resource->GetRenderTargetTexture();
     if (Texture == nullptr)
       return;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -27,7 +27,7 @@ void FPixelReader::WritePixelsToBuffer(
   check(IsInRenderingThread());
 
   auto RenderResource =
-      static_cast<const FTextureRenderTarget2DResource *>(RenderTarget.Resource);
+      static_cast<const FTextureRenderTarget2DResource *>(RenderTarget.GetResource());
   FTexture2DRHIRef Texture = RenderResource->GetRenderTargetTexture();
   if (!Texture)
   {
@@ -53,7 +53,7 @@ void FPixelReader::WritePixelsToBuffer(
     RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThread);
     TRACE_CPUPROFILER_EVENT_SCOPE_STR("query result");
     uint64 OldAbsTime = 0;
-    RHICmdList.GetRenderQueryResult(Query, OldAbsTime, true);
+    // RHICmdList.GetRenderQueryResult(Query, OldAbsTime, true);
   }
 
   AsyncTask(ENamedThreads::HighTaskPriority, [=, Readback=std::move(BackBufferReadback)]() mutable {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -28,7 +28,7 @@ void FPixelReader::WritePixelsToBuffer(
 
   auto RenderResource =
       static_cast<const FTextureRenderTarget2DResource *>(RenderTarget.GetResource());
-  FTexture2DRHIRef Texture = RenderResource->GetRenderTargetTexture();
+  auto Texture = RenderResource->GetRenderTargetTexture();
   if (!Texture)
   {
     return;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -53,7 +53,7 @@ void FPixelReader::WritePixelsToBuffer(
     RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThread);
     TRACE_CPUPROFILER_EVENT_SCOPE_STR("query result");
     uint64 OldAbsTime = 0;
-    // RHICmdList.GetRenderQueryResult(Query, OldAbsTime, true);
+    RHIGetRenderQueryResult(Query, OldAbsTime, true);
   }
 
   AsyncTask(ENamedThreads::HighTaskPriority, [=, Readback=std::move(BackBufferReadback)]() mutable {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
@@ -100,7 +100,7 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
   TRACE_CPUPROFILER_EVENT_SCOPE(FPixelReader::SendPixelsInRenderThread);
   check(Sensor.CaptureRenderTarget != nullptr);
 
-  if (!Sensor.HasActorBegunPlay() || Sensor.IsPendingKill())
+  if (!Sensor.HasActorBegunPlay() || IsValidChecked(&Sensor))
   {
     return;
   }
@@ -118,13 +118,14 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
       TRACE_CPUPROFILER_EVENT_SCOPE_STR("FWritePixels_SendPixelsInRenderThread");
 
       /// @todo Can we make sure the sensor is not going to be destroyed?
-      if (!Sensor.IsPendingKill())
+      if (IsValidChecked(&Sensor))
       {
         FPixelReader::Payload FuncForSending =
           [&Sensor, Frame = FCarlaEngine::GetFrameCounter(), Conversor = std::move(Conversor)]
           (void *LockedData, uint32 Size, uint32 Offset, uint32 ExpectedRowBytes)
           {
-            if (Sensor.IsPendingKill()) return;
+            if (!IsValidChecked(&Sensor))
+              return;
 
             TArray<TPixel> Converted;
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PostProcessConfig.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PostProcessConfig.cpp
@@ -20,8 +20,6 @@ void FPostProcessConfig::EnablePostProcessingEffects()
   EngineShowFlags.SetLightShafts(true);
   EngineShowFlags.SetPostProcessMaterial(true);
   EngineShowFlags.SetDistanceFieldAO(true);
-  // TODO: Remove when Physical page pool size scales automatically with demand
-  EngineShowFlags.SetVirtualShadowMapCaching(false);
   // } must be kept in sync with EngineShowFlags.EnableAdvancedFeatures(), AND activate Lumen.
   EngineShowFlags.SetMotionBlur(true);
 }
@@ -84,7 +82,6 @@ void FPostProcessConfig::DisablePostProcessingEffects()
   // EngineShowFlags.SetLandscape(false);
   // EngineShowFlags.SetLargeVertices(false);
   EngineShowFlags.SetLensFlares(false);
-  EngineShowFlags.SetLevelColoration(false);
   EngineShowFlags.SetLightComplexity(false);
   EngineShowFlags.SetLightFunctions(false);
   EngineShowFlags.SetLightInfluences(false);
@@ -114,7 +111,6 @@ void FPostProcessConfig::DisablePostProcessingEffects()
   // EngineShowFlags.SetPrecomputedVisibilityCells(false);
   // EngineShowFlags.SetPreviewShadowsIndicator(false);
   // EngineShowFlags.SetPrimitiveDistanceAccuracy(false);
-  EngineShowFlags.SetPropertyColoration(false);
   // EngineShowFlags.SetQuadOverdraw(false);
   // EngineShowFlags.SetReflectionEnvironment(false);
   // EngineShowFlags.SetReflectionOverride(false);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -713,7 +713,9 @@ void ASceneCaptureSensor::BeginPlay()
 
   // This ensures the camera is always spawning the raindrops in case the
   // weather was previously set to have rain.
-  GetEpisode().GetWeather()->NotifyWeather(this);
+  auto Weather = GetEpisode().GetWeather();
+  if (Weather != nullptr)
+    Weather->NotifyWeather(this);
   
   Super::BeginPlay();
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -684,7 +684,7 @@ void ASceneCaptureSensor::BeginPlay()
     CaptureRenderTarget->TargetGamma = TargetGamma;
   }
 
-  check(IsValid(CaptureComponent2D) && !CaptureComponent2D->IsPendingKill());
+  check(IsValid(CaptureComponent2D) && IsValidChecked(CaptureComponent2D));
 
   CaptureComponent2D->Deactivate();
   CaptureComponent2D->TextureTarget = CaptureRenderTarget;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -164,10 +164,10 @@ void UCarlaSettings::LoadSettingsFromString(const FString &INIFileContents)
 {
   UE_LOG(LogCarla, Log, TEXT("Loading CARLA settings from string"));
   FIniFile ConfigFile;
-  ConfigFile.ProcessInputFileContents(INIFileContents);
+  CurrentFileName = TEXT("<string-provided-by-client>");
+  ConfigFile.ProcessInputFileContents(INIFileContents, CurrentFileName);
   constexpr bool bLoadCarlaServerSection = false;
   LoadSettingsFromConfig(ConfigFile, *this, bLoadCarlaServerSection);
-  CurrentFileName = TEXT("<string-provided-by-client>");
 }
 
 void UCarlaSettings::LogSettings() const

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -50,12 +50,8 @@ static EQualityLevel QualityLevelFromString(
 
 FString QualityLevelToString(EQualityLevel QualitySettingsLevel)
 {
-  const UEnum *ptr = FindObject<UEnum>(ANY_PACKAGE, TEXT("EQualityLevel"), true);
-  if (!ptr)
-  {
-    return FString("Invalid");
-  }
-  return ptr->GetNameStringByIndex(static_cast<int32>(QualitySettingsLevel));
+  static_assert(TIsEnumClass<EQualityLevel>::Value);
+  return StaticEnum<EQualityLevel>()->GetNameStringByValue((int64)QualitySettingsLevel);
 }
 
 static void LoadSettingsFromConfig(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettingsDelegate.cpp
@@ -221,7 +221,7 @@ void UCarlaSettingsDelegate::LaunchLowQualityCommands(UWorld *world) const
   GEngine->Exec(world, TEXT("r.TranslucentLightingVolume 0"));
   GEngine->Exec(world, TEXT("r.LightShaftDownSampleFactor 4"));
   GEngine->Exec(world, TEXT("r.OcclusionQueryLocation 1"));
-  // GEngine->Exec(world,TEXT("r.BasePassOutputsVelocity 0")); //--> readonly
+  // GEngine->Exec(world,TEXT("r.VelocityOutputPass 0")); //--> readonly
   // GEngine->Exec(world,TEXT("r.DetailMode 0")); //-->will change to lods 0
   GEngine->Exec(world, TEXT("r.DefaultFeature.AutoExposure 1"));
 
@@ -412,7 +412,7 @@ void UCarlaSettingsDelegate::LaunchEpicQualityCommands(UWorld *world) const
   GEngine->Exec(world, TEXT("r.TranslucentLightingVolume 1"));
   GEngine->Exec(world, TEXT("r.LightShaftDownSampleFactor 2"));
   // GEngine->Exec(world,TEXT("r.OcclusionQueryLocation 0"));
-  // GEngine->Exec(world,TEXT("r.BasePassOutputsVelocity 0")); //readonly
+  // GEngine->Exec(world,TEXT("r.VelocityOutputPass 0")); //readonly
   GEngine->Exec(world, TEXT("r.DetailMode 2"));
 }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightBase.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightBase.cpp
@@ -16,7 +16,7 @@
 
 static bool IsValid(const ACarlaWheeledVehicle *Vehicle)
 {
-  return ((Vehicle != nullptr) && !Vehicle->IsPendingKill());
+  return ((Vehicle != nullptr) && IsValidChecked(Vehicle));
 }
 
 static ETrafficSignState ToTrafficSignState(ETrafficLightState State)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -123,7 +123,7 @@ FBoundingBox UBoundingBoxCalculator::GetVehicleBoundingBox(
   crp::CityObjectLabel Tag = ATagger::GetTagOfTaggedComponent(*ParentComp);
   if(FilterByTagEnabled && Tag != TagQueried) return {};
 
-  USkeletalMesh* SkeletalMesh = ParentComp->SkeletalMesh;
+  USkeletalMesh* SkeletalMesh = ParentComp->GetSkeletalMeshAsset();
   FBoundingBox BB = GetSkeletalMeshBoundingBox(SkeletalMesh);
 
   if(BB.Extent.IsZero())
@@ -384,7 +384,7 @@ void UBoundingBoxCalculator::GetBBsOfSkeletalMeshComponents(
 
     if(!Comp->IsVisible() || (FilterByTagEnabled && Tag != TagQueried)) continue;
 
-    USkeletalMesh* SkeletalMesh = Comp->SkeletalMesh;
+    USkeletalMesh* SkeletalMesh = Comp->GetSkeletalMeshAsset();
     FBoundingBox BoundingBox = GetSkeletalMeshBoundingBox(SkeletalMesh);
     if(BoundingBox.Extent.IsZero())
     {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -208,7 +208,7 @@ struct FShapeVisitor
       Location = LargeMap->GlobalToLocalLocation(Location);
     }
     ACarlaHUD *Hud = Cast<ACarlaHUD>(PlayerController->GetHUD());
-    Hud->AddHUDString(carla::rpc::ToFString(Str.text), Location, Color.Quantize(), LifeTime);
+    Hud->AddHUDString(carla::rpc::ToFString(Str.text), Location, Color.QuantizeRound(), LifeTime);
   }
 
 private:

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/IniFile.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/IniFile.h
@@ -59,7 +59,7 @@ public:
 
   bool HasSection(const FString &Section) const
   {
-    return (ConfigFile.Num() > 0) && (ConfigFile.Find(Section) != nullptr);
+    return (ConfigFile.Num() > 0) && (ConfigFile.FindSection(Section) != nullptr);
   }
 
   void AddSectionIfMissing(const FString &Section)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/IniFile.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/IniFile.h
@@ -52,9 +52,9 @@ public:
     return ConfigFile.Combine(FileName);
   }
 
-  void ProcessInputFileContents(const FString &INIFileContents)
+  void ProcessInputFileContents(const FString &INIFileContents, const FString &Hint)
   {
-    ConfigFile.ProcessInputFileContents(INIFileContents);
+    ConfigFile.ProcessInputFileContents(INIFileContents, Hint);
   }
 
   bool HasSection(const FString &Section) const

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
@@ -40,6 +40,7 @@
 #include "Async/Async.h"
 #include "Async/Future.h"
 #include "LandscapeProxy.h"
+#include "UObject/SavePackage.h"
 
 
 #include "Carla/Game/CarlaStatics.h"
@@ -1379,8 +1380,24 @@ void UCustomTerrainPhysicsComponent::BuildLandscapeHeightMapDataAasset(ALandscap
   Package->MarkPackageDirty();
   // FAssetRegistryModule::AssetCreated(NewTexture);
 
-  FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
-  bool bSaved = UPackage::SavePackage(Package, HeightMapAsset, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone, *PackageFileName, GError, nullptr, true, true, SAVE_NoError);
+  FSavePackageArgs SaveArgs;
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
+  SaveArgs.Error = GError;
+  SaveArgs.bForceByteSwapping = true;
+  SaveArgs.bWarnOfLongFilename = true;
+  SaveArgs.SaveFlags = SAVE_NoError;
+
+  FString PackageFileName = FPackageName::LongPackageNameToFilename(
+    PackageName,
+    FPackageName::GetAssetPackageExtension());
+  
+  bool bSaved = UPackage::SavePackage(
+    Package,
+    HeightMapAsset,
+    *PackageFileName,
+    SaveArgs);
 }
 
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
@@ -930,7 +930,7 @@ void UCustomTerrainPhysicsComponent::UpdateTexture()
     region.Width = Texture->GetSizeX();
     region.Height = Texture->GetSizeY();
 
-    FTexture2DResource* resource = (FTexture2DResource*)Texture->Resource;
+    FTexture2DResource* resource = (FTexture2DResource*)Texture->GetResource();
     RHIUpdateTexture2D(
         resource->GetTexture2DRHI(), 0, region, region.Width * sizeof(uint8_t), &NewData[0]); 
   });
@@ -1024,7 +1024,7 @@ void UCustomTerrainPhysicsComponent::UpdateLargeTexture()
     region.Width = Texture->GetSizeX();
     region.Height = Texture->GetSizeY();
 
-    FTexture2DResource* resource = (FTexture2DResource*)Texture->Resource;
+    FTexture2DResource* resource = (FTexture2DResource*)Texture->GetResource();
     RHIUpdateTexture2D(
         resource->GetTexture2DRHI(), 0, region, region.Width * sizeof(uint8_t), &NewData[0]); 
   });

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/CarlaTools.uplugin
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/CarlaTools.uplugin
@@ -37,10 +37,6 @@
       "Enabled": true
     },
     {
-      "Name": "StreetMap",
-      "Enabled": true
-    },
-    {
       "Name": "ChaosVehiclesPlugin",
       "Enabled": true
     }

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/CarlaTools.Build.cs
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/CarlaTools.Build.cs
@@ -26,6 +26,7 @@ public class CarlaTools :
 
     PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
     bEnableExceptions = true;
+    bUseRTTI = true;
     
     foreach (var Definition in File.ReadAllText(Path.Combine(PluginDirectory, "Definitions.def")).Split(';'))
       PrivateDefinitions.Add(Definition.Trim());
@@ -100,8 +101,8 @@ public class CarlaTools :
       "RHI",
       "RenderCore",
       "MeshMergeUtilities",
-      "StreetMapImporting",
-      "StreetMapRuntime",
+      // "StreetMapImporting",
+      // "StreetMapRuntime",
       "Chaos",
       "ChaosVehicles"
     });

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/MapGeneratorWidget.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/MapGeneratorWidget.cpp
@@ -776,7 +776,7 @@ bool UMapGeneratorWidget::CreateMainLargeMap(const FMapGeneratorMetaInfo& MetaIn
   {
     UE_LOG(LogCarlaToolsMapGenerator, Error, 
         TEXT("%s: Failed to cast Large Map Actor in %s."),
-        *MetaInfo.MapName); 
+        *CUR_CLASS_FUNC_LINE, *MetaInfo.MapName); 
     return false;
   }
 
@@ -1200,8 +1200,11 @@ bool UMapGeneratorWidget::CookVegetationToWorld(
         FVector(2500, 2500, 900));
 
     UActorFactory* ActorFactory = GEditor->FindActorFactoryForActorClass(AProceduralFoliageVolume::StaticClass());
+    FActorSpawnParameters SpawnParams;
+    SpawnParams.Name = InName;
+    SpawnParams.ObjectFlags = InObjectFlags;
     AProceduralFoliageVolume* FoliageVolumeActor = (AProceduralFoliageVolume*) ActorFactory->CreateActor(
-        AProceduralFoliageVolume::StaticClass(), Level, Transform, InObjectFlags, InName);
+        AProceduralFoliageVolume::StaticClass(), Level, Transform, SpawnParams);
 
     UProceduralFoliageComponent* FoliageComponent = FoliageVolumeActor->ProceduralComponent;
     FoliageComponent->FoliageSpawner = Spawner;

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/MapGeneratorWidget.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/MapGeneratorWidget.cpp
@@ -35,6 +35,7 @@
 #include "UObject/UnrealType.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/ObjectMacros.h"
+#include "UObject/SavePackage.h"
 
 #include "Dom/JsonObject.h"
 #include "JsonObjectConverter.h"
@@ -435,10 +436,23 @@ UWorld* UMapGeneratorWidget::DuplicateWorld(FString BaseWorldPath, FString Targe
   DuplicateWorld = CastChecked<UWorld>(StaticDuplicateObjectEx(Parameters));
 
   const FString PackageFileName = FPackageName::LongPackageNameToFilename(
-          PackageName, 
-          FPackageName::GetMapPackageExtension());
-      UPackage::SavePackage(WorldPackage, DuplicateWorld, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone,
-          *PackageFileName, GError, nullptr, true, true, SAVE_NoError);
+    PackageName, 
+    FPackageName::GetMapPackageExtension());
+  
+  FSavePackageArgs SaveArgs;
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
+  SaveArgs.Error = GError;
+  SaveArgs.bForceByteSwapping = true;
+  SaveArgs.bWarnOfLongFilename = true;
+  SaveArgs.SaveFlags = SAVE_NoError;
+
+  UPackage::SavePackage(
+    WorldPackage,
+    DuplicateWorld,
+    *PackageFileName,
+    SaveArgs);
 
   return DuplicateWorld;
 }
@@ -751,9 +765,21 @@ bool UMapGeneratorWidget::CreateMainLargeMap(const FMapGeneratorMetaInfo& MetaIn
   const FString PackageFileName = FPackageName::LongPackageNameToFilename(
       PackageName, 
       FPackageName::GetMapPackageExtension());
-  UPackage::SavePackage(BaseMapPackage, World, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone,
-      *PackageFileName, GError, nullptr, true, true, SAVE_NoError);
+  
+  FSavePackageArgs SaveArgs;
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
+  SaveArgs.Error = GError;
+  SaveArgs.bForceByteSwapping = true;
+  SaveArgs.bWarnOfLongFilename = true;
+  SaveArgs.SaveFlags = SAVE_NoError;
 
+  UPackage::SavePackage(
+    BaseMapPackage,
+    World,
+    *PackageFileName,
+    SaveArgs);
 
   bool bLoadedSuccess = FEditorFileUtils::LoadMap(*PackageName, false, true);
     if(!bLoadedSuccess){
@@ -810,8 +836,19 @@ bool UMapGeneratorWidget::CreateMainLargeMap(const FMapGeneratorMetaInfo& MetaIn
 
   }
 
-  UPackage::SavePackage(BaseMapPackage, World, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone,
-      *PackageFileName, GError, nullptr, true, true, SAVE_NoError);
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
+  SaveArgs.Error = GError;
+  SaveArgs.bForceByteSwapping = true;
+  SaveArgs.bWarnOfLongFilename = true;
+  SaveArgs.SaveFlags = SAVE_NoError;
+
+  UPackage::SavePackage(
+    BaseMapPackage,
+    World,
+    *PackageFileName,
+    SaveArgs);
 
   return true;
 }
@@ -1082,8 +1119,21 @@ bool UMapGeneratorWidget::CreateTilesMaps(const FMapGeneratorMetaInfo& MetaInfo)
       const FString PackageFileName = FPackageName::LongPackageNameToFilename(
           PackageName, 
           FPackageName::GetMapPackageExtension());
-      UPackage::SavePackage(TilePackage, World, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone,
-          *PackageFileName, GError, nullptr, true, true, SAVE_NoError);
+      
+      FSavePackageArgs SaveArgs;
+      SaveArgs.TopLevelFlags =
+        EObjectFlags::RF_Public |
+        EObjectFlags::RF_Standalone;
+      SaveArgs.Error = GError;
+      SaveArgs.bForceByteSwapping = true;
+      SaveArgs.bWarnOfLongFilename = true;
+      SaveArgs.SaveFlags = SAVE_NoError;
+
+      UPackage::SavePackage(
+        TilePackage,
+        World,
+        *PackageFileName,
+        SaveArgs);
 
       // TODO PROV
       FText ErrorUnloadingStr;

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/ProceduralBuildingUtilities.cpp
@@ -116,7 +116,9 @@ void AProceduralBuildingUtilities::CookProceduralBuildingToMesh(const FString& D
   UPackage* NewPackage = CreatePackage(*PackageName);
   check(NewPackage);
 
-  const IMeshMergeUtilities& MeshUtilities = FModuleManager::Get().LoadModuleChecked<IMeshMergeModule>("MeshMergeUtilities").GetUtilities();
+  auto& MeshUtilities = FModuleManager::Get().LoadModuleChecked<IMeshMergeModule>(
+    "MeshMergeUtilities").GetUtilities();
+  
   MeshUtilities.MergeComponentsToStaticMesh(
       Components,
       World,
@@ -130,15 +132,19 @@ void AProceduralBuildingUtilities::CookProceduralBuildingToMesh(const FString& D
       true);
 
   FSavePackageArgs SaveArgs;
-  SaveArgs.TopLevelFlags = EObjectFlags::RF_Public |
-                           EObjectFlags::RF_Standalone;
+  SaveArgs.TopLevelFlags =
+    EObjectFlags::RF_Public |
+    EObjectFlags::RF_Standalone;
   SaveArgs.Error = GError;
   SaveArgs.bForceByteSwapping = true;
   SaveArgs.bWarnOfLongFilename = true;
   SaveArgs.SaveFlags = SAVE_NoError;
 
-  UPackage::SavePackage(NewPackage, AssetsToSync[0],
-      *FileName, SaveArgs);
+  UPackage::SavePackage(
+    NewPackage,
+    AssetsToSync[0],
+    *FileName,
+    SaveArgs);
 
 }
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/USDImporterWidget.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/USDImporterWidget.cpp
@@ -29,6 +29,7 @@
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "BlueprintEditor.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
+#include "PhysicsEngine/SkeletalBodySetup.h"
 
 
 void UUSDImporterWidget::ImportUSDProp(
@@ -641,9 +642,9 @@ void UUSDImporterWidget::CopyCollisionToPhysicsAsset(
     UPhysicsAsset* PhysicsAssetToEdit, UStaticMesh* StaticMesh)
 {
   UE_LOG(LogCarlaTools, Log, TEXT("Num bodysetups %d"), PhysicsAssetToEdit->SkeletalBodySetups.Num());
-  UBodySetup* BodySetupPhysicsAsset = 
+  UBodySetup* BodySetupPhysicsAsset = Cast<UBodySetup>(
       PhysicsAssetToEdit->SkeletalBodySetups[
-          PhysicsAssetToEdit->FindBodyIndex(FName("Vehicle_Base"))];
+          PhysicsAssetToEdit->FindBodyIndex(FName("Vehicle_Base"))]);
   UBodySetup* BodySetupStaticMesh = StaticMesh->GetBodySetup();
   BodySetupPhysicsAsset->AggGeom = BodySetupStaticMesh->AggGeom;
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/USDImporterWidget.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/USDImporterWidget.cpp
@@ -30,6 +30,7 @@
 #include "BlueprintEditor.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 #include "PhysicsEngine/SkeletalBodySetup.h"
+#include "UObject/SavePackage.h"
 
 
 void UUSDImporterWidget::ImportUSDProp(

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/USDImporterWidget.h
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Public/USDImporterWidget.h
@@ -104,27 +104,27 @@ struct CARLATOOLS_API FMergedVehicleMeshParts
   GENERATED_BODY();
 
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* DoorFR;
+  TObjectPtr<UStaticMesh> DoorFR = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* DoorFL;
+  TObjectPtr<UStaticMesh> DoorFL = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* DoorRR;
+  TObjectPtr<UStaticMesh> DoorRR = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* DoorRL;
+  TObjectPtr<UStaticMesh> DoorRL = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* Trunk;
+  TObjectPtr<UStaticMesh> Trunk = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* Hood;
+  TObjectPtr<UStaticMesh> Hood = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* WheelFR;
+  TObjectPtr<UStaticMesh> WheelFR = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* WheelFL;
+  TObjectPtr<UStaticMesh> WheelFL = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* WheelRR;
+  TObjectPtr<UStaticMesh> WheelRR = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* WheelRL;
+  TObjectPtr<UStaticMesh> WheelRL = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
-  UStaticMesh* Body;
+  TObjectPtr<UStaticMesh> Body = nullptr;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")
   FVehicleMeshAnchorPoints Anchors;
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="USD Importer")

--- a/Unreal/CarlaUnreal/Source/CarlaUnreal.Target.cs
+++ b/Unreal/CarlaUnreal/Source/CarlaUnreal.Target.cs
@@ -20,7 +20,6 @@ public class CarlaUnrealTarget : TargetRules
     {
         DefaultBuildSettings = BuildSettingsVersion.Latest;
         IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
-
         Type = TargetType.Game;
         
         ExtraModuleNames.Add("CarlaUnreal");

--- a/Unreal/CarlaUnreal/Source/CarlaUnreal/CarlaUnreal.Build.cs
+++ b/Unreal/CarlaUnreal/Source/CarlaUnreal/CarlaUnreal.Build.cs
@@ -21,6 +21,8 @@ public class CarlaUnreal : ModuleRules
     public CarlaUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PrivatePCHHeaderFile = "CarlaUnreal.h";
+        bEnableExceptions = true;
+        bUseRTTI = true;
 
 		PublicDependencyModuleNames.AddRange(new string[]
 		{


### PR DESCRIPTION
This PR adapts CARLA to work with UE5.5.
Changes added:
 - Globally enable RTTI by default.
 - Disable Streetmap UE plugin.
 - Update LinuxToolchain.cmake for newer version of UE's clang toolchain.
 - Mark external dependencies as SYSTEM in target_link_libraries.
 - Upgrade UE UENUM to string code.
 - Fix null pointer error in LoadCurrentOpenDriveMap.
 - Many deprecation warning fixes (FSavePackageArgs, FActorSpawnParameters, ...).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8346)
<!-- Reviewable:end -->
