### PR TITLE
Allow rotation (pitch) of all vehicle wheels via API

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1984,6 +1984,58 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     return Angle;
   };
 
+  BIND_SYNC(set_wheel_pitch_angle) << [this](
+    cr::ActorId ActorId,
+    cr::VehicleWheelLocation WheelLocation,
+    float AngleInDeg) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if(!CarlaActor){
+      return RespondError(
+          "set_wheel_pitch_angle",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    ECarlaServerResponse Response =
+        CarlaActor->SetWheelPitchAngle(
+            static_cast<EVehicleWheelLocation>(WheelLocation), AngleInDeg);
+    if (Response != ECarlaServerResponse::Success)
+    {
+      return RespondError(
+          "set_wheel_pitch_angle",
+          Response,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    return R<void>::Success();
+  };
+
+  BIND_SYNC(get_wheel_pitch_angle) << [this](
+      const cr::ActorId ActorId,
+      cr::VehicleWheelLocation WheelLocation) -> R<float>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if(!CarlaActor){
+      return RespondError(
+          "get_wheel_pitch_angle",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    float Angle;
+    ECarlaServerResponse Response =
+        CarlaActor->GetWheelPitchAngle(
+            static_cast<EVehicleWheelLocation>(WheelLocation), Angle);
+    if (Response != ECarlaServerResponse::Success)
+    {
+      return RespondError(
+          "get_wheel_pitch_angle",
+          Response,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    return Angle;
+  };
+
   BIND_SYNC(set_actor_simulate_physics) << [this](
       cr::ActorId ActorId,
       bool bEnabled) -> R<void>


### PR DESCRIPTION
#### Description

@Blyron this is heavily connected to my PR from yesterday (https://github.com/carla-simulator/carla/pull/9217).

I made a mistake yesterday and pushed all of my changed files except the handling of the two new rpc calls within CarlaServer.cpp. This PR will make the API calls `set_wheel_pitch_angle()` and `get_wheel_pitch_angle()` actually work.

Everything was tested and used already for more than a year already in a co-simulation with esmini. I just noticed that the changes were not part of my PR.

#### Where has this been tested?

  * **Platform(s):** Windows 10/11, Ubuntu 20.04, Ubuntu 22.04
  * **Python version(s):** Python 3.10, Python 3.8
  * **Unreal Engine version(s):** Unreal Engine 4.26, 4.27

#### Possible Drawbacks

Setter only works with disabled physics. However, existing calls `carla::client::Vehicle:.SetWheelSteerDirection` and `carla::client::Vehicle:.GetWheelSteerAngle` already exist and have the same drawback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9218)
<!-- Reviewable:end -->
