### PR TITLE
Fix: Incorrect bounding boxes for Stop Signs in large maps (Issue #9394)

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -197,30 +197,19 @@ void ALargeMapManager::AdjustAllSignsToHeightGround()
 
       Actor->GetRootComponent()->SetMobility(EComponentMobility::Movable);
 
-      // Get all static mesh components
-      TArray<UStaticMeshComponent*> StaticMeshComps;
-      Actor->GetComponents<UStaticMeshComponent>(StaticMeshComps);
-
-      for (UStaticMeshComponent* MeshComp : StaticMeshComps)
+      Actor->SetActorLocation(AdjustedLocation);
+      TArray<UBoxComponent*> BoxComponents;
+      Actor->GetComponents<UBoxComponent>(BoxComponents);
+      for (UBoxComponent* BoxComp : BoxComponents)
       {
-        if (!MeshComp) continue;
+        if (!BoxComp) continue;
 
-        // Skip if this has a mesh parent (it's a child)
-        USceneComponent* ParentComp = MeshComp->GetAttachParent();
-        if (ParentComp && Cast<UStaticMeshComponent>(ParentComp))
-        {
-          continue;
-        }
-
-        // Move the mesh component down
-        FVector CompLocation = MeshComp->GetRelativeLocation();
-        CompLocation.Z += ZOffset;
-        MeshComp->SetRelativeLocation(CompLocation);
-
-        MeshComp->UpdateBounds();
-
-        LM_LOG(Log, "Moved mesh %s by %f cm", *Actor->GetName(), ZOffset);
+        FVector BoxLocation = BoxComp->GetRelativeLocation();
+        BoxLocation.Z -= ZOffset;
+        BoxComp->SetRelativeLocation(BoxLocation);
       }
+
+      LM_LOG(Log, "Adjusted sign %s height by %f cm", *Actor->GetName(), ZOffset);
 
       Actor->UpdateComponentTransforms();
       Actor->GetRootComponent()->SetMobility(EComponentMobility::Static);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Traffic/TrafficLightManager.cpp
@@ -291,30 +291,19 @@ void ATrafficLightManager::AdjustAllSignsToHeightGround()
 
       TS->GetRootComponent()->SetMobility(EComponentMobility::Movable);
 
-      // Get all static mesh components
-      TArray<UStaticMeshComponent*> StaticMeshComps;
-      TS->GetComponents<UStaticMeshComponent>(StaticMeshComps);
-
-      for (UStaticMeshComponent* MeshComp : StaticMeshComps)
+      TS->SetActorLocation(AdjustedLocation);
+      TArray<UBoxComponent*> BoxComponents;
+      TS->GetComponents<UBoxComponent>(BoxComponents);
+      for (UBoxComponent* BoxComp : BoxComponents)
       {
-        if (!MeshComp) continue;
+        if (!BoxComp) continue;
 
-        // Skip if this has a mesh parent (it's a child)
-        USceneComponent* ParentComp = MeshComp->GetAttachParent();
-        if (ParentComp && Cast<UStaticMeshComponent>(ParentComp))
-        {
-          continue;
-        }
-
-        // Move the mesh component down
-        FVector CompLocation = MeshComp->GetRelativeLocation();
-        CompLocation.Z += ZOffset;
-        MeshComp->SetRelativeLocation(CompLocation);
-
-        MeshComp->UpdateBounds();
-
-        UE_LOG(LogCarla, Log, TEXT("Moved mesh %s by %f cm"), *TS->GetName(), ZOffset);
+        FVector BoxLocation = BoxComp->GetRelativeLocation();
+        BoxLocation.Z -= ZOffset;
+        BoxComp->SetRelativeLocation(BoxLocation);
       }
+
+      UE_LOG(LogCarla, Log, TEXT("Adjusted sign %s height by %f cm"), *TS->GetName(), ZOffset);
 
       TS->UpdateComponentTransforms();
       TS->GetRootComponent()->SetMobility(EComponentMobility::Static);


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR fixes the mismatch between the bounding boxes of Stop Signs when using:

- Actor.bounding_box
- Actor.trigger_volume
- EnvironmentObject.bounding_box

Previously, these bounding boxes did not align correctly in large maps such as Town12 — the actor’s bounding_box and the trigger_volume were returning inconsistent transforms.
This issue has now been corrected so that all bounding boxes match the same physical area in the world.

Fixes #9394

<img width="671" height="549" alt="Screenshot from 2025-11-03 19-26-39" src="https://github.com/user-attachments/assets/80e087ab-cc43-4353-a743-ec3c884721b5" />


#### Testing

The fix was tested in Town12 using the following script:
```python
import time
import carla
import numpy as np

client = carla.Client('localhost', 2000)
client.set_timeout(80.0)
client.load_world('Town12')

time.sleep(3.0)

world = client.get_world()
sp = world.get_spectator()
sp.set_location(carla.Location(x=-1130, y=3930.0, z=360.0))

time.sleep(3.0)

actors = world.get_actors()
for x in actors:
    if 8 in x.semantic_tags and not x.is_dormant:
        bbox = x.bounding_box.get_world_vertices(x.get_transform())
        for y in bbox:
            world.debug.draw_point(y, size=0.2, color=carla.Color(0, 255, 0), life_time=100.0)

for x in actors:
    if 8 in x.semantic_tags and not x.is_dormant:
        bbox = x.trigger_volume.get_world_vertices(x.get_transform())
        for y in bbox:
            world.debug.draw_point(y, size=0.2, color=carla.Color(0, 0, 255), life_time=100.0)

time.sleep(1.0)

signs = world.get_environment_objects(carla.CityObjectLabel.TrafficSigns)
for obj in signs:
    bbox = obj.bounding_box.get_world_vertices(obj.transform)
    for y in bbox:
        world.debug.draw_point(y, size=0.2, color=carla.Color(255, 255, 255), life_time=100.0)

time.sleep(20.0)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9406)
<!-- Reviewable:end -->
