### PR TITLE
Added ability to clear debug shapes without reloading simulator UE4

### DIFF
--- a/LibCarla/source/carla/client/DebugHelper.cpp
+++ b/LibCarla/source/carla/client/DebugHelper.cpp
@@ -81,5 +81,9 @@ namespace client {
     DrawShape(_episode, string, color, life_time, persistent_lines);
   }
 
+  void DebugHelper::ClearDebugShape() {
+    _episode.Lock()->ClearDebugShape();
+  }
+
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/DebugHelper.h
+++ b/LibCarla/source/carla/client/DebugHelper.h
@@ -63,6 +63,8 @@ namespace client {
         float life_time = -1.0f,
         bool persistent_lines = true);
 
+    void ClearDebugShape();
+
   private:
 
     detail::EpisodeProxy _episode;

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -638,6 +638,10 @@ namespace detail {
     _pimpl->AsyncCall("draw_debug_shape", shape);
   }
 
+  void Client::ClearDebugShape() {
+    _pimpl->AsyncCall("clear_debug_shape");
+  }
+
   void Client::ApplyBatch(std::vector<rpc::Command> commands, bool do_tick_cue) {
     _pimpl->AsyncCall("apply_batch", std::move(commands), do_tick_cue);
   }

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -396,6 +396,8 @@ namespace detail {
 
     void DrawDebugShape(const rpc::DebugShape &shape);
 
+    void ClearDebugShape();
+    
     void ApplyBatch(
         std::vector<rpc::Command> commands,
         bool do_tick_cue);

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -461,6 +461,7 @@ EpisodeProxy Simulator::GetCurrentEpisode() {
     return _client.GetNamesOfAllObjects();
   }
 
+
 } // namespace detail
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -698,6 +698,11 @@ namespace detail {
       _client.DrawDebugShape(shape);
     }
 
+    void ClearDebugShape() {
+      _client.ClearDebugShape();
+    }
+
+
     /// @}
     // =========================================================================
     /// @name Apply commands in batch

--- a/PythonAPI/carla/source/libcarla/World.cpp
+++ b/PythonAPI/carla/source/libcarla/World.cpp
@@ -397,5 +397,6 @@ void export_world() {
          arg("color")=cc::DebugHelper::Color(255u, 0u, 0u),
          arg("life_time")=-1.0f,
          arg("persistent_lines")=true))
+    .def("clear_debug_shape", &cc::DebugHelper::ClearDebugShape)
   ;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2438,6 +2438,17 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     return R<void>::Success();
   };
 
+  // ~~ Clear debug shapes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  BIND_SYNC(clear_debug_shape) << [this]() -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    auto *World = Episode->GetWorld();
+    check(World != nullptr);
+    FDebugShapeDrawer Drawer(*World);
+    Drawer.Clear();
+    return R<void>::Success();
+  };
+
   // ~~ Apply commands in batch ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   using C = cr::Command;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.cpp
@@ -238,3 +238,8 @@ void FDebugShapeDrawer::Draw(const carla::rpc::DebugShape &Shape)
   auto Visitor = FShapeVisitor(World, Shape.color, Shape.life_time, Shape.persistent_lines);
   boost::variant2::visit(Visitor, Shape.primitive);
 }
+
+void FDebugShapeDrawer::Clear()
+{
+  World.PersistentLineBatcher->Flush();
+}

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/DebugShapeDrawer.h
@@ -18,6 +18,8 @@ public:
 
   void Draw(const carla::rpc::DebugShape &Shape);
 
+  void Clear();
+
 private:
 
   UWorld &World;


### PR DESCRIPTION
#### Description

Adds the ability to clear debug shapes without having to reload the simulator. Using World.PersistentLineBatcher->Flush() .
In PythonAPI called by:

```
world = client.get_world()
debug_helper = world.debug
debug_helper.clear_debug_shape()
```


Fixes #1999 
  

#### Where has this been tested?

  * **Platform(s):** Windows 10 x64
  * **Python version(s):** 3.7.0
  * **Unreal Engine version(s):** 4.26.2

#### Possible Drawbacks

If `PersistentLineBatcher` is used elsewhere in the code apart from `FDebugShapeDrawer ` class then flushing it using this method might remove other things apart from debug shapes. 


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8855)
<!-- Reviewable:end -->
