### PR TITLE
Add support for Plutovg in BuildOSMRenderer and CMakeLists

### DIFF
--- a/Util/BuildTools/BuildOSMRenderer.sh
+++ b/Util/BuildTools/BuildOSMRenderer.sh
@@ -12,6 +12,9 @@ LIBOSMSCOUT_COMMIT=e83e4881a4adc69c5a4bcc05de5e1f23ebf06238
 LUNASVG_SOURCE_FOLDER=${CARLA_BUILD_FOLDER}/lunasvg-source
 LUNASVG_BUILD_FOLDER=${CARLA_BUILD_FOLDER}/lunasvg-build
 
+PLUTOVG_SOURCE_FOLDER=${CARLA_BUILD_FOLDER}/plutovg-source
+PLUTOVG_BUILD_FOLDER=${CARLA_BUILD_FOLDER}/plutovg-build
+
 OSM_RENDERER_SOURCE=${CARLA_ROOT_FOLDER}/osm-world-renderer
 OSM_RENDERER_BUILD=${CARLA_BUILD_FOLDER}/osm-world-renderer-build
 
@@ -59,6 +62,22 @@ cmake ${LUNASVG_SOURCE_FOLDER} \
 make
 make install
 
+# ==============================================================================
+# -- Download and build plutovg ------------------------------------------------
+# ==============================================================================
+echo "Cloning plutovg"
+if [ ! -d ${PLUTOVG_SOURCE_FOLDER} ] ; then
+  git clone ${PLUTOVG_REPO} ${PLUTOVG_SOURCE_FOLDER}
+fi
+
+mkdir -p ${PLUTOVG_BUILD_FOLDER}
+cd ${PLUTOVG_BUILD_FOLDER}
+
+cmake ${PLUTOVG_SOURCE_FOLDER} \
+    -DCMAKE_INSTALL_PREFIX=${INSTALLATION_PATH}
+
+make
+make install
 
 # ==============================================================================
 # -- Build osm-map-renderer tool -----------------------------------------------

--- a/osm-world-renderer/CMakeLists.txt
+++ b/osm-world-renderer/CMakeLists.txt
@@ -4,6 +4,7 @@ project(OsmMapRenderer)
 # Libosmscout and Luna SVG Library
 include_directories(ThirdParties/include)
 include_directories(ThirdParties/include/lunasvg)
+include_directories(ThirdParties/include/plutovg)
 link_directories(ThirdParties/lib)
 
 add_definitions(-D_USE_MATH_DEFINES)
@@ -20,3 +21,4 @@ target_link_libraries(osm-world-renderer osmscout)
 target_link_libraries(osm-world-renderer osmscout_map)
 target_link_libraries(osm-world-renderer osmscout_map_svg)
 target_link_libraries(osm-world-renderer lunasvg)
+target_link_libraries(osm-world-renderer plutovg)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Plutovg is a vector graphics backend required by LunaSVG, which is used in your osm-world-renderer. Without properly linking it: The build failed at compile or link time.


<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s): Ubuntu 22.04.5 LTS 
  * **Python version(s):** ...
  * **Unreal Engine version(s): UE4

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
