### PR TITLE
Fix unpopulated variable in CarlaSetup.sh

### DIFF
--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -65,6 +65,7 @@ else
 fi
 
 # -- CLONE CONTENT --
+cd=$(pwd)
 if [ -d $cd/Unreal/CarlaUnreal/Content ]; then
     echo "Found CARLA content."
 else


### PR DESCRIPTION
When syncing CarlaSetup.bat to CarlaSetup.sh in 902108b, it was not respected that %CD% is always defined in a Windows command prompt. On Linux, $cd is never defined causing the subsequent steps to fail.

Fixes #8571

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8572)
<!-- Reviewable:end -->
