### PR TITLE
[Fix] Invisible spline meshes in instance segmentation (UE4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
  * carla.ad subpackages are now directly importable and are not directly importable anymore (e.g. import ad)
  * Fixed segfault in traffic manager when trying to access not available vehicles
  * Fixed invalid comparission in python examples/rss
+ * Fixed invisible spline meshes in instance segmentation
 
 ## CARLA 0.9.15
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.h
@@ -4,6 +4,7 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Engine/InstancedStaticMesh.h"
 #include "Components/HierarchicalInstancedStaticMeshComponent.h"
+#include "SplineMeshSceneProxy.h"
 #include "Landscape.h"
 #include "LandscapeRender.h"
 #include "LandscapeMaterialInstanceConstant.h"
@@ -52,6 +53,18 @@ class FTaggedStaticMeshSceneProxy : public FStaticMeshSceneProxy
 {
 public:
   FTaggedStaticMeshSceneProxy(UStaticMeshComponent * Component, bool bForceLODsShareStaticLighting, UMaterialInstance * MaterialInstance);
+
+  virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
+
+private:
+  UMaterialInstance * TaggedMaterialInstance;
+};
+
+class FTaggedSplineMeshSceneProxy : public FSplineMeshSceneProxy
+{
+public:
+
+  FTaggedSplineMeshSceneProxy(USplineMeshComponent * Component, UMaterialInstance * MaterialInstance);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 


### PR DESCRIPTION
#### Description

* Requires one minor change to UnrealCarla: https://github.com/CarlaUnreal/UnrealEngine/pull/38
* For the latest UE4.26 CARLA version

I noticed that spline meshes (e.g. the cables on PowerPoles) appear invisible in the instance segmentation (showing the decoded R channel of the instance segmentation):
![before](https://github.com/user-attachments/assets/f49d9ceb-2fbb-40f6-a442-bffa53120021)

This PR extends the implementation in TaggedCommponent to explicitly handle SplineMeshSceneProxies. SplineMeshComponents are derived from StaticMeshComponents, thus the components are technically already handled by the existing tagging code. But without explicitly deriving a FTaggedSplineMeshSceneProxy from FSplineMeshSceneProxy, they seem to not be rendered correctly. FSplineMeshSceneProxy is currently not public in UE4, thus a minor modification to UnrealCarla is required: https://github.com/CarlaUnreal/UnrealEngine/pull/38

After these changes, spline meshes are rendered correctly in the instance segmentation:
![after](https://github.com/user-attachments/assets/fbfd08f0-42e8-4ed9-be7d-1116d15e8463)

#### Where has this been tested?

  * **Platform(s):** Windows 11
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.26
  * Tested in Editor and Packaged

#### Possible Drawbacks

None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8714)
<!-- Reviewable:end -->
