### PR TITLE
Smoothed how the TrafficManager does turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Latest Changes
 
  * Improved the way the TrafficManager controls large vehicles at junctions, reducing the frequency of collisions with other elements in the simulation.
+ * Improved the turning behavior of vehicles controlled by the TrafficManager, making them smoother.
  * Added a hybrid solid-state LiDAR with adjustable parameters (blueprint attributes)
 
 ## CARLA 0.9.16

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -349,7 +349,6 @@ void LocalizationStage::HandleLargeVehicleJunction(const ActorId actor_id,
                                              middle_waypoint->GetLocation(),
                                              last_waypoint->GetLocation());
 
-    std::cout << "Radius: " << radius << std::endl;
     if (radius > LARGE_VEHICLES_JUNCTION_MAX_RADIUS){
       return; // Straight path
     }

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -160,8 +160,8 @@ void MotionPlanStage::Update(const unsigned long index) {
 
       // Get the targer data.
       const float target_point_distance = std::max(vehicle_speed * TARGET_WAYPOINT_TIME_HORIZON,
-                                                  MIN_TARGET_WAYPOINT_DISTANCE);
-      auto target_pair = GetTargetData(waypoint_buffer, target_point_distance, vehicle_location);
+                                                   MIN_TARGET_WAYPOINT_DISTANCE);
+      auto target_pair = GetTargetLocation(waypoint_buffer, target_point_distance, vehicle_location);
       cg::Location target_location = target_pair.first;
       uint64_t target_index = target_pair.second;
       SimpleWaypointPtr target_waypoint = waypoint_buffer.at(target_index);
@@ -277,9 +277,9 @@ void MotionPlanStage::Update(const unsigned long index) {
   }
 }
 
-std::pair<cg::Location, uint64_t> MotionPlanStage::GetTargetData(const Buffer &waypoint_buffer,
-                                                                 float target_distance,
-                                                                 cg::Location vehicle_location){
+std::pair<cg::Location, uint64_t> MotionPlanStage::GetTargetLocation(const Buffer &waypoint_buffer,
+                                                                     float target_distance,
+                                                                     cg::Location vehicle_location){
 
     // If there is only one point, return it.
     if (waypoint_buffer.size() == 1){
@@ -318,7 +318,9 @@ std::pair<cg::Location, uint64_t> MotionPlanStage::GetTargetData(const Buffer &w
 
     cg::Location target_location;
     if (target_far_distance != target_close_distance){
-      double t = (target_distance - target_close_distance) / (target_far_distance - target_close_distance);
+      float t = (target_distance - target_close_distance) / (target_far_distance - target_close_distance);
+      // This adds a little consistency as sometimes the buffer's front is further than the target distance.
+      t = std::max(t, 0.0f);
       target_location = cg::Location(
         target_close_location.x + (target_far_location.x - target_close_location.x) * t,
         target_close_location.y + (target_far_location.y - target_close_location.y) * t,

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -320,12 +320,18 @@ std::pair<cg::Location, uint64_t> MotionPlanStage::GetTargetData(const Buffer &w
     float target_close_distance = vehicle_location.Distance(target_close_location);
     float target_far_distance = vehicle_location.Distance(target_far_location);
 
-    double t = (target_distance - target_close_distance) / (target_far_distance - target_close_distance);
-    cg::Location target_location = cg::Location(
-      target_close_location.x + (target_far_location.x - target_close_location.x) * t,
-      target_close_location.y + (target_far_location.y - target_close_location.y) * t,
-      target_close_location.z + (target_far_location.z - target_close_location.z) * t
-    );
+    cg::Location target_location;
+    if (target_far_distance != target_close_distance){
+      double t = (target_distance - target_close_distance) / (target_far_distance - target_close_distance);
+      target_location = cg::Location(
+        target_close_location.x + (target_far_location.x - target_close_location.x) * t,
+        target_close_location.y + (target_far_location.y - target_close_location.y) * t,
+        target_close_location.z + (target_far_location.z - target_close_location.z) * t
+      );
+    } else {
+      // This actually happens, for some reason
+      target_location = target_close_location;
+    }
 
     return std::make_pair(target_location, closest_index);
   }

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -291,13 +291,9 @@ std::pair<cg::Location, uint64_t> MotionPlanStage::GetTargetData(const Buffer &w
     // Get the two closest waypoints.
     size_t closest_index = 0;
     size_t farthest_index = 0;
-    for (uint64_t i = 0; i < waypoint_buffer.size() - 1; i++) {
-        SimpleWaypointPtr target_close_waypoint = waypoint_buffer.at(i);
-        SimpleWaypointPtr target_far_waypoint = waypoint_buffer.at(i+1);
-        float close_dist_square = vehicle_location.DistanceSquared(target_close_waypoint->GetLocation());
-        float far_dist_square = vehicle_location.DistanceSquared(target_far_waypoint->GetLocation());
-
-        if (close_dist_square < target_square_distance){
+    for (uint64_t i = 0; i < waypoint_buffer.size(); i++) {
+        float close_square_dist = vehicle_location.DistanceSquared(waypoint_buffer.at(i)->GetLocation());
+        if (close_square_dist < target_square_distance){
           closest_index = i;
         } else {
           farthest_index = i;

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
@@ -58,7 +58,7 @@ private:
 
   float CalculateBaseOffset(const ActorId actor_id, 
                             const Buffer &waypoint_buffer,
-                            const SimpleWaypointPtr target_waypoint,
+                            const bool is_target_junction,
                             const uint64_t target_index);
 
   float GetLandmarkTargetVelocity(const SimpleWaypoint& waypoint,
@@ -72,6 +72,10 @@ private:
   float GetThreePointCircleRadius(cg::Location first_location,
                                   cg::Location middle_location,
                                   cg::Location last_location);
+
+  std::pair<cg::Location, uint64_t> GetTargetData(const Buffer &waypoint_buffer,
+                                                  float target_distance,
+                                                  cg::Location vehicle_location);
 
 public:
   MotionPlanStage(const std::vector<ActorId> &vehicle_id_list,

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.h
@@ -73,9 +73,9 @@ private:
                                   cg::Location middle_location,
                                   cg::Location last_location);
 
-  std::pair<cg::Location, uint64_t> GetTargetData(const Buffer &waypoint_buffer,
-                                                  float target_distance,
-                                                  cg::Location vehicle_location);
+  std::pair<cg::Location, uint64_t> GetTargetLocation(const Buffer &waypoint_buffer,
+                                                      float target_distance,
+                                                      cg::Location vehicle_location);
 
 public:
   MotionPlanStage(const std::vector<ActorId> &vehicle_id_list,


### PR DESCRIPTION
### Description

Changed the target location used by the TrafficManager control to smooth the way turns are performed.

Currently, the road is divided into waypoints every 5m, reduced to 2-3m at turns. The MotionPlanStage selects one of these waypoints and uses is as the target. This creates sudden changes in the target yaw, making the control less smooth.

This PR makes it so that instead of targeting a specific waypoint, it interpolates between the two closest ones to that target distance, picking a location in between. The PR also changes the angular metric from the dot product to the angle. It doesn't really make that much of a difference control wise, but the dot product has a non-linear relation with the steering, while the angle has so it adds a bit of robustness..

### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA's UE4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9395)
<!-- Reviewable:end -->
