### PR TITLE
add rock/stone tag

### DIFF
--- a/LibCarla/source/carla/image/CityScapesPalette.h
+++ b/LibCarla/source/carla/image/CityScapesPalette.h
@@ -48,7 +48,8 @@ namespace detail {
         { 81u,   0u,  81u},   // ground        =  25u
         {150u, 100u, 100u},   // bridge        =  26u
         {230u, 150u, 140u},   // rail track    =  27u
-        {180u, 165u, 180u}    // guard rail    =  28u
+        {180u, 165u, 180u},   // guard rail    =  28u
+        {180u, 130u,  70u},   // rock          =  29u
       };
 
 } // namespace detail

--- a/LibCarla/source/carla/rpc/ObjectLabel.h
+++ b/LibCarla/source/carla/rpc/ObjectLabel.h
@@ -45,6 +45,7 @@ namespace rpc {
     Bridge       =   26u,
     RailTrack    =   27u,
     GuardRail    =   28u,
+    Rock         =   29u,
 
     Any          =  0xFF
   };

--- a/PythonAPI/carla/src/World.cpp
+++ b/PythonAPI/carla/src/World.cpp
@@ -228,6 +228,7 @@ void export_world() {
     .value("Bus", cr::CityObjectLabel::Bus)
     .value("Rider", cr::CityObjectLabel::Rider)
     .value("Train", cr::CityObjectLabel::Train)
+    .value("Rock", cr::CityObjectLabel::Rock)
     .value("Any", cr::CityObjectLabel::Any)
   ;
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/Tagger.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/Tagger.cpp
@@ -54,6 +54,8 @@ crp::CityObjectLabel ATagger::GetLabelByFolderName(const FString &String) {
   else if (String == "Bus")          return crp::CityObjectLabel::Bus;
   else if (String == "Rider")        return crp::CityObjectLabel::Rider;
   else if (String == "Train")        return crp::CityObjectLabel::Train;
+  else if (String == "Rock")         return crp::CityObjectLabel::Rock;
+  else if (String == "Stone")        return crp::CityObjectLabel::Rock;
   else                               return crp::CityObjectLabel::None;
 }
 
@@ -225,6 +227,7 @@ crp::CityObjectLabel ATagger::GetTagFromString(FString Tag)
   if(Tag.Contains("Bus")) return crp::CityObjectLabel::Bus;
   if(Tag.Contains("Rider")) return crp::CityObjectLabel::Rider;
   if(Tag.Contains("Train")) return crp::CityObjectLabel::Train;
+  if(Tag.Contains("Rock")) return crp::CityObjectLabel::Rock;
   return crp::CityObjectLabel::None;
 }
 
@@ -262,6 +265,7 @@ FString ATagger::GetTagAsString(const crp::CityObjectLabel Label)
     CARLA_GET_LABEL_STR(Bus)
     CARLA_GET_LABEL_STR(Train)
     CARLA_GET_LABEL_STR(Rider)
+    CARLA_GET_LABEL_STR(Rock)
 
 #undef CARLA_GET_LABEL_STR
   }


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes
Add Rock/Stone asset tag, so anymap with the rock/stone assets will visible on segementation camera, including Mine01, related isseue:
https://github.com/carla-simulator/carla/issues/8559

#### Where has this been tested?

  * **Platform(s):Linux 22.04.1-Ubuntu GNU/Linux
  * **Python version(s):Python 3.8.19
  * **Unreal Engine version(s):5.5.0

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8598)
<!-- Reviewable:end -->
