### PR TITLE
fix: support all VS2022 editions for setup scripts

### DIFF
--- a/CarlaSetup.bat
+++ b/CarlaSetup.bat
@@ -77,11 +77,22 @@ if exist "%cd%\Unreal\CarlaUnreal\Content" (
 )
 
 rem Activate VS terminal development environment:
+set "vs_env_bat="
 if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_env_bat=%PROGRAMFILES%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+)
+if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_env_bat=%PROGRAMFILES%\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+)
+if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_env_bat=%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+)
+
+if not "%vs_env_bat%"=="" (
     echo Activating "x64 Native Tools Command Prompt" terminal environment.
-    call "%PROGRAMFILES%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" || exit /b
+    call "%vs_env_bat%" || exit /b
 ) else (
-    echo Could not find vcvarsall.bat, aborting setup...
+    echo Could not find vcvars64.bat for VS 2022, aborting setup...
     exit 1
 )
 

--- a/Util/SetupUtils/InstallPrerequisites.bat
+++ b/Util/SetupUtils/InstallPrerequisites.bat
@@ -47,7 +47,26 @@ rem -- MAIN --
 
 :main
 
-rem -- INSTALL VISUAL STUDIO --
+rem -- INSTALL VISUAL STUDIO IF NOT FOUND --
+setlocal EnableDelayedExpansion
+set "vs_found=false"
+if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_found=true"
+)
+if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_found=true"
+)
+if exist "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
+    set "vs_found=true"
+)
+
+if "!vs_found!"=="true" (
+    echo Found Visual Studio 2022.
+    goto end_vs_install
+) else (
+    echo Could not find Visual Studio 2022. Downloading...
+)
+
 if not exist %cd%\Temp (
     mkdir %cd%\Temp
 )
@@ -57,6 +76,8 @@ popd Temp
 %cd%\Temp\vs_community.exe --add %visual_studio_components% --installWhileDownloading --passive --wait || exit /b
 del %cd%\Temp\vs_community.exe
 rmdir %cd%\Temp
+
+:end_vs_install
 
 rem -- INSTALL NINJA --
 ninja --version >nul 2>nul


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Improved Windows setup scripts to support all editions of Visual Studio 2022 (Community, Professional, Enterprise).  
Both `CarlaSetup.bat` and `Util/SetupUtils/InstallPrerequisites.bat` now detect and use any installed VS2022 edition, making the setup process more robust for different developer environments.

Fixes #  N/A<!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows 10/11
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** 5.x

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None expected. The changes only affect Windows setup scripts and improve compatibility for different Visual Studio 2022 editions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9411)
<!-- Reviewable:end -->
