### PR TITLE
Potential bug in ALSM.cpp

### DIFF
--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -372,7 +372,7 @@ void ALSM::AddActor(const Actor actor){
     if (attribute.GetId() == "base_type"){
       std::string value = attribute.GetValue();
       std::transform(value.begin(), value.end(), value.begin(),[](unsigned char c){ return std::tolower(c);});
-      if (std::find(large_vehicle_types.begin(), large_vehicle_types.end(), attribute.GetValue()) != large_vehicle_types.end()) {
+      if (std::find(large_vehicle_types.begin(), large_vehicle_types.end(), value) != large_vehicle_types.end()) {
         large_vehicles[actor_id] = std::make_pair(0.0f, 0.0f);
       } else {
       }


### PR DESCRIPTION
The problem here is we were checking against `attribute.GetValue()` in the if statement.
This can lead to a bug because these tags are handwritten.
There is a lowered variable of the name to avoid this but we are not using that variable for the check.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9398)
<!-- Reviewable:end -->
