### PR TITLE
Custom path at OpenDriveActor (UE4)

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.cpp
@@ -106,15 +106,35 @@ FString UOpenDrive::LoadXODR(const FString &MapName)
 
   if (FilePath.IsEmpty())
   {
-    UE_LOG(LogTemp, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *MapName);
+    UE_LOG(LogCarla, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *MapName);
   }
   else if (FFileHelper::LoadFileToString(Content, *FilePath))
   {
-    UE_LOG(LogTemp, Log, TEXT("Loaded OpenDrive file '%s'"), *FilePath);
+    UE_LOG(LogCarla, Log, TEXT("Loaded OpenDrive file '%s'"), *FilePath);
   }
   else
   {
-    UE_LOG(LogTemp, Error, TEXT("Failed to load OpenDrive file '%s'"), *FilePath);
+    UE_LOG(LogCarla, Error, TEXT("Failed to load OpenDrive file '%s'"), *FilePath);
+  }
+
+  return Content;
+}
+
+FString UOpenDrive::LoadXODRFullPath(const FString &FullPath)
+{
+  FString Content;
+
+  if (FullPath.IsEmpty())
+  {
+    UE_LOG(LogCarla, Error, TEXT("Failed to find OpenDrive file for map '%s'"), *FullPath);
+  }
+  else if (FFileHelper::LoadFileToString(Content, *FullPath))
+  {
+    UE_LOG(LogCarla, Log, TEXT("Loaded OpenDrive file '%s'"), *FullPath);
+  }
+  else
+  {
+    UE_LOG(LogCarla, Error, TEXT("Failed to load OpenDrive file '%s'"), *FullPath);
   }
 
   return Content;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDrive.h
@@ -35,6 +35,9 @@ public:
   UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
   static FString LoadXODR(const FString &MapName);
 
+  UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")
+  static FString LoadXODRFullPath(const FString &FullPath);
+
   /// Load OpenDriveMap associated to the given MapName. Return nullptr if no
   /// XODR can be found with same MapName.
   UFUNCTION(BlueprintCallable, Category="CARLA|OpenDrive")

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.cpp
@@ -144,7 +144,12 @@ void AOpenDriveActor::BuildRoutes(FString MapName)
 
   // As the OpenDrive file has the same name as level, build the path to the
   // xodr file using the lavel name and the game content directory.
-  const FString XodrContent = UOpenDrive::LoadXODR(MapName);
+  static FString XodrContent;
+  if (CustomPath.IsEmpty()){
+    XodrContent = UOpenDrive::LoadXODR(MapName);
+  } else {
+    XodrContent = UOpenDrive::LoadXODRFullPath(CustomPath);
+  }
 
   auto map = carla::opendrive::OpenDriveParser::Load(carla::rpc::FromLongFString(XodrContent));
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/OpenDrive/OpenDriveActor.h
@@ -38,10 +38,14 @@ private:
 
 #if WITH_EDITORONLY_DATA
   /// Generate the road network using an OpenDrive file (named as the current
-  /// .umap)
+  /// .umap, or the custom one)
   UPROPERTY(Category = "Generate", EditAnywhere)
   bool bGenerateRoutes = false;
 #endif // WITH_EDITORONLY_DATA
+
+  /// Specify a custom path. Expected a full path to the xodr.
+  UPROPERTY(Category = "Generate", EditAnywhere)
+  FString CustomPath = "";
 
   /// Distance between waypoints where the cars will drive
   UPROPERTY(Category = "Generate", EditAnywhere, meta = (ClampMin = "0.01", UIMin = "0.01"))


### PR DESCRIPTION
### Description

Added a new attribute to the OpenDriveActor called 'CustomPath'. This results in two behaviours:

- If empty (default case), the behaviour won't change from the current implementation, and it will make use the loaded map's xodr.
- If not, the OpenDriveActor will make use of the specified path, understanding it as a full path.

### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's UE4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8603)
<!-- Reviewable:end -->
