### PR TITLE
Fix DVS camera in ue5-dev branch

### DIFF
--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -1131,6 +1131,7 @@ class CameraManager(object):
             ['sensor.camera.instance_segmentation', cc.Raw, 'Camera Instance Segmentation (Raw)', {}],
             ['sensor.lidar.ray_cast', None, 'Lidar (Ray-Cast)', {'range': '50'}],
             ['sensor.lidar.ray_cast_semantic', None, 'Semantic Lidar (Ray-Cast)', {'range': '50'}],
+            ['sensor.camera.dvs', cc.Raw, 'Dynamic Vision Sensor', {}],
             ['sensor.camera.rgb', cc.Raw, 'Camera RGB Distorted',
                 {'lens_circle_multiplier': '3.0',
                 'lens_circle_falloff': '3.0',
@@ -1230,6 +1231,15 @@ class CameraManager(object):
                 lidar_tag = image[i].object_tag
                 lidar_img[tuple(point.T)] = OBJECT_TO_COLOR[int(lidar_tag)]
             self.surface = pygame.surfarray.make_surface(lidar_img)
+        elif self.sensors[self.index][0].startswith('sensor.camera.dvs'):
+            # Example of converting the raw_data from a carla.DVSEventArray
+            # sensor into a NumPy array and using it as an image
+            dvs_events = np.frombuffer(image.raw_data, dtype=np.dtype([
+                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', bool)]))
+            dvs_img = np.zeros((image.height, image.width, 3), dtype=np.uint8)
+            # Blue is positive, red is negative
+            dvs_img[dvs_events[:]['y'], dvs_events[:]['x'], dvs_events[:]['pol'] * 2] = 255
+            self.surface = pygame.surfarray.make_surface(dvs_img.swapaxes(0, 1))
         elif self.sensors[self.index][0].startswith('sensor.camera.optical_flow'):
             image = image.get_color_coded_flow()
             array = np.frombuffer(image.raw_data, dtype=np.dtype("uint8"))

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
@@ -134,7 +134,7 @@ void ADVSCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTim
   TRACE_CPUPROFILER_EVENT_SCOPE(ADVSCamera::PostPhysTick);
   Super::PostPhysTick(World, TickType, DeltaTime);
   check(CaptureRenderTarget != nullptr);
-  if (!HasActorBegunPlay() || IsValid(this))
+  if (!HasActorBegunPlay() || !IsValid(this))
   {
     return;
   }


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #8724  <!-- If fixes an issue, please add here the issue number. -->

Fixed a logic error in the DVS Camera and added a corresponding test in `examples/manual_control.py` to verify the fix.

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.12.7
  * **Unreal Engine version(s):** 5.5.4

#### Possible Drawbacks

Currently, this version triggers an assertion error in `D3D12RenderTarget.cpp` (belong to UE5):

```c++
check( ConvertTypelessToUnorm((DXGI_FORMAT)FormatInfo.PlatformFormat) == ConvertTypelessToUnorm(DXGIFormat) );
```

This is caused by one side using srgb while the other does not. However, for the DVS Camera, this error is non-critical and can be safely ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8823)
<!-- Reviewable:end -->
