### PR TITLE
Update requirements for python versions 3.8-3.12

### DIFF
--- a/PythonAPI/examples/requirements.txt
+++ b/PythonAPI/examples/requirements.txt
@@ -1,7 +1,5 @@
-numpy==1.24; python_version <= '3.11'
-numpy==1.26; python_version > '3.11'
+numpy>=1.24
 pygame
-matplotlib
-open3d
+open3d; python_version <= '3.11'
 Pillow
 invertedai@git+https://github.com/inverted-ai/invertedai.git@develop

--- a/PythonAPI/examples/requirements.txt
+++ b/PythonAPI/examples/requirements.txt
@@ -1,5 +1,5 @@
-numpy; python_version < '3.0'
-numpy==1.24; python_version >= '3.0'
+numpy==1.24; python_version <= '3.11'
+numpy==1.26; python_version > '3.11'
 pygame
 matplotlib
 open3d


### PR DESCRIPTION
- Update and unify numpy requirement
- Remove numpy for python 2
- Remove open3d requirement for python 3.12 since that package does not officially support python 3.12
- Remove matplotlib requirement, since it is installed with open3d and only used in open3d codes
- Tested that requirements are correctly installed in environments with python versions from 3.8 to 3.12

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8467)
<!-- Reviewable:end -->
