### PR TITLE
Minor setup script and build system upgrade.

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -128,18 +128,6 @@ carla_string_option (
   "png"
 )
 
-carla_string_option (
-  GXX_COMPILER
-  "g++ compiler used by some CARLA extensions."
-  /usr/bin/g++-12
-)
-
-carla_string_option (
-  GCC_COMPILER
-  "gcc compiler used by some CARLA extensions."
-  /usr/bin/gcc-12
-)
-
 carla_option (
   VERBOSE_CONFIGURE
   "Whether to emit extra messages during CMake configure."

--- a/CMake/Toolchain.cmake
+++ b/CMake/Toolchain.cmake
@@ -8,6 +8,8 @@
 
 ]]
 
+if (LINUX)
+
 set (UE_ROOT $ENV{CARLA_UNREAL_ENGINE_PATH})
 
 if (NOT UE_ROOT)
@@ -204,3 +206,5 @@ set (
 	CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
 	${UE_INCLUDE} ${UE_INCLUDE}/c++/v1
 )
+
+endif ()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,11 +13,6 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/Build/${presetName}",
       "installDir": "${sourceDir}/Install/${presetName}",
-      "hidden": true
-    },
-    {
-      "name": "Linux-Common",
-      "inherits": "Common",
       "cacheVariables":
       {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/CMake/LinuxToolchain.cmake"
@@ -25,7 +20,7 @@
       "hidden": true
     },
     {
-      "name": "Windows-Debug",
+      "name": "Debug",
       "inherits": "Common",
       "cacheVariables":
       {
@@ -33,7 +28,7 @@
       }
     },
     {
-      "name": "Windows-Development",
+      "name": "Development",
       "inherits": "Common",
       "cacheVariables":
       {
@@ -41,32 +36,8 @@
       }
     },
     {
-      "name": "Windows-Release",
+      "name": "Release",
       "inherits": "Common",
-      "cacheVariables":
-      {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "Linux-Debug",
-      "inherits": "Linux-Common",
-      "cacheVariables":
-      {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "Linux-Development",
-      "inherits": "Linux-Common",
-      "cacheVariables":
-      {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "Linux-Release",
-      "inherits": "Linux-Common",
       "cacheVariables":
       {
         "CMAKE_BUILD_TYPE": "Release"

--- a/CarlaSetup.bat
+++ b/CarlaSetup.bat
@@ -4,6 +4,8 @@ setlocal EnableDelayedExpansion
 set SKIP_PREREQUISITES=false
 set LAUNCH=false
 set INTERACTIVE=false
+set PYTHON_PATH=python
+set PYTHON_ROOT=
 
 if not "%*"=="" (
     for %%x in ("%*") do (
@@ -19,6 +21,14 @@ if not "%*"=="" (
             set LAUNCH=true
         ) else if "%%~x"=="-l" (
             set LAUNCH=true
+        ) else if "%%~x"=="--python-path=" (
+            set PYTHON_PATH=%%~nx
+        ) else if "%%~x"=="-pypath" (
+            set PYTHON_PATH=%%~nx
+        ) else if "%%~x"=="--python-root=" (
+            set PYTHON_ROOT=%%~nx
+        ) else if "%%~x"=="-pyroot" (
+            set PYTHON_ROOT=%%~nx
         ) else (
             echo Unknown argument "%%~x"
         )
@@ -91,6 +101,9 @@ cmake ^
     -G Ninja ^
     -S . ^
     -B Build ^
+    --toolchain=CMake/Toolchain.cmake ^
+    -DPython_ROOT_DIR=%PYTHON_ROOT% ^
+    -DPython3_ROOT_DIR=%PYTHON_ROOT% ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCARLA_UNREAL_ENGINE_PATH=%CARLA_UNREAL_ENGINE_PATH% || exit /b
 echo Building CARLA...

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -72,7 +72,7 @@ fi
 # -- PREREQUISITES INSTALL STEP --
 if [ $skip_prerequisites -eq 0 ]; then
     python_path=python3
-    if [ -z "$python_root" ]; then
+    if [ "$python_root" != "" ]; then
         python_path=${python_root}/python3
     fi
     echo "Installing prerequisites..."

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -44,8 +44,6 @@ while true; do
     esac
 done
 
-python_path=${python_root}/python3
-
 # Check for root privileges:
 if [ -z "$EUID" ]; then
     EUID=$(id -u)
@@ -73,6 +71,10 @@ fi
 
 # -- PREREQUISITES INSTALL STEP --
 if [ $skip_prerequisites -eq 0 ]; then
+    python_path=python3
+    if [ -z "$python_root" ]; then
+        python_path=${python_root}/python3
+    fi
     echo "Installing prerequisites..."
     sudo -E bash -x Util/SetupUtils/InstallPrerequisites.sh --python-path=$python_path
 else

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -5,35 +5,35 @@ set -e
 interactive=0
 skip_prerequisites=0
 launch=0
-python_path=python3
 python_root=
 
 workspace_path="$(dirname $(realpath "${BASH_SOURCE[-1]}"))"
 echo "workspace_path=$workspace_path"
 
-options=$(getopt -o "i,p,l,pypath,pyroot" --long "interactive,skip-prerequisites,launch,python-path,python-root" -n 'CarlaSetup.sh' -- "$@")
+options=$(\
+    getopt \
+    -o "i,p,l,pyroot:" \
+    --long "interactive,skip-prerequisites,launch,python-root:" \
+    -n 'CarlaSetup.sh' -- "$@")
+
 eval set -- "$options"
 while true; do
     case "$1" in
-        -i | --interactive)
+        -i|--interactive)
             interactive=1
             shift
             ;;
-        -p | --skip-prerequisites)
+        -p|--skip-prerequisites)
             skip_prerequisites=1
             shift
             ;;
-        -l | --launch)
+        -l|--launch)
             launch=1
             shift
             ;;
-        -pypath | --python-path)
-            python_path='${OPTARG}'
-            shift
-            ;;
-        -pyroot | --python-root)
-            python_root='${OPTARG}'
-            shift
+        -pyroot|--python-root)
+            python_root=$2
+            shift 2
             ;;
         --)
             shift
@@ -43,6 +43,8 @@ while true; do
             ;;
     esac
 done
+
+python_path=${python_root}/python3
 
 # Check for root privileges:
 if [ -z "$EUID" ]; then

--- a/Util/SetupUtils/InstallPrerequisites.bat
+++ b/Util/SetupUtils/InstallPrerequisites.bat
@@ -1,9 +1,12 @@
 @echo off
 
-set NINJA_VERSION=1.12.1
-set PYTHON_VERSION=3.8.10
+set ninja_version=1.12.1
+
+set python_path=python
+set python_version_default=3.8.10
+
 rem https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2022&preserve-view=true
-set VISUAL_STUDIO_COMPONENTS=^
+set visual_studio_components=^
     Microsoft.VisualStudio.Workload.NativeDesktop ^
     Microsoft.VisualStudio.Workload.NativeGame ^
     Microsoft.VisualStudio.Workload.ManagedDesktop ^
@@ -14,7 +17,35 @@ set VISUAL_STUDIO_COMPONENTS=^
     Microsoft.VisualStudio.Component.VC.Llvm.Clang ^
     Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset ^
     Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ^
-    Microsoft.VisualStudio.Component.VC.14.36.17.6.x86.x64
+    Microsoft.VisualStudio.Component.VC.14.36.17.6.x86.x64 ^
+    Microsoft.Component.PythonTools
+
+rem -- PARSE COMMAND LINE ARGUMENTS --
+
+:parse
+    if "%1"=="" (
+        goto main
+    )
+    echo %1 | findstr /B /C:"--python-path=" >nul
+    if not errorlevel 1 (
+        set python_path="%1"
+        set python_path="!python_path:--python-path=!"
+    ) else if "%1"=="--python-path" (
+        set python_path=%2
+        shift
+    ) else if "%1"=="-pypath" (
+        set python_path=%2
+        shift
+    ) else (
+        echo Unknown argument "%1"
+        exit /b
+    )
+    shift
+    goto parse
+
+rem -- MAIN --
+
+:main
 
 rem -- INSTALL VISUAL STUDIO --
 if not exist %cd%\Temp (
@@ -23,38 +54,38 @@ if not exist %cd%\Temp (
 pushd Temp
 curl -L -O https://aka.ms/vs/17/release/vs_community.exe || exit /b
 popd Temp
-%cd%\Temp\vs_community.exe --add %VISUAL_STUDIO_COMPONENTS% --installWhileDownloading --passive --wait || exit /b
+%cd%\Temp\vs_community.exe --add %visual_studio_components% --installWhileDownloading --passive --wait || exit /b
 del %cd%\Temp\vs_community.exe
 rmdir %cd%\Temp
 
 rem -- INSTALL NINJA --
-ninja --version 2>NUL
+ninja --version >nul 2>nul
 if errorlevel 1 (
     echo Could not find Ninja. Downloading...
-    curl -L -o %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja-win.zip https://github.com/ninja-build/ninja/releases/download/v%NINJA_VERSION%/ninja-win.zip || exit /b
+    curl -L -o %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja-win.zip https://github.com/ninja-build/ninja/releases/download/v%ninja_version%/ninja-win.zip || exit /b
     powershell -command "Expand-Archive $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\ninja-win.zip $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\ninja-win" || exit /b
     move %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja-win\ninja.exe %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja.exe || exit /b
     rmdir /s /q %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja-win
     del /f %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\ninja-win.zip
-    echo Installed Ninja %NINJA_VERSION%.
+    echo Installed Ninja %ninja_version%.
 ) else (
     echo Found Ninja.
 )
 
 rem -- INSTALL PYTHON --
-python --version 2>NUL
+%python_path% -V >nul 2>nul
 if errorlevel 1 (
     echo Could not find Python. Downloading...
-    echo Installing Python %PYTHON_VERSION%...
-    curl -L -O https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-amd64.exe || exit /b
-    python-%PYTHON_VERSION%-amd64.exe /passive PrependPath=1  || exit /b
-    del python-%PYTHON_VERSION%-amd64.exe
+    echo Installing Python %python_version_default%...
+    curl -L -O https://www.python.org/ftp/python/%python_version_default%/python-%python_version_default%-amd64.exe || exit /b
+    python-%python_version_default%-amd64.exe /passive PrependPath=1  || exit /b
+    del python-%python_version_default%-amd64.exe
     set "PATH=%LocalAppData%\Programs\Python\Python38\Scripts\;%LocalAppData%\Programs\Python\Python38\;%PATH%"
-    echo Python %PYTHON_VERSION% installed!!!
+    echo Installed Python %python_version_default%.
 ) else (
     echo Found Python.
 )
 
 rem -- INSTALL PYTHON PACKAGES --
-python -m pip install --upgrade pip || exit /b
-python -m pip install -r requirements.txt || exit /b
+%python_path% -m pip install --upgrade pip || exit /b
+%python_path% -m pip install -r requirements.txt || exit /b

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -60,7 +60,7 @@ if [ "$python_path" -eq "python3" ]; then
     apt-get -y install \
         python3 \
         python3-dev \
-        python3-pip \
+        python3-pip
 fi
 
 # -- INSTALL PYTHON PACKAGES --

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -56,7 +56,7 @@ apt-get -y install \
     git \
     git-lfs
 
-if [ "$python_path" -eq "python3" ]; then
+if [ "$python_path" == "python3" ]; then
     apt-get -y install \
         python3 \
         python3-dev \

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -2,6 +2,24 @@
 
 set -e
 
+python_path='python3'
+options=$(getopt -o "i,p,l" --long "interactive,skip-prerequisites,launch" -n 'CarlaSetup.sh' -- "$@")
+eval set -- "$options"
+while true; do
+    case "$1" in
+        --python-path)
+            python_path='${OPTARG}'
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            ;;
+    esac
+done
+
 if [ -z "$EUID" ]; then
     EUID=$(id -u)
 fi
@@ -38,11 +56,10 @@ apt-get -y install \
 
 # -- INSTALL PYTHON PACKAGES --
 echo "Installing Python Packages..."
-pip3 install --upgrade pip
-pip3 install -r requirements.txt
+$python_path -m pip install --upgrade pip
+$python_path -m pip install -r requirements.txt
 
 # -- INSTALL CMAKE --
-
 check_cmake_version() {
     CMAKE_VERSION="$($2 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
     CMAKE_MINIMUM_VERSION=$1

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -3,13 +3,19 @@
 set -e
 
 python_path='python3'
-options=$(getopt -o "i,p,l" --long "interactive,skip-prerequisites,launch" -n 'CarlaSetup.sh' -- "$@")
+
+options=$(\
+    getopt \
+    -o "pypath:" \
+    --long "python-path:" \
+    -n 'CarlaSetup.sh' -- "$@")
+
 eval set -- "$options"
 while true; do
     case "$1" in
-        --python-path)
-            python_path='${OPTARG}'
-            shift
+        -pypath|--python-path)
+            python_path=$2
+            shift 2
             ;;
         --)
             shift

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-python_path='python3'
+python_path_default='python3'
+python_path=$python_path_default
 
 options=$(\
     getopt \
@@ -40,14 +41,9 @@ echo "Installing Ubuntu Packages..."
 apt-get update
 apt-get -y install \
     build-essential \
-    g++-12 \
-    gcc-12 \
     make \
     ninja-build \
     libvulkan1 \
-    python3 \
-    python3-dev \
-    python3-pip \
     libpng-dev \
     libtiff5-dev \
     libjpeg-dev \
@@ -59,6 +55,13 @@ apt-get -y install \
     libxml2-dev \
     git \
     git-lfs
+
+if [ "$python_path" -eq "python3" ]; then
+    apt-get -y install \
+        python3 \
+        python3-dev \
+        python3-pip \
+fi
 
 # -- INSTALL PYTHON PACKAGES --
 echo "Installing Python Packages..."


### PR DESCRIPTION
This PR adds the following:
- Simplify CMake configure commands: now all systems can just pass --toolchain=CMake/Toolchain.cmake.
- The CMake presets are now just Debug/Development/Release, instead of having the system prefixed to the name.
- The setup script now accepts the parameter -pyroot or --python-root to specify the path of an existing python installation.
- Removed the CMake options GCC_COMPILER and GXX_COMPILER, since they are no longer needed.
- Removed the (apt) dependencies on gcc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8616)
<!-- Reviewable:end -->
