### PR TITLE
[CI/CD] Use Python3.10 as the default Python version

### DIFF
--- a/.github/workflows/_ci-ubuntu.yml
+++ b/.github/workflows/_ci-ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Init conda
         run: |
           conda init bash
-          echo "source activate carla312" >> ~/.bashrc
+          echo "source activate carla310" >> ~/.bashrc
 
           cat <<'EOF' > ~/.bash_profile
           if [ -f ~/.bashrc ]; then
@@ -69,7 +69,7 @@ jobs:
 
       - name: Activate conda environment
         run: |
-          conda activate carla312
+          conda activate carla310
 
       - name: Preset
         run: |

--- a/.github/workflows/ue5_dev.yml
+++ b/.github/workflows/ue5_dev.yml
@@ -20,8 +20,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
     with:
-      python-versions: "3.12"
-      smoke-test-python-versions: "3.12"
+      python-versions: "3.10"
+      smoke-test-python-versions: "3.10"
       additional-maps: false
       upload-package: true
       upload-replace-latest: true

--- a/.github/workflows/ue5_pr.yml
+++ b/.github/workflows/ue5_pr.yml
@@ -15,8 +15,8 @@ jobs:
     name: Ubuntu PR
     uses: ./.github/workflows/_ci-ubuntu.yml
     with:
-      python-versions: "3.12"
-      smoke-test-python-versions: "3.12"
+      python-versions: "3.10"
+      smoke-test-python-versions: "3.10"
       additional-maps: false
       upload-package: false
       upload-replace-latest: false

--- a/Util/Docker/Release.Dockerfile
+++ b/Util/Docker/Release.Dockerfile
@@ -15,10 +15,10 @@ RUN packages='xdg-user-dirs' \
 
 RUN useradd -m carla
 
-COPY --chown=carla:carla . /home/carla
+WORKDIR /workspace
+COPY --chown=carla:carla . .
 
 USER carla
-WORKDIR /home/carla
 
 ENV SDL_VIDEODRIVER="x11"
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR updates the default python version in UE5 workflows from Python3.12 to Python3.10

<!-- Please explain the changes you made here as detailed as possible. -->

#### Where has this been tested?

  * **Platform(s):** -
  * **Python version(s):** -
  * **Unreal Engine version(s):** -

#### Possible Drawbacks
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9252)
<!-- Reviewable:end -->
