### PR TITLE
Fix for below ground trigger boxes.

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -266,11 +266,50 @@ void ATrafficLightManager::AdjustAllSignsToHeightGround()
 {
   for(ATrafficSignBase* TS : TrafficSigns)
   {
-    TS->GetRootComponent()->SetMobility(EComponentMobility::Movable);
-    FVector SpawnLocation = TS->GetActorLocation();
-    AdjustSignHeightToGround(SpawnLocation);
-    TS->SetActorLocation(SpawnLocation);
-    TS->GetRootComponent()->SetMobility(EComponentMobility::Static);
+    if (!IsValid(TS))
+      continue;
+    if (TS->bPositioned)
+      continue;
+
+    FVector OriginalLocation = TS->GetActorLocation();
+    FVector AdjustedLocation = OriginalLocation;
+    
+    TS->bPositioned = AdjustSignHeightToGround(AdjustedLocation);
+    
+    if (TS->bPositioned)
+    {
+      float ZOffset = AdjustedLocation.Z - OriginalLocation.Z;
+
+      TS->GetRootComponent()->SetMobility(EComponentMobility::Movable);
+      
+      // Get all static mesh components
+      TArray<UStaticMeshComponent*> StaticMeshComps;
+      TS->GetComponents<UStaticMeshComponent>(StaticMeshComps);
+      
+      for (UStaticMeshComponent* MeshComp : StaticMeshComps)
+      {
+        if (!MeshComp) continue;
+        
+        // Skip if this has a mesh parent (it's a child)
+        USceneComponent* ParentComp = MeshComp->GetAttachParent();
+        if (ParentComp && Cast<UStaticMeshComponent>(ParentComp))
+        {
+          continue;
+        }
+        
+        // Move the mesh component down
+        FVector CompLocation = MeshComp->GetRelativeLocation();
+        CompLocation.Z += ZOffset;
+        MeshComp->SetRelativeLocation(CompLocation);
+        
+        MeshComp->UpdateBounds();
+        
+        UE_LOG(LogCarla, Log, TEXT("Moved mesh %s by %f cm"), *TS->GetName(), ZOffset);
+      }
+      
+      TS->UpdateComponentTransforms();
+      TS->GetRootComponent()->SetMobility(EComponentMobility::Static);
+    }
   }
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -909,7 +909,7 @@ void ATrafficLightManager::RemoveAttachedProps(TArray<AActor*> Actors) const
 
 bool ATrafficLightManager::AdjustSignHeightToGround(FVector& SpawnLocation) const
 {
-  const FVector Start = SpawnLocation + FVector(0, 0, 10.0f);
+  const FVector Start = SpawnLocation + FVector(0, 0, 200.0f);
   const FVector End = SpawnLocation - FVector(0, 0, 10000.0f);
 
   FHitResult HitResult;


### PR DESCRIPTION
Fixes #9362 , does not fix #9361 as that seems to be an ObjectRegister issue. Basically, instead of moving actors to ground height, this only moves the static mesh component, preserving the location of the trigger boxes. I have also increased the Start search height to 200.0f since traffic lights in Town12 are spawn ~70 cm below the ground level and need to be brought up.

I've been using the following script to test this:

```Python
import time
import carla

import numpy as np 

client = carla.Client('localhost', 2000)
client.set_timeout(80.0)
client.load_world('Town12')

time.sleep(3.0)

world = client.get_world()
sp = world.get_spectator()
sp.set_location(carla.Location(x=-1130, y=3930.0, z=360.0))

time.sleep(3.0)

actors = world.get_actors()
for x in actors:
    if 8 in x.semantic_tags and not x.is_dormant:
        bbox = x.bounding_box.get_world_vertices(x.get_transform())
        for y in bbox:
            world.debug.draw_point(y, size=0.5, color=carla.Color(255, 0, 0), life_time=100.0)

time.sleep(1.0)

signs = world.get_environment_objects(carla.CityObjectLabel.TrafficSigns)
for obj in signs:
    bbox = obj.bounding_box.get_local_vertices()
    for y in bbox:
        world.debug.draw_point(y, size=0.5, color=carla.Color(255, 255, 255), life_time=100.0)

time.sleep(20.0)

sp.set_location(carla.Location(x=-800, y=3930.0, z=370.0))

time.sleep(3.0)

for x in actors:
    if 7 in x.semantic_tags and not x.is_dormant:
        bbox = x.bounding_box.get_world_vertices(x.get_transform())
        for y in bbox:
            world.debug.draw_point(y, size=0.5, color=carla.Color(0, 255, 0), life_time=100.0)

time.sleep(20.0)

for x in actors:
    if 7 in x.semantic_tags and not x.is_dormant:
        bboxes = x.get_light_boxes()
        for box in bboxes:
            bbox = box.get_local_vertices()
            x_diff = round((x.get_location().x - box.location.x)/1000.0) * 1000.0
            y_diff = round((x.get_location().y - box.location.y)/1000.0) * 1000.0
            for y in bbox:
                world.debug.draw_point(y + carla.Vector3D(x=x_diff, y=y_diff, z=0.0), size=0.5, color=carla.Color(0, 0, 255), life_time=100.0)
```

<img width="3840" height="2106" alt="Screenshot from 2025-10-22 17-16-39" src="https://github.com/user-attachments/assets/89eb2c39-88c5-4414-846c-d67774cdaf75" />
<img width="3840" height="2106" alt="Screenshot from 2025-10-22 17-17-30" src="https://github.com/user-attachments/assets/d94eaae6-4a6b-4f2d-b01d-be8e5094e330" />
<img width="3840" height="2106" alt="Screenshot from 2025-10-22 17-17-47" src="https://github.com/user-attachments/assets/7bd8f572-8f89-464e-a253-7c0f1b4946d4" />


#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

N/A at the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9381)
<!-- Reviewable:end -->
