### PR TITLE
Simplify importing methods from carla.command in example scripts

### DIFF
--- a/PythonAPI/examples/generate_traffic.py
+++ b/PythonAPI/examples/generate_traffic.py
@@ -24,6 +24,7 @@ except IndexError:
 import carla
 
 from carla import VehicleLightState as vls
+from carla.command import SpawnActor, SetAutopilot, FutureActor, DestroyActor
 
 import argparse
 import logging
@@ -214,11 +215,6 @@ def main():
             logging.warning(msg, args.number_of_vehicles, number_of_spawn_points)
             args.number_of_vehicles = number_of_spawn_points
 
-        # @todo cannot import these directly.
-        SpawnActor = carla.command.SpawnActor
-        SetAutopilot = carla.command.SetAutopilot
-        FutureActor = carla.command.FutureActor
-
         # --------------
         # Spawn vehicles
         # --------------
@@ -360,14 +356,14 @@ def main():
             world.apply_settings(settings)
 
         print('\ndestroying %d vehicles' % len(vehicles_list))
-        client.apply_batch([carla.command.DestroyActor(x) for x in vehicles_list])
+        client.apply_batch([DestroyActor(x) for x in vehicles_list])
 
         # stop walker controllers (list is [controller, actor, controller, actor ...])
         for i in range(0, len(all_id), 2):
             all_actors[i].stop()
 
         print('\ndestroying %d walkers' % len(walkers_list))
-        client.apply_batch([carla.command.DestroyActor(x) for x in all_id])
+        client.apply_batch([DestroyActor(x) for x in all_id])
 
         time.sleep(0.5)
 

--- a/PythonAPI/examples/invertedai_traffic.py
+++ b/PythonAPI/examples/invertedai_traffic.py
@@ -19,8 +19,7 @@ import math
 import random
 import invertedai as iai
 from invertedai.common import AgentProperties, AgentState, TrafficLightState
-
-SpawnActor = carla.command.SpawnActor
+from carla.command import SpawnActor, DestroyActor
 
 #---------
 # CARLA Utils
@@ -637,7 +636,7 @@ def main():
 
         vehicles_list = world.get_actors().filter('vehicle.*')
         print('\ndestroying %d vehicles' % len(vehicles_list))
-        client.apply_batch([carla.command.DestroyActor(x) for x in vehicles_list])
+        client.apply_batch([DestroyActor(x) for x in vehicles_list])
 
         walkercontrollers_list = world.get_actors().filter('controller.*')
         for control in walkercontrollers_list:
@@ -646,7 +645,7 @@ def main():
 
         walkers_list = world.get_actors().filter('walker.*')
         print('\ndestroying %d walkers' % len(walkers_list))
-        client.apply_batch([carla.command.DestroyActor(x) for x in walkers_list])
+        client.apply_batch([DestroyActor(x) for x in walkers_list])
 
         time.sleep(0.5)
 

--- a/PythonAPI/examples/start_recording.py
+++ b/PythonAPI/examples/start_recording.py
@@ -24,7 +24,7 @@ import argparse
 import random
 import time
 import logging
-
+from carla.command import SpawnActor, SetAutopilot, FutureActor, DestroyActor
 
 def main():
     argparser = argparse.ArgumentParser(
@@ -108,11 +108,6 @@ def main():
             logging.warning(msg, count, number_of_spawn_points)
             count = number_of_spawn_points
 
-        # @todo cannot import these directly.
-        SpawnActor = carla.command.SpawnActor
-        SetAutopilot = carla.command.SetAutopilot
-        FutureActor = carla.command.FutureActor
-
         batch = []
         for n, transform in enumerate(spawn_points):
             if n >= count:
@@ -142,7 +137,7 @@ def main():
     finally:
 
         print('\ndestroying %d actors' % len(actor_list))
-        client.apply_batch_sync([carla.command.DestroyActor(x) for x in actor_list])
+        client.apply_batch_sync([DestroyActor(x) for x in actor_list])
 
         print("Stop recording")
         client.stop_recorder()


### PR DESCRIPTION
[Previous commit](https://github.com/carla-simulator/carla/commit/aeeff9907eb1b64f66dddbc1a0de9d7379a566a8) allows to import methods directly from `carla.command` without a workaround, as required previously. This PR updates 3 example scripts simplifying the code and making it more user friendly to account for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8587)
<!-- Reviewable:end -->
