### PR TITLE
[Hotfix, UE4] CARLA can crash in PIE due to name collision of dyn. created materials

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.h
@@ -34,6 +34,7 @@ protected:
   void InjectTag(UMaterialInterface* MaterialInterface);
   void InjectTagIntoMaterial(UMaterial* Material);
   void InjectTagIntoMaterialInstance(UMaterialInstance* MaterialInstance);
+  FString GetTaggedName(const FString& OriginalName);
 
   // Copies the given expression and all the material graph of its inputs to the target material. Returns the copy of the root expression.
   UMaterialExpression* CopyMaterialExpressions(UMaterial* TargetMaterial, UMaterialExpression* RootExpression);


### PR DESCRIPTION
With the PR https://github.com/carla-simulator/carla/pull/8795, a bug was accidentally introduced into the ue4-dev branch, which can cause crashes of CARLA in PIE.
This bug previously went under the radar, since it only occurs, when spawning certain vehicles (e.g. `vehicle.dodge.charger_police_2020`) during PIE. The bug originates here:

https://github.com/carla-simulator/carla/blob/c426b448199f6c0f195cd589c468aa37e924c215/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/TaggedMaterials.cpp#L299-L300

The problem arises, if the name is already in use in the TaggedMaterialsRegistry, which can happen, when materials in different packages use the exact same name. For `vehicle.dodge.charger_police_2020`, those are `Content/Carla/Static/Car/4Wheeled/DodgeCharger2020/Materials/MI_ChargerCop_Interior` and `Content/Carla/Static/Car/4Wheeled/ParkedVehicles/Charger/MI_ChargerCop_Interior`.

This PR fixes this issue by checking, if a name is already in use. If this is the case, an index is appended as a suffix to the new name.
