### PR TITLE
Automatically check if numpy is supported.

### DIFF
--- a/PythonAPI/CMakeLists.txt
+++ b/PythonAPI/CMakeLists.txt
@@ -8,6 +8,26 @@ find_package (
   REQUIRED
 )
 
+# -- Temporary check for numpy 2 presence, which breaks our current version of Boost.Python.
+execute_process (
+  COMMAND
+    ${Python3_EXECUTABLE}
+      -c
+      "import numpy; print(numpy.__version__)"
+  OUTPUT_VARIABLE
+    NUMPY_VERSION_STRING
+  RESULT_VARIABLE
+    NUMPY_VERSION_QUERY_RESULT
+)
+if (NUMPY_VERSION_QUERY_RESULT)
+  carla_error ("Failed to query numpy version.")
+endif ()
+carla_message ("Found Numpy ${NUMPY_VERSION_STRING}.")
+if ("${NUMPY_VERSION_STRING}" VERSION_GREATER "2.0.0")
+  carla_error ("Unsupported Numpy version, please downgrade to a version prior to numpy 2.")
+endif ()
+# --
+
 set (
   PYTHON_API_DEPENDENCIES
   carla-client


### PR DESCRIPTION
This PR adds an automatic check for the version of numpy. numpy >= 2 is currently unsupported and will break the build.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9164)
<!-- Reviewable:end -->
