### PR TITLE
Added additional width to roads

### DIFF
--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -235,7 +235,7 @@ namespace road {
     }
 
     float lane_width = static_cast<float>(GetWidth(s)) / 2.0f;
-    if (extra_width != 0.f && road->IsJunction() && GetType() == Lane::LaneType::Driving) {
+    if (extra_width != 0.f && GetType() == Lane::LaneType::Driving) {
       lane_width += extra_width;
     }
 


### PR DESCRIPTION
### Description

Removed the condition to only expand roads at junction when building OpenDrive maps

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA's UE4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/8975)
<!-- Reviewable:end -->
