### PR TITLE
Disable motion blur when under resolutions 1080p.

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -713,6 +713,9 @@ void ASceneCaptureSensor::BeginPlay()
   UpdatePostProcessConfig(PostProcessConfig);
   CaptureComponent2D->ShowFlags = PostProcessConfig.EngineShowFlags;
   CaptureComponent2D->PostProcessSettings = PostProcessConfig.PostProcessSettings;
+
+  if (ImageWidth < 1920 || ImageHeight < 1080)
+    CaptureComponent2D->ShowFlags.SetMotionBlur(false);
   
   // This ensures the camera is always spawning the raindrops in case the
   // weather was previously set to have rain.


### PR DESCRIPTION
This PR temporarily disables motion blur whenever a sensor is running under 1080p. This is to mitigate some motion blur artifacts that appear as dither trails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8421)
<!-- Reviewable:end -->
