### PR TITLE
Fix for Pedestrian Bounding Box Calculations (Including Wheelchair Users)

### DIFF
--- a/LibCarla/source/carla/client/Actor.cpp
+++ b/LibCarla/source/carla/client/Actor.cpp
@@ -35,11 +35,10 @@ namespace client {
   geom::BoundingBox Actor::GetBoundingBox() const {
     geom::BoundingBox bounding_box = GetEpisode().Lock()->GetActorBoundingBox(*this); 
     if (bounding_box.extent.x == 0.0f && bounding_box.extent.y == 0.0f && bounding_box.extent.z == 0.0f) {
-      return bounding_box;
-    }
-    else{
+      // Only fall back to cached value if the server returns a zero bounding box
       return Super::GetBoundingBox();
     }
+    return bounding_box;  // Return the fresh calculation, not the cached one
   }
 
   geom::Transform Actor::GetComponentWorldTransform(const std::string componentName) const {


### PR DESCRIPTION
#### Description

Fixes #9332 and #9410. The main issue all along was that the client was not updating the bounding boxes. I also made adjustments to make sure the bounding boxes fit Gen3 kids and wheelchair users.

![SimBEV-scene-0000-frame-0258-RGB-CAM_FRONT](https://github.com/user-attachments/assets/d2e2915f-e666-4bbb-b5fc-a88069defdb3)
![SimBEV-scene-0000-frame-0263-RGB-CAM_FRONT](https://github.com/user-attachments/assets/261449ed-f1bf-4955-a742-209c2f93e6a5)
![SimBEV-scene-0000-frame-0719-RGB-CAM_FRONT](https://github.com/user-attachments/assets/81fe4461-c424-465f-888b-edfab07bbbd2)

https://github.com/user-attachments/assets/e837acf0-b855-44f5-b3c4-2ee06f7e0348

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9421)
<!-- Reviewable:end -->
