### PR TITLE
Fix crash in Mine map when activating semantic lidar

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -21,7 +21,6 @@
 #include "PhysicsEngine/PhysicsObjectExternalInterface.h"
 #include "Async/ParallelFor.h"
 #include <util/ue-header-guard-end.h>
-// #include "LandscapeProxy.h"
 #include "Landscape.h"
 
 #include <cmath>

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -21,6 +21,8 @@
 #include "PhysicsEngine/PhysicsObjectExternalInterface.h"
 #include "Async/ParallelFor.h"
 #include <util/ue-header-guard-end.h>
+// #include "LandscapeProxy.h"
+#include "Landscape.h"
 
 #include <cmath>
 
@@ -217,7 +219,14 @@ void ARayCastSemanticLidar::ComputeRawDetection(const FHitResult& HitInfo, const
 
     const AActor* actor = HitInfo.GetActor();
     Detection.object_idx = 0;
-    Detection.object_tag = static_cast<uint32_t>(ATagger::GetTagFromString(HitInfo.Component->ComponentTags[0].ToString()));
+    
+    // Given that landscapes do not have tags for now, asign it here if the actor is a landscape, otherwise get the component tag
+    if (actor->IsA<ALandscape>()){
+      Detection.object_tag = static_cast<uint32_t>(ATagger::GetTagFromString("Terrain"));
+    }
+    else {
+      Detection.object_tag = static_cast<uint32_t>(ATagger::GetTagFromString(HitInfo.Component->ComponentTags[0].ToString()));
+    }
 
     if (actor != nullptr) {
 


### PR DESCRIPTION
As stated by [this issue](https://github.com/carla-simulator/carla/issues/8529), activating the semantic lidar in the Mine map in Carla UE5 led to a crash in the server. This was due to the landscapes lacking tags. Hence, when the semantic lidar sensor tried to access the tag of the object, it got a null value, leading to a crash.

In order to fix that, this PR includes a condition to check whether the actor is a landscape, and in that case, asign on the fly a terrain tag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8568)
<!-- Reviewable:end -->
