### PR TITLE
Minor CMakePresets.json improvements.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,19 +20,12 @@
       "hidden": true
     },
     {
-      "name": "Debug",
-      "inherits": "Common",
-      "cacheVariables":
-      {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
       "name": "Development",
       "inherits": "Common",
       "cacheVariables":
       {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_EXPORT_COMPILE_COMMANDS" : true
       }
     },
     {
@@ -41,6 +34,15 @@
       "cacheVariables":
       {
         "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "Debug",
+      "inherits": "Common",
+      "cacheVariables":
+      {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS" : true
       }
     }
   ]


### PR DESCRIPTION
This PR changes the declaration order to force Visual Studio to pick the Development preset by default (as Debug will fail to build Unreal targets). It also activates CMAKE_EXPORT_COMPILE_COMMANDS by default, which is useful for VS Code development purposes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8625)
<!-- Reviewable:end -->
