### PR TITLE
Chrono: Update Generic Sedan COM

### DIFF
--- a/Co-Simulation/Chrono/Vehicles/sedan/chassis/Sedan_Chassis.json
+++ b/Co-Simulation/Chrono/Vehicles/sedan/chassis/Sedan_Chassis.json
@@ -7,7 +7,7 @@
   [
    {
      "Centroidal Frame":    {
-                              "Location":    [0, 0, 0.7],
+                              "Location":    [0, 0, 0.52],
                               "Orientation": [1, 0, 0, 0]
                             },
      "Mass":                1250,


### PR DESCRIPTION
Updated generic sedan COM to 0.52 meters for more realistic sedan dynamics

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9126)
<!-- Reviewable:end -->
