### PR TITLE
Add CARLA_UNREAL_LOG_WINDOW.

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -202,10 +202,21 @@ if (BUILD_CARLA_UNREAL)
   endif ()
 endif ()
 
+carla_option (
+  CARLA_UNREAL_LOG_WINDOW
+  "Whether to open a terminal window along the Unreal editor."
+  ON
+)
+
+set (CARLA_LAUNCH_ARGS_DEFAULT)
+if (CARLA_UNREAL_LOG_WINDOW)
+  list (APPEND CARLA_LAUNCH_ARGS_DEFAULT -log)
+endif ()
+
 carla_string_option (
   CARLA_LAUNCH_ARGS
   "CMake-style semicolon-separated list of arguments to pass when launching the Unreal Editor with CARLA."
-  ""
+  "${CARLA_LAUNCH_ARGS_DEFAULT}"
 )
 
 carla_string_option (


### PR DESCRIPTION
This PR adds the CMake option CARLA_UNREAL_LOG_WINDOW (ON by default). This makes UE show a separate terminal window with the output log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8828)
<!-- Reviewable:end -->
