### PR TITLE
Modify default CarlaSetup.sh behavior.

### DIFF
--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -1,57 +1,65 @@
 #!/bin/bash
 
+set -e
 
+options=$(getopt -o "i" --long "interactive" -n 'CarlaSetup.sh' -- "$@")
+eval set -- "$options"
 
-# ==================================================================================================
-# -- FUNCTIONS -------------------------------------------------------------------------------------
-# ==================================================================================================
+interactive=0
 
-satisfies_minimum_version() {
-    CMAKE_VERSION="$($2 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-    CMAKE_MINIMUM_VERSION=$1
-    MAJOR="${CMAKE_VERSION%%.*}"
-    REMAINDER="${CMAKE_VERSION#*.}"
-    MINOR="${REMAINDER%.*}"
-    REVISION="${REMAINDER#*.}"
-    MINIMUM_MAJOR="${CMAKE_MINIMUM_VERSION%%.*}"
-    MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
-    MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
+while true; do
+    case "$1" in
+        -i | --interactive)
+            interactive=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            ;;
+    esac
+done
 
-    if [ $MAJOR -gt $MINIMUM_MAJOR ] ||
-        ( [ $MAJOR -eq $MINIMUM_MAJOR ] &&
-            ( [ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])) ; then
-        true
-    else
-        false
+if [ $interactive -eq 1 ]; then
+    echo "Requesting root rights."
+    sudo echo "Acquired root rights."
+else
+    if [ -z "$EUID" ]; then
+        EUID=$(id -u)
     fi
-}
 
+    if [ "$EUID" -ne 0 ]; then
+        echo "Please run this script as root."
+        exit 1
+    fi
+fi
 
+arrIN=(${GIT_LOCAL_CREDENTIALS//@/ })
+GIT_LOCAL_USER=${arrIN[0]}
+GIT_LOCAL_TOKEN=${arrIN[1]}
+if [ -z "$GIT_LOCAL_CREDENTIALS" ]; then
+    if [ $interactive -eq 1 ]; then
+        echo "Warning: git credentials are not set"
+    else
+        echo "Git credentials are not set, can not continue setup in unatteded mode."
+        exit 1
+    fi
+fi
 
 # ==================================================================================================
 # -- MAIN ------------------------------------------------------------------------------------------
 # ==================================================================================================
 
-set -e
-sudo echo "Got super powers..."
-
-echo "Parsing GIT_LOCAL_CREDENTIALS local variable "
-arrIN=(${GIT_LOCAL_CREDENTIALS//@/ })
-GIT_LOCAL_USER=${arrIN[0]}
-GIT_LOCAL_TOKEN=${arrIN[1]}
-if [ -z "$GIT_LOCAL_CREDENTIALS" ]
-then
-    echo "Git credentials are not set, they will be requested later on during the download of Unreal Engine Carla fork"
-fi
-
 echo "Installing Ubuntu Packages..."
 if ! command -v retry &> /dev/null
 then
-    sudo apt update
-    sudo apt-get install retry
+    apt update
+    apt-get install retry
 fi
-retry --until=success --times=12 --delay=300 -- sudo apt-get update
-retry --until=success --times=12 --delay=300 -- sudo apt-get -y install \
+retry --until=success --times=12 --delay=300 -- apt-get update
+retry --until=success --times=12 --delay=300 -- apt-get -y install \
     build-essential \
     g++-12 \
     gcc-12 \
@@ -79,9 +87,28 @@ pip3 install --upgrade pip
 pip3 install -r requirements.txt
 echo "Python Packages Installed..."
 
-echo "Clonning CARLA Content asynchronously... (see the progres in ContentClone.log)"
+echo "Clonning CARLA Content asynchronously... (see the progress in ContentClone.log)"
 mkdir -p Unreal/CarlaUnreal/Content
 git -C Unreal/CarlaUnreal/Content clone -b ue5-dev https://bitbucket.org/carla-simulator/carla-content.git Carla &> ContentClone.log&
+
+satisfies_minimum_version() {
+    CMAKE_VERSION="$($2 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+    CMAKE_MINIMUM_VERSION=$1
+    MAJOR="${CMAKE_VERSION%%.*}"
+    REMAINDER="${CMAKE_VERSION#*.}"
+    MINOR="${REMAINDER%.*}"
+    REVISION="${REMAINDER#*.}"
+    MINIMUM_MAJOR="${CMAKE_MINIMUM_VERSION%%.*}"
+    MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
+    MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
+
+    if [ $MAJOR -gt $MINIMUM_MAJOR ] || ( [ $MAJOR -eq $MINIMUM_MAJOR ] &&
+            ( [ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])) ; then
+        true
+    else
+        false
+    fi
+}
 
 CMAKE_MINIMUM_VERSION=3.28.0
 if (satisfies_minimum_version $CMAKE_MINIMUM_VERSION cmake) || (satisfies_minimum_version $CMAKE_MINIMUM_VERSION /opt/cmake-3.28.3-linux-x86_64/bin/cmake); then
@@ -90,8 +117,8 @@ else
     echo "Found CMake $CMAKE_VERSION - FAIL"
     echo "Installing CMake 3.28.3..."
     curl -L -O https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz
-    sudo mkdir -p /opt
-    sudo tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
+    mkdir -p /opt
+    tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
     if [[ ":$PATH:" != *":/opt/cmake-3.28.3-linux-x86_64/bin:"* ]]; then
         echo -e '\n#CARLA CMake 3.28.3\nPATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH' >> ~/.bashrc
         export PATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -2,15 +2,19 @@
 
 set -e
 
-options=$(getopt -o "i" --long "interactive" -n 'CarlaSetup.sh' -- "$@")
-eval set -- "$options"
-
 interactive=0
+skip_prerequisites=0
 
+options=$(getopt -o "i,p" --long "interactive,skip-prerequisites" -n 'CarlaSetup.sh' -- "$@")
+eval set -- "$options"
 while true; do
     case "$1" in
         -i | --interactive)
             interactive=1
+            shift
+            ;;
+        -p | --skip-prerequisites)
+            skip_prerequisites=1
             shift
             ;;
         --)
@@ -22,105 +26,37 @@ while true; do
     esac
 done
 
-if [ $interactive -eq 1 ]; then
-    echo "Requesting root rights."
-    sudo echo "Acquired root rights."
-else
-    if [ -z "$EUID" ]; then
-        EUID=$(id -u)
-    fi
-
-    if [ "$EUID" -ne 0 ]; then
-        echo "Please run this script as root."
-        exit 1
+# Check for root privileges:
+if [ -z "$EUID" ]; then
+    EUID=$(id -u)
+fi
+if [ "$EUID" -ne 0 ]; then
+    if [ $interactive -eq 0 ]; then
+        if [ $skip_prerequisites -eq 0 ]; then
+            echo "Please run this script as root. Otherwise pass --interactive to be prompted whenever root privileges or Git credentials are needed."
+            exit 1
+        fi
     fi
 fi
 
-arrIN=(${GIT_LOCAL_CREDENTIALS//@/ })
-GIT_LOCAL_USER=${arrIN[0]}
-GIT_LOCAL_TOKEN=${arrIN[1]}
+# Check for Git credentials:
+CREDENTIAL_INFO=(${GIT_LOCAL_CREDENTIALS//@/ })
+GIT_LOCAL_USER=${CREDENTIAL_INFO[0]}
+GIT_LOCAL_TOKEN=${CREDENTIAL_INFO[1]}
 if [ -z "$GIT_LOCAL_CREDENTIALS" ]; then
     if [ $interactive -eq 1 ]; then
-        echo "Warning: git credentials are not set"
+        echo "Warning: git credentials are not set. You may be required to manually enter them later."
     else
         echo "Git credentials are not set, can not continue setup in unatteded mode."
         exit 1
     fi
 fi
 
-echo "Installing Ubuntu Packages..."
-if ! command -v retry &> /dev/null
-then
-    apt update
-    apt-get install retry
-fi
-retry --until=success --times=12 --delay=300 -- apt-get update
-retry --until=success --times=12 --delay=300 -- apt-get -y install \
-    build-essential \
-    g++-12 \
-    gcc-12 \
-    make \
-    ninja-build \
-    libvulkan1 \
-    python3 \
-    python3-dev \
-    python3-pip \
-    libpng-dev \
-    libtiff5-dev \
-    libjpeg-dev \
-    tzdata \
-    sed \
-    curl \
-    libtool \
-    rsync \
-    libxml2-dev \
-    git \
-    git-lfs
-echo "Ubuntu Packages Installed..."
-
-echo "Installing Python Packages..."
-pip3 install --upgrade pip
-pip3 install -r requirements.txt
-echo "Python Packages Installed..."
-
-echo "Cloning CARLA Content asynchronously... (see progress in ContentClone.log)"
-mkdir -p Unreal/CarlaUnreal/Content
-git -C Unreal/CarlaUnreal/Content clone -b ue5-dev https://bitbucket.org/carla-simulator/carla-content.git Carla &> ContentClone.log&
-
-satisfies_minimum_version() {
-    CMAKE_VERSION="$($2 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-    CMAKE_MINIMUM_VERSION=$1
-    MAJOR="${CMAKE_VERSION%%.*}"
-    REMAINDER="${CMAKE_VERSION#*.}"
-    MINOR="${REMAINDER%.*}"
-    REVISION="${REMAINDER#*.}"
-    MINIMUM_MAJOR="${CMAKE_MINIMUM_VERSION%%.*}"
-    MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
-    MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
-
-    if [ $MAJOR -gt $MINIMUM_MAJOR ] || ( [ $MAJOR -eq $MINIMUM_MAJOR ] &&
-            ( [ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])) ; then
-        true
-    else
-        false
-    fi
-}
-
-CMAKE_MINIMUM_VERSION=3.28.0
-if (satisfies_minimum_version $CMAKE_MINIMUM_VERSION cmake) || (satisfies_minimum_version $CMAKE_MINIMUM_VERSION /opt/cmake-3.28.3-linux-x86_64/bin/cmake); then
-    echo "Found CMake $CMAKE_VERSION"
+if [ $skip_prerequisites -eq 0 ]; then
+    echo "Installing prerequisites..."
+    sudo bash -x Util/SetupUtils/InstallPrerequisites.sh
 else
-    echo "Could not find CMake $CMAKE_VERSION."
-    echo "Installing CMake 3.28.3..."
-    curl -L -O https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz
-    mkdir -p /opt
-    tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
-    if [[ ":$PATH:" != *":/opt/cmake-3.28.3-linux-x86_64/bin:"* ]]; then
-        echo -e '\n#CARLA CMake 3.28.3\nPATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH' >> ~/.bashrc
-        export PATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH
-    fi
-    rm -rf cmake-3.28.3-linux-x86_64.tar.gz
-    echo "Installed CMake 3.28.3."
+    echo "Skipping prerequisites install step."
 fi
 
 if [ ! -z $CARLA_UNREAL_ENGINE_PATH ] && [ -d $CARLA_UNREAL_ENGINE_PATH ]; then
@@ -134,8 +70,7 @@ elif [ -d ../UnrealEngine5_carla ]; then
     popd
     popd
 else
-    echo "Could not find CARLA Unreal Engine."
-    echo "Cloning CARLA Unreal Engine..."
+    echo "Could not find CARLA Unreal Engine, downloading..."
     pushd ..
     if [ -z "$GIT_LOCAL_CREDENTIALS" ]
     then

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -48,10 +48,6 @@ if [ -z "$GIT_LOCAL_CREDENTIALS" ]; then
     fi
 fi
 
-# ==================================================================================================
-# -- MAIN ------------------------------------------------------------------------------------------
-# ==================================================================================================
-
 echo "Installing Ubuntu Packages..."
 if ! command -v retry &> /dev/null
 then
@@ -87,7 +83,7 @@ pip3 install --upgrade pip
 pip3 install -r requirements.txt
 echo "Python Packages Installed..."
 
-echo "Clonning CARLA Content asynchronously... (see the progress in ContentClone.log)"
+echo "Cloning CARLA Content asynchronously... (see progress in ContentClone.log)"
 mkdir -p Unreal/CarlaUnreal/Content
 git -C Unreal/CarlaUnreal/Content clone -b ue5-dev https://bitbucket.org/carla-simulator/carla-content.git Carla &> ContentClone.log&
 
@@ -112,9 +108,9 @@ satisfies_minimum_version() {
 
 CMAKE_MINIMUM_VERSION=3.28.0
 if (satisfies_minimum_version $CMAKE_MINIMUM_VERSION cmake) || (satisfies_minimum_version $CMAKE_MINIMUM_VERSION /opt/cmake-3.28.3-linux-x86_64/bin/cmake); then
-    echo "Found CMake $CMAKE_VERSION - OK"
+    echo "Found CMake $CMAKE_VERSION"
 else
-    echo "Found CMake $CMAKE_VERSION - FAIL"
+    echo "Could not find CMake $CMAKE_VERSION."
     echo "Installing CMake 3.28.3..."
     curl -L -O https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz
     mkdir -p /opt
@@ -124,22 +120,22 @@ else
         export PATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH
     fi
     rm -rf cmake-3.28.3-linux-x86_64.tar.gz
-    echo "CMake Intalled 3.28.3..."
+    echo "Installed CMake 3.28.3."
 fi
 
 if [ ! -z $CARLA_UNREAL_ENGINE_PATH ] && [ -d $CARLA_UNREAL_ENGINE_PATH ]; then
-    echo "Found UnrealEngine5 $CARLA_UNREAL_ENGINE_PATH - OK"
+    echo "Found CARLA Unreal Engine at $CARLA_UNREAL_ENGINE_PATH"
 elif [ -d ../UnrealEngine5_carla ]; then
     pushd ..
     pushd UnrealEngine5_carla
-    echo "Found UnrealEngine5 ../UnrealEngine5_carla - OK"
+    echo "Found CARLA Unreal Engine at ../UnrealEngine5_carla"
     export CARLA_UNREAL_ENGINE_PATH=$PWD
     echo -e '\n#CARLA UnrealEngine5\nexport CARLA_UNREAL_ENGINE_PATH='$CARLA_UNREAL_ENGINE_PATH >> ~/.bashrc
     popd
     popd
 else
-    echo "Found UnrealEngine5 $CARLA_UNREAL_ENGINE_PATH - FAIL"
-    echo "Cloning CARLA UnrealEngine5..."
+    echo "Could not find CARLA Unreal Engine."
+    echo "Cloning CARLA Unreal Engine..."
     pushd ..
     if [ -z "$GIT_LOCAL_CREDENTIALS" ]
     then
@@ -152,26 +148,26 @@ else
     export CARLA_UNREAL_ENGINE_PATH=$PWD
     popd
     popd
-    echo "CARLA UnrealEngine5 Installed..."
+    echo "Installed CARLA Unreal Engine..."
 fi
 pushd ..
 pushd $CARLA_UNREAL_ENGINE_PATH
-echo Checking if UnreaEngine5 is in the last commit...
+echo Checking if Unreal Engine is in the most recent commit...
 git fetch
 if [[ $(git status) =~ "up to date" ]]; then
-    echo UnreaEngine5 is already in the last commit - OK
+    echo CARLA Unreal Engine is already in the last commit
 else
-    echo UnreaEngine5 is NOT in the last commit - FAIL
-    echo Cleaning UnrealEngine5 build...
+    echo CARLA Unreal Engine is NOT in the last commit.
+    echo Running git clean...
     git clean -fdx
-    echo Pulling last UnrealEngine5 changes...
+    echo Running git pull...
     git pull
 fi
-echo "Setup CARLA UnrealEngine5..."
+echo "Running CARLA Unreal Engine setup..."
 ./Setup.sh --force
-echo "GenerateProjectFiles CARLA UnrealEngine5..."
+echo "Creating CARLA Unreal Engine project files..."
 ./GenerateProjectFiles.sh
-echo "Build CARLA UnrealEngine5..."
+echo "Building CARLA Unreal Engine..."
 make
 popd
 popd
@@ -186,10 +182,10 @@ retry --until=success --times=10 -- cmake -G Ninja -S . -B Build \
     -DCARLA_UNREAL_ENGINE_PATH=$CARLA_UNREAL_ENGINE_PATH
 echo "Building CARLA..."
 retry --until=success --times=10 -- cmake --build Build
-echo "Installing PythonAPI..."
+echo "Building + installing Python API..."
 cmake --build Build --target carla-python-api-install
-echo "Waitting for Content to be downloaded... (see the progres in ContentClone.log)"
+echo "Waiting for Content to finish downloading..."
 wait #Waitting for content
-echo "Instalation and build succesfull! :)"
-echo "Lauching Carla with Unreal Editor..."
+echo "Installation and build succesful."
+echo "Lauching Carla - Unreal Editor..."
 cmake --build Build --target launch

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -58,7 +58,7 @@ fi
 
 if [ $skip_prerequisites -eq 0 ]; then
     echo "Installing prerequisites..."
-    sudo bash -x Util/SetupUtils/InstallPrerequisites.sh
+    sudo -E bash -x Util/SetupUtils/InstallPrerequisites.sh
 else
     echo "Skipping prerequisites install step."
 fi

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$EUID" ]; then
+    EUID=$(id -u)
+fi
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run this script as root."
+    exit 1
+fi
+
+echo "Installing Ubuntu Packages..."
+if ! command -v retry &> /dev/null
+then
+    apt update
+    apt-get install retry
+fi
+retry --until=success --times=12 --delay=300 -- apt-get update
+retry --until=success --times=12 --delay=300 -- apt-get -y install \
+    build-essential \
+    g++-12 \
+    gcc-12 \
+    make \
+    ninja-build \
+    libvulkan1 \
+    python3 \
+    python3-dev \
+    python3-pip \
+    libpng-dev \
+    libtiff5-dev \
+    libjpeg-dev \
+    tzdata \
+    sed \
+    curl \
+    libtool \
+    rsync \
+    libxml2-dev \
+    git \
+    git-lfs
+
+echo "Installing Python Packages..."
+pip3 install --upgrade pip
+pip3 install -r requirements.txt
+
+echo "Cloning CARLA Content asynchronously... (see progress in ContentClone.log)"
+mkdir -p Unreal/CarlaUnreal/Content
+git -C Unreal/CarlaUnreal/Content clone -b ue5-dev https://bitbucket.org/carla-simulator/carla-content.git Carla &> ContentClone.log&
+
+check_cmake_version() {
+    CMAKE_VERSION="$($2 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+    CMAKE_MINIMUM_VERSION=$1
+    MAJOR="${CMAKE_VERSION%%.*}"
+    REMAINDER="${CMAKE_VERSION#*.}"
+    MINOR="${REMAINDER%.*}"
+    REVISION="${REMAINDER#*.}"
+    MINIMUM_MAJOR="${CMAKE_MINIMUM_VERSION%%.*}"
+    MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
+    MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
+
+    if [ $MAJOR -gt $MINIMUM_MAJOR ] || ( [ $MAJOR -eq $MINIMUM_MAJOR ] &&
+            ( [ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])) ; then
+        true
+    else
+        false
+    fi
+}
+
+CMAKE_MINIMUM_VERSION=3.28.0
+if (check_cmake_version $CMAKE_MINIMUM_VERSION cmake) || (check_cmake_version $CMAKE_MINIMUM_VERSION /opt/cmake-3.28.3-linux-x86_64/bin/cmake); then
+    echo "Found CMake $CMAKE_VERSION"
+else
+    echo "Could not find CMake >=$CMAKE_MINIMUM_VERSION."
+    echo "Installing CMake 3.28.3..."
+    curl -L -O https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz
+    mkdir -p /opt
+    tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
+    if [[ ":$PATH:" != *":/opt/cmake-3.28.3-linux-x86_64/bin:"* ]]; then
+        echo -e '\n#CARLA CMake 3.28.3\nPATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH' >> ~/.bashrc
+        export PATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH
+    fi
+    rm -rf cmake-3.28.3-linux-x86_64.tar.gz
+    echo "Installed CMake 3.28.3."
+fi

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -59,17 +59,20 @@ check_cmake_version() {
     MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
     MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
 
-    if [ $MAJOR -gt $MINIMUM_MAJOR ] || ( [ $MAJOR -eq $MINIMUM_MAJOR ] &&
-            ( [ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])) ; then
-        true
-    else
+    if [ "$CMAKE_VERSION" == "" ]; then
         false
+    else
+        if [ $MAJOR -gt $MINIMUM_MAJOR ] || ([ $MAJOR -eq $MINIMUM_MAJOR ] && ([ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])); then
+            true
+        else
+            false
+        fi
     fi
 }
 
 CMAKE_MINIMUM_VERSION=3.28.0
 if (check_cmake_version $CMAKE_MINIMUM_VERSION cmake) || (check_cmake_version $CMAKE_MINIMUM_VERSION /opt/cmake-3.28.3-linux-x86_64/bin/cmake); then
-    echo "Found CMake $CMAKE_VERSION"
+    echo "Found CMake $CMAKE_MINIMUM_VERSION"
 else
     echo "Could not find CMake >=$CMAKE_MINIMUM_VERSION."
     echo "Installing CMake 3.28.3..."

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -59,7 +59,7 @@ check_cmake_version() {
     MINIMUM_REMAINDER="${CMAKE_MINIMUM_VERSION#*.}"
     MINIMUM_MINOR="${MINIMUM_REMAINDER%.*}"
 
-    if [ "$CMAKE_VERSION" == "" ]; then
+    if [ -z "$CMAKE_VERSION" ]; then
         false
     else
         if [ $MAJOR -gt $MINIMUM_MAJOR ] || ([ $MAJOR -eq $MINIMUM_MAJOR ] && ([ $MINOR -gt $MINIMUM_MINOR ] || [ $MINOR -eq $MINIMUM_MINOR ])); then


### PR DESCRIPTION
This PR modifies the default behavior for the CarlaSetup.sh script.
To recover the old behavior use: `CarlaSetup.sh --interactive`
The new behavior assumes a headless environment by default, which requires the user to provide git credentials in their environment and to run the script as sudo (pass the -E flag to sudo to preserve the environment!). Alternatively you can install the prerequisites separately using Util/SetupUtils/InstallPrerequisites.sh, at which point you stop needing to use sudo for the main script: `CarlaSetup.sh --skip-prerequisites`.
Additionally, automatically launching of the editor has been disabled, unless you pass `--launch`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8558)
<!-- Reviewable:end -->
