### PR TITLE
Update cosmos scripts to have fisheye sensor support.

### DIFF
--- a/LibCarla/source/carla/sensor/SensorRegistry.h
+++ b/LibCarla/source/carla/sensor/SensorRegistry.h
@@ -52,6 +52,7 @@ class ARssSensor;
 class FWorldObserver;
 class ASceneCaptureCamera_WideAngleLens;
 class ADepthCamera_WideAngleLens;
+class ANormalsCamera_WideAngleLens;
 class AInstanceSegmentationCamera_WideAngleLens;
 class ASemanticSegmentationCamera_WideAngleLens;
 struct FCameraGBufferUint8;
@@ -90,6 +91,7 @@ namespace sensor {
     std::pair<FWorldObserver *, s11n::EpisodeStateSerializer>,
     std::pair<ASceneCaptureCamera_WideAngleLens *, s11n::ImageSerializer>,
     std::pair<ADepthCamera_WideAngleLens *, s11n::ImageSerializer>,
+    std::pair<ANormalsCamera_WideAngleLens *, s11n::ImageSerializer>,
     std::pair<AInstanceSegmentationCamera_WideAngleLens *, s11n::ImageSerializer>,
     std::pair<ASemanticSegmentationCamera_WideAngleLens *, s11n::ImageSerializer>,
     std::pair<FCameraGBufferUint8 *, s11n::GBufferUint8Serializer>,
@@ -127,6 +129,7 @@ namespace sensor {
 #include "Carla/Sensor/CosmosControlSensor.h"
 #include "Carla/Sensor/WorldObserver.h"
 #include "Carla/Sensor/DepthCamera_WideAngleLens.h"
+#include "Carla/Sensor/NormalsCamera_WideAngleLens.h"
 #include "Carla/Sensor/SceneCaptureCamera_WideAngleLens.h"
 #include "Carla/Sensor/SemanticSegmentationCamera_WideAngleLens.h"
 #include "Carla/Sensor/InstanceSegmentationCamera_WideAngleLens.h"

--- a/PythonAPI/examples/carla_cosmos_gen.py
+++ b/PythonAPI/examples/carla_cosmos_gen.py
@@ -317,7 +317,7 @@ def main():
         name = entry['sensor']
         sensor_name = f"sensor.camera.{name}"
         attributes = entry.get('attributes', {})
-        if ('camera_model' in attributes and name != 'normals') or 'wide_angle_lens' in entry:
+        if ('camera_model' in attributes and name != 'normals') or entry.get('wide_angle_lens', False):
             sensor_name += '.wide_angle_lens'
         bp = world.get_blueprint_library().find(sensor_name)
         for k,v in attributes.items(): bp.set_attribute(k,str(v))

--- a/PythonAPI/examples/carla_cosmos_gen.py
+++ b/PythonAPI/examples/carla_cosmos_gen.py
@@ -163,6 +163,7 @@ class SensorInfo:
     def _callback(self, data):
         conv_map = {
             AOV.RGB: carla.ColorConverter.Raw,
+            AOV.NORMALS: carla.ColorConverter.Raw,
             AOV.SEMANTIC_SEGMENTATION: carla.ColorConverter.CityScapesPalette,
             AOV.COSMOS_VISUALIZATION: carla.ColorConverter.Raw
         }
@@ -192,6 +193,8 @@ def post_processing_worker(raw_q: mp.Queue, proc_q: mp.Queue):
         frames = bundle.frames
         if AOV.RGB in frames:
             processed['RGB'] = frames[AOV.RGB]
+        if AOV.NORMALS in frames:
+            processed['NORMALS'] = frames[AOV.NORMALS]
         if AOV.RGB in frames and AOV.SEMANTIC_SEGMENTATION in frames:
             masked, edges = masked_edges_from_semseg(
                 frames[AOV.RGB], frames[AOV.SEMANTIC_SEGMENTATION], CLASSES_TO_KEEP_CANNY
@@ -317,7 +320,7 @@ def main():
         name = entry['sensor']
         sensor_name = f"sensor.camera.{name}"
         attributes = entry.get('attributes', {})
-        if ('camera_model' in attributes and name != 'normals') or entry.get('wide_angle_lens', False):
+        if entry.get('wide_angle_lens', False):
             sensor_name += '.wide_angle_lens'
         bp = world.get_blueprint_library().find(sensor_name)
         for k,v in attributes.items(): bp.set_attribute(k,str(v))

--- a/PythonAPI/examples/carla_cosmos_gen.py
+++ b/PythonAPI/examples/carla_cosmos_gen.py
@@ -311,8 +311,13 @@ def main():
     vehicle = world.get_actor(args.camera)
     sensor_infos = []
     for entry in sensor_cfg:
-        bp = world.get_blueprint_library().find(f"sensor.camera.{entry['sensor']}")
-        for k,v in entry.get('attributes',{}).items(): bp.set_attribute(k,str(v))
+        name = entry['sensor']
+        sensor_name = f"sensor.camera.{name}"
+        attributes = entry.get('attributes', {})
+        if ('camera_model' in attributes and name != 'normals') or 'wide_angle_lens' in entry:
+            sensor_name += '.wide_angle_lens'
+        bp = world.get_blueprint_library().find(sensor_name)
+        for k,v in attributes.items(): bp.set_attribute(k,str(v))
         tf = entry.get('transform',{})
         transform = carla.Transform(
             carla.Location(**tf.get('location',{})),

--- a/PythonAPI/examples/carla_cosmos_gen.py
+++ b/PythonAPI/examples/carla_cosmos_gen.py
@@ -52,6 +52,7 @@ CLASSES_TO_KEEP_SHADED_SEG: List[Sequence[int]] = []
 CLASSES_TO_KEEP_CANNY: List[Sequence[int]] = []
 
 def load_class_filter_config(path: str):
+    path = Path(path).resolve()
     with open(path, 'r') as f:
         config = yaml.safe_load(f)
     global CLASSES_TO_KEEP_SHADED_SEG, CLASSES_TO_KEEP_CANNY
@@ -286,7 +287,8 @@ def main():
     client.set_timeout(60.0)
     client.reload_world()
     
-    info = client.show_recorder_file_info(args.recorder_filename, False)
+    recorder_filename = Path(args.recorder_filename).resolve()
+    info = client.show_recorder_file_info(str(recorder_filename), False)
     log_frames, log_duration = parse_frames_duration(info)
 
     log_delta = log_duration / log_frames
@@ -297,7 +299,7 @@ def main():
     client.set_replayer_ignore_hero(args.ignore_hero)
     client.set_replayer_ignore_spectator(not args.move_spectator)
     client.replay_file(
-        args.recorder_filename, args.start, args.duration, args.camera, args.spawn_sensors
+        str(recorder_filename), args.start, args.duration, args.camera, args.spawn_sensors
     )
 
     world = client.get_world()
@@ -306,7 +308,8 @@ def main():
     settings.fixed_delta_seconds = log_delta
     world.apply_settings(settings)
 
-    with open(args.sensors.replace('file:',''), 'r') as f:
+    sensors_filepath = Path(args.sensors.replace('file:','')).resolve()
+    with open(sensors_filepath, 'r') as f:
         sensor_cfg = yaml.safe_load(f)
     vehicle = world.get_actor(args.camera)
     sensor_infos = []
@@ -337,7 +340,7 @@ def main():
         )
         p.start(); workers.append(p)
 
-    out_dir = Path(args.output_dir)
+    out_dir = Path(args.output_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
     writer = mp.Process(
         target=video_writer_worker,

--- a/PythonAPI/examples/manual_control_fisheye.py
+++ b/PythonAPI/examples/manual_control_fisheye.py
@@ -1131,6 +1131,7 @@ class CameraManager(object):
             ['sensor.camera.semantic_segmentation.wide_angle_lens', cc.CityScapesPalette, 'Camera Semantic Segmentation (CityScapes Palette, Wide Angle Lens)', {}],
             ['sensor.camera.instance_segmentation.wide_angle_lens', cc.CityScapesPalette, 'Camera Instance Segmentation (CityScapes Palette, Wide Angle Lens)', {}],
             ['sensor.camera.instance_segmentation.wide_angle_lens', cc.Raw, 'Camera Instance Segmentation (Raw, Wide Angle Lens)', {}],
+            ['sensor.camera.normals.wide_angle_lens', cc.Raw, 'Camera Normals (Wide Angle Lens)', {}],
 
             # ['sensor.camera.rgb', cc.Raw, 'Camera RGB', {}],
             # ['sensor.camera.depth', cc.Raw, 'Camera Depth (Raw)', {}],

--- a/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
+++ b/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
@@ -313,8 +313,13 @@ def main():
     vehicle = world.get_actor(args.camera)
     sensor_infos = []
     for entry in sensor_cfg:
-        bp = world.get_blueprint_library().find(f"sensor.camera.{entry['sensor']}")
-        for k,v in entry.get('attributes',{}).items(): bp.set_attribute(k,str(v))
+        name = entry['sensor']
+        sensor_name = f"sensor.camera.{name}"
+        attributes = entry.get('attributes', {})
+        if ('camera_model' in attributes and name != 'depth') or 'fisheye' in entry:
+            sensor_name += '-wide_angle_lens'
+        bp = world.get_blueprint_library().find(sensor_name)
+        for k,v in attributes.items(): bp.set_attribute(k,str(v))
         tf = entry.get('transform',{})
         transform = carla.Transform(
             carla.Location(**tf.get('location',{})),

--- a/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
+++ b/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
@@ -167,6 +167,7 @@ class SensorInfo:
     def _callback(self, data):
         conv_map = {
             AOV.RGB: carla.ColorConverter.Raw,
+            AOV.NORMALS: carla.ColorConverter.Raw,
             AOV.SEMANTIC_SEGMENTATION: carla.ColorConverter.CityScapesPalette
         }
         conv = conv_map.get(self.sensor_type, carla.ColorConverter.Raw)
@@ -319,7 +320,7 @@ def main():
         name = entry['sensor']
         sensor_name = f"sensor.camera.{name}"
         attributes = entry.get('attributes', {})
-        if ('camera_model' in attributes and name != 'normals') or 'wide_angle_lens' in entry:
+        if entry.get('wide_angle_lens', False):
             sensor_name += '.wide_angle_lens'
         bp = world.get_blueprint_library().find(sensor_name)
         for k,v in attributes.items(): bp.set_attribute(k,str(v))

--- a/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
+++ b/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
@@ -316,8 +316,8 @@ def main():
         name = entry['sensor']
         sensor_name = f"sensor.camera.{name}"
         attributes = entry.get('attributes', {})
-        if ('camera_model' in attributes and name != 'depth') or 'fisheye' in entry:
-            sensor_name += '-wide_angle_lens'
+        if ('camera_model' in attributes and name != 'normals') or 'wide_angle_lens' in entry:
+            sensor_name += '.wide_angle_lens'
         bp = world.get_blueprint_library().find(sensor_name)
         for k,v in attributes.items(): bp.set_attribute(k,str(v))
         tf = entry.get('transform',{})

--- a/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
+++ b/PythonAPI/examples/nvidia/cosmos/client/carla_cosmos_gen.py
@@ -56,6 +56,7 @@ CLASSES_TO_KEEP_SHADED_SEG: List[Sequence[int]] = []
 CLASSES_TO_KEEP_CANNY: List[Sequence[int]] = []
 
 def load_class_filter_config(path: str):
+    path = Path(path).resolve()
     with open(path, 'r') as f:
         config = yaml.safe_load(f)
     global CLASSES_TO_KEEP_SHADED_SEG, CLASSES_TO_KEEP_CANNY
@@ -288,7 +289,8 @@ def main():
     client.set_timeout(60.0)
     client.reload_world()
     
-    info = client.show_recorder_file_info(args.recorder_filename, False)
+    recorder_filename = Path(args.recorder_filename).resolve()
+    info = client.show_recorder_file_info(str(recorder_filename), False)
     log_frames, log_duration = parse_frames_duration(info)
 
     log_delta = log_duration / log_frames
@@ -299,7 +301,7 @@ def main():
     client.set_replayer_ignore_hero(args.ignore_hero)
     client.set_replayer_ignore_spectator(not args.move_spectator)
     client.replay_file(
-        args.recorder_filename, args.start, args.duration, args.camera, args.spawn_sensors
+        str(recorder_filename), args.start, args.duration, args.camera, args.spawn_sensors
     )
 
     world = client.get_world()
@@ -308,7 +310,8 @@ def main():
     settings.fixed_delta_seconds = log_delta
     world.apply_settings(settings)
 
-    with open(args.sensors.replace('file:',''), 'r') as f:
+    sensors_filepath = Path(args.sensors.replace('file:','')).resolve()
+    with open(sensors_filepath, 'r') as f:
         sensor_cfg = yaml.safe_load(f)
     vehicle = world.get_actor(args.camera)
     sensor_infos = []
@@ -334,7 +337,7 @@ def main():
         )
         p.start(); workers.append(p)
 
-    out_dir = Path(args.output_dir)
+    out_dir = Path(args.output_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
     writer = mp.Process(
         target=video_writer_worker,

--- a/PythonAPI/test/smoke/test_sensor_tick_time.py
+++ b/PythonAPI/test/smoke/test_sensor_tick_time.py
@@ -43,6 +43,7 @@ class TestSensorTickTime(SyncSmokeTest):
       "sensor.other.v2x_custom",
       "sensor.camera.cosmos_visualization",
       "sensor.camera.rgb.wide_angle_lens",
+      "sensor.camera.normals.wide_angle_lens",
       "sensor.camera.depth.wide_angle_lens",
       "sensor.camera.semantic_segmentation.wide_angle_lens",
       "sensor.camera.instance_segmentation.wide_angle_lens"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -326,16 +326,12 @@ FActorDefinition UActorBlueprintFunctionLibrary::MakeCameraDefinition(
   return Definition;
 }
 
-void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
+void UActorBlueprintFunctionLibrary::AddCommonCameraParameters(
     const FString &Id,
     const bool bEnableModifyingPostProcessEffects,
     bool &Success,
     FActorDefinition &Definition)
 {
-  FillIdAndTags(Definition, TEXT("sensor"), TEXT("camera"), Id);
-  AddRecommendedValuesForSensorRoleNames(Definition);
-  AddVariationsForSensor(Definition);
-
   // FOV
   FActorVariation FOV;
   FOV.Id = TEXT("fov");
@@ -403,303 +399,284 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
       LensKcube,
       LensXSize,
       LensYSize});
-
-  if (bEnableModifyingPostProcessEffects)
-  {
-    FActorVariation PostProccess;
-    PostProccess.Id = TEXT("enable_postprocess_effects");
-    PostProccess.Type = EActorAttributeType::Bool;
-    PostProccess.RecommendedValues = { TEXT("true") };
-    PostProccess.bRestrictToRecommended = false;
-
-    // Gamma
-    FActorVariation Gamma;
-    Gamma.Id = TEXT("gamma");
-    Gamma.Type = EActorAttributeType::Float;
-    Gamma.RecommendedValues = { TEXT("2.2") };
-    Gamma.bRestrictToRecommended = false;
-
-    // Motion Blur
-    FActorVariation MBIntesity;
-    MBIntesity.Id = TEXT("motion_blur_intensity");
-    MBIntesity.Type = EActorAttributeType::Float;
-    MBIntesity.RecommendedValues = { TEXT("0.45") };
-    MBIntesity.bRestrictToRecommended = false;
-
-    FActorVariation MBMaxDistortion;
-    MBMaxDistortion.Id = TEXT("motion_blur_max_distortion");
-    MBMaxDistortion.Type = EActorAttributeType::Float;
-    MBMaxDistortion.RecommendedValues = { TEXT("0.35") };
-    MBMaxDistortion.bRestrictToRecommended = false;
-
-    FActorVariation MBMinObjectScreenSize;
-    MBMinObjectScreenSize.Id = TEXT("motion_blur_min_object_screen_size");
-    MBMinObjectScreenSize.Type = EActorAttributeType::Float;
-    MBMinObjectScreenSize.RecommendedValues = { TEXT("0.1") };
-    MBMinObjectScreenSize.bRestrictToRecommended = false;
-
-    // Lens Flare
-    FActorVariation LensFlareIntensity;
-    LensFlareIntensity.Id = TEXT("lens_flare_intensity");
-    LensFlareIntensity.Type = EActorAttributeType::Float;
-    LensFlareIntensity.RecommendedValues = { TEXT("0.1") };
-    LensFlareIntensity.bRestrictToRecommended = false;
-
-    // Bloom
-    FActorVariation BloomIntensity;
-    BloomIntensity.Id = TEXT("bloom_intensity");
-    BloomIntensity.Type = EActorAttributeType::Float;
-    BloomIntensity.RecommendedValues = { TEXT("0.675") };
-    BloomIntensity.bRestrictToRecommended = false;
-
-    // More info at:
-    // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/AutomaticExposure/index.html
-    // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/DepthOfField/CinematicDOFMethods/index.html
-    // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/ColorGrading/index.html
-
-    // Exposure
-    FActorVariation ExposureMode;
-    ExposureMode.Id = TEXT("exposure_mode");
-    ExposureMode.Type = EActorAttributeType::String;
-    ExposureMode.RecommendedValues = { TEXT("histogram"), TEXT("manual") };
-    ExposureMode.bRestrictToRecommended = true;
-
-    // Logarithmic adjustment for the exposure. Only used if a tonemapper is
-    // specified.
-    //  0 : no adjustment
-    // -1 : 2x darker
-    // -2 : 4x darker
-    //  1 : 2x brighter
-    //  2 : 4x brighter.
-    FActorVariation ExposureCompensation;
-    ExposureCompensation.Id = TEXT("exposure_compensation");
-    ExposureCompensation.Type = EActorAttributeType::Float;
-    ExposureCompensation.RecommendedValues = { TEXT("0.0") };
-    ExposureCompensation.bRestrictToRecommended = false;
-
-    // - Manual ------------------------------------------------
-
-    // The formula used to compute the camera exposure scale is:
-    // Exposure = 1 / (1.2 * 2^(log2( N²/t * 100/S )))
-
-    // The camera shutter speed in seconds.
-    FActorVariation ShutterSpeed; // (1/t)
-    ShutterSpeed.Id = TEXT("shutter_speed");
-    ShutterSpeed.Type = EActorAttributeType::Float;
-    ShutterSpeed.RecommendedValues = { TEXT("200.0") };
-    ShutterSpeed.bRestrictToRecommended = false;
-
-    // The camera sensor sensitivity.
-    FActorVariation ISO; // S
-    ISO.Id = TEXT("iso");
-    ISO.Type = EActorAttributeType::Float;
-    ISO.RecommendedValues = { TEXT("100.0") };
-    ISO.bRestrictToRecommended = false;
-
-    // Defines the size of the opening for the camera lens.
-    // Using larger numbers will reduce the DOF effect.
-    FActorVariation Aperture; // N
-    Aperture.Id = TEXT("fstop");
-    Aperture.Type = EActorAttributeType::Float;
-    Aperture.RecommendedValues = { TEXT("1.4") };
-    Aperture.bRestrictToRecommended = false;
-
-    // - Histogram ---------------------------------------------
-
-    // The minimum brightness for auto exposure that limits the lower
-    // brightness the eye can adapt within
-    FActorVariation ExposureMinBright;
-    ExposureMinBright.Id = TEXT("exposure_min_bright");
-    ExposureMinBright.Type = EActorAttributeType::Float;
-    ExposureMinBright.RecommendedValues = { TEXT("10.0") };
-    ExposureMinBright.bRestrictToRecommended = false;
-
-    // The maximum brightness for auto exposure that limits the upper
-    // brightness the eye can adapt within
-    FActorVariation ExposureMaxBright;
-    ExposureMaxBright.Id = TEXT("exposure_max_bright");
-    ExposureMaxBright.Type = EActorAttributeType::Float;
-    ExposureMaxBright.RecommendedValues = { TEXT("12.0") };
-    ExposureMaxBright.bRestrictToRecommended = false;
-
-    // The speed at which the adaptation occurs from a dark environment
-    // to a bright environment.
-    FActorVariation ExposureSpeedUp;
-    ExposureSpeedUp.Id = TEXT("exposure_speed_up");
-    ExposureSpeedUp.Type = EActorAttributeType::Float;
-    ExposureSpeedUp.RecommendedValues = { TEXT("3.0") };
-    ExposureSpeedUp.bRestrictToRecommended = false;
-
-    // The speed at which the adaptation occurs from a bright environment
-    // to a dark environment.
-    FActorVariation ExposureSpeedDown;
-    ExposureSpeedDown.Id = TEXT("exposure_speed_down");
-    ExposureSpeedDown.Type = EActorAttributeType::Float;
-    ExposureSpeedDown.RecommendedValues = { TEXT("1.0") };
-    ExposureSpeedDown.bRestrictToRecommended = false;
-
-    // Calibration constant for 18% Albedo.
-    FActorVariation CalibrationConstant;
-    CalibrationConstant.Id = TEXT("calibration_constant");
-    CalibrationConstant.Type = EActorAttributeType::Float;
-    CalibrationConstant.RecommendedValues = { TEXT("16.0") };
-    CalibrationConstant.bRestrictToRecommended = false;
-
-    // Distance in which the Depth of Field effect should be sharp,
-    // in unreal units (cm)
-    FActorVariation FocalDistance;
-    FocalDistance.Id = TEXT("focal_distance");
-    FocalDistance.Type = EActorAttributeType::Float;
-    FocalDistance.RecommendedValues = { TEXT("1000.0") };
-    FocalDistance.bRestrictToRecommended = false;
-
-    // Depth blur km for 50%
-    FActorVariation DepthBlurAmount;
-    DepthBlurAmount.Id = TEXT("blur_amount");
-    DepthBlurAmount.Type = EActorAttributeType::Float;
-    DepthBlurAmount.RecommendedValues = { TEXT("1.0") };
-    DepthBlurAmount.bRestrictToRecommended = false;
-
-    // Depth blur radius in pixels at 1920x
-    FActorVariation DepthBlurRadius;
-    DepthBlurRadius.Id = TEXT("blur_radius");
-    DepthBlurRadius.Type = EActorAttributeType::Float;
-    DepthBlurRadius.RecommendedValues = { TEXT("0.0") };
-    DepthBlurRadius.bRestrictToRecommended = false;
-
-    // Defines the opening of the camera lens, Aperture is 1.0/fstop,
-    // typical lens go down to f/1.2 (large opening),
-    // larger numbers reduce the DOF effect
-    FActorVariation MaxAperture;
-    MaxAperture.Id = TEXT("min_fstop");
-    MaxAperture.Type = EActorAttributeType::Float;
-    MaxAperture.RecommendedValues = { TEXT("1.2") };
-    MaxAperture.bRestrictToRecommended = false;
-
-    // Defines the number of blades of the diaphragm within the
-    // lens (between 4 and 16)
-    FActorVariation BladeCount;
-    BladeCount.Id = TEXT("blade_count");
-    BladeCount.Type = EActorAttributeType::Int;
-    BladeCount.RecommendedValues = { TEXT("5") };
-    BladeCount.bRestrictToRecommended = false;
-
-    // - Tonemapper Settings -----------------------------------
-    // You can adjust these tonemapper controls to emulate other
-    // types of film stock for your project
-    FActorVariation FilmSlope;
-    FilmSlope.Id = TEXT("slope");
-    FilmSlope.Type = EActorAttributeType::Float;
-    FilmSlope.RecommendedValues = { TEXT("0.88") };
-    FilmSlope.bRestrictToRecommended = false;
-
-    FActorVariation FilmToe;
-    FilmToe.Id = TEXT("toe");
-    FilmToe.Type = EActorAttributeType::Float;
-    FilmToe.RecommendedValues = { TEXT("0.55") };
-    FilmToe.bRestrictToRecommended = false;
-
-    FActorVariation FilmShoulder;
-    FilmShoulder.Id = TEXT("shoulder");
-    FilmShoulder.Type = EActorAttributeType::Float;
-    FilmShoulder.RecommendedValues = { TEXT("0.26") };
-    FilmShoulder.bRestrictToRecommended = false;
-
-    FActorVariation FilmBlackClip;
-    FilmBlackClip.Id = TEXT("black_clip");
-    FilmBlackClip.Type = EActorAttributeType::Float;
-    FilmBlackClip.RecommendedValues = { TEXT("0.0") };
-    FilmBlackClip.bRestrictToRecommended = false;
-
-    FActorVariation FilmWhiteClip;
-    FilmWhiteClip.Id = TEXT("white_clip");
-    FilmWhiteClip.Type = EActorAttributeType::Float;
-    FilmWhiteClip.RecommendedValues = { TEXT("0.04") };
-    FilmWhiteClip.bRestrictToRecommended = false;
-
-    // Color
-    FActorVariation Temperature;
-    Temperature.Id = TEXT("temp");
-    Temperature.Type = EActorAttributeType::Float;
-    Temperature.RecommendedValues = { TEXT("6500.0") };
-    Temperature.bRestrictToRecommended = false;
-
-    FActorVariation Tint;
-    Tint.Id = TEXT("tint");
-    Tint.Type = EActorAttributeType::Float;
-    Tint.RecommendedValues = { TEXT("0.0") };
-    Tint.bRestrictToRecommended = false;
-
-    FActorVariation ChromaticIntensity;
-    ChromaticIntensity.Id = TEXT("chromatic_aberration_intensity");
-    ChromaticIntensity.Type = EActorAttributeType::Float;
-    ChromaticIntensity.RecommendedValues = { TEXT("0.0") };
-    ChromaticIntensity.bRestrictToRecommended = false;
-
-    FActorVariation ChromaticOffset;
-    ChromaticOffset.Id = TEXT("chromatic_aberration_offset");
-    ChromaticOffset.Type = EActorAttributeType::Float;
-    ChromaticOffset.RecommendedValues = { TEXT("0.0") };
-    ChromaticOffset.bRestrictToRecommended = false;
-
-    Definition.Variations.Append({
-      ExposureMode,
-      ExposureCompensation,
-      ShutterSpeed,
-      ISO,
-      Aperture,
-      PostProccess,
-      Gamma,
-      MBIntesity,
-      MBMaxDistortion,
-      LensFlareIntensity,
-      BloomIntensity,
-      MBMinObjectScreenSize,
-      ExposureMinBright,
-      ExposureMaxBright,
-      ExposureSpeedUp,
-      ExposureSpeedDown,
-      CalibrationConstant,
-      FocalDistance,
-      MaxAperture,
-      BladeCount,
-      DepthBlurAmount,
-      DepthBlurRadius,
-      FilmSlope,
-      FilmToe,
-      FilmShoulder,
-      FilmBlackClip,
-      FilmWhiteClip,
-      Temperature,
-      Tint,
-      ChromaticIntensity,
-      ChromaticOffset});
-  }
-
-  Success = CheckActorDefinition(Definition);
 }
 
-FActorDefinition UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
-    const FString& Id,
-    bool bEnableModifyingPostProcessEffects)
+void UActorBlueprintFunctionLibrary::AddCommonPostProcessingEffectsParameters(
+    const FString &Id,
+    const bool bEnableModifyingPostProcessEffects,
+    bool &Success,
+    FActorDefinition &Definition)
 {
-  FActorDefinition Definition;
-  bool Success;
-  MakeWideAngleLensCameraDefinition(Id, bEnableModifyingPostProcessEffects, Success, Definition);
-  check(Success);
-  return Definition;
+  FActorVariation PostProccess;
+  PostProccess.Id = TEXT("enable_postprocess_effects");
+  PostProccess.Type = EActorAttributeType::Bool;
+  PostProccess.RecommendedValues = { TEXT("true") };
+  PostProccess.bRestrictToRecommended = false;
+
+  // Gamma
+  FActorVariation Gamma;
+  Gamma.Id = TEXT("gamma");
+  Gamma.Type = EActorAttributeType::Float;
+  Gamma.RecommendedValues = { TEXT("2.2") };
+  Gamma.bRestrictToRecommended = false;
+
+  // Motion Blur
+  FActorVariation MBIntesity;
+  MBIntesity.Id = TEXT("motion_blur_intensity");
+  MBIntesity.Type = EActorAttributeType::Float;
+  MBIntesity.RecommendedValues = { TEXT("0.45") };
+  MBIntesity.bRestrictToRecommended = false;
+
+  FActorVariation MBMaxDistortion;
+  MBMaxDistortion.Id = TEXT("motion_blur_max_distortion");
+  MBMaxDistortion.Type = EActorAttributeType::Float;
+  MBMaxDistortion.RecommendedValues = { TEXT("0.35") };
+  MBMaxDistortion.bRestrictToRecommended = false;
+
+  FActorVariation MBMinObjectScreenSize;
+  MBMinObjectScreenSize.Id = TEXT("motion_blur_min_object_screen_size");
+  MBMinObjectScreenSize.Type = EActorAttributeType::Float;
+  MBMinObjectScreenSize.RecommendedValues = { TEXT("0.1") };
+  MBMinObjectScreenSize.bRestrictToRecommended = false;
+
+  // Lens Flare
+  FActorVariation LensFlareIntensity;
+  LensFlareIntensity.Id = TEXT("lens_flare_intensity");
+  LensFlareIntensity.Type = EActorAttributeType::Float;
+  LensFlareIntensity.RecommendedValues = { TEXT("0.1") };
+  LensFlareIntensity.bRestrictToRecommended = false;
+
+  // Bloom
+  FActorVariation BloomIntensity;
+  BloomIntensity.Id = TEXT("bloom_intensity");
+  BloomIntensity.Type = EActorAttributeType::Float;
+  BloomIntensity.RecommendedValues = { TEXT("0.675") };
+  BloomIntensity.bRestrictToRecommended = false;
+
+  // More info at:
+  // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/AutomaticExposure/index.html
+  // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/DepthOfField/CinematicDOFMethods/index.html
+  // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/ColorGrading/index.html
+  // Exposure
+  FActorVariation ExposureMode;
+  ExposureMode.Id = TEXT("exposure_mode");
+  ExposureMode.Type = EActorAttributeType::String;
+  ExposureMode.RecommendedValues = { TEXT("histogram"), TEXT("manual") };
+  ExposureMode.bRestrictToRecommended = true;
+
+  // Logarithmic adjustment for the exposure. Only used if a tonemapper is
+  // specified.
+  //  0 : no adjustment
+  // -1 : 2x darker
+  // -2 : 4x darker
+  //  1 : 2x brighter
+  //  2 : 4x brighter.
+  FActorVariation ExposureCompensation;
+  ExposureCompensation.Id = TEXT("exposure_compensation");
+  ExposureCompensation.Type = EActorAttributeType::Float;
+  ExposureCompensation.RecommendedValues = { TEXT("0.0") };
+  ExposureCompensation.bRestrictToRecommended = false;
+
+  // - Manual ------------------------------------------------
+  // The formula used to compute the camera exposure scale is:
+  // Exposure = 1 / (1.2 * 2^(log2( N²/t * 100/S )))
+  // The camera shutter speed in seconds.
+  FActorVariation ShutterSpeed; // (1/t)
+  ShutterSpeed.Id = TEXT("shutter_speed");
+  ShutterSpeed.Type = EActorAttributeType::Float;
+  ShutterSpeed.RecommendedValues = { TEXT("200.0") };
+  ShutterSpeed.bRestrictToRecommended = false;
+
+  // The camera sensor sensitivity.
+  FActorVariation ISO; // S
+  ISO.Id = TEXT("iso");
+  ISO.Type = EActorAttributeType::Float;
+  ISO.RecommendedValues = { TEXT("100.0") };
+  ISO.bRestrictToRecommended = false;
+
+  // Defines the size of the opening for the camera lens.
+  // Using larger numbers will reduce the DOF effect.
+  FActorVariation Aperture; // N
+  Aperture.Id = TEXT("fstop");
+  Aperture.Type = EActorAttributeType::Float;
+  Aperture.RecommendedValues = { TEXT("1.4") };
+  Aperture.bRestrictToRecommended = false;
+
+  // - Histogram ---------------------------------------------
+  // The minimum brightness for auto exposure that limits the lower
+  // brightness the eye can adapt within
+  FActorVariation ExposureMinBright;
+  ExposureMinBright.Id = TEXT("exposure_min_bright");
+  ExposureMinBright.Type = EActorAttributeType::Float;
+  ExposureMinBright.RecommendedValues = { TEXT("10.0") };
+  ExposureMinBright.bRestrictToRecommended = false;
+
+  // The maximum brightness for auto exposure that limits the upper
+  // brightness the eye can adapt within
+  FActorVariation ExposureMaxBright;
+  ExposureMaxBright.Id = TEXT("exposure_max_bright");
+  ExposureMaxBright.Type = EActorAttributeType::Float;
+  ExposureMaxBright.RecommendedValues = { TEXT("12.0") };
+  ExposureMaxBright.bRestrictToRecommended = false;
+
+  // The speed at which the adaptation occurs from a dark environment
+  // to a bright environment.
+  FActorVariation ExposureSpeedUp;
+  ExposureSpeedUp.Id = TEXT("exposure_speed_up");
+  ExposureSpeedUp.Type = EActorAttributeType::Float;
+  ExposureSpeedUp.RecommendedValues = { TEXT("3.0") };
+  ExposureSpeedUp.bRestrictToRecommended = false;
+
+  // The speed at which the adaptation occurs from a bright environment
+  // to a dark environment.
+  FActorVariation ExposureSpeedDown;
+  ExposureSpeedDown.Id = TEXT("exposure_speed_down");
+  ExposureSpeedDown.Type = EActorAttributeType::Float;
+  ExposureSpeedDown.RecommendedValues = { TEXT("1.0") };
+  ExposureSpeedDown.bRestrictToRecommended = false;
+
+  // Calibration constant for 18% Albedo.
+  FActorVariation CalibrationConstant;
+  CalibrationConstant.Id = TEXT("calibration_constant");
+  CalibrationConstant.Type = EActorAttributeType::Float;
+  CalibrationConstant.RecommendedValues = { TEXT("16.0") };
+  CalibrationConstant.bRestrictToRecommended = false;
+
+  // Distance in which the Depth of Field effect should be sharp,
+  // in unreal units (cm)
+  FActorVariation FocalDistance;
+  FocalDistance.Id = TEXT("focal_distance");
+  FocalDistance.Type = EActorAttributeType::Float;
+  FocalDistance.RecommendedValues = { TEXT("1000.0") };
+  FocalDistance.bRestrictToRecommended = false;
+
+  // Depth blur km for 50%
+  FActorVariation DepthBlurAmount;
+  DepthBlurAmount.Id = TEXT("blur_amount");
+  DepthBlurAmount.Type = EActorAttributeType::Float;
+  DepthBlurAmount.RecommendedValues = { TEXT("1.0") };
+  DepthBlurAmount.bRestrictToRecommended = false;
+
+  // Depth blur radius in pixels at 1920x
+  FActorVariation DepthBlurRadius;
+  DepthBlurRadius.Id = TEXT("blur_radius");
+  DepthBlurRadius.Type = EActorAttributeType::Float;
+  DepthBlurRadius.RecommendedValues = { TEXT("0.0") };
+  DepthBlurRadius.bRestrictToRecommended = false;
+
+  // Defines the opening of the camera lens, Aperture is 1.0/fstop,
+  // typical lens go down to f/1.2 (large opening),
+  // larger numbers reduce the DOF effect
+  FActorVariation MaxAperture;
+  MaxAperture.Id = TEXT("min_fstop");
+  MaxAperture.Type = EActorAttributeType::Float;
+  MaxAperture.RecommendedValues = { TEXT("1.2") };
+  MaxAperture.bRestrictToRecommended = false;
+
+  // Defines the number of blades of the diaphragm within the
+  // lens (between 4 and 16)
+  FActorVariation BladeCount;
+  BladeCount.Id = TEXT("blade_count");
+  BladeCount.Type = EActorAttributeType::Int;
+  BladeCount.RecommendedValues = { TEXT("5") };
+  BladeCount.bRestrictToRecommended = false;
+
+  // - Tonemapper Settings -----------------------------------
+  // You can adjust these tonemapper controls to emulate other
+  // types of film stock for your project
+  FActorVariation FilmSlope;
+  FilmSlope.Id = TEXT("slope");
+  FilmSlope.Type = EActorAttributeType::Float;
+  FilmSlope.RecommendedValues = { TEXT("0.88") };
+  FilmSlope.bRestrictToRecommended = false;
+
+  FActorVariation FilmToe;
+  FilmToe.Id = TEXT("toe");
+  FilmToe.Type = EActorAttributeType::Float;
+  FilmToe.RecommendedValues = { TEXT("0.55") };
+  FilmToe.bRestrictToRecommended = false;
+
+  FActorVariation FilmShoulder;
+  FilmShoulder.Id = TEXT("shoulder");
+  FilmShoulder.Type = EActorAttributeType::Float;
+  FilmShoulder.RecommendedValues = { TEXT("0.26") };
+  FilmShoulder.bRestrictToRecommended = false;
+
+  FActorVariation FilmBlackClip;
+  FilmBlackClip.Id = TEXT("black_clip");
+  FilmBlackClip.Type = EActorAttributeType::Float;
+  FilmBlackClip.RecommendedValues = { TEXT("0.0") };
+  FilmBlackClip.bRestrictToRecommended = false;
+  FActorVariation FilmWhiteClip;
+  FilmWhiteClip.Id = TEXT("white_clip");
+  FilmWhiteClip.Type = EActorAttributeType::Float;
+  FilmWhiteClip.RecommendedValues = { TEXT("0.04") };
+  FilmWhiteClip.bRestrictToRecommended = false;
+  // Color
+  FActorVariation Temperature;
+  Temperature.Id = TEXT("temp");
+  Temperature.Type = EActorAttributeType::Float;
+  Temperature.RecommendedValues = { TEXT("6500.0") };
+  Temperature.bRestrictToRecommended = false;
+
+  FActorVariation Tint;
+  Tint.Id = TEXT("tint");
+  Tint.Type = EActorAttributeType::Float;
+  Tint.RecommendedValues = { TEXT("0.0") };
+  Tint.bRestrictToRecommended = false;
+
+  FActorVariation ChromaticIntensity;
+  ChromaticIntensity.Id = TEXT("chromatic_aberration_intensity");
+  ChromaticIntensity.Type = EActorAttributeType::Float;
+  ChromaticIntensity.RecommendedValues = { TEXT("0.0") };
+  ChromaticIntensity.bRestrictToRecommended = false;
+
+  FActorVariation ChromaticOffset;
+  ChromaticOffset.Id = TEXT("chromatic_aberration_offset");
+  ChromaticOffset.Type = EActorAttributeType::Float;
+  ChromaticOffset.RecommendedValues = { TEXT("0.0") };
+  ChromaticOffset.bRestrictToRecommended = false;
+
+  Definition.Variations.Append({
+    ExposureMode,
+    ExposureCompensation,
+    ShutterSpeed,
+    ISO,
+    Aperture,
+    PostProccess,
+    Gamma,
+    MBIntesity,
+    MBMaxDistortion,
+    LensFlareIntensity,
+    BloomIntensity,
+    MBMinObjectScreenSize,
+    ExposureMinBright,
+    ExposureMaxBright,
+    ExposureSpeedUp,
+    ExposureSpeedDown,
+    CalibrationConstant,
+    FocalDistance,
+    MaxAperture,
+    BladeCount,
+    DepthBlurAmount,
+    DepthBlurRadius,
+    FilmSlope,
+    FilmToe,
+    FilmShoulder,
+    FilmBlackClip,
+    FilmWhiteClip,
+    Temperature,
+    Tint,
+    ChromaticIntensity,
+    ChromaticOffset});
 }
 
-void UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
-    const FString& Id,
-    bool bEnableModifyingPostProcessEffects,
-    bool& Success,
-    FActorDefinition& Definition)
+void UActorBlueprintFunctionLibrary::AddCommonWideAngleLensCameraParameters(
+    const FString &Id,
+    const bool bEnableModifyingPostProcessEffects,
+    bool &Success,
+    FActorDefinition &Definition)
 {
-  FillIdAndTags(Definition, TEXT("sensor"), TEXT("camera"), Id, TEXT("wide_angle_lens"));
-  AddRecommendedValuesForSensorRoleNames(Definition);
-  AddVariationsForSensor(Definition);
-
   // Camera Model
   FActorVariation CameraModel;
   CameraModel.Id = TEXT("camera_model");
@@ -734,13 +711,6 @@ void UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
   K3.Type = EActorAttributeType::Float;
   K3.RecommendedValues = { FString::SanitizeFloat(DefaultKannalaBrandtCoefficients[3]) };
   K3.bRestrictToRecommended = false;
-
-  // FOV
-  FActorVariation FOV;
-  FOV.Id = TEXT("fov");
-  FOV.Type = EActorAttributeType::Float;
-  FOV.RecommendedValues = { TEXT("90.0") };
-  FOV.bRestrictToRecommended = false;
 
   // Focal Length
   FActorVariation FocalLength;
@@ -779,433 +749,63 @@ void UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
   LongitudeOffset.RecommendedValues = { TEXT("0.0") };
   LongitudeOffset.bRestrictToRecommended = false;
 
-  // Resolution
-  FActorVariation ResX;
-  ResX.Id = TEXT("image_size_x");
-  ResX.Type = EActorAttributeType::Int;
-  ResX.RecommendedValues = { TEXT("800") };
-  ResX.bRestrictToRecommended = false;
-
-  FActorVariation ResY;
-  ResY.Id = TEXT("image_size_y");
-  ResY.Type = EActorAttributeType::Int;
-  ResY.RecommendedValues = { TEXT("600") };
-  ResY.bRestrictToRecommended = false;
-
-  // Lens parameters
-  FActorVariation LensCircleFalloff;
-  LensCircleFalloff.Id = TEXT("lens_circle_falloff");
-  LensCircleFalloff.Type = EActorAttributeType::Float;
-  LensCircleFalloff.RecommendedValues = { TEXT("5.0") };
-  LensCircleFalloff.bRestrictToRecommended = false;
-
-  FActorVariation LensCircleMultiplier;
-  LensCircleMultiplier.Id = TEXT("lens_circle_multiplier");
-  LensCircleMultiplier.Type = EActorAttributeType::Float;
-  LensCircleMultiplier.RecommendedValues = { TEXT("0.0") };
-  LensCircleMultiplier.bRestrictToRecommended = false;
-
-  FActorVariation LensK;
-  LensK.Id = TEXT("lens_k");
-  LensK.Type = EActorAttributeType::Float;
-  LensK.RecommendedValues = { TEXT("-1.0") };
-  LensK.bRestrictToRecommended = false;
-
-  FActorVariation LensKcube;
-  LensKcube.Id = TEXT("lens_kcube");
-  LensKcube.Type = EActorAttributeType::Float;
-  LensKcube.RecommendedValues = { TEXT("0.0") };
-  LensKcube.bRestrictToRecommended = false;
-
-  FActorVariation LensXSize;
-  LensXSize.Id = TEXT("lens_x_size");
-  LensXSize.Type = EActorAttributeType::Float;
-  LensXSize.RecommendedValues = { TEXT("0.08") };
-  LensXSize.bRestrictToRecommended = false;
-
-  FActorVariation LensYSize;
-  LensYSize.Id = TEXT("lens_y_size");
-  LensYSize.Type = EActorAttributeType::Float;
-  LensYSize.RecommendedValues = { TEXT("0.08") };
-  LensYSize.bRestrictToRecommended = false;
-
   Definition.Variations.Append({
       CameraModel,
       K0, K1, K2, K3,
-      ResX,
-      ResY,
-      FOV,
       FocalLength,
       Equirectangular,
       FOVMask,
       FOVFadeSize,
       LongitudeOffset,
-      Perspective,
-      LensCircleFalloff,
-      LensCircleMultiplier,
-      LensK,
-      LensKcube,
-      LensXSize,
-      LensYSize});
+      Perspective
+  });
+}
 
+void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
+    const FString &Id,
+    const bool bEnableModifyingPostProcessEffects,
+    bool &Success,
+    FActorDefinition &Definition)
+{
+  FillIdAndTags(Definition, TEXT("sensor"), TEXT("camera"), Id);
+  AddRecommendedValuesForSensorRoleNames(Definition);
+  AddVariationsForSensor(Definition);
+  AddCommonCameraParameters(Id, bEnableModifyingPostProcessEffects, Success, Definition);
   if (bEnableModifyingPostProcessEffects)
   {
-      FActorVariation PostProccess;
-      PostProccess.Id = TEXT("enable_postprocess_effects");
-      PostProccess.Type = EActorAttributeType::Bool;
-      PostProccess.RecommendedValues = { TEXT("true") };
-      PostProccess.bRestrictToRecommended = false;
-
-      // Gamma
-      FActorVariation Gamma;
-      Gamma.Id = TEXT("gamma");
-      Gamma.Type = EActorAttributeType::Float;
-      Gamma.RecommendedValues = { TEXT("2.2") };
-      Gamma.bRestrictToRecommended = false;
-
-      // Motion Blur
-      FActorVariation MBIntesity;
-      MBIntesity.Id = TEXT("motion_blur_intensity");
-      MBIntesity.Type = EActorAttributeType::Float;
-      MBIntesity.RecommendedValues = { TEXT("0.45") };
-      MBIntesity.bRestrictToRecommended = false;
-
-      FActorVariation MBMaxDistortion;
-      MBMaxDistortion.Id = TEXT("motion_blur_max_distortion");
-      MBMaxDistortion.Type = EActorAttributeType::Float;
-      MBMaxDistortion.RecommendedValues = { TEXT("0.35") };
-      MBMaxDistortion.bRestrictToRecommended = false;
-
-      FActorVariation MBMinObjectScreenSize;
-      MBMinObjectScreenSize.Id = TEXT("motion_blur_min_object_screen_size");
-      MBMinObjectScreenSize.Type = EActorAttributeType::Float;
-      MBMinObjectScreenSize.RecommendedValues = { TEXT("0.1") };
-      MBMinObjectScreenSize.bRestrictToRecommended = false;
-
-      // Lens Flare
-      FActorVariation LensFlareIntensity;
-      LensFlareIntensity.Id = TEXT("lens_flare_intensity");
-      LensFlareIntensity.Type = EActorAttributeType::Float;
-      LensFlareIntensity.RecommendedValues = { TEXT("0.1") };
-      LensFlareIntensity.bRestrictToRecommended = false;
-
-      // Bloom
-      FActorVariation BloomIntensity;
-      BloomIntensity.Id = TEXT("bloom_intensity");
-      BloomIntensity.Type = EActorAttributeType::Float;
-      BloomIntensity.RecommendedValues = { TEXT("0.675") };
-      BloomIntensity.bRestrictToRecommended = false;
-
-      // More info at:
-      // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/AutomaticExposure/index.html
-      // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/DepthOfField/CinematicDOFMethods/index.html
-      // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/ColorGrading/index.html
-
-      // Exposure
-      FActorVariation ExposureMode;
-      ExposureMode.Id = TEXT("exposure_mode");
-      ExposureMode.Type = EActorAttributeType::String;
-      ExposureMode.RecommendedValues = { TEXT("histogram"), TEXT("manual") };
-      ExposureMode.bRestrictToRecommended = true;
-
-      // Logarithmic adjustment for the exposure. Only used if a tonemapper is
-      // specified.
-      //  0 : no adjustment
-      // -1 : 2x darker
-      // -2 : 4x darker
-      //  1 : 2x brighter
-      //  2 : 4x brighter.
-      FActorVariation ExposureCompensation;
-      ExposureCompensation.Id = TEXT("exposure_compensation");
-      ExposureCompensation.Type = EActorAttributeType::Float;
-      ExposureCompensation.RecommendedValues = { TEXT("0.0") };
-      ExposureCompensation.bRestrictToRecommended = false;
-
-      // - Manual ------------------------------------------------
-
-      // The formula used to compute the camera exposure scale is:
-      // Exposure = 1 / (1.2 * 2^(log2( N²/t * 100/S )))
-
-      // The camera shutter speed in seconds.
-      FActorVariation ShutterSpeed; // (1/t)
-      ShutterSpeed.Id = TEXT("shutter_speed");
-      ShutterSpeed.Type = EActorAttributeType::Float;
-      ShutterSpeed.RecommendedValues = { TEXT("200.0") };
-      ShutterSpeed.bRestrictToRecommended = false;
-
-      // The camera sensor sensitivity.
-      FActorVariation ISO; // S
-      ISO.Id = TEXT("iso");
-      ISO.Type = EActorAttributeType::Float;
-      ISO.RecommendedValues = { TEXT("100.0") };
-      ISO.bRestrictToRecommended = false;
-
-      // Defines the size of the opening for the camera lens.
-      // Using larger numbers will reduce the DOF effect.
-      FActorVariation Aperture; // N
-      Aperture.Id = TEXT("fstop");
-      Aperture.Type = EActorAttributeType::Float;
-      Aperture.RecommendedValues = { TEXT("1.4") };
-      Aperture.bRestrictToRecommended = false;
-
-      // - Histogram ---------------------------------------------
-
-      // The minimum brightness for auto exposure that limits the lower
-      // brightness the eye can adapt within
-      FActorVariation ExposureMinBright;
-      ExposureMinBright.Id = TEXT("exposure_min_bright");
-      ExposureMinBright.Type = EActorAttributeType::Float;
-      ExposureMinBright.RecommendedValues = { TEXT("10.0") };
-      ExposureMinBright.bRestrictToRecommended = false;
-
-      // The maximum brightness for auto exposure that limits the upper
-      // brightness the eye can adapt within
-      FActorVariation ExposureMaxBright;
-      ExposureMaxBright.Id = TEXT("exposure_max_bright");
-      ExposureMaxBright.Type = EActorAttributeType::Float;
-      ExposureMaxBright.RecommendedValues = { TEXT("12.0") };
-      ExposureMaxBright.bRestrictToRecommended = false;
-
-      // The speed at which the adaptation occurs from a dark environment
-      // to a bright environment.
-      FActorVariation ExposureSpeedUp;
-      ExposureSpeedUp.Id = TEXT("exposure_speed_up");
-      ExposureSpeedUp.Type = EActorAttributeType::Float;
-      ExposureSpeedUp.RecommendedValues = { TEXT("3.0") };
-      ExposureSpeedUp.bRestrictToRecommended = false;
-
-      // The speed at which the adaptation occurs from a bright environment
-      // to a dark environment.
-      FActorVariation ExposureSpeedDown;
-      ExposureSpeedDown.Id = TEXT("exposure_speed_down");
-      ExposureSpeedDown.Type = EActorAttributeType::Float;
-      ExposureSpeedDown.RecommendedValues = { TEXT("1.0") };
-      ExposureSpeedDown.bRestrictToRecommended = false;
-
-      // Calibration constant for 18% Albedo.
-      FActorVariation CalibrationConstant;
-      CalibrationConstant.Id = TEXT("calibration_constant");
-      CalibrationConstant.Type = EActorAttributeType::Float;
-      CalibrationConstant.RecommendedValues = { TEXT("16.0") };
-      CalibrationConstant.bRestrictToRecommended = false;
-
-      // Distance in which the Depth of Field effect should be sharp,
-      // in unreal units (cm)
-      FActorVariation FocalDistance;
-      FocalDistance.Id = TEXT("focal_distance");
-      FocalDistance.Type = EActorAttributeType::Float;
-      FocalDistance.RecommendedValues = { TEXT("1000.0") };
-      FocalDistance.bRestrictToRecommended = false;
-
-      // Depth blur km for 50%
-      FActorVariation DepthBlurAmount;
-      DepthBlurAmount.Id = TEXT("blur_amount");
-      DepthBlurAmount.Type = EActorAttributeType::Float;
-      DepthBlurAmount.RecommendedValues = { TEXT("1.0") };
-      DepthBlurAmount.bRestrictToRecommended = false;
-
-      // Depth blur radius in pixels at 1920x
-      FActorVariation DepthBlurRadius;
-      DepthBlurRadius.Id = TEXT("blur_radius");
-      DepthBlurRadius.Type = EActorAttributeType::Float;
-      DepthBlurRadius.RecommendedValues = { TEXT("0.0") };
-      DepthBlurRadius.bRestrictToRecommended = false;
-
-      // Defines the opening of the camera lens, Aperture is 1.0/fstop,
-      // typical lens go down to f/1.2 (large opening),
-      // larger numbers reduce the DOF effect
-      FActorVariation MaxAperture;
-      MaxAperture.Id = TEXT("min_fstop");
-      MaxAperture.Type = EActorAttributeType::Float;
-      MaxAperture.RecommendedValues = { TEXT("1.2") };
-      MaxAperture.bRestrictToRecommended = false;
-
-      // Defines the number of blades of the diaphragm within the
-      // lens (between 4 and 16)
-      FActorVariation BladeCount;
-      BladeCount.Id = TEXT("blade_count");
-      BladeCount.Type = EActorAttributeType::Int;
-      BladeCount.RecommendedValues = { TEXT("5") };
-      BladeCount.bRestrictToRecommended = false;
-
-      // - Tonemapper Settings -----------------------------------
-      // You can adjust these tonemapper controls to emulate other
-      // types of film stock for your project
-      FActorVariation FilmSlope;
-      FilmSlope.Id = TEXT("slope");
-      FilmSlope.Type = EActorAttributeType::Float;
-      FilmSlope.RecommendedValues = { TEXT("0.88") };
-      FilmSlope.bRestrictToRecommended = false;
-
-      FActorVariation FilmToe;
-      FilmToe.Id = TEXT("toe");
-      FilmToe.Type = EActorAttributeType::Float;
-      FilmToe.RecommendedValues = { TEXT("0.55") };
-      FilmToe.bRestrictToRecommended = false;
-
-      FActorVariation FilmShoulder;
-      FilmShoulder.Id = TEXT("shoulder");
-      FilmShoulder.Type = EActorAttributeType::Float;
-      FilmShoulder.RecommendedValues = { TEXT("0.26") };
-      FilmShoulder.bRestrictToRecommended = false;
-
-      FActorVariation FilmBlackClip;
-      FilmBlackClip.Id = TEXT("black_clip");
-      FilmBlackClip.Type = EActorAttributeType::Float;
-      FilmBlackClip.RecommendedValues = { TEXT("0.0") };
-      FilmBlackClip.bRestrictToRecommended = false;
-
-      FActorVariation FilmWhiteClip;
-      FilmWhiteClip.Id = TEXT("white_clip");
-      FilmWhiteClip.Type = EActorAttributeType::Float;
-      FilmWhiteClip.RecommendedValues = { TEXT("0.04") };
-      FilmWhiteClip.bRestrictToRecommended = false;
-
-      // Color
-      FActorVariation Temperature;
-      Temperature.Id = TEXT("temp");
-      Temperature.Type = EActorAttributeType::Float;
-      Temperature.RecommendedValues = { TEXT("6500.0") };
-      Temperature.bRestrictToRecommended = false;
-
-      FActorVariation Tint;
-      Tint.Id = TEXT("tint");
-      Tint.Type = EActorAttributeType::Float;
-      Tint.RecommendedValues = { TEXT("0.0") };
-      Tint.bRestrictToRecommended = false;
-
-      FActorVariation ChromaticIntensity;
-      ChromaticIntensity.Id = TEXT("chromatic_aberration_intensity");
-      ChromaticIntensity.Type = EActorAttributeType::Float;
-      ChromaticIntensity.RecommendedValues = { TEXT("0.0") };
-      ChromaticIntensity.bRestrictToRecommended = false;
-
-      FActorVariation ChromaticOffset;
-      ChromaticOffset.Id = TEXT("chromatic_aberration_offset");
-      ChromaticOffset.Type = EActorAttributeType::Float;
-      ChromaticOffset.RecommendedValues = { TEXT("0.0") };
-      ChromaticOffset.bRestrictToRecommended = false;
-
-      Definition.Variations.Append({
-        ExposureMode,
-        ExposureCompensation,
-        ShutterSpeed,
-        ISO,
-        Aperture,
-        PostProccess,
-        Gamma,
-        MBIntesity,
-        MBMaxDistortion,
-        LensFlareIntensity,
-        BloomIntensity,
-        MBMinObjectScreenSize,
-        ExposureMinBright,
-        ExposureMaxBright,
-        ExposureSpeedUp,
-        ExposureSpeedDown,
-        CalibrationConstant,
-        FocalDistance,
-        MaxAperture,
-        BladeCount,
-        DepthBlurAmount,
-        DepthBlurRadius,
-        FilmSlope,
-        FilmToe,
-        FilmShoulder,
-        FilmBlackClip,
-        FilmWhiteClip,
-        Temperature,
-        Tint,
-        ChromaticIntensity,
-        ChromaticOffset });
+    AddCommonPostProcessingEffectsParameters(
+      Id, bEnableModifyingPostProcessEffects, Success, Definition);
   }
-
   Success = CheckActorDefinition(Definition);
 }
 
-FActorDefinition UActorBlueprintFunctionLibrary::MakeNormalsCameraDefinition()
+FActorDefinition UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
+    const FString& Id,
+    bool bEnableModifyingPostProcessEffects)
 {
   FActorDefinition Definition;
   bool Success;
-  MakeNormalsCameraDefinition(Success, Definition);
+  MakeWideAngleLensCameraDefinition(Id, bEnableModifyingPostProcessEffects, Success, Definition);
   check(Success);
   return Definition;
 }
 
-void UActorBlueprintFunctionLibrary::MakeNormalsCameraDefinition(bool &Success, FActorDefinition &Definition)
+void UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(
+    const FString& Id,
+    bool bEnableModifyingPostProcessEffects,
+    bool& Success,
+    FActorDefinition& Definition)
 {
-  FillIdAndTags(Definition, TEXT("sensor"), TEXT("camera"), TEXT("normals"));
+  FillIdAndTags(Definition, TEXT("sensor"), TEXT("camera"), Id, TEXT("wide_angle_lens"));
   AddRecommendedValuesForSensorRoleNames(Definition);
   AddVariationsForSensor(Definition);
-
-  // FOV
-  FActorVariation FOV;
-  FOV.Id = TEXT("fov");
-  FOV.Type = EActorAttributeType::Float;
-  FOV.RecommendedValues = { TEXT("90.0") };
-  FOV.bRestrictToRecommended = false;
-
-  // Resolution
-  FActorVariation ResX;
-  ResX.Id = TEXT("image_size_x");
-  ResX.Type = EActorAttributeType::Int;
-  ResX.RecommendedValues = { TEXT("800") };
-  ResX.bRestrictToRecommended = false;
-
-  FActorVariation ResY;
-  ResY.Id = TEXT("image_size_y");
-  ResY.Type = EActorAttributeType::Int;
-  ResY.RecommendedValues = { TEXT("600") };
-  ResY.bRestrictToRecommended = false;
-
-  // Lens parameters
-  FActorVariation LensCircleFalloff;
-  LensCircleFalloff.Id = TEXT("lens_circle_falloff");
-  LensCircleFalloff.Type = EActorAttributeType::Float;
-  LensCircleFalloff.RecommendedValues = { TEXT("5.0") };
-  LensCircleFalloff.bRestrictToRecommended = false;
-
-  FActorVariation LensCircleMultiplier;
-  LensCircleMultiplier.Id = TEXT("lens_circle_multiplier");
-  LensCircleMultiplier.Type = EActorAttributeType::Float;
-  LensCircleMultiplier.RecommendedValues = { TEXT("0.0") };
-  LensCircleMultiplier.bRestrictToRecommended = false;
-
-  FActorVariation LensK;
-  LensK.Id = TEXT("lens_k");
-  LensK.Type = EActorAttributeType::Float;
-  LensK.RecommendedValues = { TEXT("-1.0") };
-  LensK.bRestrictToRecommended = false;
-
-  FActorVariation LensKcube;
-  LensKcube.Id = TEXT("lens_kcube");
-  LensKcube.Type = EActorAttributeType::Float;
-  LensKcube.RecommendedValues = { TEXT("0.0") };
-  LensKcube.bRestrictToRecommended = false;
-
-  FActorVariation LensXSize;
-  LensXSize.Id = TEXT("lens_x_size");
-  LensXSize.Type = EActorAttributeType::Float;
-  LensXSize.RecommendedValues = { TEXT("0.08") };
-  LensXSize.bRestrictToRecommended = false;
-
-  FActorVariation LensYSize;
-  LensYSize.Id = TEXT("lens_y_size");
-  LensYSize.Type = EActorAttributeType::Float;
-  LensYSize.RecommendedValues = { TEXT("0.08") };
-  LensYSize.bRestrictToRecommended = false;
-
-  Definition.Variations.Append({
-      ResX,
-      ResY,
-      FOV,
-      LensCircleFalloff,
-      LensCircleMultiplier,
-      LensK,
-      LensKcube,
-      LensXSize,
-      LensYSize});
-
+  AddCommonCameraParameters(Id, bEnableModifyingPostProcessEffects, Success, Definition);
+  AddCommonWideAngleLensCameraParameters(Id, bEnableModifyingPostProcessEffects, Success, Definition);
+  if (bEnableModifyingPostProcessEffects)
+  {
+    AddCommonPostProcessingEffectsParameters(
+      Id, bEnableModifyingPostProcessEffects, Success, Definition);
+  }
   Success = CheckActorDefinition(Definition);
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.h
@@ -1,266 +1,277 @@
-// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma
-// de Barcelona (UAB).
-//
-// This work is licensed under the terms of the MIT license.
-// For a copy, see <https://opensource.org/licenses/MIT>.
+  // Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma
+  // de Barcelona (UAB).
+  //
+  // This work is licensed under the terms of the MIT license.
+  // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#pragma once
+  #pragma once
 
-#include "Carla/Actor/ActorDefinition.h"
-#include "Carla/Actor/ActorDescription.h"
-#include "Carla/Actor/PedestrianParameters.h"
-#include "Carla/Actor/PropParameters.h"
-#include "Carla/Actor/VehicleParameters.h"
-#include "Carla/Sensor/GnssSensor.h"
-#include "Carla/Sensor/Radar.h"
-#include "Carla/Sensor/InertialMeasurementUnit.h"
-#include "Carla/Sensor/V2XSensor.h"
-#include "Carla/Sensor/CustomV2XSensor.h"
-#include "Carla/Sensor/V2XSensor.h"
-#include "Carla/Sensor/CustomV2XSensor.h"
+  #include "Carla/Actor/ActorDefinition.h"
+  #include "Carla/Actor/ActorDescription.h"
+  #include "Carla/Actor/PedestrianParameters.h"
+  #include "Carla/Actor/PropParameters.h"
+  #include "Carla/Actor/VehicleParameters.h"
+  #include "Carla/Sensor/GnssSensor.h"
+  #include "Carla/Sensor/Radar.h"
+  #include "Carla/Sensor/InertialMeasurementUnit.h"
+  #include "Carla/Sensor/V2XSensor.h"
+  #include "Carla/Sensor/CustomV2XSensor.h"
+  #include "Carla/Sensor/V2XSensor.h"
+  #include "Carla/Sensor/CustomV2XSensor.h"
 
-#include "Kismet/BlueprintFunctionLibrary.h"
+  #include "Kismet/BlueprintFunctionLibrary.h"
 
-#include "ActorBlueprintFunctionLibrary.generated.h"
+  #include "ActorBlueprintFunctionLibrary.generated.h"
 
-class ASceneCaptureSensor;
-class AShaderBasedSensor;
-class ASceneCaptureSensor_WideAngleLens;
-class AShaderBasedSensor_WideAngleLens;
-struct FLidarDescription;
+  class ASceneCaptureSensor;
+  class AShaderBasedSensor;
+  class ASceneCaptureSensor_WideAngleLens;
+  class AShaderBasedSensor_WideAngleLens;
+  struct FLidarDescription;
 
-UCLASS()
-class UActorBlueprintFunctionLibrary : public UBlueprintFunctionLibrary
-{
-  GENERATED_BODY()
+  UCLASS()
+  class UActorBlueprintFunctionLibrary : public UBlueprintFunctionLibrary
+  {
+    GENERATED_BODY()
 
-public:
+  public:
 
-  /// @}
-  /// ==========================================================================
-  /// @name Actor definition validators
-  /// ==========================================================================
-  /// @{
+    /// @}
+    /// ==========================================================================
+    /// @name Actor definition validators
+    /// ==========================================================================
+    /// @{
 
-  /// Return whether the actor definition is valid. Prints all the errors found.
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static bool CheckActorDefinition(const FActorDefinition &ActorDefinitions);
+    /// Return whether the actor definition is valid. Prints all the errors found.
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static bool CheckActorDefinition(const FActorDefinition &ActorDefinitions);
 
-  /// Return whether the list of actor definitions is valid. Prints all the
-  /// errors found.
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static bool CheckActorDefinitions(const TArray<FActorDefinition> &ActorDefinitions);
+    /// Return whether the list of actor definitions is valid. Prints all the
+    /// errors found.
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static bool CheckActorDefinitions(const TArray<FActorDefinition> &ActorDefinitions);
 
-  /// @}
-  /// ==========================================================================
-  /// @name Helpers to create actor definitions
-  /// ==========================================================================
-  /// @{
+    /// @}
+    /// ==========================================================================
+    /// @name Helpers to create actor definitions
+    /// ==========================================================================
+    /// @{
 
-  static FActorDefinition MakeGenericDefinition(
-      const FString &Category,
-      const FString &Type,
-      const FString &Id);
+    static void AddCommonCameraParameters(
+        const FString &Id,
+        bool bEnableModifyingPostProcessEffects,
+        bool &Success,
+        FActorDefinition &Definition);
+    
+    static void AddCommonWideAngleLensCameraParameters(
+        const FString &Id,
+        bool bEnableModifyingPostProcessEffects,
+        bool &Success,
+        FActorDefinition &Definition);
+    
+    static void AddCommonPostProcessingEffectsParameters(
+        const FString &Id,
+        bool bEnableModifyingPostProcessEffects,
+        bool &Success,
+        FActorDefinition &Definition);
+      
+    static FActorDefinition MakeGenericDefinition(
+        const FString &Category,
+        const FString &Type,
+        const FString &Id);
 
-  static FActorDefinition MakeGenericSensorDefinition(
-      const FString &Type,
-      const FString &Id);
+    static FActorDefinition MakeGenericSensorDefinition(
+        const FString &Type,
+        const FString &Id);
 
-  static FActorDefinition MakeCameraDefinition(
-      const FString &Id,
-      bool bEnableModifyingPostProcessEffects = false);
+    static FActorDefinition MakeCameraDefinition(
+        const FString &Id,
+        bool bEnableModifyingPostProcessEffects = false);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeCameraDefinition(
-      const FString &Id,
-      bool bEnableModifyingPostProcessEffects,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeCameraDefinition(
+        const FString &Id,
+        bool bEnableModifyingPostProcessEffects,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeWideAngleLensCameraDefinition(
-      const FString& Id,
-      bool bEnableModifyingPostProcessEffects = false);
+    static FActorDefinition MakeWideAngleLensCameraDefinition(
+        const FString& Id,
+        bool bEnableModifyingPostProcessEffects = false);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeWideAngleLensCameraDefinition(
-      const FString& Id,
-      bool bEnableModifyingPostProcessEffects,
-      bool& Success,
-      FActorDefinition& Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeWideAngleLensCameraDefinition(
+        const FString& Id,
+        bool bEnableModifyingPostProcessEffects,
+        bool& Success,
+        FActorDefinition& Definition);
 
-  static FActorDefinition MakeNormalsCameraDefinition();
+    static FActorDefinition MakeLidarDefinition(
+        const FString &Id);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeNormalsCameraDefinition(
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeLidarDefinition(
+        const FString &Id,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeLidarDefinition(
-      const FString &Id);
+    static FActorDefinition MakeGnssDefinition();
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeLidarDefinition(
-      const FString &Id,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeGnssDefinition(
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeGnssDefinition();
+    static FActorDefinition MakeIMUDefinition();
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeGnssDefinition(
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeIMUDefinition(
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeIMUDefinition();
+    static FActorDefinition MakeRadarDefinition();
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeIMUDefinition(
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeRadarDefinition(
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeRadarDefinition();
+    static FActorDefinition MakeV2XDefinition();
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeRadarDefinition(
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeV2XDefinition(
+        bool &Success,
+        FActorDefinition &Definition);
 
-  static FActorDefinition MakeV2XDefinition();
+    static FActorDefinition MakeCustomV2XDefinition();
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeV2XDefinition(
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeCustomV2XDefinition(
+        bool &Success,
+        FActorDefinition &Definition);            
 
-  static FActorDefinition MakeCustomV2XDefinition();
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeVehicleDefinition(
+        const FVehicleParameters &Parameters,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeCustomV2XDefinition(
-      bool &Success,
-      FActorDefinition &Definition);            
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeVehicleDefinitions(
+        const TArray<FVehicleParameters> &ParameterArray,
+        TArray<FActorDefinition> &Definitions);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeVehicleDefinition(
-      const FVehicleParameters &Parameters,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakePedestrianDefinition(
+        const FPedestrianParameters &Parameters,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeVehicleDefinitions(
-      const TArray<FVehicleParameters> &ParameterArray,
-      TArray<FActorDefinition> &Definitions);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakePedestrianDefinitions(
+        const TArray<FPedestrianParameters> &ParameterArray,
+        TArray<FActorDefinition> &Definitions);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakePedestrianDefinition(
-      const FPedestrianParameters &Parameters,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeTriggerDefinitions(
+        const TArray<FString> &ParameterArray,
+        TArray<FActorDefinition> &Definitions);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakePedestrianDefinitions(
-      const TArray<FPedestrianParameters> &ParameterArray,
-      TArray<FActorDefinition> &Definitions);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakeTriggerDefinition(
+        const FString &Id,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeTriggerDefinitions(
-      const TArray<FString> &ParameterArray,
-      TArray<FActorDefinition> &Definitions);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakePropDefinition(
+        const FPropParameters &Parameters,
+        bool &Success,
+        FActorDefinition &Definition);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakeTriggerDefinition(
-      const FString &Id,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void MakePropDefinitions(
+        const TArray<FPropParameters> &ParameterArray,
+        TArray<FActorDefinition> &Definitions);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakePropDefinition(
-      const FPropParameters &Parameters,
-      bool &Success,
-      FActorDefinition &Definition);
+    UFUNCTION()
+    static void MakeObstacleDetectorDefinitions(
+        const FString &Type,
+        const FString &Id,
+        FActorDefinition &Definition);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void MakePropDefinitions(
-      const TArray<FPropParameters> &ParameterArray,
-      TArray<FActorDefinition> &Definitions);
+    /// @}
+    /// ==========================================================================
+    /// @name Helpers to retrieve attribute values
+    /// ==========================================================================
+    /// @{
 
-  UFUNCTION()
-  static void MakeObstacleDetectorDefinitions(
-      const FString &Type,
-      const FString &Id,
-      FActorDefinition &Definition);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static bool ActorAttributeToBool(const FActorAttribute &ActorAttribute, bool Default);
 
-  /// @}
-  /// ==========================================================================
-  /// @name Helpers to retrieve attribute values
-  /// ==========================================================================
-  /// @{
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static int32 ActorAttributeToInt(const FActorAttribute &ActorAttribute, int32 Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static bool ActorAttributeToBool(const FActorAttribute &ActorAttribute, bool Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static float ActorAttributeToFloat(const FActorAttribute &ActorAttribute, float Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static int32 ActorAttributeToInt(const FActorAttribute &ActorAttribute, int32 Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static FString ActorAttributeToString(const FActorAttribute &ActorAttribute, const FString &Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static float ActorAttributeToFloat(const FActorAttribute &ActorAttribute, float Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static FColor ActorAttributeToColor(const FActorAttribute &ActorAttribute, const FColor &Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static FString ActorAttributeToString(const FActorAttribute &ActorAttribute, const FString &Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static bool RetrieveActorAttributeToBool(
+        const FString &Id,
+        const TMap<FString, FActorAttribute> &Attributes,
+        bool Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static FColor ActorAttributeToColor(const FActorAttribute &ActorAttribute, const FColor &Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static int32 RetrieveActorAttributeToInt(
+        const FString &Id,
+        const TMap<FString, FActorAttribute> &Attributes,
+        int32 Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static bool RetrieveActorAttributeToBool(
-      const FString &Id,
-      const TMap<FString, FActorAttribute> &Attributes,
-      bool Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static float RetrieveActorAttributeToFloat(
+        const FString &Id,
+        const TMap<FString, FActorAttribute> &Attributes,
+        float Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static int32 RetrieveActorAttributeToInt(
-      const FString &Id,
-      const TMap<FString, FActorAttribute> &Attributes,
-      int32 Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static FString RetrieveActorAttributeToString(
+        const FString &Id,
+        const TMap<FString, FActorAttribute> &Attributes,
+        const FString &Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static float RetrieveActorAttributeToFloat(
-      const FString &Id,
-      const TMap<FString, FActorAttribute> &Attributes,
-      float Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static FColor RetrieveActorAttributeToColor(
+        const FString &Id,
+        const TMap<FString, FActorAttribute> &Attributes,
+        const FColor &Default);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static FString RetrieveActorAttributeToString(
-      const FString &Id,
-      const TMap<FString, FActorAttribute> &Attributes,
-      const FString &Default);
+    /// @}
+    /// ==========================================================================
+    /// @name Helpers to set Actors
+    /// ==========================================================================
+    /// @{
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static FColor RetrieveActorAttributeToColor(
-      const FString &Id,
-      const TMap<FString, FActorAttribute> &Attributes,
-      const FColor &Default);
+    UFUNCTION(Category = "Carla Actor", BlueprintCallable)
+    static void SetCamera(const FActorDescription &Description, ASceneCaptureSensor *Camera);
+    static void SetCamera(const FActorDescription &Description, AShaderBasedSensor *Camera);
+    
+    static void SetCamera(const FActorDescription &Description, ASceneCaptureSensor_WideAngleLens *Camera);
+    static void SetCamera(const FActorDescription &Description, AShaderBasedSensor_WideAngleLens *Camera);
 
-  /// @}
-  /// ==========================================================================
-  /// @name Helpers to set Actors
-  /// ==========================================================================
-  /// @{
+    static void SetLidar(const FActorDescription &Description, FLidarDescription &Lidar);
 
-  UFUNCTION(Category = "Carla Actor", BlueprintCallable)
-  static void SetCamera(const FActorDescription &Description, ASceneCaptureSensor *Camera);
-  static void SetCamera(const FActorDescription &Description, AShaderBasedSensor *Camera);
-  
-  static void SetCamera(const FActorDescription &Description, ASceneCaptureSensor_WideAngleLens *Camera);
-  static void SetCamera(const FActorDescription &Description, AShaderBasedSensor_WideAngleLens *Camera);
+    static void SetGnss(const FActorDescription &Description, AGnssSensor *Gnss);
 
-  static void SetLidar(const FActorDescription &Description, FLidarDescription &Lidar);
+    static void SetIMU(const FActorDescription &Description, AInertialMeasurementUnit *IMU);
 
-  static void SetGnss(const FActorDescription &Description, AGnssSensor *Gnss);
+    static void SetRadar(const FActorDescription &Description, ARadar *Radar);
 
-  static void SetIMU(const FActorDescription &Description, AInertialMeasurementUnit *IMU);
-
-  static void SetRadar(const FActorDescription &Description, ARadar *Radar);
-
-  static void SetV2X(const FActorDescription &Description, AV2XSensor *V2X);
-  static void SetCustomV2X(const FActorDescription &Description, ACustomV2XSensor *V2X);
-};
+    static void SetV2X(const FActorDescription &Description, AV2XSensor *V2X);
+    static void SetCustomV2X(const FActorDescription &Description, ACustomV2XSensor *V2X);
+  };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/NormalsCamera_WideAngleLens.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/NormalsCamera_WideAngleLens.cpp
@@ -5,31 +5,28 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "Carla.h"
-#include "Carla/Sensor/NormalsCamera.h"
+#include "Carla/Sensor/NormalsCamera_WideAngleLens.h"
 
 #include "Carla/Sensor/PixelReader.h"
 
 #include "Carla/Actor/ActorBlueprintFunctionLibrary.h"
 
-FActorDefinition ANormalsCamera::GetSensorDefinition()
+FActorDefinition ANormalsCamera_WideAngleLens::GetSensorDefinition()
 {
-  return UActorBlueprintFunctionLibrary::MakeCameraDefinition(
-    TEXT("normals"),
-    false);
+  return UActorBlueprintFunctionLibrary::MakeWideAngleLensCameraDefinition(TEXT("normals"));
 }
 
-ANormalsCamera::ANormalsCamera(const FObjectInitializer &ObjectInitializer)
+ANormalsCamera_WideAngleLens::ANormalsCamera_WideAngleLens(const FObjectInitializer &ObjectInitializer)
   : Super(ObjectInitializer)
 {
-  Enable16BitFormat(false);
   AddPostProcessingMaterial(
       TEXT("Material'/Carla/PostProcessingMaterials/PhysicLensDistortion.PhysicLensDistortion'"));
   AddPostProcessingMaterial(
       TEXT("Material'/Carla/PostProcessingMaterials/NormalsEffectMaterial.NormalsEffectMaterial'"));
 }
 
-void ANormalsCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSeconds)
+void ANormalsCamera_WideAngleLens::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSeconds)
 {
-  TRACE_CPUPROFILER_EVENT_SCOPE(ANormalsCamera::PostPhysTick);
-  FPixelReader::SendPixelsInRenderThread<ANormalsCamera, FColor>(*this);
+  TRACE_CPUPROFILER_EVENT_SCOPE(ANormalsCamera_WideAngleLens::PostPhysTick);
+  FPixelReader::SendPixelsInRenderThread<ANormalsCamera_WideAngleLens, FColor>(*this);
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/NormalsCamera_WideAngleLens.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/NormalsCamera_WideAngleLens.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "Carla/Sensor/ShaderBasedSensor_WideAngleLens.h"
+
+#include "Carla/Actor/ActorDefinition.h"
+
+#include "NormalsCamera_WideAngleLens.generated.h"
+
+/// Sensor that produces "normals" images.
+UCLASS()
+class CARLA_API ANormalsCamera_WideAngleLens : public AShaderBasedSensor_WideAngleLens
+{
+  GENERATED_BODY()
+
+public:
+
+  static FActorDefinition GetSensorDefinition();
+
+  ANormalsCamera_WideAngleLens(const FObjectInitializer &ObjectInitializer);
+
+protected:
+
+  void PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSeconds) override;
+};


### PR DESCRIPTION
This PR adds support for fisheye/wide angle lens sensors to the carla_cosmos_gen.py scripts. To enable support for fisheye cameras, add the top-level field `wide_angle_lens` to YAML sensor configuration file and set it to true. Alternatively, provide the attribute `camera_model` and set it to a valid value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9291)
<!-- Reviewable:end -->
