### PR TITLE
Fix for Actor ID Tagging in Large Maps

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -989,6 +989,7 @@ void ALargeMapManager::ConvertDormantToActiveActors()
         *((View->GetActor()->GetActorLocation()).ToString()) \
       );
       ActiveActors.Add(Id);
+      ATagger::TagActor(*View->GetActor(), true, Id);
     }
     else
     {


### PR DESCRIPTION
#### Description

Fixes #9391. Large map actors that become dormant need to be re-tagged when they wake up to appear with the proper ID in segmentation sensors.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9422)
<!-- Reviewable:end -->
