### PR TITLE
Update setuptools in requirements to avoid problems in higher python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ requests
 scikit-build-core
 wheel
 numpy<2.0,>=1.24.4
-setuptools==47.3.1
+setuptools>=47.3.1
 build
 pygame


### PR DESCRIPTION
setuptools required version in python >3.8 was too low and led to issues of the form:
`C:\Users\TDA\Desktop\CARLA\Carla-0.10.0-Win64-Development\PythonAPI\examples`
Allowing it to be higher avoids that issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8483)
<!-- Reviewable:end -->
