### PR TITLE
Added Python 3.12 build instructions, fixed -fno-strict-overflow issue

### DIFF
--- a/Docs/build_linux.md
+++ b/Docs/build_linux.md
@@ -221,6 +221,18 @@ sudo apt install python3.X python3.X-dev python3.X-distutils
 # Delete versions as required
 make PythonAPI ARGS="--python-version=3.8, 3.9, 3.10, 3.11"
 
+* **For Python 3.12**, the *distutils* library does not exist for Ubuntu and therefore *setuptools* may
+ need to be updated, run the following commands to update *setuptools*:
+
+```sh
+sudo apt install python3.12 python3.12-dev python3.12-venv
+python3.12 -m ensurepip --upgrade
+python3.12 -m pip install --upgrade pip setuptools
+
+# Then run make from the CARLA root directory
+make PythonAPI ARGS="--python-version=3.12"
+```
+
 * If you are using a non-standard Python installation or a Python virtual environment manager like PyEnv, Rye or Conda. Instead of the `--python-version` argument it may be better to use the `--python-root` argument (you can locate the installation using `which python3`):
 
 ```sh

--- a/PythonAPI/carla/setup.py
+++ b/PythonAPI/carla/setup.py
@@ -62,6 +62,7 @@ def get_libcarla_extensions():
                 '-Wpessimizing-move', '-Wold-style-cast', '-Wnull-dereference',
                 '-Wduplicate-enum', '-Wnon-virtual-dtor', '-Wheader-hygiene',
                 '-Wconversion', '-Wfloat-overflow-conversion',
+                '-Wno-error=unused-command-line-argument',
                 '-DBOOST_ERROR_CODE_HEADER_ONLY', '-DLIBCARLA_WITH_PYTHON_SUPPORT',
                 '-stdlib=libstdc++'
             ]


### PR DESCRIPTION
* Added build instructions to docs to fix setuptools issues with building Python 3.12 wheels.

* Added new build flag to setup.py to fix `-fno-strict-overflow` error

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9117)
<!-- Reviewable:end -->
