### PR TITLE
build: fix Makefile target given more than once & force execute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-launch PythonAPI LibCarla CarlaUnrealEditor CarlaUnrealEditor launch-only:
+launch PythonAPI LibCarla CarlaUnrealEditor launch-only: FORCE
 	@echo "MakeFile build is currently disabled."
+FORCE: ;
 
 # include Util/BuildTools/Vars.mk
 # ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

- Fixes Makefile target 'CarlaUnrealEditor' given more than once in the same rule

#### Where has this been tested?

Not needed.

#### Possible Drawbacks

None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8580)
<!-- Reviewable:end -->
