### PR TITLE
Update build_linux.md

### DIFF
--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -89,6 +89,13 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-8/bin/
 sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-8/bin/clang 180
 ```
 
+__Ubuntu > 18.04__.
+Create a symbolic link that would tell the system to use version 10 whenever it encounters usr/bin/clang-8 in one of the CARLA setup or installation scripts:
+```sh
+sudo ln -s /usr/bin/clang /usr/bin/clang-8
+sudo ln -s /usr/bin/clang++ /usr/bin/clang++-8
+```
+
 __All Ubuntu systems__.
 
 Starting with CARLA 0.9.12, users have the option to install the CARLA Python API using `pip` or `pip3`. Version 20.3 or higher is required. To check if you have a suitable version, run the following command:
@@ -119,7 +126,13 @@ pip3 install --user -Iv setuptools==47.3.1 &&
 pip install --user distro &&
 pip3 install --user distro &&
 pip install --user wheel &&
-pip3 install --user wheel auditwheel
+pip3 install --user wheel auditwheel &&
+pip3 install nose2
+```
+
+Some of the installation and setup scripts use the deprecated python command. One way to avoid the issues caused by this is with a symbolic link:
+```sh
+sudo ln -s /usr/bin/python3 /usr/bin/python
 ```
 
 ---


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

One of the issues specific to Ubuntu 20.04 installation is the clang compiler. The CARLA  uses clang-8 and LLVM's libc++. while clang-8 can be installed on Ubuntu 20.04, it is rather outdated and does not catch some of the existing bugs within carla. Then there will be an issue when running make

#  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):**  Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks
No
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8621)
<!-- Reviewable:end -->
