### PR TITLE
Fix mistakes in bounding boxes docs

### DIFF
--- a/Docs/tuto_G_bounding_boxes.md
+++ b/Docs/tuto_G_bounding_boxes.md
@@ -108,7 +108,7 @@ CARLA objects all have an associated bounding box. CARLA [actors](python_api.md#
 It is important to note that to get the 3D coordinates of the bounding box in world coordinates, you need to include the transform of the actor as an argument to the `get_world_vertices()` method like so:
 
 ```py
-actor.get_world_vertices(actor.get_transform())
+bounding_box.get_world_vertices(actor.get_transform())
 
 ```
 

--- a/Docs/tuto_G_bounding_boxes.md
+++ b/Docs/tuto_G_bounding_boxes.md
@@ -21,6 +21,9 @@ client = carla.Client('localhost', 2000)
 world  = client.get_world()
 bp_lib = world.get_blueprint_library()
 
+# Get the map spawn points
+spawn_points = world.get_map().get_spawn_points()
+
 # spawn vehicle
 vehicle_bp =bp_lib.find('vehicle.lincoln.mkz_2020')
 vehicle = world.try_spawn_actor(vehicle_bp, random.choice(spawn_points))
@@ -36,9 +39,6 @@ settings = world.get_settings()
 settings.synchronous_mode = True # Enables synchronous mode
 settings.fixed_delta_seconds = 0.05
 world.apply_settings(settings)
-
-# Get the map spawn points
-spawn_points = world.get_map().get_spawn_points()
 
 # Create a queue to store and retrieve the sensor data
 image_queue = queue.Queue()


### PR DESCRIPTION
Spawn points were used before being defined in the example code for setting up the simulation, this PR fixed that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8462)
<!-- Reviewable:end -->
