### PR TITLE
Fix for Pedestrian BBox Calculations

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.h
@@ -50,6 +50,9 @@ public:
     uint8 InTagQueried = 0xFF);
 
   UFUNCTION(Category = "Carla Util", BlueprintCallable)
+  static FBoundingBox GetSkeletalMeshBoundingBoxFromComponent(const USkeletalMeshComponent* SkeletalMeshComp);
+  
+  UFUNCTION(Category = "Carla Util", BlueprintCallable)
   static FBoundingBox GetSkeletalMeshBoundingBox(const USkeletalMesh* SkeletalMesh);
 
   UFUNCTION(Category = "Carla Util", BlueprintCallable)


### PR DESCRIPTION
#### Description

Partially fixes #9332 This PR modifies the calculation of pedestrian bounding boxes to use the skeletal mesh component instead of the collision cylinder capsule component.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

While this PR improves the calculation of pedestrian bounding boxes and allows them to encapsulate the contours of pedestrians, it does not adapt to their motion, nor to wheelchair users, but neither does the previous implementation. There has also been an issue with Walkers 50 and 51 (Gen 3 kids, AB001 and AG001) where their bounding box is adult-sized (even when using the collision cyliner) and this PR does not address that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9335)
<!-- Reviewable:end -->
