### PR TITLE
Updated NuRec image path to public location

### DIFF
--- a/Docs/nvidia-nurec.md
+++ b/Docs/nvidia-nurec.md
@@ -53,7 +53,7 @@ If you'd rather customize the datasets you use, follow the instructions below to
 
     * `NUREC_IMAGE` is required and must be set to the full path of the NuRec image in the CARLA repository. Run the following command to set it:
         ```bash
-        export NUREC_IMAGE="nvcr.io/nvidia/nre/nurec-grpc:0.1.0"
+        export NUREC_IMAGE="docker.io/carlasimulator/nvidia-nurec-grpc:0.1.0"
         ```
     * [`CUDA_VISIBLE_DEVICES`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars) is optional and you can use it to designate the GPU that runs the replays. If you don't set it to a specific GPU, the script defaults to "0" and runs on GPU 0. If you've already set this environment variable, the script inherits whatever has previously been set.
 

--- a/PythonAPI/examples/nvidia/install_nurec.sh
+++ b/PythonAPI/examples/nvidia/install_nurec.sh
@@ -135,11 +135,11 @@ done
 
 # Download NuRec GRPC Container
 echo "Checking NuRec GRPC container..."
-if check_NuRec_container "nvcr.io/nvidia/nre/nurec-grpc:0.1.0"; then
+if check_NuRec_container "docker.io/carlasimulator/nvidia-nurec-grpc:0.1.0"; then
     echo "NuRec GRPC container already exists, skipping download."
 else
     echo "Initiating NuRec GRPC Container Downloads..."
-    docker pull nvcr.io/nvidia/nre/nurec-grpc:0.1.0
+    docker pull docker.io/carlasimulator/nvidia-nurec-grpc:0.1.0
     if [ $? -ne 0 ]; then
         echo "Error: Failed to download NuRec GRPC Container"
         exit 1
@@ -183,7 +183,7 @@ else
 fi
 
 # Set the NuRec image path
-NUREC_IMAGE="nvcr.io/nvidia/nre/nurec-grpc:0.1.0"
+NUREC_IMAGE="docker.io/carlasimulator/nvidia-nurec-grpc:0.1.0"
 export NUREC_IMAGE
 echo "NUREC_IMAGE: $NUREC_IMAGE"
 


### PR DESCRIPTION
#### Description

There was an issue with the image name in the install script and documentation in my previous PR #9043 . This fixes the issue by pointing to a public registry instead of a private one.

#### Where has this been tested?

  * **Platform(s):**  x86 workstations with 32GB Ram and NVIDIA GeForce RTX 4090
  * **Python version(s):** 3.10.18
  * **Unreal Engine version(s):** UE4

#### Possible Drawbacks

The edits only encompass the install script and docs. As a result drawbacks are limited.
