### PR TITLE
FIX ROS2 transformation calculation

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
@@ -30,13 +30,16 @@ geometry_msgs::msg::Transform CarlaTransformPublisher::ComputeTransform(std::str
     }
   }
 
+  // Better readability
   const float tx = transform.location.x;
-  const float ty = transform.location.y;
+  const float ty = transform.location.y * -1.0f;
   const float tz = transform.location.z;
 
-  const float rx = (transform.rotation.pitch * -1.0f) * (float(M_PI_2) / 180.0f);
-  const float ry = (transform.rotation.yaw * -1.0f) * (float(M_PI_2) / 180.0f);
-  const float rz = transform.rotation.roll * (float(M_PI_2) / 180.0f);
+  // Rotations was not correctly computed Radians = Degrees * (π / 180)
+  const float DEG_TO_RAD = float(M_PI) / 180.0f;
+  const float rx = (transform.rotation.pitch * -1.0f) * DEG_TO_RAD;
+  const float ry = (transform.rotation.yaw * -1.0f) * DEG_TO_RAD;
+  const float rz = transform.rotation.roll * DEG_TO_RAD;
 
   const float cr = cosf(rz * 0.5f);
   const float sr = sinf(rz * 0.5f);
@@ -48,7 +51,7 @@ geometry_msgs::msg::Transform CarlaTransformPublisher::ComputeTransform(std::str
   geometry_msgs::msg::Transform tf;
 
   tf.translation().x(tx);
-  tf.translation().y(-ty);
+  tf.translation().y(ty);
   tf.translation().z(tz);
 
   tf.rotation().w(cr * cp * cy + sr * sp * sy);


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

I found an error in the calculation of ROS2 transformations from CARLA data and corrected it. I would be happy to help, if you allow me! It would fill me with great pride!

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

No drawbacks, just correct ROS2 transformation frames!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9123)
<!-- Reviewable:end -->
