### PR TITLE
Fixing crash when Lane.GetLaneCorners and the requested lane s is big…

### DIFF
--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -204,7 +204,7 @@ namespace road {
   }
 
   std::pair<geom::Vector3D, geom::Vector3D> Lane::GetCornerPositions(
-      const double s, const float extra_width) const {
+      const double parameter_s, const float extra_width) const {
     const Road *road = GetRoad();
     DEBUG_ASSERT(road != nullptr);
 
@@ -217,6 +217,7 @@ namespace road {
     RELEASE_ASSERT(GetId() >= lanes.begin()->first);
     RELEASE_ASSERT(GetId() <= lanes.rbegin()->first);
 
+    const double s = geom::Math::Clamp(parameter_s, 0.0, road->GetLength());
     float lane_t_offset = 0.0f;
 
     if (GetId() < 0) {


### PR DESCRIPTION

Fixing crash when Lane.GetLaneCorners and the requested lane s is bigger than lane distance. 
Sanity check with a clamp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9237)
<!-- Reviewable:end -->
