### PR TITLE
Fix sim ready traffic light export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Latest Changes
+ * Fix SimReady USD export for left-handed traffic support
  * Added NVIDIA Cosmos Transfer1 integration
  * Added NVIDIA Neural Reconstruction Engine (NuRec) integration
  * Added the SimReady OpenUSD and MDL Converters to provide export and import support for SimReady OpenUSD stages and MDL materials.

--- a/Unreal/CarlaUE4/Plugins/Converters/SimReady/Source/SimReadyCarlaWrapper/Private/SimReadyCarlaWrapper.cpp
+++ b/Unreal/CarlaUE4/Plugins/Converters/SimReady/Source/SimReadyCarlaWrapper/Private/SimReadyCarlaWrapper.cpp
@@ -15,6 +15,8 @@
 
 #include <disable-ue4-macros.h>
 #include <carla/opendrive/OpenDriveParser.h>
+#include <carla/road/Map.h>
+#include <carla/road/Road.h>
 #include <carla/road/SignalType.h>
 #include <carla/rpc/String.h>
 #include <enable-ue4-macros.h>
@@ -279,15 +281,22 @@ namespace SimReadyCarlaWrapper
             return;
         }
 
-        TSubclassOf<AActor> TrafficLightModel;
+        TSubclassOf<AActor> TrafficLightLHTModel;
+        TSubclassOf<AActor> TrafficLightRHTModel;
         TMap<FString, TSubclassOf<USignComponent>> SignComponentModels;
         TMap<FString, TSubclassOf<AActor>> TrafficSignsModels;
         TMap<FString, TSubclassOf<AActor>> SpeedLimitModels;
 
-        UClass* TrafficLightClass = LoadClass<AActor>(nullptr, TEXT("/Game/Carla/Blueprints/TrafficLight/BP_TLOpenDrive.BP_TLOpenDrive_C"));
-        if (TrafficLightClass)
+        UClass* TrafficLightLHTClass = LoadClass<AActor>(nullptr, TEXT("/Game/Carla/Blueprints/TrafficLight/BP_TLOpenDrive_LHT.BP_TLOpenDrive_LHT_C"));
+        if (TrafficLightLHTClass)
         {
-            TrafficLightModel = TrafficLightClass;
+            TrafficLightLHTModel = TrafficLightLHTClass;
+        }
+
+        UClass* TrafficLightRHTClass = LoadClass<AActor>(nullptr, TEXT("/Game/Carla/Blueprints/TrafficLight/BP_TLOpenDrive_RHT.BP_TLOpenDrive_RHT_C"));
+        if (TrafficLightRHTClass)
+        {
+            TrafficLightRHTModel = TrafficLightRHTClass;
         }
         // Default traffic signs models
         UClass* StopClass = LoadClass<AActor>(nullptr, TEXT("/Game/Carla/Static/TrafficSign/BP_Stop.BP_Stop_C"));
@@ -465,6 +474,19 @@ namespace SimReadyCarlaWrapper
             const auto& Signal = Signals.at(SignalId);
             auto CarlaTransform = Signal->GetTransform();
             FTransform SpawnTransform(CarlaTransform);
+            
+            // Determine right hand or left hand traffic light
+            TSubclassOf<AActor> TrafficLightModel = TrafficLightRHTModel;
+            const auto& Roads = XodrMap->GetRoads();
+            auto RoadIt = Roads.find(Signal->GetRoadId());
+            if (RoadIt != Roads.end())
+            {
+                const auto& Road = RoadIt->second;
+                if (!Road.IsRHT())
+                {
+                    TrafficLightModel = TrafficLightLHTModel;
+                }
+            }
 
             FVector SpawnLocation = SpawnTransform.GetLocation();
             FRotator SpawnRotation(SpawnTransform.GetRotation());


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This fixes the SimReady USD export to support the left and right hand traffic light blueprints.

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9224)
<!-- Reviewable:end -->
