### PR TITLE
Fix potential null pointer dereference in pugixml (#8491)

### DIFF
--- a/LibCarla/source/test/common/test_pugixml.cpp
+++ b/LibCarla/source/test/common/test_pugixml.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "test.h"
+#include <pugixml/pugixml.hpp>
+
+using namespace pugi;
+
+TEST(pugixml, null_pointer_dereference_insert_move_before) {
+  // Create an empty node (without root, _root = nullptr)
+  xml_node empty_node;
+  ASSERT_FALSE(empty_node);
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child1 = root.append_child("child1");
+  xml_node child2 = root.append_child("child2");
+
+  // Attempt insert_move_before from an empty node
+  // Before the patch this would crash, now it should return an empty xml_node
+  xml_node result = empty_node.insert_move_before(child2, child1);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_move_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child1 = root.append_child("child1");
+  xml_node child2 = root.append_child("child2");
+
+  // Attempt insert_move_after from an empty node
+  xml_node result = empty_node.insert_move_after(child2, child1);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_child_before) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+
+  // Attempt insert_child_before from an empty node
+  xml_node result = empty_node.insert_child_before(node_element, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_child_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+
+  // Attempt insert_child_after from an empty node
+  xml_node result = empty_node.insert_child_after(node_element, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_copy_before) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+  xml_node proto = root.append_child("proto");
+
+  // Attempt insert_copy_before from an empty node
+  xml_node result = empty_node.insert_copy_before(proto, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_copy_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+  xml_node proto = root.append_child("proto");
+
+  // Attempt insert_copy_after from an empty node
+  xml_node result = empty_node.insert_copy_after(proto, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}

--- a/LibCarla/source/third-party/pugixml/pugixml.cpp
+++ b/LibCarla/source/third-party/pugixml/pugixml.cpp
@@ -5826,7 +5826,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_child_before(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5844,7 +5844,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_child_after(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5933,7 +5933,7 @@ namespace pugi
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5951,7 +5951,7 @@ namespace pugi
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -6000,7 +6000,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_move_after(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 		if (moved._root == node._root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
@@ -6018,7 +6018,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_move_before(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 		if (moved._root == node._root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);


### PR DESCRIPTION
#### Description

  This PR addresses issue #8491 reported by the Qianxin CodeSafe Team regarding a potential null pointer dereference in pugixml.

  **The Issue:**
  The issue identifies that in several `insert_*` functions, the validation check:
  ```cpp
  if (!node._root || node._root->parent != _root) return xml_node();
```
  does not explicitly verify that _root itself is non-null before comparing it with `node._root->parent`. This could theoretically allow
  execution to continue when both are nullptr.

  The Fix:
  Added explicit `!_root` checks as a defensive programming measure in 6 functions:
  - insert_move_before, insert_move_after
  - insert_child_before, insert_child_after
  - insert_copy_before, insert_copy_after

  Changed from:
  ```cpp
  if (!node._root || node._root->parent != _root) return xml_node();
```
  To:
 ```cpp
if (!_root || !node._root || node._root->parent != _root) return xml_node();
```
  Testing:
  Added 6 unit tests in test_pugixml.cpp that verify the functions correctly handle edge cases with empty nodes.

  Note: This is a defensive programming improvement. In practice, the vulnerable code path is difficult to
  reach due to other safety checks that execute first (`get_allocator` checks), but this patch provides defense-in-depth and prevents potential future issues if the code is refactored.

  Fixes #8491

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9407)
<!-- Reviewable:end -->
