### PR TITLE
Address issue #9250

### DIFF
--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -23,6 +23,7 @@
 
 #include <exception>
 #include <thread>
+#include <chrono>
 
 using namespace std::string_literals;
 
@@ -50,7 +51,7 @@ namespace detail {
     bool result = true;
     auto start = std::chrono::system_clock::now();
     while (frame > episode.GetState()->GetTimestamp().frame) {
-      std::this_thread::yield();
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
       auto end = std::chrono::system_clock::now();
       auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
       if(timeout.to_chrono() < diff) {

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <thread>
+#include <chrono>
 
 namespace carla {
 namespace streaming {
@@ -86,7 +87,7 @@ namespace tcp {
         if (_server.IsSynchronousMode()) {
           // wait until previous message has been sent
           while (_is_writing) {
-            std::this_thread::yield();
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
           }
         } else {
           // ignore this message

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -12,6 +12,9 @@
 #include "HighResScreenshot.h"
 #include "Runtime/ImageWriteQueue/Public/ImageWriteQueue.h"
 
+#include <thread>
+#include <chrono>
+
 // =============================================================================
 // -- FPixelReader -------------------------------------------------------------
 // =============================================================================
@@ -60,7 +63,7 @@ void FPixelReader::WritePixelsToBuffer(
       TRACE_CPUPROFILER_EVENT_SCOPE_STR("Wait GPU transfer");
       while (!Readback->IsReady())
       {
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
       }
     }
 


### PR DESCRIPTION
Replace all std::this_thread::yield() calls with std::this_thread::sleep_for(std::chrono::microseconds(100)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9354)
<!-- Reviewable:end -->
