### PR TITLE
Fixed TrafficManager's race condition

### DIFF
--- a/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
+++ b/LibCarla/source/carla/trafficmanager/TrafficManagerLocal.h
@@ -99,16 +99,10 @@ private:
   TrafficManagerServer server;
   /// Switch to turn on / turn off traffic manager.
   std::atomic<bool> run_traffic_manger{true};
-  /// Flags to signal step begin and end.
-  std::atomic<bool> step_begin{false};
-  std::atomic<bool> step_end{false};
-  /// Mutex for progressing synchronous execution.
-  std::mutex step_execution_mutex;
-  /// Condition variables for progressing synchronous execution.
-  std::condition_variable step_begin_trigger;
-  std::condition_variable step_end_trigger;
   /// Single worker thread for sequential execution of sub-components.
   std::unique_ptr<std::thread> worker_thread;
+  /// Last processed frame
+  size_t last_frame;
   /// Randomization seed.
   uint64_t seed {static_cast<uint64_t>(time(NULL))};
   /// Structure holding random devices per vehicle.
@@ -138,6 +132,9 @@ public:
 
   /// To start the TrafficManager.
   void Start();
+
+  /// To do one step of the TrafficManager.
+  void Step();
 
   /// Initiates thread to run the TrafficManager sequentially.
   void Run();


### PR DESCRIPTION
#### Description

This PR is in response of issue #9172, where it is explained how the TM can deadlock the simulation when the synchronous mode is activated.

The changes made in here are the ones explained in that same PR. The Run() loop has been move into the Step() function, so that the SynchronousTick() can call it, removing the need for the lock and therefore, fixing the race condition.

Note that all the changed github detects in the Step function are the removal of one indentation, only the mutex variables have been removed

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA's UE4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9344)
<!-- Reviewable:end -->
