### PR TITLE
Added a stored pose to the CarlaWheeledVehicle to prevent client / se…

### DIFF
--- a/LibCarla/source/carla/client/Vehicle.cpp
+++ b/LibCarla/source/carla/client/Vehicle.cpp
@@ -107,6 +107,10 @@ namespace client {
     return GetEpisode().Lock()->GetVehicleLightState(*this).GetLightStateEnum();
   }
 
+  std::vector<geom::Transform> Vehicle::GetVehicleBoneWorldTransforms() const {
+    return GetEpisode().Lock()->GetVehicleBoneWorldTransforms(*this);
+  }
+
   float Vehicle::GetSpeedLimit() const {
     return GetEpisode().Lock()->GetActorSnapshot(*this).state.vehicle_data.speed_limit;
   }

--- a/LibCarla/source/carla/client/Vehicle.h
+++ b/LibCarla/source/carla/client/Vehicle.h
@@ -107,6 +107,8 @@ namespace client {
     /// received in the last tick.
     LightState GetLightState() const;
 
+    std::vector<geom::Transform> GetVehicleBoneWorldTransforms() const;
+
     /// Return the speed limit currently affecting this vehicle.
     ///
     /// @note This function does not call the simulator, it returns the data

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -435,6 +435,11 @@ namespace detail {
     return _pimpl->CallAndWait<return_t>("get_actor_bone_world_transforms", actor);
   }
 
+  std::vector<geom::Transform> Client::GetVehicleBoneWorldTransforms(rpc::ActorId actor) {
+    using return_t = std::vector<geom::Transform>;
+    return _pimpl->CallAndWait<return_t>("get_vehicle_bone_world_transforms", actor);
+  }
+
   std::vector<geom::Transform> Client::GetActorBoneRelativeTransforms(rpc::ActorId actor) {
     using return_t = std::vector<geom::Transform>;
     return _pimpl->CallAndWait<return_t>("get_actor_bone_relative_transforms", actor);

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -251,6 +251,9 @@ namespace detail {
 
     std::vector<geom::Transform> GetActorBoneWorldTransforms(
         rpc::ActorId actor);
+        
+    std::vector<geom::Transform> GetVehicleBoneWorldTransforms(
+        rpc::ActorId actor);
 
     std::vector<geom::Transform> GetActorBoneRelativeTransforms(
         rpc::ActorId actor);

--- a/LibCarla/source/carla/client/detail/Episode.h
+++ b/LibCarla/source/carla/client/detail/Episode.h
@@ -19,6 +19,8 @@
 
 #include <vector>
 
+class FPoseSnapshot;
+
 namespace carla {
 namespace client {
 namespace detail {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -462,6 +462,10 @@ namespace detail {
     std::vector<geom::Transform> GetActorBoneWorldTransforms(const Actor &actor) {
       return _client.GetActorBoneWorldTransforms(actor.GetId());
     }
+    
+    std::vector<geom::Transform> GetVehicleBoneWorldTransforms(const Vehicle &vehicle) {
+      return _client.GetVehicleBoneWorldTransforms(vehicle.GetId());
+    }
 
     std::vector<geom::Transform> GetActorBoneRelativeTransforms(const Actor &actor) {
       return _client.GetActorBoneRelativeTransforms(actor.GetId());

--- a/PythonAPI/carla/source/libcarla/Actor.cpp
+++ b/PythonAPI/carla/source/libcarla/Actor.cpp
@@ -206,6 +206,7 @@ void export_actor() {
       .def("enable_chrono_physics", &cc::Vehicle::EnableChronoPhysics, (arg("max_substeps")=30, arg("max_substep_delta_time")=0.002, arg("vehicle_json")="", arg("powetrain_json")="", arg("tire_json")="", arg("base_json_path")=""))
       .def("restore_physx_physics", &cc::Vehicle::RestorePhysXPhysics)
       .def("get_failure_state", &cc::Vehicle::GetFailureState)
+      .def("get_vehicle_bone_world_transforms", &cc::Vehicle::GetVehicleBoneWorldTransforms)
       .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -14,6 +14,7 @@
 #include "Components/SceneComponent.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/SkeletalMeshSocket.h"
+#include "Animation/PoseSnapshot.h"
 
 #include "Carla/OpenDrive/OpenDrive.h"
 #include "Carla/Util/DebugShapeDrawer.h"
@@ -1487,6 +1488,25 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
         }
         return MakeVectorFromTArray<cr::Transform>(BoneWorldTransforms);
       }      
+    }
+  };
+
+  BIND_SYNC(get_vehicle_bone_world_transforms) << [this](
+      cr::ActorId ActorId) -> R<std::vector<cr::Transform>>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if (!CarlaActor)
+    {
+      return RespondError(
+          "get_vehicle_bone_world_transforms",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    else
+    {
+      ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(CarlaActor->GetActor());
+      return MakeVectorFromTArray<cr::Transform>(CarlaVehicle->GetWorldTransformedPose().LocalTransforms);
     }
   };
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -202,6 +202,20 @@ void ACarlaWheeledVehicle::BeginPlay()
   AddReferenceToManager();
 }
 
+void ACarlaWheeledVehicle::TickActor(float DeltaTime, enum ELevelTick TickType, FActorTickFunction& ThisTickFunction){
+  Super::TickActor(DeltaTime, TickType, ThisTickFunction);
+
+  FPoseSnapshot pose;
+  GetMesh()->SnapshotPose(pose);
+  for(FTransform &transform : pose.LocalTransforms)
+  {
+    transform *= GetMesh()->GetComponentTransform();
+  }
+  
+  WorldTransformedPose = pose;
+
+}
+
 bool ACarlaWheeledVehicle::IsInVehicleRange(const FVector& Location) const
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(ACarlaWheeledVehicle::IsInVehicleRange);
@@ -1197,4 +1211,18 @@ void ACarlaWheeledVehicle::SetPhysicsConstraintAngle(
     UPhysicsConstraintComponent* Component, const FRotator &NewAngle)
 {
   Component->ConstraintInstance.AngularRotationOffset = NewAngle;
+}
+
+FPoseSnapshot ACarlaWheeledVehicle::GetWorldTransformedPose()
+{
+  if(WorldTransformedPose.bIsValid == false)
+  {
+    SetActorTickEnabled(true);
+    GetMesh()->SnapshotPose(WorldTransformedPose);
+    for(FTransform &transform : WorldTransformedPose.LocalTransforms)
+    {
+      transform *= GetMesh()->GetComponentTransform();
+    }
+  }
+  return WorldTransformedPose;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -311,6 +311,7 @@ public:
 protected:
 
   virtual void BeginPlay() override;
+  virtual void TickActor(float DeltaTime, enum ELevelTick TickType, FActorTickFunction& ThisTickFunction) override;
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason);
 
   UFUNCTION(BlueprintImplementableEvent)
@@ -415,6 +416,9 @@ public:
 
   virtual FVector GetVelocity() const override;
 
+  UFUNCTION()
+  FPoseSnapshot GetWorldTransformedPose();
+
 //-----CARSIM--------------------------------
   UPROPERTY(Category="CARLA Wheeled Vehicle", EditAnywhere)
   float CarSimOriginOffset = 150.f;
@@ -470,6 +474,7 @@ private:
 public:
   float SpeedAnim { 0.0f };
   float RotationAnim { 0.0f };
+  FPoseSnapshot WorldTransformedPose;
 
   UFUNCTION(Category = "CARLA Wheeled Vehicle", BlueprintCallable)
   float GetSpeedAnim() const { return SpeedAnim; }


### PR DESCRIPTION
…rver the mismatch

The pose is stored on the vehicle Tick, but it will only enable if the function GetWorldTransformedPose is called at least once (through the client function GetVehicleBoneWorldTransforms)

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8639)
<!-- Reviewable:end -->
