### PR TITLE
Add is_weather_enabled function

### DIFF
--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -91,6 +91,10 @@ namespace client {
     _episode.Lock()->SetWeatherParameters(weather);
   }
 
+  bool World::IsWeatherEnabled() const {
+    return _episode.Lock()->IsWeatherEnabled();
+  }
+
   WorldSnapshot World::GetSnapshot() const {
     return _episode.Lock()->GetWorldSnapshot();
   }

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -93,6 +93,9 @@ namespace client {
     /// Change the weather in the simulation.
     void SetWeather(const rpc::WeatherParameters &weather);
 
+    /// Query if the Weather is enabled or not
+    bool IsWeatherEnabled() const;
+
     /// Return a snapshot of the world at this moment.
     WorldSnapshot GetSnapshot() const;
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -284,8 +284,7 @@ namespace detail {
   }
 
   bool Client::IsWeatherEnabled() {
-    return false;
-    //return _pimpl->CallAndWait<bool>("is_weather_enabled");
+    return _pimpl->CallAndWait<bool>("is_weather_enabled");
   }
 
   std::vector<rpc::Actor> Client::GetActorsById(

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -283,6 +283,11 @@ namespace detail {
     _pimpl->AsyncCall("set_weather_parameters", weather);
   }
 
+  bool Client::IsWeatherEnabled() {
+    return false;
+    //return _pimpl->CallAndWait<bool>("is_weather_enabled");
+  }
+
   std::vector<rpc::Actor> Client::GetActorsById(
       const std::vector<ActorId> &ids) {
     using return_t = std::vector<rpc::Actor>;

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -159,6 +159,8 @@ namespace detail {
 
     void SetWeatherParameters(const rpc::WeatherParameters &weather);
 
+    bool IsWeatherEnabled(); 
+
     std::vector<rpc::Actor> GetActorsById(const std::vector<ActorId> &ids);
 
     rpc::VehiclePhysicsControl GetVehiclePhysicsControl(rpc::ActorId vehicle) const;

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -259,6 +259,10 @@ namespace detail {
       _client.SetWeatherParameters(weather);
     }
 
+    bool IsWeatherEnabled() {
+      return _client.IsWeatherEnabled();
+    }
+
     rpc::VehiclePhysicsControl GetVehiclePhysicsControl(const Vehicle &vehicle) const {
       return _client.GetVehiclePhysicsControl(vehicle.GetId());
     }

--- a/LibCarla/source/carla/trafficmanager/VehicleLightStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/VehicleLightStage.cpp
@@ -24,7 +24,9 @@ VehicleLightStage::VehicleLightStage(
 void VehicleLightStage::UpdateWorldInfo() {
   // Get the global weather and all the vehicle light states at once
   all_light_states = world.GetVehiclesLightStates();
-  weather = world.GetWeather();
+  is_weather_enabled = world.IsWeatherEnabled();
+  if (is_weather_enabled)
+    weather = world.GetWeather();
 }
 
 void VehicleLightStage::Update(const unsigned long index) {
@@ -78,30 +80,32 @@ void VehicleLightStage::Update(const unsigned long index) {
     }
   }
 
-  // Determine position, fog and beams
+  // Determine position, fog and beams. Do nothing if the weather is disabled.
+  if (is_weather_enabled) {
 
-  // Turn on beams & positions from sunset to dawn
-  if (weather.sun_altitude_angle < SUN_ALTITUDE_DEGREES_BEFORE_DAWN ||
-      weather.sun_altitude_angle >SUN_ALTITUDE_DEGREES_AFTER_SUNSET)
-  {
-    position = true;
-    low_beam = true;
-  }
-  else if (weather.sun_altitude_angle < SUN_ALTITUDE_DEGREES_JUST_AFTER_DAWN ||
-           weather.sun_altitude_angle > SUN_ALTITUDE_DEGREES_JUST_BEFORE_SUNSET)
-  {
-    position = true;
-  }
-  // Turn on lights under heavy rain
-  if (weather.precipitation > HEAVY_PRECIPITATION_THRESHOLD) {
-    position = true;
-    low_beam = true;
-  }
-  // Turn on fog lights
-  if (weather.fog_density > FOG_DENSITY_THRESHOLD) {
-    position = true;
-    low_beam = true;
-    fog_lights = true;
+    // Turn on beams & positions from sunset to dawn
+    if (weather.sun_altitude_angle < SUN_ALTITUDE_DEGREES_BEFORE_DAWN ||
+        weather.sun_altitude_angle > SUN_ALTITUDE_DEGREES_AFTER_SUNSET)
+    {
+      position = true;
+      low_beam = true;
+    }
+    else if (weather.sun_altitude_angle < SUN_ALTITUDE_DEGREES_JUST_AFTER_DAWN ||
+            weather.sun_altitude_angle > SUN_ALTITUDE_DEGREES_JUST_BEFORE_SUNSET)
+    {
+      position = true;
+    }
+    // Turn on lights under heavy rain
+    if (weather.precipitation > HEAVY_PRECIPITATION_THRESHOLD) {
+      position = true;
+      low_beam = true;
+    }
+    // Turn on fog lights
+    if (weather.fog_density > FOG_DENSITY_THRESHOLD) {
+      position = true;
+      low_beam = true;
+      fog_lights = true;
+    }
   }
 
   // Determine the new vehicle light state

--- a/LibCarla/source/carla/trafficmanager/VehicleLightStage.h
+++ b/LibCarla/source/carla/trafficmanager/VehicleLightStage.h
@@ -23,6 +23,8 @@ private:
   rpc::VehicleLightStateList all_light_states;
   /// Current weather parameters
   rpc::WeatherParameters weather;
+  /// Weather enabled
+  bool is_weather_enabled;
 
 public:
   VehicleLightStage(const std::vector<ActorId> &vehicle_id_list,

--- a/PythonAPI/carla/src/World.cpp
+++ b/PythonAPI/carla/src/World.cpp
@@ -312,7 +312,7 @@ void export_world() {
     .def("apply_settings", &ApplySettings, (arg("settings"), arg("seconds")=0.0))
     .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, GetWeather))
     .def("set_weather", &cc::World::SetWeather)
-    .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, IsWeatherEnabled))
+    .def("is_weather_enabled", CONST_CALL_WITHOUT_GIL(cc::World, IsWeatherEnabled))
     .def("get_snapshot", &cc::World::GetSnapshot)
     .def("get_actor", CONST_CALL_WITHOUT_GIL_1(cc::World, GetActor, carla::ActorId), (arg("actor_id")))
     .def("get_actors", CONST_CALL_WITHOUT_GIL(cc::World, GetActors))

--- a/PythonAPI/carla/src/World.cpp
+++ b/PythonAPI/carla/src/World.cpp
@@ -312,6 +312,7 @@ void export_world() {
     .def("apply_settings", &ApplySettings, (arg("settings"), arg("seconds")=0.0))
     .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, GetWeather))
     .def("set_weather", &cc::World::SetWeather)
+    .def("get_weather", CONST_CALL_WITHOUT_GIL(cc::World, IsWeatherEnabled))
     .def("get_snapshot", &cc::World::GetSnapshot)
     .def("get_actor", CONST_CALL_WITHOUT_GIL_1(cc::World, GetActor, carla::ActorId), (arg("actor_id")))
     .def("get_actors", CONST_CALL_WITHOUT_GIL(cc::World, GetActors))

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -691,7 +691,7 @@ void FCarlaServer::FPimpl::BindActions()
     auto *Weather = Episode->GetWeather();
     if (Weather == nullptr)
     {
-      UE_LOG(LogCarla, Error, TEXT("internal error: unable to find weather:: weather is disabled"));
+      UE_LOG(LogCarla, Error, TEXT("get_weather_parameters internal error: unable to find weather:: weather is disabled"));
       return cr::WeatherParameters();
     }
     return Weather->GetCurrentWeather();
@@ -704,10 +704,21 @@ void FCarlaServer::FPimpl::BindActions()
     auto *Weather = Episode->GetWeather();
     if (Weather == nullptr)
     {
-      RESPOND_ERROR("internal error: unable to find weather:: weather is disabled");
+      RESPOND_ERROR("set_weather_parameters internal error: unable to find weather:: weather is disabled");
     }
     Weather->ApplyWeather(weather);
     return R<void>::Success();
+  };
+
+  BIND_SYNC(is_weather_enabled) << [this]() -> R<bool>
+  {
+    REQUIRE_CARLA_EPISODE();
+    auto *Weather = Episode->GetWeather();
+    if (Weather == nullptr)
+    {
+      return false;
+    }
+    return true;
   };
 
   // ~~ Actor operations ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -691,7 +691,6 @@ void FCarlaServer::FPimpl::BindActions()
     auto *Weather = Episode->GetWeather();
     if (Weather == nullptr)
     {
-      UE_LOG(LogCarla, Error, TEXT("get_weather_parameters internal error: unable to find weather:: weather is disabled"));
       return cr::WeatherParameters();
     }
     return Weather->GetCurrentWeather();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -691,6 +691,7 @@ void FCarlaServer::FPimpl::BindActions()
     auto *Weather = Episode->GetWeather();
     if (Weather == nullptr)
     {
+      UE_LOG(LogCarla, Log, TEXT("internal error: unable to find weather:: weather is disabled"));
       return cr::WeatherParameters();
     }
     return Weather->GetCurrentWeather();


### PR DESCRIPTION
### Description

Added a `world.is_weather_enabled()` function to differentiate between towns that have their weather API enabled and those that haven't (like Town10HD)

### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8373)
<!-- Reviewable:end -->
