### PR TITLE
[CI/CD] Add placeholder UE4 workdlows to allow manual dispatch

### DIFF
--- a/.github/workflows/ue4_content.yml
+++ b/.github/workflows/ue4_content.yml
@@ -1,0 +1,23 @@
+name: UE4-Content
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Specify the target branch for the content build"
+        required: true
+        default: "master"
+        type: string
+
+jobs:
+  content:
+    name: Dummy Content
+    runs-on: ubuntu-latest
+    steps:
+      - name: Info Only - Do not use on this branch
+        run: |
+          echo "This is a placeholder workflow on the default branch."
+          echo "It exists solely to make the 'Run workflow' button visible in the GitHub Actions page."
+          echo "The actual workflow should run on ue4-dev."
+          echo "Exiting intentionally."
+          exit 1

--- a/.github/workflows/ue4_dev.yml
+++ b/.github/workflows/ue4_dev.yml
@@ -1,0 +1,33 @@
+name: UE4-Dev
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: push-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu-dev:
+    name: Ubuntu Dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Info Only - Do not use on this branch
+        run: |
+          echo "This is a placeholder workflow on the default branch."
+          echo "It exists solely to make the 'Run workflow' button visible in the GitHub Actions page."
+          echo "The actual workflow should run on ue4-dev."
+          echo "Exiting intentionally."
+          exit 1
+
+  windows-dev:
+    name: Windows Dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Info Only - Do not use on this branch
+        run: |
+          echo "This is a placeholder workflow on the default branch."
+          echo "It exists solely to make the 'Run workflow' button visible in the GitHub Actions page."
+          echo "The actual workflow should run on ue4-dev."
+          echo "Exiting intentionally."
+          exit 1


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR adds dummy workflows to the default branch (`ue5-dev`) for the UE4 workflows. GitHub Actions only allows manually dispatched workflows to be triggered via the Web UI if they reside in the default branch. Since the actual workflows live in the `ue4-dev` branch, they are not directly accessible for manual dispatch. To work around this, a placeholder workflow has been added in the default branch. **Make sure to update the ref input to target the correct branch (i.e., `ue4-dev`) before triggering the workflow.**

<!-- Please explain the changes you made here as detailed as possible. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.10,3.11,3.12
  * **Unreal Engine version(s):** CARLA fork

#### Possible Drawbacks

We have to manually set the ref branch to `ue4-dev` before running the workflows. If this is not done, the workflow will run on the default `ue5-dev` branch, and a message will be shown indicating that the branch is incorrect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9003)
<!-- Reviewable:end -->
