### PR TITLE
Fix mistake in bounding box documentation.

### DIFF
--- a/Docs/tuto_G_bounding_boxes.md
+++ b/Docs/tuto_G_bounding_boxes.md
@@ -114,7 +114,7 @@ CARLA objects all have an associated bounding box. CARLA [actors](python_api.md#
 It is important to note that to get the 3D coordinates of the bounding box in world coordinates, you need to include the transform of the actor as an argument to the `get_world_vertices()` method like so:
 
 ```py
-actor.get_world_vertices(actor.get_transform())
+bounding_box.get_world_vertices(actor.get_transform())
 
 ```
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux and ue4-dev)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes mistake in documentation about bounding boxed mistakenly calling `get_world_vertices()` on the actor instead of the bounding box object

#### Where has this been tested?

  * Ne tests needed

#### Possible Drawbacks

  * None
