### PR TITLE
Fix for Incorrect Actor Semantic Tags.

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -190,6 +190,11 @@ void ACarlaGameModeBase::BeginPlay()
   LoadMapLayer(GameInstance->GetCurrentMapLayer());
   ReadyToRegisterObjects = true;
 
+  if (true) { /// @todo If semantic segmentation enabled.
+    ATagger::TagActorsInLevel(*World, true);
+    TaggerDelegate->SetSemanticSegmentationEnabled();
+  }
+
   // HACK: fix transparency see-through issues
   // The problem: transparent objects are visible through walls.
   // This is due to a weird interaction between the SkyAtmosphere component,


### PR DESCRIPTION
#### Description

Fixes #9356 , where incorrect semantic tags were being assigned to actors in Town01-Town10HD that were a part of the map (notably traffic lights and signs). The issue seems to have been introduced in e8947a4 when the tagging of world actors was moved to after the episode had been initialized, preventing the tagger from setting the correct stencil values before the actor got registered. Tagging the actors twice, once to assign the correct stencil values and the second time to assign the proper Carla ID for segmentation seems to be the solution.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9423)
<!-- Reviewable:end -->
