### PR TITLE
Fix the bounding box call

### DIFF
--- a/LibCarla/source/carla/client/Actor.cpp
+++ b/LibCarla/source/carla/client/Actor.cpp
@@ -33,7 +33,13 @@ namespace client {
   }
 
   geom::BoundingBox Actor::GetBoundingBox() const {
-    return GetEpisode().Lock()->GetActorBoundingBox(*this);
+    geom::BoundingBox bounding_box = GetEpisode().Lock()->GetActorBoundingBox(*this); 
+    if (bounding_box.extent.x == 0.0f && bounding_box.extent.y == 0.0f && bounding_box.extent.z == 0.0f) {
+      return bounding_box;
+    }
+    else{
+      return Super::GetBoundingBox();
+    }
   }
 
   geom::Transform Actor::GetComponentWorldTransform(const std::string componentName) const {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1348,9 +1348,6 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
   BIND_SYNC(get_actor_bounding_box) << [this](
       cr::ActorId ActorId) -> R<cr::BoundingBox>
   {
-    //return cr::BoundingBox();
-    // Commenting it out due to an unknown bug where sometimes the server tryes to act on a destroyed actor, crashing the simulation.
-
     REQUIRE_CARLA_EPISODE();
     FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
     if (!CarlaActor)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
This PR aims to get a proper bounding box from the actor. if the actor exist in the server, it uses the one on the server. if not it uses the latest in the client. 

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** Python 3.8.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8882)
<!-- Reviewable:end -->
