### PR TITLE
Fix SUMO Co-simulation warning deprecated call to lxml

### DIFF
--- a/Co-Simulation/Sumo/sumo_integration/sumo_simulation.py
+++ b/Co-Simulation/Sumo/sumo_integration/sumo_simulation.py
@@ -294,7 +294,7 @@ def _get_sumo_net(cfg_file):
     cfg_file = os.path.join(os.getcwd(), cfg_file)
 
     tree = ET.parse(cfg_file)
-    tag = tree.find('//net-file')
+    tag = tree.find('.//net-file')
     if tag is None:
         return None
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
This PR avoids the SUMO Co-simulation warning and updated the deprecated call to the lxml library.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA fork

#### Possible Drawbacks

None

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9106)
<!-- Reviewable:end -->
