### PR TITLE
Commented "get_actor_bounding_box" out due to a bug

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1348,18 +1348,19 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
   BIND_SYNC(get_actor_bounding_box) << [this](
       cr::ActorId ActorId) -> R<cr::BoundingBox>
   {
-    REQUIRE_CARLA_EPISODE();
-    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
-    if (!CarlaActor)
-    {
-      return RespondError(
-          "get_actor_bounding_box",
-          ECarlaServerResponse::ActorNotFound,
-          " Actor Id: " + FString::FromInt(ActorId));
-    }
-    FBoundingBox bounding_box = UBoundingBoxCalculator::GetActorBoundingBox(CarlaActor->GetActor(), 0);
-    bounding_box.ActorId = CarlaActor->GetActorId();
-    return cr::BoundingBox(bounding_box);
+    return cr::BoundingBox();
+    // REQUIRE_CARLA_EPISODE();
+    // FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    // if (!CarlaActor)
+    // {
+    //   return RespondError(
+    //       "get_actor_bounding_box",
+    //       ECarlaServerResponse::ActorNotFound,
+    //       " Actor Id: " + FString::FromInt(ActorId));
+    // }
+    // FBoundingBox bounding_box = UBoundingBoxCalculator::GetActorBoundingBox(CarlaActor->GetActor(), 0);
+    // bounding_box.ActorId = CarlaActor->GetActorId();
+    // return cr::BoundingBox(bounding_box);
   };
 
   BIND_SYNC(get_actor_component_world_transform) << [this](

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1349,6 +1349,8 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       cr::ActorId ActorId) -> R<cr::BoundingBox>
   {
     return cr::BoundingBox();
+    // Commenting it out due to an unknown bug where sometimes the server tryes to act on a destroyed actor, crashing the simulation.
+
     // REQUIRE_CARLA_EPISODE();
     // FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
     // if (!CarlaActor)


### PR DESCRIPTION
### Description

The server call "get_actor_bounding_box" seems to be bugged sometimes the server to try to act on a destroyed actor, crashing the simulation. This PR comments it out to temporarily avoid it but a fix is required

### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8832)
<!-- Reviewable:end -->
