### PR TITLE
Fix get_physics_control while physics are not being simulated

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -487,15 +487,13 @@ FVehiclePhysicsControl ACarlaWheeledVehicle::GetVehiclePhysicsControl() const
         PhysicsWheel.LatStiffMaxLoad = PTireData.mLatStiffX;
         PhysicsWheel.LatStiffValue = PTireData.mLatStiffY;
         PhysicsWheel.LongStiffValue = PTireData.mLongitudinalStiffnessPerUnitGravity;
+        PhysicsWheel.TireFriction = Vehicle4W->Wheels[i]->TireConfig->GetFrictionScale();
+        PhysicsWheel.Position = Vehicle4W->Wheels[i]->Location;
       } else {
         if (i < LastPhysicsControl.Wheels.Num()) {
           PhysicsWheel = LastPhysicsControl.Wheels[i];
         }
       }
-
-      PhysicsWheel.TireFriction = Vehicle4W->Wheels[i]->TireConfig->GetFrictionScale();
-      PhysicsWheel.Position = Vehicle4W->Wheels[i]->Location;
-
       Wheels.Add(PhysicsWheel);
     }
 


### PR DESCRIPTION


<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [X] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [X] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Add the wheels into the check of physics being enabled because physics state of wheels are destroyed while deactivating vehicles physics
<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #8884   <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):**4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
As expected while getting physics control while physics are deactivated it will return properly the last physics control for the wheels

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8887)
<!-- Reviewable:end -->
