### PR TITLE
 Added actor description as Actor TAGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## LATEST Changes
+
+* Added actor description as Actor TAGs
+
+
 ## CARLA 0.10.0
 
 * Unreal Engine migration from version 4.26 to version 5.5
@@ -51,4 +56,6 @@
 * RSS functionality removed from docs
 * Removed Light Manager from API and docs
 * Added Mine01 off-road mining map from Synkrotron
+
+
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorRegistry.cpp
@@ -105,6 +105,18 @@ FCarlaActor* FActorRegistry::Register(AActor &Actor, FActorDescription Descripti
   }
   Ids.Emplace(&Actor, Id);
 
+// Add the actor description to the Unreal actor as TAGs
+
+  for (const auto& Elem : Description.Variations)
+  {
+      const FString& Key = Elem.Key;
+      const FActorAttribute& Attribute = Elem.Value;
+
+      // Optional: You can use only the value, or a key-value combination as the tag
+      FString TagString = Key + TEXT(":") + Attribute.Value; // or just Attribute.Value
+      Actor.Tags.Add(FName(*TagString));
+  }
+
   TSharedPtr<FCarlaActor> View =
       MakeCarlaActor(Id, Actor, std::move(Description), crp::ActorState::Active);
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the `ue5-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR adds support for assigning custom tags to Unreal actors based on their CARLA description.

The new logic sets the `Tags` array of each actor using the description variations, allowing them to be queried or filtered directly from the Unreal Editor or via gameplay logic.

For instance, ego vehicles will now include the tag role_name:hero

Other roles or attributes can be added similarly using key-value combinations from the description dictionary.

This helps with debugging, editor filtering, and future logic that relies on actor metadata.

Fixes # <!-- Add issue number here if applicable -->

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** 5.3

#### Possible Drawbacks

Setting too many tags or overly complex key-value structures could slightly impact performance if used heavily in gameplay queries. However, for typical use cases in CARLA, the overhead should be minimal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8833)
<!-- Reviewable:end -->
