### PR TITLE
Fixes to spline generation from geojson

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
@@ -54,7 +54,6 @@ USplineComponent *UGeometryImporter::CreateSpline(UWorld *World, const TArray<FV
         UE_LOG(LogTemp, Log, TEXT("Spline actor not created"));
         return nullptr;
     }
-    // SplineActor->Rename(*SplineName);
 
     USplineComponent *Spline = NewObject<USplineComponent>(SplineActor);
     Spline->ClearSplinePoints();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
@@ -54,9 +54,10 @@ USplineComponent *UGeometryImporter::CreateSpline(UWorld *World, const TArray<FV
         UE_LOG(LogTemp, Log, TEXT("Spline actor not created"));
         return nullptr;
     }
-    SplineActor->Rename(*SplineName);
+    // SplineActor->Rename(*SplineName);
 
     USplineComponent *Spline = NewObject<USplineComponent>(SplineActor);
+    Spline->ClearSplinePoints();
     Spline->RegisterComponent();
     Spline->SetMobility(EComponentMobility::Movable);
     SplineActor->SetRootComponent(Spline);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/GeometryImporter.cpp
@@ -59,7 +59,7 @@ USplineComponent *UGeometryImporter::CreateSpline(UWorld *World, const TArray<FV
     USplineComponent *Spline = NewObject<USplineComponent>(SplineActor);
     Spline->ClearSplinePoints();
     Spline->RegisterComponent();
-    Spline->SetMobility(EComponentMobility::Movable);
+    Spline->SetMobility(EComponentMobility::Static);
     SplineActor->SetRootComponent(Spline);
 
     for (int32 i = 0; i < Points.Num(); ++i)


### PR DESCRIPTION
- Clear spline when spawning to avoid a point at the origin
- Set spline to static
- Remove renaming since leads to crash at runtime