### PR TITLE
Fix OpenDrive Builder lane width handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  * Improved the way the TrafficManager controls large vehicles at junctions, reducing the frequency of collisions with other elements in the simulation.
  * Improved the turning behavior of vehicles controlled by the TrafficManager, making them smoother.
  * Added a hybrid solid-state LiDAR with adjustable parameters (blueprint attributes)
+ * Fix OpenDrive Builder lane width
 
 ## CARLA 0.9.16
 

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -38,10 +38,12 @@ namespace parser {
         map_builder.CreateLaneWidth(lane, s_offset + s, a, b, c, d);
         width_count++;
       }
-      if (width_count == 0 && lane->GetId() != 0) {
+      if (width_count == 0) {
         map_builder.CreateLaneWidth(lane, s, 0.0, 0.0, 0.0, 0.0);
-        std::cout << "WARNING: In road " << lane->GetRoad()->GetId() << " lane " << lane->GetId() <<
-        " no \"<width>\" parameter found under \"<lane>\" tag. Using default values." << std::endl;
+        if (lane->GetId() != 0) {
+          std::cout << "WARNING: In road " << lane->GetRoad()->GetId() << " lane " << lane->GetId() <<
+          " no \"<width>\" parameter found under \"<lane>\" tag. Using default values." << std::endl;
+        }
       }
 
       // Lane Border


### PR DESCRIPTION
Ensure at least one lane width attribute is always available. Leave out only the warning message for the center line.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [X ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ n/a] Extended the README / documentation, if necessary
  - [ X] Code compiles correctly
  - [no] All tests passing with `make check` (only Linux)
=> benchmark_streaming.image_1920x1080_mt is failing with only 1063 out of 1080, but I guess this is due to timing issues using only a gaming laptop
  - [ X] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Maybe there is already an issue on segfaults when loading some OpenDrive maps, then this would fix it -- at least if it's related to the missing lane width.
In our map the initialization code tried to find a good spot for placing a traffic sign outside the junction, and while calculation the code asserted during getting the lane width of the center lane in YieldSignComponent.cpp:138.
Due to the bug, all center lanes without an explicit width definition in the OpenDrive code won't have any width information created and though code accessing the lane width always will assert.
This fixes that behavior.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->


#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9419)
<!-- Reviewable:end -->
