### PR TITLE
Set visual studio 2022 to default generator in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
  * Fixed segfault in traffic manager when trying to access not available vehicles
  * Fixed invalid comparission in python examples/rss
  * Fixed invisible spline meshes in instance segmentation
+ * Set to default Visual Studio 2022 in Windows
+ * Added env CARLA_CACHE_DIR to be able to set CARLA CACHE location
 
 ## CARLA 0.9.15
 

--- a/Docs/build_windows.md
+++ b/Docs/build_windows.md
@@ -12,7 +12,7 @@ If you come across errors or difficulties then have a look at the **[F.A.Q.](bui
         - [Minor installations](#minor-installations)
         - [Python dependencies](#python-dependencies)
         - [Major installations](#major-installations)
-            - [Visual Studio 2019](#visual-studio-2019)
+            - [Visual Studio 2022](#visual-studio-2022)
             - [Unreal Engine](#unreal-engine)
 - [__Part Two: Build CARLA__](#part-two-build-carla)
     - [Clone the CARLA repository](#clone-the-carla-repository)
@@ -70,19 +70,80 @@ pip3 install --user wheel
 ```
 
 #### Major installations
-##### Visual Studio 2019
+##### Visual Studio 2022
 
-Get the 2019 version of Visual Studio from [here](https://developerinsider.co/download-visual-studio-2019-web-installer-iso-community-professional-enterprise/). Choose __Community__ for the free version. Use the _Visual Studio Installer_ to install three additional elements: 
+Get the 2022 version of Visual Studio from [here](https://visualstudio.microsoft.com/downloads/). Choose __Community__ for the free version. Use the _Visual Studio Installer_ to install three additional elements: 
 
-* __Windows 8.1 SDK.__ Select it in the _Installation details_ section on the right or go to the _Indivdual Components_ tab and look under the _SDKs, libraries, and frameworks_ heading.
-* __x64 Visual C++ Toolset.__ In the _Workloads_ section, choose __Desktop development with C++__. This will enable a x64 command prompt that will be used for the build. Check that it has been installed correctly by pressing the `Windows` button and searching for `x64`. Be careful __not to open a `x86_x64` prompt__.  
-* __.NET framework 4.6.2__. In the _Workloads_ section, choose __.NET desktop development__ and then in the _Installation details_ panel on the right, select `.NET Framework 4.6.2 development tools`. This is required to build Unreal Engine. 
+This is our recommended visual studio configuration. 
+You can try to [import](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022) it.
+```
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.Net.Component.4.8.SDK",
+    "Microsoft.Net.Component.4.7.2.TargetingPack",
+    "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.SQL.CLR",
+    "Microsoft.Component.ClickOnce",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
+    "Microsoft.NetCore.Component.Runtime.8.0",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.Net.Component.4.8.TargetingPack",
+    "Microsoft.NetCore.Component.Runtime.6.0",
+    "Microsoft.Net.Component.4.6.2.TargetingPack",
+    "Microsoft.Net.Component.4.7.TargetingPack",
+    "Microsoft.Net.Component.4.7.1.TargetingPack",
+    "Microsoft.Net.Component.4.8.1.SDK",
+    "Microsoft.Net.Component.4.8.1.TargetingPack",
+    "Microsoft.Net.ComponentGroup.4.8.1.DeveloperTools",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.Windows10SDK",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Component.IncredibuildMenu",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+    "Microsoft.VisualStudio.Component.Windows11Sdk.WindowsPerformanceToolkit",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake",
+    "Microsoft.VisualStudio.Component.VC.CMake.Project",
+    "Microsoft.VisualStudio.Component.VC.CLI.Support",
+    "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
+    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang",
+    "Microsoft.VisualStudio.Component.Windows10SDK.20348",
+    "Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
+    "Microsoft.Component.VC.Runtime.UCRTSDK",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
+    "Microsoft.VisualStudio.Component.UWP.VC.ARM64EC",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+    "Microsoft.VisualStudio.Component.UWP.VC.ARM64",
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Component.HLSL",
+    "Microsoft.VisualStudio.Workload.NativeGame",
+    "Microsoft.Net.Component.4.6.TargetingPack",
+    "Microsoft.VisualStudio.Component.WinXP",
+    "Microsoft.VisualStudio.Component.VC.14.29.16.11.CLI.Support",
+    "Microsoft.Net.Component.4.6.1.TargetingPack",
+    "Microsoft.VisualStudio.Component.VC.14.36.17.6.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.14.38.17.8.CLI.Support",
+    "Microsoft.Net.Component.4.6.2.SDK"
+  ],
+  "extensions": []
+}
+
+```
 
 !!! Important
     Other Visual Studio versions may cause conflict. Even if these have been uninstalled, some registers may persist. To completely clean Visual Studio from the computer, go to `Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\layout` and run `.\InstallCleanup.exe -full`  
-
-!!! Note
-    It is also possible to use Visual Studio 2022 using the above steps and substituting the Windows 8.1 SDK for the Windows 11/10 SDK. To override the default Visual Studio 2019 Generator in CMake, specify GENERATOR="Visual Studio 17 2022" when using the makefile commands (see [table](build_windows.md#other-make-commands)). You may specify any generator that works with the build commands as specific in the build scripts, for a full list run `cmake -G` (Ninja has been tested to work for building LibCarla so far).
 
 ##### Unreal Engine
 

--- a/Util/BuildTools/BuildLibCarla.bat
+++ b/Util/BuildTools/BuildLibCarla.bat
@@ -72,7 +72,7 @@ rem Set the visual studio solution directory
 rem
 set LIBCARLA_VSPROJECT_PATH=%INSTALLATION_DIR:/=\%libcarla-visualstudio\
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 
 set LIBCARLA_SERVER_INSTALL_PATH=%ROOT_PATH:/=\%Unreal\CarlaUE4\Plugins\Carla\CarlaDependencies\

--- a/Util/BuildTools/BuildOSM2ODR.bat
+++ b/Util/BuildTools/BuildOSM2ODR.bat
@@ -76,7 +76,7 @@ set OSM2ODR_INSTALL_PATH=%ROOT_PATH:/=\%PythonAPI\carla\dependencies\
 set OSM2ODR__SERVER_INSTALL_PATH=%ROOT_PATH:/=\%Unreal\CarlaUE4\Plugins\Carla\CarlaDependencies
 set CARLA_DEPENDENCIES_FOLDER=%ROOT_PATH:/=\%Unreal\CarlaUE4\Plugins\Carla\CarlaDependencies\
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 if %REMOVE_INTERMEDIATE% == true (
     rem Remove directories

--- a/Util/BuildTools/BuildOSMRenderer.bat
+++ b/Util/BuildTools/BuildOSMRenderer.bat
@@ -38,7 +38,7 @@ if not exist "%LIBOSMSCOUT_SOURCE_PATH%" git clone %LIBOSMSCOUT_REPO% %LIBOSMSCO
 if not exist "%LIBOSMSCOUT_VSPROJECT_PATH%" mkdir "%LIBOSMSCOUT_VSPROJECT_PATH%"
 cd "%LIBOSMSCOUT_VSPROJECT_PATH%"
 
-cmake -G "Visual Studio 16 2019"^
+cmake -G "Visual Studio 17 2022"^
     -DCMAKE_INSTALL_PREFIX="%DEPENDENCIES_INSTALLATION_PATH:\=/%"^
     -DOSMSCOUT_BUILD_TOOL_STYLEEDITOR=OFF^
     -DOSMSCOUT_BUILD_TOOL_OSMSCOUT2=OFF^
@@ -60,7 +60,7 @@ if not exist "%LUNASVG_SOURCE_PATH%" git clone %LUNASVG_REPO% %LUNASVG_SOURCE_PA
 if not exist "%LUNASVG_VSPROJECT_PATH%" mkdir "%LUNASVG_VSPROJECT_PATH%"
 cd "%LUNASVG_VSPROJECT_PATH%"
 
-cmake -G "Visual Studio 16 2019" -A x64^
+cmake -G "Visual Studio 17 2022" -A x64^
     -DCMAKE_INSTALL_PREFIX="%DEPENDENCIES_INSTALLATION_PATH:\=/%"^
     "%LUNASVG_SOURCE_PATH%"
 
@@ -74,7 +74,7 @@ rem ===========================================================================
 if not exist "%OSM_RENDERER_VSPROJECT_PATH%" mkdir "%OSM_RENDERER_VSPROJECT_PATH%"
 cd "%OSM_RENDERER_VSPROJECT_PATH%"
 
-cmake -G "Visual Studio 16 2019" -A x64^
+cmake -G "Visual Studio 17 2022" -A x64^
     -DCMAKE_CXX_FLAGS_RELEASE="/std:c++17 /wd4251 /I%INSTALLATION_DIR:/=\%boost-1.80.0-install\include"^
     "%OSM_RENDERER_SOURCE%"
 

--- a/Util/BuildTools/Setup.bat
+++ b/Util/BuildTools/Setup.bat
@@ -64,8 +64,8 @@ if not "%1"=="" (
 )
 
 rem If not defined, use Visual Studio 2019 as tool set
-if "%TOOLSET%" == "" set TOOLSET=msvc-14.2
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if "%TOOLSET%" == "" set TOOLSET=msvc-14.3
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If is not set, set the number of parallel jobs to the number of CPU threads
 if "%NUMBER_OF_ASYNC_JOBS%" == "" set NUMBER_OF_ASYNC_JOBS=%NUMBER_OF_PROCESSORS%
@@ -460,8 +460,8 @@ rem ============================================================================
     echo                               Visual Studio 2013 -^> msvc-12.0
     echo                               Visual Studio 2015 -^> msvc-14.0
     echo                               Visual Studio 2017 -^> msvc-14.1
-    echo                               Visual Studio 2019 -^> msvc-14.2 *
-    echo                               Visual Studio 2022 -^> msvc-14.3
+    echo                               Visual Studio 2019 -^> msvc-14.2 
+    echo                               Visual Studio 2022 -^> msvc-14.3 *
     goto good_exit
 
 :error_cl

--- a/Util/InstallersWin/install_boost.bat
+++ b/Util/InstallersWin/install_boost.bat
@@ -56,7 +56,7 @@ if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
 
 rem If not defined, use Visual Studio 2019 as tool set
-if "%TOOLSET%" == "" set TOOLSET=msvc-14.2
+if "%TOOLSET%" == "" set TOOLSET=msvc-14.3
 
 rem If is not set, set the number of parallel jobs to the number of CPU threads
 if "%NUMBER_OF_ASYNC_JOBS%" == "" set NUMBER_OF_ASYNC_JOBS=%NUMBER_OF_PROCESSORS%

--- a/Util/InstallersWin/install_chrono.bat
+++ b/Util/InstallersWin/install_chrono.bat
@@ -38,7 +38,7 @@ if not "%1"=="" (
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem ============================================================================
 rem -- Get Eigen (Chrono dependency) -------------------------------------------

--- a/Util/InstallersWin/install_fastDDS.bat
+++ b/Util/InstallersWin/install_fastDDS.bat
@@ -69,7 +69,7 @@ if not exist "%FASTDDS_SRC_DIR%/thirdparty/fastcdr/build" (
 cd "%FASTDDS_SRC_DIR%/thirdparty/fastcdr/build"
 echo %FILE_N% Generating build...
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+cmake .. -G "Visual Studio 17 2022" -A x64^
     -DCMAKE_BUILD_TYPE=Release^
     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
     -DCMAKE_INSTALL_PREFIX="%FASTDDS_INSTALL_DIR:\=/%"^
@@ -95,7 +95,7 @@ cd ../../..
 @REM cd "%FASTDDS_SRC_DIR%/thirdparty/asio/asio/build"
 @REM echo %FILE_N% Generating build...
 
-@REM cmake .. -G "Visual Studio 16 2019" -A x64^
+@REM cmake .. -G "Visual Studio 17 2022" -A x64^
 @REM     -DCMAKE_BUILD_TYPE=Release^
 @REM     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
 @REM     -DCMAKE_INSTALL_PREFIX="%FASTDDS_INSTALL_DIR:\=/%"^
@@ -117,7 +117,7 @@ if not exist "%FASTDDS_BUILD_DIR%" (
 cd "%FASTDDS_BUILD_DIR%"
 echo %FILE_N% Generating build...
 
-cmake .. -G "Visual Studio 16 2019" -A x64^
+cmake .. -G "Visual Studio 17 2022" -A x64^
     -DCMAKE_BUILD_TYPE=Release^
     -DCMAKE_CXX_FLAGS_RELEASE="/MD /MP"^
     -DCMAKE_INSTALL_PREFIX="%FASTDDS_INSTALL_DIR:\=/%"^
@@ -169,8 +169,8 @@ rem ============================================================================
 
 :error_install
     echo.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] An error ocurred while installing using Visual Studio 16 2019 Win64.
-    echo %FILE_N% [Visual Studio 16 2019 Win64 ERROR] Possible causes:
+    echo %FILE_N% [Visual Studio 17 2022 Win64 ERROR] An error ocurred while installing using Visual Studio 17 2022 Win64.
+    echo %FILE_N% [Visual Studio 17 2022 Win64 ERROR] Possible causes:
     echo %FILE_N%                - Make sure you have Visual Studio installed.
     echo %FILE_N%                - Make sure you have the "x64 Visual C++ Toolset" in your path.
     echo %FILE_N%                  For example using the "Visual Studio x64 Native Tools Command Prompt",

--- a/Util/InstallersWin/install_gtest.bat
+++ b/Util/InstallersWin/install_gtest.bat
@@ -35,7 +35,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0

--- a/Util/InstallersWin/install_proj.bat
+++ b/Util/InstallersWin/install_proj.bat
@@ -35,7 +35,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0

--- a/Util/InstallersWin/install_recast.bat
+++ b/Util/InstallersWin/install_recast.bat
@@ -34,7 +34,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -34,7 +34,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0

--- a/Util/InstallersWin/install_xercesc.bat
+++ b/Util/InstallersWin/install_xercesc.bat
@@ -35,7 +35,7 @@ if not "%1"=="" (
     goto :arg-parse
 )
 
-if %GENERATOR% == "" set GENERATOR="Visual Studio 16 2019"
+if %GENERATOR% == "" set GENERATOR="Visual Studio 17 2022"
 
 rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [X] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [X] All tests passing with `make check` (only Linux)
  - [X] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

This PR aims to upgrade default VS used in windows to compile Windows version for ue4-dev

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows11
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Documentation is not updated properly
You will need to do a clean setup of the project to be able to compile properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8815)
<!-- Reviewable:end -->
