### PR TITLE
Fixed Traffic Signals being spawned in the air

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -572,6 +572,8 @@ void ATrafficLightManager::SpawnTrafficLights()
     SpawnRotation.Roll = 0;
     SpawnRotation.Pitch = 0;
 
+    AdjustSignHeightToGround(SpawnLocation);
+
     FActorSpawnParameters SpawnParams;
     SpawnParams.Owner = this;
     SpawnParams.SpawnCollisionHandlingOverride =
@@ -667,6 +669,8 @@ void ATrafficLightManager::SpawnSignals()
       SpawnRotation.Roll = 0;
       SpawnRotation.Pitch = 0;
 
+      AdjustSignHeightToGround(SpawnLocation);
+
       FActorSpawnParameters SpawnParams;
       SpawnParams.Owner = this;
       SpawnParams.SpawnCollisionHandlingOverride =
@@ -723,6 +727,8 @@ void ATrafficLightManager::SpawnSignals()
       // Remove road inclination
       SpawnRotation.Roll = 0;
       SpawnRotation.Pitch = 0;
+
+      AdjustSignHeightToGround(SpawnLocation);
 
       FActorSpawnParameters SpawnParams;
       SpawnParams.Owner = this;
@@ -861,5 +867,31 @@ void ATrafficLightManager::RemoveAttachedProps(TArray<AActor*> Actors) const
     Actor->GetAttachedActors(AttachedActors, true);
     RemoveAttachedProps(AttachedActors);
     Actor->Destroy();
+  }
+}
+
+void ATrafficLightManager::AdjustSignHeightToGround(FVector& SpawnLocation) const
+{
+  const FVector Start = SpawnLocation + FVector(0, 0, 10000.0f);
+  const FVector End = SpawnLocation - FVector(0, 0, 10000.0f);
+
+  FHitResult HitResult;
+  FCollisionQueryParams CollisionParams;
+  CollisionParams.bTraceComplex = true;
+  CollisionParams.bReturnPhysicalMaterial = false;
+
+  if (GetWorld()->LineTraceSingleByChannel(
+      HitResult,
+      Start,
+      End,
+      ECC_WorldStatic,
+      CollisionParams))
+  {
+    SpawnLocation.Z = HitResult.Location.Z + 5.0f;
+  }
+  else
+  {
+    carla::log_warning("Could not find ground for traffic sign placement at location",
+        TCHAR_TO_UTF8(*SpawnLocation.ToString()));
   }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -880,6 +880,7 @@ void ATrafficLightManager::AdjustSignHeightToGround(FVector& SpawnLocation) cons
   CollisionParams.bTraceComplex = true;
   CollisionParams.bReturnPhysicalMaterial = false;
 
+  constexpr float ZOffsetSignToGround = 0.5f;
   if (GetWorld()->LineTraceSingleByChannel(
       HitResult,
       Start,
@@ -887,7 +888,7 @@ void ATrafficLightManager::AdjustSignHeightToGround(FVector& SpawnLocation) cons
       ECC_WorldStatic,
       CollisionParams))
   {
-    SpawnLocation.Z = HitResult.Location.Z + 5.0f;
+    SpawnLocation.Z = HitResult.Location.Z + ZOffsetSignToGround;
   }
   else
   {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.h
@@ -69,6 +69,8 @@ private:
 
   void RemoveAttachedProps(TArray<AActor*> Actors) const;
 
+  void AdjustSignHeightToGround(FVector& SpawnLocation) const;
+
   // Mapped references to ATrafficLightGroup (junction)
   UPROPERTY()
   TMap<int, ATrafficLightGroup *> TrafficGroups;


### PR DESCRIPTION
Add AdjustSignHeightToGround: use vertical line trace to place signs at correct ground height
Tested in Linux

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9239)
<!-- Reviewable:end -->
