### PR TITLE
Fix Prop Factory - Enable prop spawning from Python API

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -15,6 +15,7 @@
 #include "Carla/Sensor/ShaderBasedSensor.h"
 #include "Carla/Util/ScopedStack.h"
 #include "BlueprintLibary/PostProcessJsonUtils.h"
+#include "Engine/StaticMeshActor.h"
 
 #include <algorithm>
 #include <limits>
@@ -1063,6 +1064,16 @@ void UActorBlueprintFunctionLibrary::MakePropDefinition(
   FillIdAndTags(Definition, TEXT("static"), TEXT("prop"), Parameters.Name);
   AddRecommendedValuesForActorRoleName(Definition, {TEXT("prop")});
 
+  Definition.Class = AStaticMeshActor::StaticClass();
+  if (Parameters.Mesh != nullptr)
+  {
+    Definition.Variations.Emplace(FActorVariation{
+        TEXT("mesh_path"),
+        EActorAttributeType::String,
+        {Parameters.Mesh->GetPathName()},
+        false});
+  }
+
   auto GetSize = [](EPropSize Value)
   {
     switch (Value)
@@ -1364,7 +1375,6 @@ void UActorBlueprintFunctionLibrary::SetCamera(
 
     FString PostProcessDefaultName = RetrieveActorAttributeToString("post_process_profile",
         Description.Variations, TEXT("default"));
-    
     UPostProcessJsonUtils::LoadAllPostProcessFromJsonToSceneCapture(
         Camera->GetCaptureComponent(),
         PostProcessDefaultName);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/Factory/PropActorFactory.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/Factory/PropActorFactory.cpp
@@ -15,12 +15,14 @@
 #include "JsonUtilities.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+#include "Engine/StaticMeshActor.h"
+#include "Components/StaticMeshComponent.h"
 #include <util/ue-header-guard-end.h>
 
 TArray<FActorDefinition> APropActorFactory::GetDefinitions()
 {
   LoadPropParametersArrayFromFile("PropParameters.json", PropsParams);
-  
+
   UActorBlueprintFunctionLibrary::MakePropDefinitions(PropsParams, Definitions);
   return Definitions;
 }
@@ -37,22 +39,77 @@ FActorSpawnResult APropActorFactory::SpawnActor(
     return SpawnResult;
   }
 
-  AActor* SpawnedActor = GetWorld()->SpawnActor<AActor>(ActorDescription.Class, SpawnAtTransform);
-  SpawnResult.Actor = SpawnedActor;
+  FActorSpawnParameters SpawnParameters;
+  SpawnParameters.SpawnCollisionHandlingOverride =
+      ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 
-  if(SpawnedActor == nullptr)
+  AStaticMeshActor* StaticMeshActor = GetWorld()->SpawnActor<AStaticMeshActor>(
+      ActorDescription.Class, SpawnAtTransform, SpawnParameters);
+
+  SpawnResult.Actor = StaticMeshActor;
+
+  if(StaticMeshActor == nullptr)
   {
     SpawnResult.Status = EActorSpawnResultStatus::Collision;
     return SpawnResult;
   }
 
-  if(PostProcessProp(SpawnedActor, ActorDescription))
+  UStaticMeshComponent* StaticMeshComponent = Cast<UStaticMeshComponent>(
+      StaticMeshActor->GetRootComponent());
+
+  if (!StaticMeshComponent)
   {
-    SpawnResult.Status = EActorSpawnResultStatus::Success;
+    UE_LOG(LogCarla, Error, TEXT("Prop spawn failed: StaticMeshComponent is null for actor %s"),
+        *ActorDescription.Id);
+    StaticMeshActor->Destroy();
+    SpawnResult.Status = EActorSpawnResultStatus::UnknownError;
     return SpawnResult;
   }
 
-  SpawnResult.Status = EActorSpawnResultStatus::UnknownError;
+  if (!ActorDescription.Variations.Contains("mesh_path"))
+  {
+    UE_LOG(LogCarla, Error, TEXT("Prop spawn failed: No mesh_path variation found for actor %s"),
+        *ActorDescription.Id);
+    StaticMeshActor->Destroy();
+    SpawnResult.Status = EActorSpawnResultStatus::InvalidDescription;
+    return SpawnResult;
+  }
+
+  FString MeshPath = UActorBlueprintFunctionLibrary::ActorAttributeToString(
+      ActorDescription.Variations["mesh_path"], "");
+
+  if (MeshPath.IsEmpty())
+  {
+    UE_LOG(LogCarla, Error, TEXT("Prop spawn failed: mesh_path is empty for actor %s"),
+        *ActorDescription.Id);
+    StaticMeshActor->Destroy();
+    SpawnResult.Status = EActorSpawnResultStatus::InvalidDescription;
+    return SpawnResult;
+  }
+
+  UStaticMesh* Mesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+  if (Mesh == nullptr)
+  {
+    UE_LOG(LogCarla, Error, TEXT("Prop spawn failed: Failed to load mesh '%s' for actor %s"),
+        *MeshPath, *ActorDescription.Id);
+    StaticMeshActor->Destroy();
+    SpawnResult.Status = EActorSpawnResultStatus::UnknownError;
+    return SpawnResult;
+  }
+
+  StaticMeshComponent->SetMobility(EComponentMobility::Movable);
+  if (!StaticMeshComponent->SetStaticMesh(Mesh))
+  {
+    UE_LOG(LogCarla, Error, TEXT("Prop spawn failed: Failed to set mesh '%s' for actor %s"),
+        *MeshPath, *ActorDescription.Id);
+    StaticMeshActor->Destroy();
+    SpawnResult.Status = EActorSpawnResultStatus::UnknownError;
+    return SpawnResult;
+  }
+
+  StaticMeshComponent->SetMobility(EComponentMobility::Static);
+  PostProcessProp(StaticMeshActor, ActorDescription);
+  SpawnResult.Status = EActorSpawnResultStatus::Success;
   return SpawnResult;
 }
 


### PR DESCRIPTION
This PR is related with [this content PR](https://bitbucket.org/carla-simulator/carla-content/pull-requests/1981)

## Problem
  The prop factory was not working - props could not be spawned from the Python API. Attempting to spawn any prop would fail silently or return errors.

## Root Cause
  Three main issues prevented props from spawning:

  1. **Missing Class Assignment**: `MakePropDefinition()` in `ActorBlueprintFunctionLibrary.cpp` was not assigning `Definition.Class`, leaving it null. This caused `SpawnActor()` to fail the validity check.

  2. **No Mesh Path Propagation**: There was no mechanism to pass the mesh path from the prop definition to the spawner, making it impossible to load the correct mesh at spawn time.

  3. **Incomplete SpawnActor Implementation**: `PropActorFactory::SpawnActor()` returned `UnknownError` immediately without any actual spawning logic.

## Testing
Tested in Ubuntu 22 in Town10.

<img width="469" height="660" alt="Screenshot from 2025-10-29 18-48-40" src="https://github.com/user-attachments/assets/bd309848-9181-4701-b511-d4e59ce0772a" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9396)
<!-- Reviewable:end -->
