### PR TITLE
Fix color_saturation's and highlights_gamma's type.

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -652,7 +652,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     
     FActorVariation ColorSaturation;
     ColorSaturation.Id = TEXT("color_saturation");
-    ColorSaturation.Type = EActorAttributeType::Float;
+    ColorSaturation.Type = EActorAttributeType::RGBColor;
     ColorSaturation.RecommendedValues = { ColorToFString(FLinearColor(0.5f, 0.5f, 0.5f).ToFColorSRGB()) };
     ColorSaturation.bRestrictToRecommended = false;
 
@@ -670,7 +670,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
 
     FActorVariation HighlightsGamma;
     HighlightsGamma.Id = TEXT("highlights_gamma");
-    HighlightsGamma.Type = EActorAttributeType::Float;
+    HighlightsGamma.Type = EActorAttributeType::RGBColor;
     HighlightsGamma.RecommendedValues = { ColorToFString(FLinearColor(0.5f, 0.5f, 0.5f).ToFColorSRGB()) };
     HighlightsGamma.bRestrictToRecommended = false;
 


### PR DESCRIPTION
This PR fixes color_saturation and highlights_gamma being incorrectly marked as floating point attributes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8618)
<!-- Reviewable:end -->
