### PR TITLE
Change conterintuitive package and editor build configuration rules.

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -220,10 +220,21 @@ carla_string_option (
   ""
 )
 
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Debug)
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Development)
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Shipping)
+else ()
+  carla_warning("Unexpected CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\". Unreal builds will default to Development. Manually override CARLA_UNREAL_BUILD_TYPE if this behavior is not desired.")
+  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Development)
+endif ()
+
 carla_string_option (
   CARLA_UNREAL_BUILD_TYPE
-  "Carla Unreal-style build type (Debug/Development/Shipping)."
-  "Development"
+  "Set the default Unreal build configuration."
+  "${CARLA_UNREAL_BUILD_TYPE_DEFAULT}"
 )
 
 

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -220,21 +220,30 @@ carla_string_option (
   ""
 )
 
+carla_string_option (
+  CARLA_UNREAL_BUILD_TYPE
+  "Set the default CARLA Unreal Editor build configuration."
+  "Development"
+)
+
+# Docs for UE5 build configurations:
+# https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/BuildConfigurations/
+
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Debug)
+  set (CARLA_UNREAL_PACKAGE_BUILD_TYPE_DEFAULT Debug)
 elseif (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
-  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Development)
+  set (CARLA_UNREAL_PACKAGE_BUILD_TYPE_DEFAULT Development)
 elseif (${CMAKE_BUILD_TYPE} STREQUAL "Release")
-  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Shipping)
+  set (CARLA_UNREAL_PACKAGE_BUILD_TYPE_DEFAULT Shipping)
 else ()
-  carla_warning("Unexpected CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\". Unreal builds will default to Development. Manually override CARLA_UNREAL_BUILD_TYPE if this behavior is not desired.")
-  set (CARLA_UNREAL_BUILD_TYPE_DEFAULT Development)
+  carla_warning("Unexpected CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\". Unreal packages will default to Development. Manually override DEFAULT_PACKAGE_CONFIGURATION if this behavior is not desired.")
+  set (CARLA_UNREAL_PACKAGE_BUILD_TYPE_DEFAULT Development)
 endif ()
 
 carla_string_option (
-  CARLA_UNREAL_BUILD_TYPE
-  "Set the default Unreal build configuration."
-  "${CARLA_UNREAL_BUILD_TYPE_DEFAULT}"
+  CARLA_UNREAL_PACKAGE_BUILD_TYPE
+  "Set the default CARLA package build configuration."
+  "${CARLA_UNREAL_PACKAGE_BUILD_TYPE_DEFAULT}"
 )
 
 

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -503,7 +503,7 @@ endfunction()
 
 # Docs for UE5 build configurations:
 # https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/BuildConfigurations/
-add_carla_ue_package_target("" Shipping)
+add_carla_ue_package_target("" ${CARLA_UNREAL_BUILD_TYPE})
 add_carla_ue_package_target(Shipping Shipping)
 add_carla_ue_package_target(Debug Debug)
 add_carla_ue_package_target(DebugGame DebugGame)

--- a/Unreal/CMakeLists.txt
+++ b/Unreal/CMakeLists.txt
@@ -503,7 +503,8 @@ endfunction()
 
 # Docs for UE5 build configurations:
 # https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/BuildConfigurations/
-add_carla_ue_package_target("" ${CARLA_UNREAL_BUILD_TYPE})
+
+add_carla_ue_package_target("" ${CARLA_UNREAL_PACKAGE_BUILD_TYPE})
 add_carla_ue_package_target(Shipping Shipping)
 add_carla_ue_package_target(Debug Debug)
 add_carla_ue_package_target(DebugGame DebugGame)


### PR DESCRIPTION
This PR changes what UE build configuration the `package` target defaults to. Previously it was always set to shipping, now it defaults to the UE equivalent of the current CMake configuration:

- Debug -> Debug
- RelWithDebInfo -> Development
- Release -> Shipping

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8472)
<!-- Reviewable:end -->
