### PR TITLE
Fix missing files in the Python API ROS2 examples folder.

### DIFF
--- a/Unreal/Package/CopyCarlaAdditionalFiles.cmake
+++ b/Unreal/Package/CopyCarlaAdditionalFiles.cmake
@@ -30,7 +30,7 @@ file (COPY_FILE ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/requirements.txt ${CA
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
 file (GLOB PYTHON_EXAMPLE_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*)
 file (COPY ${PYTHON_EXAMPLE_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
-make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
+make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2/config)
 file (GLOB PYTHON_EXAMPLE_CONFIG_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/config/*)
 file (COPY ${PYTHON_EXAMPLE_CONFIG_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2/config)
 

--- a/Unreal/Package/CopyCarlaAdditionalFiles.cmake
+++ b/Unreal/Package/CopyCarlaAdditionalFiles.cmake
@@ -28,19 +28,11 @@ file (COPY ${PYTHON_EXAMPLE_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/Pyt
 file (COPY_FILE ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/requirements.txt ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/requirements.txt)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
-file (
-    GLOB_RECURSE
-    PYTHON_EXAMPLE_ROS2_FILES
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.md
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.py
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.json
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.sh
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.rviz
-    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.xml
-    # Add more patterns here as needed.
-    # Alternatively, we could consider including all files in examples/ros2.
-)
+file (GLOB PYTHON_EXAMPLE_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*)
 file (COPY ${PYTHON_EXAMPLE_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
+make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
+file (GLOB PYTHON_EXAMPLE_CONFIG_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/config/*)
+file (COPY ${PYTHON_EXAMPLE_CONFIG_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2/config)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/util/)
 file (GLOB PYTHON_UTIL_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/util/*.py)

--- a/Unreal/Package/CopyCarlaAdditionalFiles.cmake
+++ b/Unreal/Package/CopyCarlaAdditionalFiles.cmake
@@ -28,7 +28,18 @@ file (COPY ${PYTHON_EXAMPLE_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/Pyt
 file (COPY_FILE ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/requirements.txt ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/requirements.txt)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
-file (GLOB PYTHON_EXAMPLE_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.py ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.json)
+file (
+    GLOB_RECURSE
+    PYTHON_EXAMPLE_ROS2_FILES
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.md
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.py
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.json
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.sh
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.rviz
+    ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.xml
+    # Add more patterns here as needed.
+    # Alternatively, we could consider including all files in examples/ros2.
+)
 file (COPY ${PYTHON_EXAMPLE_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/util/)

--- a/Unreal/Package/CopyCarlaAdditionalFiles.cmake
+++ b/Unreal/Package/CopyCarlaAdditionalFiles.cmake
@@ -28,7 +28,7 @@ file (COPY ${PYTHON_EXAMPLE_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/Pyt
 file (COPY_FILE ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/requirements.txt ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/requirements.txt)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
-file (GLOB PYTHON_EXAMPLE_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/*./ros2py ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.json)
+file (GLOB PYTHON_EXAMPLE_ROS2_FILES ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.py ${CARLA_WORKSPACE_PATH}/PythonAPI/examples/ros2/*.json)
 file (COPY ${PYTHON_EXAMPLE_ROS2_FILES} DESTINATION ${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/examples/ros2)
 
 make_directory (${CARLA_PACKAGE_ARCHIVE_PATH}/PythonAPI/util/)


### PR DESCRIPTION
This PR fixes a typo in CopyCarlaAdditionalFiles.cmake. It also expands the pattern list to include more files in the ROS2 example folder of the Python API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8519)
<!-- Reviewable:end -->
