### PR TITLE
[Feature] Support of masked materials in instance segmentation (UE4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
  * Fixed invisible spline meshes in instance segmentation
  * Set to default Visual Studio 2022 in Windows
  * Added env CARLA_CACHE_DIR to be able to set CARLA CACHE location
+ * Support of masked materials in instance segmentation, resulting in fine-grained annotations on e.g. leaves or fences (as in semantic segmentation)
 
 ## CARLA 0.9.15
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Content/PostProcessingMaterials/TaggedMaterials/.gitignore
+++ b/Unreal/CarlaUE4/Plugins/Carla/Content/PostProcessingMaterials/TaggedMaterials/.gitignore
@@ -1,0 +1,7 @@
+# These files are automatically generated either when playing in editor
+# or via the GenerateTaggedMaterialsRegistryCommandlet during packaging.
+# We only require the directory for keeping a common place for the
+# generated .uassets, so that they can also be used for cooking.
+
+*
+!.gitignore

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -113,6 +113,7 @@ public class Carla : ModuleRules
         "PhysX",
         "PhysXVehicles",
         "PhysXVehicleLib",
+        "Projects",
         "Slate",
         "SlateCore",
         "PhysicsCore"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.cpp
@@ -1,0 +1,154 @@
+#include "GenerateTaggedMaterialsRegistry.h"
+#include "PrepareAssetsForCookingCommandlet.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Materials/MaterialInstanceConstant.h"
+
+#if WITH_EDITOR
+#include "FileHelpers.h"
+#include "Settings/ProjectPackagingSettings.h"
+#endif // WITH_EDITOR
+
+UGenerateTaggedMaterialsRegistryCommandlet::UGenerateTaggedMaterialsRegistryCommandlet() {
+  // Set necessary flags to run commandlet
+  IsClient = false;
+  IsEditor = true;
+  IsServer = false;
+  LogToConsole = true;
+}
+
+#if WITH_EDITOR
+IAssetRegistry& UGenerateTaggedMaterialsRegistryCommandlet::GetAssetRegistry() const
+{
+  if (!CachedAssetRegistry)
+  {
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+    CachedAssetRegistry = &AssetRegistryModule.Get();
+  }
+  return *CachedAssetRegistry;
+}
+
+TSet<UMaterialInterface*> UGenerateTaggedMaterialsRegistryCommandlet::FindMaskedMaterialInterfaces(const FName& PackageName) {
+  if (ScannedAssets.Contains(PackageName)) {
+    return {};
+  } else {
+    ScannedAssets.Add(PackageName);
+  }
+
+  IAssetRegistry& AssetRegistry = GetAssetRegistry();
+  TSet<UMaterialInterface*> FoundMaterialInterfaces;
+
+  // Check the assets in this package, whether they are UMaterials or UMaterialInstanceConstants and add those
+  TArray<FAssetData> AssetsData;
+  AssetRegistry.GetAssetsByPackageName(PackageName, AssetsData);
+  for (const FAssetData& AssetData : AssetsData) {
+    if (AssetData.AssetClass == UMaterial::StaticClass()->GetFName() ||
+        AssetData.AssetClass == UMaterialInstanceConstant::StaticClass()->GetFName()) {
+      UMaterialInterface* MaterialInterface = CastChecked<UMaterialInterface>(AssetData.GetAsset());
+      if (MaterialInterface->IsMasked()) {
+        FoundMaterialInterfaces.Add(MaterialInterface);
+      }
+    }
+  }
+
+  // Check the dependencies of this package and recursively add all referenced UMaterials and UMaterialInstanceConstants
+  TArray<FName> Dependencies;
+  AssetRegistry.GetDependencies(PackageName, Dependencies);
+  for (const FName& Dependency : Dependencies) {
+    FoundMaterialInterfaces.Append(FindMaskedMaterialInterfaces(Dependency));
+  }
+
+  return FoundMaterialInterfaces;
+}
+
+void UGenerateTaggedMaterialsRegistryCommandlet::CreateMapPackage(const FString& PackageName, UTaggedMaterialsRegistry* TaggedMaterialsRegistry) {
+  // Create new package for the map
+  FString WorldPackageName = TEXT("TaggedMaterials_") + PackageName + TEXT("_Map");
+  FString PackagePath = UTaggedMaterialsRegistry::TaggedMaterialsRootDir / WorldPackageName;
+  UPackage* Package = CreatePackage(*PackagePath);
+
+  // Create a duplicate of the BaseMap, that we will modify
+  FSoftObjectPath BaseMapPath = FSoftObjectPath("/Game/Carla/Maps/BaseMap/BaseMap.BaseMap");
+  UObject* BaseMapObject = BaseMapPath.TryLoad();
+  UWorld* World = DuplicateObject<UWorld>(CastChecked<UWorld>(BaseMapObject), Package);
+  World->Rename(*WorldPackageName);
+  FAssetRegistryModule::AssetCreated(World);
+
+  // Add the TaggedMaterialsRegistry to the map
+  ATaggedMaterialsRegistryActor* RegistryActor = World->SpawnActor<ATaggedMaterialsRegistryActor>(ATaggedMaterialsRegistryActor::StaticClass(), FTransform());
+  RegistryActor->TaggedMaterialsRegistry = TaggedMaterialsRegistry;
+  World->MarkPackageDirty();
+
+  // Save the new package
+  const FString PackageFileName = FPackageName::LongPackageNameToFilename(PackagePath, FPackageName::GetMapPackageExtension());
+  UPackage::SavePackage(Package, World, RF_Public | RF_Standalone, *PackageFileName);
+}
+
+TArray<FString> UGenerateTaggedMaterialsRegistryCommandlet::GetPackagePaths(const FString& PackageName) {
+  TArray<FString> TopLevelPackages;
+
+  if (PackageName == TEXT("Carla")) {
+    // Find maps for default Carla package
+    UProjectPackagingSettings* PackagingSettings = GetMutableDefault<UProjectPackagingSettings>();
+    PackagingSettings->LoadConfig();
+    for (const FFilePath& MapFilePath : PackagingSettings->MapsToCook) {
+      TopLevelPackages.Add(MapFilePath.FilePath);
+    }
+
+    // The default Carla package should also contain the spawnable actors
+    TopLevelPackages.Add(TEXT("/Game/Carla/Blueprints/Vehicles/VehicleFactory"));
+    TopLevelPackages.Add(TEXT("/Game/Carla/Blueprints/Walkers/WalkerFactory"));
+    TopLevelPackages.Add(TEXT("/Game/Carla/Blueprints/Props/PropFactory"));
+  } else {
+    FAssetsPaths AssetsPaths = UPrepareAssetsForCookingCommandlet::GetAssetsPathFromPackage(PackageName);
+    for (FMapData MapPath : AssetsPaths.MapsPaths) {
+      TopLevelPackages.Add(MapPath.Path + TEXT("/") + MapPath.Name);
+    }
+  }
+
+  return TopLevelPackages;
+}
+
+int32 UGenerateTaggedMaterialsRegistryCommandlet::Main(const FString& Params)
+{
+  UE_LOG(LogCarla, Log, TEXT("Running UGenerateTaggedMaterialsRegistryCommandlet..."));
+
+  FString PackageName;
+  FParse::Value(*Params, TEXT("PackageName="), PackageName);
+
+  // 1. Collect all relevant top-level packages
+  TArray<FString> RequestedTopLevelPackages = GetPackagePaths(PackageName);
+
+  // 2. If non-default Carla package is requested, we search for those assets anyway.
+  //    These assets are then already part of ScannedAssets, avoiding duplicates in the requested package.
+  if (PackageName != TEXT("Carla")) {
+    UE_LOG(LogCarla, Log, TEXT("Inspecting default Carla packages to avoid duplicates."));
+    TArray<FString> CarlaTopLevelPackages = GetPackagePaths(TEXT("Carla"));
+    for (const FString& TopLevelPackage : CarlaTopLevelPackages) {
+      FindMaskedMaterialInterfaces(*TopLevelPackage);
+    }
+  }
+
+  // 3. Recursively search for all masked material interfaces in the requested top-level packages and create tag-injected versions
+  UTaggedMaterialsRegistry* TaggedMaterialsRegistry = UTaggedMaterialsRegistry::Create(PackageName);
+  for (const FString& TopLevelPackage : RequestedTopLevelPackages) {
+    UE_LOG(LogCarla, Log, TEXT("Creating tag-injected materials for package: %s"), *TopLevelPackage);
+
+    TSet<UMaterialInterface*> MaterialInterfaces = FindMaskedMaterialInterfaces(*TopLevelPackage);
+    for (UMaterialInterface* MaterialInterface : MaterialInterfaces) {
+      // Calling GetTaggedMaterial creates and registers a new tag-injected version of the MaterialInterface
+      TaggedMaterialsRegistry->GetTaggedMaterial(MaterialInterface);
+    }
+  }
+  if (TaggedMaterialsRegistry->Num() > 0) {
+    TaggedMaterialsRegistry->Save();
+  }
+
+  // 4. Create empty map containing the TaggedMaterialsRegistry for cooking
+  UE_LOG(LogCarla, Log, TEXT("Creating empty map containing the TaggedMaterialsRegistry for cooking."));
+  CreateMapPackage(PackageName, TaggedMaterialsRegistry);
+
+  UE_LOG(LogCarla, Log, TEXT("UGenerateTaggedMaterialsRegistryCommandlet finished."));
+
+  return 0;
+}
+#endif // WITH_EDITOR

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commandlets/Commandlet.h"
+#include "Carla/Game/TaggedMaterials.h"
+#include "GenerateTaggedMaterialsRegistry.generated.h"
+
+UCLASS()
+class CARLA_API UGenerateTaggedMaterialsRegistryCommandlet : public UCommandlet
+{
+  GENERATED_BODY()
+
+  UGenerateTaggedMaterialsRegistryCommandlet();
+
+#if WITH_EDITOR
+public:
+
+  virtual int32 Main(const FString& Params) override;
+
+private:
+  class IAssetRegistry& GetAssetRegistry() const;
+  TSet<UMaterialInterface*> FindMaskedMaterialInterfaces(const FName& PackageName);
+  void CreateMapPackage(const FString& PackageName, UTaggedMaterialsRegistry* TaggedMaterialsRegistry);
+
+  static TArray<FString> GetPackagePaths(const FString& PackageName);
+  
+  TSet<FName> ScannedAssets;
+  mutable class IAssetRegistry* CachedAssetRegistry;
+#endif // WITH_EDITOR
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/GenerateTaggedMaterialsRegistry.h
@@ -19,12 +19,12 @@ public:
 
 private:
   class IAssetRegistry& GetAssetRegistry() const;
-  TSet<UMaterialInterface*> FindMaskedMaterialInterfaces(const FName& PackageName);
+  TSet<UMaterialInterface*> FindMaskedMaterialInterfaces(const FName& PackageName, TSet<FName>& ScannedAssets);
   void CreateMapPackage(const FString& PackageName, UTaggedMaterialsRegistry* TaggedMaterialsRegistry);
 
+  static TArray<FString> ParseAndSplitParamList(const TArray<FString>& Switches, const FString& SwitchKey);
   static TArray<FString> GetPackagePaths(const FString& PackageName);
   
-  TSet<FName> ScannedAssets;
   mutable class IAssetRegistry* CachedAssetRegistry;
 #endif // WITH_EDITOR
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.cpp
@@ -380,7 +380,7 @@ bool UPrepareAssetsForCookingCommandlet::SaveWorld(
   return bPackageSaved;
 }
 
-FString UPrepareAssetsForCookingCommandlet::GetFirstPackagePath(const FString &PackageName) const
+FString UPrepareAssetsForCookingCommandlet::GetFirstPackagePath(const FString &PackageName)
 {
   // Get all Package names
   TArray<FString> PackageList;
@@ -396,7 +396,7 @@ FString UPrepareAssetsForCookingCommandlet::GetFirstPackagePath(const FString &P
   return IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*PackageList[0]);
 }
 
-FAssetsPaths UPrepareAssetsForCookingCommandlet::GetAssetsPathFromPackage(const FString &PackageName) const
+FAssetsPaths UPrepareAssetsForCookingCommandlet::GetAssetsPathFromPackage(const FString &PackageName)
 {
   const FString PackageJsonFilePath = GetFirstPackagePath(PackageName);
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Commandlet/PrepareAssetsForCookingCommandlet.h
@@ -107,7 +107,7 @@ public:
 
   /// Gets the Path of all the Assets contained in the package to cook with name
   /// @a PackageName
-  FAssetsPaths GetAssetsPathFromPackage(const FString &PackageName) const;
+  static FAssetsPaths GetAssetsPathFromPackage(const FString &PackageName);
 
   /// Generates the MapPaths file provided @a AssetsPaths and @a PropsMapPath
   void GenerateMapPathsFile(const FAssetsPaths &AssetsPaths, const FString &PropsMapPath);
@@ -195,6 +195,6 @@ private:
 
   /// Gets the first .Package.json file found in Unreal Content Directory with
   /// @a PackageName
-  FString GetFirstPackagePath(const FString &PackageName) const;
+  static FString GetFirstPackagePath(const FString &PackageName);
 
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -18,6 +18,8 @@
 #include "Vehicle/VehicleSpawnPoint.h"
 #include "Util/BoundingBoxCalculator.h"
 #include "EngineUtils.h"
+#include "Tagger.h"
+#include "TaggedComponent.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include "carla/opendrive/OpenDriveParser.h"
@@ -365,6 +367,21 @@ void ACarlaGameModeBase::ApplyTextureToActor(
           DynamicMaterial->SetTextureParameterValue("ORMH 3", Texture);
           DynamicMaterial->SetTextureParameterValue("ORMH 4", Texture);
           break;
+      }
+    }
+
+    if (TextureParam == cr::MaterialParameter::Tex_Diffuse) {
+      // If there is a tagged component attached, it might use a masked material, which must be updated, too.
+      UTaggedComponent* TaggedComponent = ATagger::FindTaggedComponent(Mesh);
+      if (TaggedComponent)
+      {
+        for (UMaterialInstanceDynamic* TaggedMaterial : TaggedComponent->GetTaggedMaterials()) {
+          TaggedMaterial->SetTextureParameterValue("BaseColor", Texture);
+          TaggedMaterial->SetTextureParameterValue("Difuse", Texture);
+          TaggedMaterial->SetTextureParameterValue("Difuse 2", Texture);
+          TaggedMaterial->SetTextureParameterValue("Difuse 3", Texture);
+          TaggedMaterial->SetTextureParameterValue("Difuse 4", Texture);
+        }
       }
     }
   }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.cpp
@@ -1,6 +1,6 @@
 #include "Carla.h"
 #include "TaggedComponent.h"
-#include "ConstructorHelpers.h"
+#include "TaggedMaterials.h"
 
 #include "Rendering/SkeletalMeshRenderData.h"
 #include "SkeletalRenderPublic.h"
@@ -12,11 +12,6 @@ UTaggedComponent::UTaggedComponent(const FObjectInitializer& ObjectInitializer) 
   UPrimitiveComponent(ObjectInitializer),
   Color(1, 1, 1, 1)
 {
-  FString MaterialPath = TEXT("Material'/Carla/PostProcessingMaterials/AnnotationColor.AnnotationColor'");
-  static ConstructorHelpers::FObjectFinder<UMaterial> TaggedMaterialObject(*MaterialPath);
-  // TODO: Replace with VertexColorViewModeMaterial_ColorOnly?
-
-  TaggedMaterial = TaggedMaterialObject.Object;
   PrimaryComponentTick.bCanEverTick = true;
   PrimaryComponentTick.bStartWithTickEnabled = false;
 }
@@ -25,11 +20,23 @@ void UTaggedComponent::OnRegister()
 {
   Super::OnRegister();
 
-  TaggedMID = UMaterialInstanceDynamic::Create(TaggedMaterial, this, TEXT("TaggedMaterialMID"));
+  TaggedMID = UTaggedMaterialsRegistry::Get()->GetTaggedMaterial();
 
   if (!IsValid(TaggedMID))
   {
     UE_LOG(LogCarla, Error, TEXT("Failed to create MID!"));
+  }
+
+  if(USceneComponent* ParentSceneComponent = GetAttachParent()) {
+    UPrimitiveComponent* ParentComponent = CastChecked<UPrimitiveComponent>(ParentSceneComponent);
+    TArray<UMaterialInterface*> UsedMaterials;
+    ParentComponent->GetUsedMaterials(UsedMaterials);
+    for (UMaterialInterface* UsedMaterial : UsedMaterials) {
+      UMaterialInstanceDynamic* TaggedMaterial = UTaggedMaterialsRegistry::Get()->GetTaggedMaterial(UsedMaterial);
+      if (TaggedMaterial) {
+        TaggedMaterials.Add(UsedMaterial, TaggedMaterial);
+      }
+    }
   }
 
   SetColor(Color);
@@ -43,11 +50,24 @@ void UTaggedComponent::SetColor(FLinearColor NewColor)
   {
     TaggedMID->SetVectorParameterValue("AnnotationColor", Color);
   }
+
+  for (auto& Pair : TaggedMaterials) {
+    Pair.Value->SetVectorParameterValue("AnnotationColor", Color);
+  }
 }
 
 FLinearColor UTaggedComponent::GetColor()
 {
   return Color;
+}
+
+TArray<UMaterialInstanceDynamic*> UTaggedComponent::GetTaggedMaterials()
+{
+  TArray<UMaterialInstanceDynamic*> Ret;
+  for (auto& Pair : TaggedMaterials) {
+    Ret.Add(Pair.Value);
+  }
+  return Ret;
 }
 
 FBoxSphereBounds UTaggedComponent::CalcBounds(const FTransform & LocalToWorld) const
@@ -125,9 +145,9 @@ FPrimitiveSceneProxy * UTaggedComponent::CreateSceneProxy(UStaticMeshComponent *
 
   USplineMeshComponent* SplineMeshComponent = Cast<USplineMeshComponent>(StaticMeshComponent);
   if (SplineMeshComponent) {
-    return new FTaggedSplineMeshSceneProxy(SplineMeshComponent, TaggedMID);
+    return new FTaggedSplineMeshSceneProxy(SplineMeshComponent, TaggedMID, TaggedMaterials);
   } else {
-    return new FTaggedStaticMeshSceneProxy(StaticMeshComponent, true, TaggedMID);
+    return new FTaggedStaticMeshSceneProxy(StaticMeshComponent, true, TaggedMID, TaggedMaterials);
   }
 }
 
@@ -152,7 +172,7 @@ FPrimitiveSceneProxy * UTaggedComponent::CreateSceneProxy(USkeletalMeshComponent
 		int32 MaxSupportedNumBones = SkeletalMeshComponent->MeshObject->IsCPUSkinned() ? MAX_int32 : GetFeatureLevelMaxNumberOfBones(SceneFeatureLevel);
 		if (MaxBonesPerChunk <= MaxSupportedNumBones)
 		{
-			return new FTaggedSkeletalMeshSceneProxy(SkeletalMeshComponent, SkelMeshRenderData, TaggedMID);
+			return new FTaggedSkeletalMeshSceneProxy(SkeletalMeshComponent, SkelMeshRenderData, TaggedMID, TaggedMaterials);
 		}
 	}
   return nullptr;
@@ -174,7 +194,7 @@ FPrimitiveSceneProxy * UTaggedComponent::CreateSceneProxy(UHierarchicalInstanced
 	if (bMeshIsValid)
 	{
 		bool bIsGrass = !MeshComponent->PerInstanceSMData.Num();
-		return new FTaggedHierarchicalStaticMeshSceneProxy(MeshComponent, bIsGrass, GetWorld()->FeatureLevel, TaggedMID);
+		return new FTaggedHierarchicalStaticMeshSceneProxy(MeshComponent, bIsGrass, GetWorld()->FeatureLevel, TaggedMID, TaggedMaterials);
 	}
 	return nullptr;
 }
@@ -194,7 +214,7 @@ FPrimitiveSceneProxy * UTaggedComponent::CreateSceneProxy(UInstancedStaticMeshCo
 
 	if (bMeshIsValid)
 	{
-		return new FTaggedInstancedStaticMeshSceneProxy(MeshComponent, GetWorld()->FeatureLevel, TaggedMID);
+		return new FTaggedInstancedStaticMeshSceneProxy(MeshComponent, GetWorld()->FeatureLevel, TaggedMID, TaggedMaterials);
 	}
 	return nullptr;
 }
@@ -222,7 +242,7 @@ void UTaggedComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActo
 //
 // FTaggedStaticMeshSceneProxy
 //
-FTaggedStaticMeshSceneProxy::FTaggedStaticMeshSceneProxy(UStaticMeshComponent * Component, bool bForceLODsShareStaticLighting, UMaterialInstance * MaterialInstance) :
+FTaggedStaticMeshSceneProxy::FTaggedStaticMeshSceneProxy(UStaticMeshComponent * Component, bool bForceLODsShareStaticLighting, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials) :
   FStaticMeshSceneProxy(Component, bForceLODsShareStaticLighting)
 {
   TaggedMaterialInstance = MaterialInstance;
@@ -232,7 +252,12 @@ FTaggedStaticMeshSceneProxy::FTaggedStaticMeshSceneProxy(UStaticMeshComponent * 
 
   for (FLODInfo& LODInfo : LODs) {
     for (FLODInfo::FSectionInfo& SectionInfo : LODInfo.Sections) {
+      UMaterialInstanceDynamic** TaggedMaterial = TaggedMaterials.Find(SectionInfo.Material);
+      if (TaggedMaterial) {
+        SectionInfo.Material = *TaggedMaterial;
+      } else {
         SectionInfo.Material = TaggedMaterialInstance;
+      }
     }
   }
 }
@@ -250,7 +275,7 @@ FPrimitiveViewRelevance FTaggedStaticMeshSceneProxy::GetViewRelevance(const FSce
 //
 // FTaggedSplineMeshSceneProxy
 //
-FTaggedSplineMeshSceneProxy::FTaggedSplineMeshSceneProxy(USplineMeshComponent * Component, UMaterialInstance * MaterialInstance) :
+FTaggedSplineMeshSceneProxy::FTaggedSplineMeshSceneProxy(USplineMeshComponent * Component, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials) :
   FSplineMeshSceneProxy(Component)
 {
   TaggedMaterialInstance = MaterialInstance;
@@ -260,7 +285,12 @@ FTaggedSplineMeshSceneProxy::FTaggedSplineMeshSceneProxy(USplineMeshComponent * 
 
   for (FLODInfo& LODInfo : LODs) {
     for (FLODInfo::FSectionInfo& SectionInfo : LODInfo.Sections) {
-      SectionInfo.Material = TaggedMaterialInstance;
+      UMaterialInstanceDynamic** TaggedMaterial = TaggedMaterials.Find(SectionInfo.Material);
+      if (TaggedMaterial) {
+        SectionInfo.Material = *TaggedMaterial;
+      } else {
+        SectionInfo.Material = TaggedMaterialInstance;
+      }
     }
   }
 }
@@ -278,7 +308,7 @@ FPrimitiveViewRelevance FTaggedSplineMeshSceneProxy::GetViewRelevance(const FSce
 //
 // FTaggedSkeletalMeshSceneProxy
 //
-FTaggedSkeletalMeshSceneProxy::FTaggedSkeletalMeshSceneProxy(const USkinnedMeshComponent * Component, FSkeletalMeshRenderData * InSkeletalMeshRenderData, UMaterialInstance * MaterialInstance) :
+FTaggedSkeletalMeshSceneProxy::FTaggedSkeletalMeshSceneProxy(const USkinnedMeshComponent * Component, FSkeletalMeshRenderData * InSkeletalMeshRenderData, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials) :
   FSkeletalMeshSceneProxy(Component, InSkeletalMeshRenderData)
 {
   TaggedMaterialInstance = MaterialInstance;
@@ -288,7 +318,12 @@ FTaggedSkeletalMeshSceneProxy::FTaggedSkeletalMeshSceneProxy(const USkinnedMeshC
 
   for (FLODSectionElements& LODSection : LODSections) {
     for (FSectionElementInfo& ElementInfo : LODSection.SectionElements) {
+      UMaterialInstanceDynamic** TaggedMaterial = TaggedMaterials.Find(ElementInfo.Material);
+      if (TaggedMaterial) {
+        ElementInfo.Material = *TaggedMaterial;
+      } else {
         ElementInfo.Material = TaggedMaterialInstance;
+      }
     }
   }
 }
@@ -304,7 +339,7 @@ FPrimitiveViewRelevance FTaggedSkeletalMeshSceneProxy::GetViewRelevance(const FS
 }
 
 FTaggedInstancedStaticMeshSceneProxy::FTaggedInstancedStaticMeshSceneProxy(
-    UInstancedStaticMeshComponent * Component, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance)
+    UInstancedStaticMeshComponent * Component, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials)
   : FInstancedStaticMeshSceneProxy(Component, InFeatureLevel)
 {
   TaggedMaterialInstance = MaterialInstance;
@@ -314,7 +349,12 @@ FTaggedInstancedStaticMeshSceneProxy::FTaggedInstancedStaticMeshSceneProxy(
 
   for (FLODInfo& LODInfo : LODs) {
     for (FLODInfo::FSectionInfo& SectionInfo : LODInfo.Sections) {
+      UMaterialInstanceDynamic** TaggedMaterial = TaggedMaterials.Find(SectionInfo.Material);
+      if (TaggedMaterial) {
+        SectionInfo.Material = *TaggedMaterial;
+      } else {
         SectionInfo.Material = TaggedMaterialInstance;
+      }
     }
   }
 }
@@ -331,7 +371,7 @@ FPrimitiveViewRelevance FTaggedInstancedStaticMeshSceneProxy::GetViewRelevance(c
 
 
 FTaggedHierarchicalStaticMeshSceneProxy::FTaggedHierarchicalStaticMeshSceneProxy(
-    UHierarchicalInstancedStaticMeshComponent * Component, bool bInIsGrass, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance)
+    UHierarchicalInstancedStaticMeshComponent * Component, bool bInIsGrass, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials)
   : FHierarchicalStaticMeshSceneProxy(bInIsGrass, Component, InFeatureLevel)
 {
   TaggedMaterialInstance = MaterialInstance;
@@ -341,7 +381,12 @@ FTaggedHierarchicalStaticMeshSceneProxy::FTaggedHierarchicalStaticMeshSceneProxy
 
   for (FLODInfo& LODInfo : LODs) {
     for (FLODInfo::FSectionInfo& SectionInfo : LODInfo.Sections) {
+      UMaterialInstanceDynamic** TaggedMaterial = TaggedMaterials.Find(SectionInfo.Material);
+      if (TaggedMaterial) {
+        SectionInfo.Material = *TaggedMaterial;
+      } else {
         SectionInfo.Material = TaggedMaterialInstance;
+      }
     }
   }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedComponent.h
@@ -28,14 +28,16 @@ public:
   void SetColor(FLinearColor color);
   FLinearColor GetColor();
 
+  TArray<UMaterialInstanceDynamic*> GetTaggedMaterials();
+
 private:
   FLinearColor Color;
 
   UPROPERTY()
-  UMaterial * TaggedMaterial;
+  UMaterialInstanceDynamic * TaggedMID;
 
   UPROPERTY()
-  UMaterialInstanceDynamic * TaggedMID;
+  TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials;
 
   bool bSkeletalMesh = false;
 
@@ -52,7 +54,8 @@ private:
 class FTaggedStaticMeshSceneProxy : public FStaticMeshSceneProxy
 {
 public:
-  FTaggedStaticMeshSceneProxy(UStaticMeshComponent * Component, bool bForceLODsShareStaticLighting, UMaterialInstance * MaterialInstance);
+
+  FTaggedStaticMeshSceneProxy(UStaticMeshComponent * Component, bool bForceLODsShareStaticLighting, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 
@@ -64,7 +67,7 @@ class FTaggedSplineMeshSceneProxy : public FSplineMeshSceneProxy
 {
 public:
 
-  FTaggedSplineMeshSceneProxy(USplineMeshComponent * Component, UMaterialInstance * MaterialInstance);
+  FTaggedSplineMeshSceneProxy(USplineMeshComponent * Component, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 
@@ -75,7 +78,7 @@ private:
 class FTaggedSkeletalMeshSceneProxy : public FSkeletalMeshSceneProxy
 {
 public:
-  FTaggedSkeletalMeshSceneProxy(const USkinnedMeshComponent * Component, FSkeletalMeshRenderData * InSkeletalMeshRenderData, UMaterialInstance * MaterialInstance);
+  FTaggedSkeletalMeshSceneProxy(const USkinnedMeshComponent * Component, FSkeletalMeshRenderData * InSkeletalMeshRenderData, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 
@@ -86,7 +89,7 @@ private:
 class FTaggedInstancedStaticMeshSceneProxy : public FInstancedStaticMeshSceneProxy
 {
 public:
-  FTaggedInstancedStaticMeshSceneProxy(UInstancedStaticMeshComponent * Component, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance);
+  FTaggedInstancedStaticMeshSceneProxy(UInstancedStaticMeshComponent * Component, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 
@@ -98,7 +101,7 @@ private:
 class FTaggedHierarchicalStaticMeshSceneProxy : public FHierarchicalStaticMeshSceneProxy
 {
 public:
-  FTaggedHierarchicalStaticMeshSceneProxy(UHierarchicalInstancedStaticMeshComponent * Component, bool bInIsGrass, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance);
+  FTaggedHierarchicalStaticMeshSceneProxy(UHierarchicalInstancedStaticMeshComponent * Component, bool bInIsGrass, ERHIFeatureLevel::Type InFeatureLevel, UMaterialInstance * MaterialInstance, TMap<UMaterialInterface*, UMaterialInstanceDynamic*> TaggedMaterials);
 
   virtual FPrimitiveViewRelevance GetViewRelevance(const FSceneView * View) const override;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.cpp
@@ -1,0 +1,257 @@
+#include "TaggedMaterials.h"
+#include "ConstructorHelpers.h"
+#include "Interfaces/IPluginManager.h"
+#include "HAL/FileManager.h"
+
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "Materials/MaterialExpressionSetMaterialAttributes.h"
+#include "Materials/MaterialExpressionMakeMaterialAttributes.h"
+
+const FString UTaggedMaterialsRegistry::TaggedMaterialsRootDir = TEXT("/Carla/PostProcessingMaterials/TaggedMaterials");
+UTaggedMaterialsRegistry* UTaggedMaterialsRegistry::Registry = nullptr;
+
+UTaggedMaterialsRegistry::UTaggedMaterialsRegistry() {
+  FString MaterialPath = TEXT("Material'/Carla/PostProcessingMaterials/AnnotationColor.AnnotationColor'");
+  static ConstructorHelpers::FObjectFinder<UMaterial> TaggedOpaqueMaterialObject(*MaterialPath);
+  // TODO: Replace with VertexColorViewModeMaterial_ColorOnly?
+  TaggedOpaqueMaterial = TaggedOpaqueMaterialObject.Object;
+}
+
+UTaggedMaterialsRegistry* UTaggedMaterialsRegistry::Create(const FString& RegistryName) {
+  UTaggedMaterialsRegistry* NewRegistry = nullptr;
+  if (RegistryName.Len() > 0) {
+    FString PackageName = TEXT("TaggedMaterials_") + RegistryName;
+    FString PackagePath = TaggedMaterialsRootDir / PackageName;
+    UPackage* Package = CreatePackage(*PackagePath);
+
+    NewRegistry = NewObject<UTaggedMaterialsRegistry>(Package, *PackageName, RF_Public | RF_Standalone);
+  } else {
+    NewRegistry = NewObject<UTaggedMaterialsRegistry>();
+  }
+
+  return NewRegistry;
+}
+
+UTaggedMaterialsRegistry* UTaggedMaterialsRegistry::Get() {
+  if (!Registry) {
+#if WITH_EDITOR
+    // Try loading if editor-registry already exists, else instantiate new one
+    FString RegistryNameEditor = TEXT("Editor");
+    Registry = Load(RegistryNameEditor);
+    if (!Registry) {
+      Registry = Create(RegistryNameEditor);
+    }
+#else
+    // Try loading (multiple) precomputed UTaggedMaterialsRegistry (each map package ships its own registry)
+    FString PluginPath = IPluginManager::Get().FindPlugin(TEXT("Carla"))->GetBaseDir();
+    FString RegistriesDirPath = PluginPath / TEXT("Content/PostProcessingMaterials/TaggedMaterials");
+    TArray<FString> RegistryFiles;
+    IFileManager::Get().FindFiles(RegistryFiles, *(RegistriesDirPath / TEXT("*.uasset")), true, false);
+
+    Registry = Create(TEXT(""));
+    for (const FString& RegistryFile : RegistryFiles) {
+      FString RegistryName = FPaths::GetBaseFilename(RegistryFile, true);
+      UTaggedMaterialsRegistry* LoadedRegistry = Load(RegistryName, false);
+      Registry->TaggedMaskedMaterials.Append(LoadedRegistry->TaggedMaskedMaterials);
+    }
+#endif // WITH_EDITOR
+    Registry->AddToRoot(); // Prevent GC deleting the materials of this registry
+  }
+  return Registry;
+}
+
+UMaterialInstanceDynamic* UTaggedMaterialsRegistry::GetTaggedMaterial() {
+  return UMaterialInstanceDynamic::Create(TaggedOpaqueMaterial, this);
+}
+
+UMaterialInstanceDynamic* UTaggedMaterialsRegistry::GetTaggedMaterial(UMaterialInterface* UsedMaterial) {
+  // If UsedMaterial is null OR neither masked nor using WorldPositionOffset OR is using ShadingModel from
+  // MaterialExpression (which results in an error when changing the ShadingModel), we return NULL to indicate,
+  // that the requested material does not require a fine-grained tag-injected correspondence.
+  if (!UsedMaterial
+      || !(UsedMaterial->IsMasked() || UsedMaterial->GetMaterial()->WorldPositionOffset.IsConnected())
+      || UsedMaterial->IsShadingModelFromMaterialExpression()) {
+    return NULL;
+  }
+
+#if WITH_EDITOR
+  // Create tag-injected correspondence of UsedMaterial, if it does not exist already
+  if (!TaggedMaskedMaterials.Contains(UsedMaterial->GetPathName())) {
+    if (GIsEditor || IsRunningCommandlet()) {
+      UTaggedMaterialsRegistry::InjectTag(UsedMaterial);
+    } else {
+      UE_LOG(LogCarla, Warning, TEXT("Can only create new materials in editor (PIE) or during cooking. %s will render coarsely in instance segmentation."),
+             *UsedMaterial->GetPathName());
+    }
+  }
+#endif // WITH_EDITOR
+
+  // Create an instance-specific MID for this UsedMaterial
+  UMaterialInstanceDynamic* UsedMaterialMID = Cast<UMaterialInstanceDynamic>(UsedMaterial);
+  if (UsedMaterialMID) {
+    // UsedMaterial is a MID, so we create a tagged MID based on the parent and copy the original parameters
+    UMaterialInterface** TagInjectedParent = TaggedMaskedMaterials.Find(UsedMaterialMID->Parent->GetPathName());
+    if (TagInjectedParent) {
+      UMaterialInstanceDynamic* TagInjectedMID = UMaterialInstanceDynamic::Create(*TagInjectedParent, this);
+      TagInjectedMID->CopyParameterOverrides(UsedMaterialMID);
+      return TagInjectedMID;
+    }
+  } else {
+    // We can simply wrap the UMaterial or UMaterialInstanceConstant in a UMaterialInstanceDynamic
+    UMaterialInterface** TagInjectedMaterial = TaggedMaskedMaterials.Find(UsedMaterial->GetPathName());
+    if (TagInjectedMaterial) {
+      return UMaterialInstanceDynamic::Create(*TagInjectedMaterial, this);
+    }
+  }
+  // Reaching this could happen in a cooked build, if UsedMaterial is missing in the cooked TaggedMaterialsRegistries
+  return NULL;
+}
+
+#if WITH_EDITOR
+void UTaggedMaterialsRegistry::InjectTag(UMaterialInterface* MaterialInterface) {
+  UMaterial* Material = Cast<UMaterial>(MaterialInterface);
+  UMaterialInstance* MaterialInstance = Cast<UMaterialInstance>(MaterialInterface);
+  if (Material) {
+    InjectTagIntoMaterial(Material);
+  } else if (MaterialInstance) {
+    InjectTagIntoMaterialInstance(MaterialInstance);
+  } else {
+    UE_LOG(LogCarla, Error, TEXT("MaterialInterface '%s' is neither UMaterial nor UMaterialInstance."), *MaterialInterface->GetPathName());
+  }
+}
+
+const static FGuid EmissiveColorGuid = FMaterialAttributeDefinitionMap::GetID(EMaterialProperty::MP_EmissiveColor);
+
+void UTaggedMaterialsRegistry::InjectTagIntoMaterial(UMaterial* Material) {
+  if (TaggedMaskedMaterials.Contains(Material->GetPathName())) {
+    // Tag-injected material already exists -> do nothing
+    return;
+  }
+
+  UMaterial* TagInjectedMaterial = DuplicateObject<UMaterial>(Material, this);
+  TagInjectedMaterial->SetFlags(RF_Public | RF_Standalone);
+
+  UMaterialExpressionVectorParameter* ExpressionInstSegColor = NewObject<UMaterialExpressionVectorParameter>(TagInjectedMaterial);
+  ExpressionInstSegColor->SetParameterName(FName("AnnotationColor"));
+  ExpressionInstSegColor->DefaultValue = FLinearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  ExpressionInstSegColor->Material = TagInjectedMaterial;
+  TagInjectedMaterial->Expressions.Add(ExpressionInstSegColor);
+
+  if (TagInjectedMaterial->bUseMaterialAttributes) {
+    // Create a SetAttributeExpression which will be injected between the existing input and the material node
+    // and additionally has a emissive color parameter.
+    UMaterialExpressionSetMaterialAttributes* SetAttributeExpression = NewObject<UMaterialExpressionSetMaterialAttributes>(TagInjectedMaterial);
+    SetAttributeExpression->Material = TagInjectedMaterial;
+
+    SetAttributeExpression->Inputs[0].Connect(0, TagInjectedMaterial->MaterialAttributes.GetTracedInput().Expression);
+
+    FMaterialAttributesInput SetAttributeEmissiveInput = FMaterialAttributesInput();
+    SetAttributeEmissiveInput.Expression = ExpressionInstSegColor;
+    SetAttributeExpression->Inputs.Add(SetAttributeEmissiveInput);
+    SetAttributeExpression->AttributeSetTypes.Add(EmissiveColorGuid);
+
+    TagInjectedMaterial->MaterialAttributes.Connect(0, SetAttributeExpression);
+    TagInjectedMaterial->Expressions.Add(SetAttributeExpression);
+  } else {
+    // Simply plug the tag node into emissive color. Existing values are simply replaced.
+    TagInjectedMaterial->EmissiveColor.Connect(0, ExpressionInstSegColor);
+  }
+  // Set ShadingModel to unlit and recompile
+  TagInjectedMaterial->SetShadingModel(MSM_Unlit);
+  TagInjectedMaterial->PreEditChange(nullptr);
+  TagInjectedMaterial->PostEditChange();
+  TaggedMaskedMaterials.Add(Material->GetPathName(), TagInjectedMaterial);
+  bPendingChanges = true;
+}
+
+void UTaggedMaterialsRegistry::InjectTagIntoMaterialInstance(UMaterialInstance* MaterialInstance) {
+  if (TaggedMaskedMaterials.Contains(MaterialInstance->GetPathName())) {
+    // Tag-injected material instance already exists -> do nothing
+    return;
+  }
+
+  UMaterial* MaterialParent = Cast<UMaterial>(MaterialInstance->Parent);
+  UMaterialInstance* MaterialInstanceParent = Cast<UMaterialInstance>(MaterialInstance->Parent);
+  if (MaterialInstanceParent) {
+    // Recursively inject tag into chains of material instances
+    InjectTagIntoMaterialInstance(MaterialInstanceParent);
+  } else if (MaterialParent) {
+    // Found base material -> inject tag
+    InjectTagIntoMaterial(MaterialParent);
+  } else {
+    UE_LOG(LogCarla, Error, TEXT("Parent of '%s' is neither UMaterialInstance nor UMaterial."), *MaterialInstance->Parent->GetPathName());
+    return;
+  }
+
+  UMaterialInterface* TagInjectedParent = TaggedMaskedMaterials.FindChecked(MaterialInstance->Parent->GetPathName());
+
+  // Now, we definitively have a tag-injected version of the parent.
+  // Create a copy of the current material instance and change its parent to the tag-injected one.
+  // We can ignore UMaterialInstanceDynamic here, since it cannot do any modifications to the shader.
+  UMaterialInstanceConstant* MaterialInstanceConstant = Cast<UMaterialInstanceConstant>(MaterialInstance);
+  if (MaterialInstanceConstant) {
+    UMaterialInstanceConstant* TagInjectedMIC = DuplicateObject<UMaterialInstanceConstant>(MaterialInstanceConstant, this);
+    TagInjectedMIC->SetFlags(RF_Public | RF_Standalone);
+    TagInjectedMIC->SetParentEditorOnly(TagInjectedParent);
+    if (TagInjectedMIC->BasePropertyOverrides.bOverride_ShadingModel) {
+      TagInjectedMIC->BasePropertyOverrides.ShadingModel = MSM_Unlit;
+    }
+    FMaterialUpdateContext LocalMaterialUpdateContext(FMaterialUpdateContext::EOptions::RecreateRenderStates);
+    LocalMaterialUpdateContext.AddMaterialInstance(TagInjectedMIC);
+    TaggedMaskedMaterials.Add(MaterialInstance->GetPathName(), TagInjectedMIC);
+    bPendingChanges = true;
+  }
+}
+
+void UTaggedMaterialsRegistry::PostInitProperties() {
+  Super::PostInitProperties();
+
+  if (GIsEditor) {
+    FWorldDelegates::OnWorldCleanup.AddUObject(this, &UTaggedMaterialsRegistry::OnWorldCleanup);
+  }
+}
+
+void UTaggedMaterialsRegistry::BeginDestroy() {
+  if (GIsEditor) {
+    FWorldDelegates::OnWorldCleanup.RemoveAll(this);
+  }
+
+  Super::BeginDestroy();
+}
+
+void UTaggedMaterialsRegistry::OnWorldCleanup(UWorld* InWorld, bool bSessionEnded, bool bCleanupResources) {
+  if (bPendingChanges) {
+    Save();
+    bPendingChanges = false;
+  }
+}
+
+void UTaggedMaterialsRegistry::Save() {
+  UPackage* Package = GetPackage();
+  FString PackagePath = Package->GetName();
+
+  MarkPackageDirty();
+  FAssetRegistryModule::AssetCreated(this);
+  UPackage::SavePackage(Package, this, RF_Public | RF_Standalone,
+                        *FPackageName::LongPackageNameToFilename(PackagePath, FPackageName::GetAssetPackageExtension()));
+}
+#endif // WITH_EDITOR
+
+UTaggedMaterialsRegistry* UTaggedMaterialsRegistry::Load(const FString& RegistryName, bool bIsSuffix /* = true */) {
+  FString FullRegistryName = RegistryName;
+  if (bIsSuffix) {
+    FullRegistryName = TEXT("TaggedMaterials_") + RegistryName;
+  }
+  FSoftObjectPath RegistryPath = FSoftObjectPath(*(TaggedMaterialsRootDir / FullRegistryName + TEXT(".") + FullRegistryName));
+
+  UTaggedMaterialsRegistry* LoadedRegistry = nullptr;
+  UObject* RegistryObject = RegistryPath.TryLoad();
+  if (RegistryObject) {
+    LoadedRegistry = Cast<UTaggedMaterialsRegistry>(RegistryObject);
+  }
+
+  if (!LoadedRegistry) {
+    UE_LOG(LogCarla, Warning, TEXT("Failed to load UTaggedMaterialsRegistry '%s' in '%s'."), *RegistryName, *TaggedMaterialsRootDir);
+  }
+  return LoadedRegistry;
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "TaggedMaterials.generated.h"
+
+
+UCLASS(BlueprintType)
+class CARLA_API UTaggedMaterialsRegistry : public UObject
+{
+  GENERATED_BODY()
+
+public:
+  static UTaggedMaterialsRegistry* Create(const FString& RegistryName);
+  static UTaggedMaterialsRegistry* Get();
+  static UTaggedMaterialsRegistry* Load(const FString& RegistryName, bool bIsSuffix = true);
+
+  UMaterialInstanceDynamic* GetTaggedMaterial();
+  UMaterialInstanceDynamic* GetTaggedMaterial(UMaterialInterface* UsedMaterial);
+  FORCEINLINE int32 Num() const {return TaggedMaskedMaterials.Num();}
+
+#if WITH_EDITOR
+  virtual void PostInitProperties() override;
+  virtual void BeginDestroy() override;
+
+  void Save();
+#endif // WITH_EDITOR
+
+  static const FString TaggedMaterialsRootDir;
+protected:
+  UTaggedMaterialsRegistry();
+
+#if WITH_EDITOR
+  void InjectTag(UMaterialInterface* MaterialInterface);
+  void InjectTagIntoMaterial(UMaterial* Material);
+  void InjectTagIntoMaterialInstance(UMaterialInstance* MaterialInstance);
+
+  void OnWorldCleanup(UWorld* InWorld, bool bSessionEnded, bool bCleanupResources);
+#endif // WITH_EDITOR
+
+private:
+  UPROPERTY(VisibleAnywhere)
+  UMaterial* TaggedOpaqueMaterial;
+
+  UPROPERTY(VisibleAnywhere)
+  TMap<FString, UMaterialInterface*> TaggedMaskedMaterials;
+
+  bool bPendingChanges = false;
+
+  static UTaggedMaterialsRegistry* Registry;
+};
+
+// The actor is only required for cooking a UTaggedMaterialsRegistry as part of a UWorld
+UCLASS()
+class ATaggedMaterialsRegistryActor : public AActor
+{
+  GENERATED_BODY()
+
+public:
+  UPROPERTY(VisibleAnywhere)
+  UTaggedMaterialsRegistry* TaggedMaterialsRegistry;
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
@@ -35,6 +35,9 @@ protected:
   void InjectTagIntoMaterial(UMaterial* Material);
   void InjectTagIntoMaterialInstance(UMaterialInstance* MaterialInstance);
 
+  // Copies the given expression and all the material graph of its inputs to the target material. Returns the copy of the root expression.
+  UMaterialExpression* CopyMaterialExpressions(UMaterial* TargetMaterial, UMaterialExpression* RootExpression);
+
   void OnWorldCleanup(UWorld* InWorld, bool bSessionEnded, bool bCleanupResources);
 #endif // WITH_EDITOR
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.cpp
@@ -101,6 +101,18 @@ FLinearColor ATagger::GetLabelColor(const uint32_t ActorID, const crp::CityObjec
 // -- static ATagger functions -------------------------------------------------
 // =============================================================================
 
+template<class T /* = UTaggedComponent*/>
+T* ATagger::FindTaggedComponent(const USceneComponent* Component) {
+  TArray<USceneComponent *> AttachedComponents = Component->GetAttachChildren();
+  for (USceneComponent *SceneComponent : AttachedComponents) {
+    T *TaggedSceneComponent = Cast<T>(SceneComponent);
+    if (IsValid(TaggedSceneComponent)) {
+        return TaggedSceneComponent;
+    }
+  }
+  return NULL;
+}
+
 void ATagger::TagActor(const AActor &Actor, bool bTagForSemanticSegmentation, uint32_t ActorID)
 {
 #ifdef CARLA_TAGGER_EXTRA_LOG
@@ -129,21 +141,13 @@ void ATagger::TagActor(const AActor &Actor, bool bTagForSemanticSegmentation, ui
     }
 
     // Find a tagged component that is attached to this component
-    UTaggedComponent *TaggedComponent = NULL;
-    TArray<USceneComponent *> AttachedComponents = Component->GetAttachChildren();
-    for (USceneComponent *SceneComponent : AttachedComponents) {
-      UTaggedComponent *TaggedSceneComponent = Cast<UTaggedComponent>(SceneComponent);
-      if (IsValid(TaggedSceneComponent)) {
-          TaggedComponent = TaggedSceneComponent;
+    UTaggedComponent *TaggedComponent = FindTaggedComponent(Component);
+    if (TaggedComponent) {
 #ifdef CARLA_TAGGER_EXTRA_LOG
-          UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
+      UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
 #endif // CARLA_TAGGER_EXTRA_LOG
-          break;
-      }
-    }
-
-    // If not found, then create new tagged component and attach it to this component
-    if (!TaggedComponent) {
+    } else {
+      // If not found, then create new tagged component and attach it to this component
       TaggedComponent = NewObject<UTaggedComponent>(Component);
       TaggedComponent->SetupAttachment(Component);
       TaggedComponent->RegisterComponent();
@@ -184,21 +188,13 @@ void ATagger::TagActor(const AActor &Actor, bool bTagForSemanticSegmentation, ui
     }
 
     // Find a tagged component that is attached to this component
-    UTaggedComponent *TaggedComponent = NULL;
-    TArray<USceneComponent *> AttachedComponents = Component->GetAttachChildren();
-    for (USceneComponent *SceneComponent : AttachedComponents) {
-      UTaggedComponent *TaggedSceneComponent = Cast<UTaggedComponent>(SceneComponent);
-      if (IsValid(TaggedSceneComponent)) {
-          TaggedComponent = TaggedSceneComponent;
+    UTaggedComponent *TaggedComponent = FindTaggedComponent(Component);
+    if (TaggedComponent) {
 #ifdef CARLA_TAGGER_EXTRA_LOG
-          UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
+      UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
 #endif // CARLA_TAGGER_EXTRA_LOG
-          break;
-      }
-    }
-
-    // If not found, then create new tagged component and attach it to this component
-    if (!TaggedComponent) {
+    } else {
+      // If not found, then create new tagged component and attach it to this component
       TaggedComponent = NewObject<UTaggedComponent>(Component);
       TaggedComponent->SetupAttachment(Component);
       TaggedComponent->RegisterComponent();
@@ -230,21 +226,13 @@ void ATagger::TagActor(const AActor &Actor, bool bTagForSemanticSegmentation, ui
 #endif // CARLA_TAGGER_EXTRA_LOG
 
     // Find a tagged component that is attached to this component
-    UTaggedLandscapeComponent *TaggedComponent = NULL;
-    TArray<USceneComponent *> AttachedComponents = Component->GetAttachChildren();
-    for (USceneComponent *SceneComponent : AttachedComponents) {
-      UTaggedLandscapeComponent *TaggedSceneComponent = Cast<UTaggedLandscapeComponent>(SceneComponent);
-      if (IsValid(TaggedSceneComponent)) {
-          TaggedComponent = TaggedSceneComponent;
+    UTaggedLandscapeComponent *TaggedComponent = FindTaggedComponent<UTaggedLandscapeComponent>(Component);
+    if (TaggedComponent) {
 #ifdef CARLA_TAGGER_EXTRA_LOG
-          UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
+      UE_LOG(LogCarla, Log, TEXT("    - Found Tag"));
 #endif // CARLA_TAGGER_EXTRA_LOG
-          break;
-      }
-    }
-
-    // If not found, then create new tagged component and attach it to this component
-    if (!TaggedComponent) {
+    } else {
+      // If not found, then create new tagged component and attach it to this component
       TaggedComponent = NewObject<UTaggedLandscapeComponent>(Component);
       TaggedComponent->SetupAttachment(Component);
       TaggedComponent->RegisterComponent();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/Tagger.h
@@ -18,6 +18,7 @@
 namespace crp = carla::rpc;
 
 class UCarlaEpisode;
+class UTaggedComponent;
 
 /// Sets actors' custom depth stencil value for semantic segmentation according
 /// to their meshes.
@@ -30,6 +31,10 @@ class CARLA_API ATagger : public AActor
   GENERATED_BODY()
 
 public:
+
+  // Find a tagged component that is attached to the given component.
+  template<class T = UTaggedComponent>
+  static T* FindTaggedComponent(const USceneComponent* Component);
 
   /// Set the tag of an actor.
   ///

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -52,7 +52,7 @@ void AInertialMeasurementUnit::SetOwner(AActor *Owner)
 }
 
 // Returns the angular velocity of Actor, expressed in the frame of Actor
-static FVector FIMU_GetActorAngularVelocityInRadians(
+FVector AInertialMeasurementUnit::GetActorAngularVelocityInRadians(
     AActor &Actor)
 {
   const auto RootComponent = Cast<UPrimitiveComponent>(Actor.GetRootComponent());
@@ -148,7 +148,7 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeGyroscope()
 {
   check(GetOwner() != nullptr);
   const FVector AngularVelocity =
-      FIMU_GetActorAngularVelocityInRadians(*GetOwner());
+      GetActorAngularVelocityInRadians(*GetOwner());
 
   const FQuat SensorLocalRotation =
       RootComponent->GetRelativeTransform().GetRotation();

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
@@ -29,6 +29,7 @@ public:
   AInertialMeasurementUnit(const FObjectInitializer &ObjectInitializer);
 
   static FActorDefinition GetSensorDefinition();
+  static FVector GetActorAngularVelocityInRadians(AActor &Actor);
 
   void Set(const FActorDescription &ActorDescription) override;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/V2X/CaService.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/V2X/CaService.cpp
@@ -6,6 +6,8 @@
 
 #include "Carla.h"
 #include "CaService.h"
+#include "Carla/Game/CarlaStatics.h"
+#include "Carla/Sensor/InertialMeasurementUnit.h"
 #include <boost/algorithm/clamp.hpp>
 #include "carla/rpc/String.h"
 #include "Carla/Util/BoundingBoxCalculator.h"
@@ -622,7 +624,7 @@ float CaService::ComputeYawRate()
 {
     check(mActorOwner != nullptr);
     const FVector AngularVelocity =
-        FIMU_GetActorAngularVelocityInRadians(*mActorOwner);
+        AInertialMeasurementUnit::GetActorAngularVelocityInRadians(*mActorOwner);
 
     const FQuat SensorLocalRotation =
         mActorOwner->GetRootComponent()->GetRelativeTransform().GetRotation();


### PR DESCRIPTION
#### Description

Currently, the instance segmentation replaces all materials on all meshes simply using an opaque material, which can be colorized with an RGB encoding of the type and the object ID. Secondary SceneProxies of all meshes are then rendered with these tagged materials resulting in the instance segmentation output. The current solution has the drawback, that masked materials are simply ignored. Thus, partial transparent surfaces in the RGB image appear fully opaque in the instance segmentation, resulting in very coarse annotations, which also do not match to the semantic segmentation.

This PR addresses this issue by introducing additional logic, that tackles masked materials for the instance segmentation. The following images show a before/after comparison of the semantic channel in the instance segmentation.

|         Town01_Opt          |          Town10HD_Opt           |
| :-------------------------: | :-----------------------------: |
| ![Town01-1](https://github.com/user-attachments/assets/179be03a-4d01-440a-963a-10a0cc24dea4) | ![Town10HD-1](https://github.com/user-attachments/assets/442b4d31-cf30-4a0e-885b-2b266b42eba7) |
| ![Town01-2](https://github.com/user-attachments/assets/e14299fc-4c30-4816-90b5-de25766dcd23) | ![Town10HD-2](https://github.com/user-attachments/assets/8dd39ba9-adb4-448a-9d9f-fca1139a16a7) |

In general, the instance segmentation on vegetation and fences is now as fine-grained as the semantic segmentation. Note, that the main problem with the sky and the lane markings in Town01 (and Town02) are fixed. Also, trees in Town10HD in the background (with LOD4) were previously invisible (since it uses a very special material) and are now visible. The only remaining difference between the semantic segmentation and the instance segmentation is, that the semantic segmentation looks through translucent surfaces, while the instance segmentation does not.

#### Implementation

* The core of this PR is the `UTaggedMaterialsRegistry`, which is now responsible to handle tagged materials for the `UTaggedComponents`
  * It holds a mapping from original materials to modified materials, which are duplicates of the originals, but introduce some additional expressions into the material graph, so that they render with the tag color
  * This keeps the relevant aspects of the original material intact (especially `OpacityMask` and `WorldPositionOffset`), so that the duplicated material behaves like the original, except that it renders with the tag color
* If a `UTaggedComponent's` parent uses a masked material, a tag-injected corresponding material is requested from the registry
  * Otherwise, the default opaque tagged material is used
* When playing in editor (PIE), these tagged materials are created and compiled on demand
* For the packaged version, a commandlet creates a `UTaggedMaterialsRegistry` for the current package, which then will be cooked and copied to the package

#### Where has this been tested?

* **Platform(s):** Windows 11, Ubuntu 18.04
* **Python version(s):** 3.8
* **Unreal Engine version(s):** 4.26
* Tested in Editor (Windows) and Packaged (Windows + Linux)

#### Possible Drawbacks

IMO, very small drawbacks, but for completion:
* Packaging takes some additional time, due to additionally generating and cooking the `TaggedMaterialsRegistry`
* The resulting package(s) grow in size, due to the additional `TaggedMaterialsRegistry`
  * For the "Carla" package (which is the largest), additionally 44MB (Windows) or 25MB (Linux) are needed, respectively
  * Other packages (e.g. "AdditionalMaps" or "Town07_Opt") only consume additionally ~1MB
* When playing a map in the editor (PIE) the first time, creating and compiling the required materials slows down the startup
  * Since these are stored, all further in-game sessions in the editor of this map are not affected anymore
* When playing in the editor but as "Standalone", runtime modification and compiling of materials is not possible
  * Warnings are logged and the instance segmentation falls back to the usual fully-opaque tagged material (i.e. same behavior before this PR)
  * If the map was previously played in editor, it also works in standalone

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8795)
<!-- Reviewable:end -->
