### PR TITLE
Extend ROS2 support Step 2: Fine grained ServerSynchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
  * Introduced geom::AngularVelocity, geom::Velocity, geom::Acceleration, geom::Quaternion types
  * Fixed geom::Rotation::RotateVector() rotation directions of pitch and roll
  * Prepare server for multistream support and ROS2 client calls
- * Improved V2X sensor capabilities: send complex custom user-defined data, support V2I sensors not attached to a vehicle
+ * Introduced fine grained ServerSynchronization mechanism: each client decides for its own if it requires synchronization or not and provides its own synchronization window.
+   Be aware: some existing code using master/slave sync mechanism might need rework. See also generate_traffic.py.
 
 ## CARLA 0.9.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * Introduced geom::AngularVelocity, geom::Velocity, geom::Acceleration, geom::Quaternion types
  * Fixed geom::Rotation::RotateVector() rotation directions of pitch and roll
  * Prepare server for multistream support and ROS2 client calls
+ * Improved V2X sensor capabilities: send complex custom user-defined data, support V2I sensors not attached to a vehicle
  * Introduced fine grained ServerSynchronization mechanism: each client decides for its own if it requires synchronization or not and provides its own synchronization window.
    Be aware: some existing code using master/slave sync mechanism might need rework. See also generate_traffic.py.
 

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -75,7 +75,10 @@ namespace client {
         if (tics_correct >= 2)
           return id;
 
-        Tick(local_timeout);
+        if (settings.synchronous_mode) {
+          // tick if synchronous mode is active
+          Tick(local_timeout);
+        }
       }
 
       log_warning("World::ApplySettings: After", number_of_attemps, " attemps, the settings were not correctly set. Please check that everything is consistent.");

--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -79,6 +79,10 @@ namespace client {
           // tick if synchronous mode is active
           Tick(local_timeout);
         }
+        else {
+          WaitForTick(local_timeout);
+        } 
+
       }
 
       log_warning("World::ApplySettings: After", number_of_attemps, " attemps, the settings were not correctly set. Please check that everything is consistent.");

--- a/LibCarla/source/carla/rpc/RpcServerInterface.h
+++ b/LibCarla/source/carla/rpc/RpcServerInterface.h
@@ -87,8 +87,9 @@ public:
    * @{
    */
   virtual Response<uint64_t> call_tick(
-      synchronization_client_id_type const &client_id = ALL_CLIENTS,
-      synchronization_participant_id_type const &participant_id = ALL_PARTICIPANTS) = 0;
+      synchronization_client_id_type const &client_id,
+      synchronization_participant_id_type const &participant_id,
+      carla::rpc::SynchronizationTickMode synchronization_tick_mode) = 0;
   virtual Response<synchronization_participant_id_type> call_register_synchronization_participant(
       synchronization_client_id_type const &client_id,
       synchronization_participant_id_type const &participant_id_hint = ALL_PARTICIPANTS) = 0;

--- a/LibCarla/source/carla/rpc/RpcServerInterface.h
+++ b/LibCarla/source/carla/rpc/RpcServerInterface.h
@@ -14,6 +14,7 @@
 #include "carla/rpc/MapInfo.h"
 #include "carla/rpc/MapLayer.h"
 #include "carla/rpc/Response.h"
+#include "carla/rpc/ServerSynchronizationTypes.h"
 #include "carla/rpc/Transform.h"
 #include "carla/rpc/VehicleTelemetryData.h"
 #include "carla/streaming/detail/Dispatcher.h"
@@ -77,6 +78,26 @@ public:
   virtual carla::rpc::Response<void> call_enable_actor_for_ros(ActorId actor_id) = 0;
   virtual carla::rpc::Response<void> call_disable_actor_for_ros(ActorId actor_id) = 0;
   virtual carla::rpc::Response<bool> call_is_actor_enabled_for_ros(ActorId actor_id) = 0;
+  /**
+   * @}
+   */
+
+  /**
+   * @brief synchronization calls
+   * @{
+   */
+  virtual Response<uint64_t> call_tick(
+      synchronization_client_id_type const &client_id = ALL_CLIENTS,
+      synchronization_participant_id_type const &participant_id = ALL_PARTICIPANTS) = 0;
+  virtual Response<synchronization_participant_id_type> call_register_synchronization_participant(
+      synchronization_client_id_type const &client_id,
+      synchronization_participant_id_type const &participant_id_hint = ALL_PARTICIPANTS) = 0;
+  virtual Response<bool> call_deregister_synchronization_participant(
+      synchronization_client_id_type const &client_id, synchronization_participant_id_type const &participant_id) = 0;
+  virtual Response<bool> call_update_synchronization_window(
+      synchronization_client_id_type const &client_id, synchronization_participant_id_type const &participant_id,
+      synchronization_target_game_time const &target_game_time = NO_SYNC_TARGET_GAME_TIME) = 0;
+  virtual carla::rpc::Response<std::pair< bool , std::vector<carla::rpc::synchronization_window_participant_state> > >  call_get_synchronization_window_status() = 0;
   /**
    * @}
    */

--- a/LibCarla/source/carla/rpc/ServerSynchronizationTypes.h
+++ b/LibCarla/source/carla/rpc/ServerSynchronizationTypes.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <locale>
+
+namespace carla {
+namespace rpc {
+
+using synchronization_client_id_type = std::string;
+static const carla::rpc::synchronization_client_id_type ALL_CLIENTS{};
+
+using synchronization_participant_id_type = uint32_t;
+static constexpr carla::rpc::synchronization_participant_id_type ALL_PARTICIPANTS{0};
+
+using synchronization_target_game_time = double;
+static constexpr synchronization_target_game_time NO_SYNC_TARGET_GAME_TIME{0.};
+static constexpr synchronization_target_game_time BLOCKING_TARGET_GAME_TIME{1e-6};
+
+struct synchronization_window_participant_state {
+    synchronization_client_id_type client_id;
+    synchronization_participant_id_type participant_id;
+    synchronization_target_game_time target_game_time;
+};
+
+
+
+}  // namespace rpc
+}  // namespace carla

--- a/LibCarla/source/carla/rpc/ServerSynchronizationTypes.h
+++ b/LibCarla/source/carla/rpc/ServerSynchronizationTypes.h
@@ -27,7 +27,10 @@ struct synchronization_window_participant_state {
     synchronization_target_game_time target_game_time;
 };
 
-
+enum class SynchronizationTickMode {
+    FORCE_ENABLE_SYNC,
+    TICK_ONLY_IF_SYNC_ENABLED
+};
 
 }  // namespace rpc
 }  // namespace carla

--- a/PythonAPI/test/smoke/__init__.py
+++ b/PythonAPI/test/smoke/__init__.py
@@ -48,6 +48,8 @@ class SyncSmokeTest(SmokeTest):
 
     def tearDown(self):
         self.world.apply_settings(self.settings)
-        self.world.tick()
+        if self.settings.synchronous_mode:
+            # tick if synchronous mode is active
+            self.world.tick()
         self.settings = None
         super(SyncSmokeTest, self).tearDown()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.h
@@ -105,8 +105,6 @@ private:
 
   bool bIsRunning = false;
 
-  bool bSynchronousMode = false;
-
   bool bMapChanged = false;
 
   FCarlaServer Server;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -5,9 +5,11 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "Carla.h"
+#include "rpc/this_session.h"
 #include "Carla/Server/CarlaServer.h"
 #include "Carla/Server/CarlaServerResponse.h"
 #include "Carla/Game/CarlaHUD.h"
+#include "Carla/Server/ServerSynchronization.h"
 #include "Carla/Traffic/TrafficLightGroup.h"
 #include "EngineUtils.h"
 #include "Components/SkeletalMeshComponent.h"
@@ -122,6 +124,24 @@ public:
     SecondaryServer = std::make_shared<carla::multigpu::Router>(SecondaryPort);
     SecondaryServer->SetCallbacks();
     BindActions();
+
+    auto const RegisterResponse = ServerSync.RegisterSynchronizationParticipant(SynchronizationClientId());
+    if ( RegisterResponse ) {
+      ServerSynchronizationParticipantId = RegisterResponse.Get();
+      UE_LOG(
+        LogCarlaServer,
+        Verbose,
+        TEXT("Server registered for sync (session_id=%s, sync_id=%d)"),
+        UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+        ServerSynchronizationParticipantId);
+    }
+    else {
+      UE_LOG(
+        LogCarlaServer,
+        Error,
+        TEXT("Server registered for sync (session_id=%s) failed)"),
+        UTF8_TO_TCHAR(SynchronizationClientId().c_str()));
+    }
   }
 
   std::shared_ptr<carla::multigpu::Router> GetSecondaryServer() {
@@ -210,7 +230,56 @@ public:
     
   void NotifyEndEpisode();
 
-  std::atomic_size_t TickCuesReceived { 0u };
+  ServerSynchronization ServerSync;
+
+
+  /**
+   * @brief synchronization calls
+   * @{
+   */
+  carla::rpc::Response<uint64_t> call_tick(
+      carla::rpc::synchronization_client_id_type const &client_id,
+      carla::rpc::synchronization_participant_id_type const &participant_id) override;
+  carla::rpc::Response<carla::rpc::synchronization_participant_id_type> call_register_synchronization_participant(
+      carla::rpc::synchronization_client_id_type const &client_id,
+      carla::rpc::synchronization_participant_id_type const &participant_id_hint = carla::rpc::ALL_PARTICIPANTS) override;
+  carla::rpc::Response<bool> call_deregister_synchronization_participant(
+      carla::rpc::synchronization_client_id_type const &client_id, carla::rpc::synchronization_participant_id_type const &participant_id) override;
+  carla::rpc::Response<bool> call_update_synchronization_window(
+      carla::rpc::synchronization_client_id_type const &client_id, carla::rpc::synchronization_participant_id_type const &participant_id,
+      carla::rpc::synchronization_target_game_time const &target_game_time = carla::rpc::NO_SYNC_TARGET_GAME_TIME) override;
+  carla::rpc::Response<std::pair< bool , std::vector<carla::rpc::synchronization_window_participant_state> > >  call_get_synchronization_window_status() override;
+  /**
+   * @}
+   */
+  void OnClientDisconnected(std::shared_ptr<rpc::detail::server_session> server_session);
+  void OnClientConnected(std::shared_ptr<rpc::detail::server_session> server_session);
+  bool IsNextGameTickAllowed();
+
+  void EnableSynchronousMode();
+  void DisableSynchronousMode();
+  carla::rpc::synchronization_client_id_type SynchronizationClientId() const { return "CarlaServer"; }
+  carla::rpc::synchronization_participant_id_type TickParticipantId() {
+    ::rpc::session_id_t RpcSessionId = ::rpc::this_session().id();
+    carla::rpc::synchronization_participant_id_type SynchronizationParticipantId = ServerSynchronizationParticipantId;
+    auto TickParticipantIdIter = TickSynchronizationParticipantMap.find(RpcSessionId);
+    if ( TickParticipantIdIter!=TickSynchronizationParticipantMap.end()) {
+      SynchronizationParticipantId = TickParticipantIdIter->second;
+    }
+    return SynchronizationParticipantId;
+  }
+
+  
+  carla::rpc::synchronization_participant_id_type ServerSynchronizationParticipantId{0};
+  std::map<::rpc::session_id_t, carla::rpc::synchronization_participant_id_type> TickSynchronizationParticipantMap;
+
+   double GetTickDeltaSeconds() {
+    double FixedDeltaSeconds = 1./20.;
+    if ((Episode != nullptr) && Episode->GetSettings().FixedDeltaSeconds.IsSet()) {
+      FixedDeltaSeconds = Episode->GetSettings().FixedDeltaSeconds.GetValue();
+    }
+    return FixedDeltaSeconds;
+  }
 
 private:
 
@@ -302,6 +371,9 @@ void FCarlaServer::FPimpl::BindActions()
   namespace cr = carla::rpc;
   namespace cg = carla::geom;
 
+  Server.BindOnClientConnected(std::bind(&FCarlaServer::FPimpl::OnClientConnected, this, std::placeholders::_1));
+  Server.BindOnClientDisconnected(std::bind(&FCarlaServer::FPimpl::OnClientDisconnected, this, std::placeholders::_1));
+
   /// Looks for a Traffic Manager running on port
   BIND_SYNC(is_traffic_manager_running) << [this] (uint16_t port) ->R<bool>
   {
@@ -353,9 +425,14 @@ void FCarlaServer::FPimpl::BindActions()
   BIND_SYNC(tick_cue) << [this]() -> R<uint64_t>
   {
     TRACE_CPUPROFILER_EVENT_SCOPE(TickCueReceived);
-    auto Current = FCarlaEngine::GetFrameCounter();
-    (void)TickCuesReceived.fetch_add(1, std::memory_order_release);
-    return Current + 1;
+    UE_LOG(
+      LogCarlaServer,
+      Verbose,
+      TEXT("Tick received (session_id=%s, sync_id=%d, rpc_sid=%li)"),
+      UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+      TickParticipantId(),
+      ::rpc::this_session().id());
+    return call_tick(SynchronizationClientId(), TickParticipantId());
   };
 
   // ~~ Load new episode ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3587,6 +3664,109 @@ void FCarlaServer::FPimpl::NotifyEndEpisode()
   Episode = nullptr;
 }
 
+
+carla::rpc::Response<uint64_t> FCarlaServer::FPimpl::call_tick(
+    carla::rpc::synchronization_client_id_type const &client_id,
+    carla::rpc::synchronization_participant_id_type const&participant_id)
+{
+  REQUIRE_CARLA_EPISODE();
+  auto Current = FCarlaEngine::GetFrameCounter();
+  auto const TargetGameTime = Episode->GetElapsedGameTime() + GetTickDeltaSeconds();
+  (void) call_update_synchronization_window(client_id, participant_id, TargetGameTime);
+  return Current + 1;
+}
+
+carla::rpc::Response<carla::rpc::synchronization_participant_id_type> FCarlaServer::FPimpl::call_register_synchronization_participant(
+    carla::rpc::synchronization_client_id_type const &client_id,
+    carla::rpc::synchronization_participant_id_type const&participant_id_hint)
+{
+  return ServerSync.RegisterSynchronizationParticipant(client_id, participant_id_hint);
+}
+
+carla::rpc::Response<bool> FCarlaServer::FPimpl::call_deregister_synchronization_participant(
+  carla::rpc::synchronization_client_id_type const &client_id,
+  carla::rpc::synchronization_participant_id_type const &participant_id)
+{
+  return ServerSync.DeregisterSynchronizationParticipant(client_id, participant_id);
+}
+
+carla::rpc::Response<bool> FCarlaServer::FPimpl::call_update_synchronization_window(
+    carla::rpc::synchronization_client_id_type const &client_id,
+    carla::rpc::synchronization_participant_id_type const&participant_id,
+    carla::rpc::synchronization_target_game_time const &target_game_time)
+{
+  return ServerSync.UpdateSynchronizationWindow(client_id, participant_id, target_game_time);
+}
+
+carla::rpc::Response<std::pair< bool , std::vector<carla::rpc::synchronization_window_participant_state> > > FCarlaServer::FPimpl::call_get_synchronization_window_status() {
+  return ServerSync.GetSynchronizationWindowParticipantStates();
+}
+
+void FCarlaServer::FPimpl::OnClientConnected(std::shared_ptr<rpc::detail::server_session> server_session) {
+  auto const RegisterResponse = ServerSync.RegisterSynchronizationParticipant(SynchronizationClientId());
+  if ( RegisterResponse ) {
+    TickSynchronizationParticipantMap.insert({::rpc::this_session().id(), RegisterResponse.Get()});
+    UE_LOG(
+        LogCarlaServer,
+        Verbose,
+        TEXT("Client connected (session_id=%s, sync_id=%d, rpc_sid=%li)"),
+        UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+        RegisterResponse.Get(),
+        ::rpc::this_session().id());
+  }
+  else {
+    UE_LOG(
+        LogCarlaServer,
+        Error,
+        TEXT("Client connected (session_id=%s, rpc_sid=%li) registering for sync failed."),
+        UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+        ::rpc::this_session().id());
+  }
+}
+
+void FCarlaServer::FPimpl::OnClientDisconnected(std::shared_ptr<rpc::detail::server_session> server_session) {
+  UE_LOG(
+      LogCarlaServer,
+      Verbose,
+      TEXT("Client disconnected (session_id=%s, sync_id=%d, rpc_sid=%li)"),
+      UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+      TickParticipantId(),
+      ::rpc::this_session().id());
+  ServerSync.DeregisterSynchronizationParticipant(SynchronizationClientId(), TickParticipantId());
+  TickSynchronizationParticipantMap.erase(::rpc::this_session().id());
+}
+
+bool FCarlaServer::FPimpl::IsNextGameTickAllowed() {
+  if (Episode == nullptr) {
+    return false;
+  }
+  auto const ElapsedGameTime = Episode->GetElapsedGameTime();
+  auto TargetGameTime = ServerSync.GetTargetSynchronizationTime(ElapsedGameTime , GetTickDeltaSeconds());
+  return TargetGameTime > ElapsedGameTime;
+}
+
+void FCarlaServer::FPimpl::EnableSynchronousMode() {
+  UE_LOG(
+    LogCarlaServer,
+    Verbose,
+    TEXT("EnableSynchronousMode (session_id=%s, sync_id=%d, rpc_sid=%li)"),
+    UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+    TickParticipantId(),
+    ::rpc::this_session().id())
+  ServerSync.EnableSynchronousMode(SynchronizationClientId(), TickParticipantId());
+}
+
+void FCarlaServer::FPimpl::DisableSynchronousMode() {
+  UE_LOG(
+    LogCarlaServer,
+    Verbose,
+    TEXT("DisableSynchronousMode (session_id=%s, sync_id=%d, rpc_sid=%li)"),
+    UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
+    TickParticipantId(),
+    ::rpc::this_session().id());
+  ServerSync.DisableSynchronousMode(SynchronizationClientId(), TickParticipantId());
+}
+
 // =============================================================================
 // -- Undef helper macros ------------------------------------------------------
 // =============================================================================
@@ -3597,6 +3777,7 @@ void FCarlaServer::FPimpl::NotifyEndEpisode()
 #undef RESPOND_ERROR_FSTRING
 #undef RESPOND_ERROR
 #undef CARLA_ENSURE_GAME_THREAD
+
 
 // =============================================================================
 // -- FCarlaServer -------------------------------------------------------
@@ -3680,18 +3861,30 @@ void FCarlaServer::SetROS2TopicVisibilityDefaultEnabled(bool _topic_visibility_d
   Pimpl->StreamingServer.SetROS2TopicVisibilityDefaultEnabled(_topic_visibility_default_enabled);
 }
 
+void FCarlaServer::EnableSynchronousMode() {
+  Pimpl->EnableSynchronousMode();
+}
+
+void FCarlaServer::DisableSynchronousMode() {
+  Pimpl->DisableSynchronousMode();
+}
+
+bool FCarlaServer::IsSynchronousModeActive() {
+  return Pimpl->ServerSync.IsSynchronousModeActive();
+}
+
+double FCarlaServer::GetTickDeltaSeconds() {
+  return Pimpl->GetTickDeltaSeconds();
+}
+
 void FCarlaServer::Tick()
 {
-  (void)Pimpl->TickCuesReceived.fetch_add(1, std::memory_order_release);
+  (void)Pimpl->call_tick(Pimpl->SynchronizationClientId(), Pimpl->ServerSynchronizationParticipantId);
 }
 
 bool FCarlaServer::TickCueReceived()
 {
-  auto k = Pimpl->TickCuesReceived.fetch_sub(1, std::memory_order_acquire);
-  bool flag = (k > 0);
-  if (!flag)
-    (void)Pimpl->TickCuesReceived.fetch_add(1, std::memory_order_release);
-  return flag;
+  return Pimpl->IsNextGameTickAllowed();
 }
 
 void FCarlaServer::Stop()
@@ -3792,5 +3985,39 @@ carla::rpc::Response<bool> FCarlaServer::call_is_actor_enabled_for_ros(carla::rp
 carla::rpc::Response<carla::rpc::VehicleTelemetryData> FCarlaServer::call_get_telemetry_data(carla::rpc::ActorId ActorId)
 {
   return Pimpl->call_get_telemetry_data(ActorId);
+}
+
+  
+carla::rpc::Response<uint64_t> FCarlaServer::call_tick(
+  carla::rpc::synchronization_client_id_type const &client_id,
+  carla::rpc::synchronization_participant_id_type const&synchronization_participant)
+{
+  return Pimpl->call_tick(client_id, synchronization_participant);
+}
+
+carla::rpc::Response<carla::rpc::synchronization_participant_id_type> FCarlaServer::call_register_synchronization_participant(
+  carla::rpc::synchronization_client_id_type const &client_id,
+  carla::rpc::synchronization_participant_id_type const &participant_id_hint)
+{
+  return Pimpl->call_register_synchronization_participant(client_id, participant_id_hint);
+}
+
+carla::rpc::Response<bool> FCarlaServer::call_deregister_synchronization_participant(
+  carla::rpc::synchronization_client_id_type const &client_id,
+  carla::rpc::synchronization_participant_id_type const&synchronization_participant)
+{
+  return Pimpl->call_deregister_synchronization_participant(client_id, synchronization_participant);
+}
+
+carla::rpc::Response<bool> FCarlaServer::call_update_synchronization_window(
+  carla::rpc::synchronization_client_id_type const &client_id,
+  carla::rpc::synchronization_participant_id_type const&synchronization_participant,
+  carla::rpc::synchronization_target_game_time const &target_game_time)
+{
+  return Pimpl->call_update_synchronization_window(client_id, synchronization_participant, target_game_time);
+}
+
+carla::rpc::Response<std::pair< bool , std::vector<carla::rpc::synchronization_window_participant_state> > >  FCarlaServer::call_get_synchronization_window_status() {
+  return Pimpl->call_get_synchronization_window_status();
 }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -239,7 +239,8 @@ public:
    */
   carla::rpc::Response<uint64_t> call_tick(
       carla::rpc::synchronization_client_id_type const &client_id,
-      carla::rpc::synchronization_participant_id_type const &participant_id) override;
+      carla::rpc::synchronization_participant_id_type const &participant_id,
+      carla::rpc::SynchronizationTickMode synchronization_tick_mode) override;
   carla::rpc::Response<carla::rpc::synchronization_participant_id_type> call_register_synchronization_participant(
       carla::rpc::synchronization_client_id_type const &client_id,
       carla::rpc::synchronization_participant_id_type const &participant_id_hint = carla::rpc::ALL_PARTICIPANTS) override;
@@ -424,6 +425,7 @@ void FCarlaServer::FPimpl::BindActions()
 
   BIND_SYNC(tick_cue) << [this]() -> R<uint64_t>
   {
+    REQUIRE_CARLA_EPISODE();
     TRACE_CPUPROFILER_EVENT_SCOPE(TickCueReceived);
     UE_LOG(
       LogCarlaServer,
@@ -432,7 +434,7 @@ void FCarlaServer::FPimpl::BindActions()
       UTF8_TO_TCHAR(SynchronizationClientId().c_str()),
       TickParticipantId(),
       ::rpc::this_session().id());
-    return call_tick(SynchronizationClientId(), TickParticipantId());
+    return call_tick(SynchronizationClientId(), TickParticipantId(), carla::rpc::SynchronizationTickMode::TICK_ONLY_IF_SYNC_ENABLED);
   };
 
   // ~~ Load new episode ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3667,12 +3669,20 @@ void FCarlaServer::FPimpl::NotifyEndEpisode()
 
 carla::rpc::Response<uint64_t> FCarlaServer::FPimpl::call_tick(
     carla::rpc::synchronization_client_id_type const &client_id,
-    carla::rpc::synchronization_participant_id_type const&participant_id)
+    carla::rpc::synchronization_participant_id_type const&participant_id,
+    carla::rpc::SynchronizationTickMode synchronization_tick_mode)
 {
-  REQUIRE_CARLA_EPISODE();
   auto Current = FCarlaEngine::GetFrameCounter();
-  auto const TargetGameTime = Episode->GetElapsedGameTime() + GetTickDeltaSeconds();
-  (void) call_update_synchronization_window(client_id, participant_id, TargetGameTime);
+
+  if ( (synchronization_tick_mode == carla::rpc::SynchronizationTickMode::FORCE_ENABLE_SYNC)
+        || ServerSync.IsSynchronousModeActive() ) {
+    auto const TargetGameTime = Episode->GetElapsedGameTime() + GetTickDeltaSeconds();
+    ServerSync.UpdateSynchronizationWindow(client_id, participant_id, TargetGameTime);
+  }
+  else { 
+    UE_LOG(LogCarla, Warning, TEXT("CarlaServer::call_tick[%s:%d] received, but synchronous mode not running. Tick is ignored."), 
+                                   UTF8_TO_TCHAR(client_id.c_str()), participant_id);
+  }
   return Current + 1;
 }
 
@@ -3879,9 +3889,11 @@ double FCarlaServer::GetTickDeltaSeconds() {
 
 void FCarlaServer::Tick()
 {
-  (void)Pimpl->call_tick(Pimpl->SynchronizationClientId(), Pimpl->ServerSynchronizationParticipantId);
+  (void)Pimpl->call_tick(Pimpl->SynchronizationClientId(), 
+                         Pimpl->ServerSynchronizationParticipantId,
+                         carla::rpc::SynchronizationTickMode::TICK_ONLY_IF_SYNC_ENABLED);
 }
-
+  
 bool FCarlaServer::TickCueReceived()
 {
   return Pimpl->IsNextGameTickAllowed();
@@ -3987,12 +3999,12 @@ carla::rpc::Response<carla::rpc::VehicleTelemetryData> FCarlaServer::call_get_te
   return Pimpl->call_get_telemetry_data(ActorId);
 }
 
-  
 carla::rpc::Response<uint64_t> FCarlaServer::call_tick(
   carla::rpc::synchronization_client_id_type const &client_id,
-  carla::rpc::synchronization_participant_id_type const&synchronization_participant)
+  carla::rpc::synchronization_participant_id_type const&synchronization_participant,
+  carla::rpc::SynchronizationTickMode synchronization_tick_mode)
 {
-  return Pimpl->call_tick(client_id, synchronization_participant);
+  return Pimpl->call_tick(client_id, synchronization_participant, synchronization_tick_mode);
 }
 
 carla::rpc::Response<carla::rpc::synchronization_participant_id_type> FCarlaServer::call_register_synchronization_participant(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
@@ -44,6 +44,11 @@ public:
 
   void SetROS2TopicVisibilityDefaultEnabled(bool _topic_visibility_default_enabled);
 
+  void EnableSynchronousMode();
+  void DisableSynchronousMode();
+  bool IsSynchronousModeActive();
+
+  double GetTickDeltaSeconds();
   void Tick();
   
   bool TickCueReceived();
@@ -109,6 +114,26 @@ public:
   carla::rpc::Response<void> call_enable_actor_for_ros(carla::rpc::ActorId actor_id) override;
   carla::rpc::Response<void> call_disable_actor_for_ros(carla::rpc::ActorId actor_id) override;
   carla::rpc::Response<bool> call_is_actor_enabled_for_ros(carla::rpc::ActorId actor_id) override;
+  /**
+   * @}
+   */
+
+  /**
+   * @brief synchronization calls
+   * @{
+   */
+  carla::rpc::Response<uint64_t> call_tick(
+      carla::rpc::synchronization_client_id_type const &client_id = carla::rpc::ALL_CLIENTS,
+      carla::rpc::synchronization_participant_id_type const &participant_id = carla::rpc::ALL_PARTICIPANTS) override;
+  carla::rpc::Response<carla::rpc::synchronization_participant_id_type> call_register_synchronization_participant(
+      carla::rpc::synchronization_client_id_type const &client_id,
+      carla::rpc::synchronization_participant_id_type const &participant_id_hint = carla::rpc::ALL_PARTICIPANTS) override;
+  carla::rpc::Response<bool> call_deregister_synchronization_participant(
+      carla::rpc::synchronization_client_id_type const &client_id, carla::rpc::synchronization_participant_id_type const &participant_id) override;
+  carla::rpc::Response<bool> call_update_synchronization_window(
+      carla::rpc::synchronization_client_id_type const &client_id, carla::rpc::synchronization_participant_id_type const &participant_id,
+      carla::rpc::synchronization_target_game_time const &target_game_time = carla::rpc::NO_SYNC_TARGET_GAME_TIME) override;
+  carla::rpc::Response<std::pair< bool , std::vector<carla::rpc::synchronization_window_participant_state> > >  call_get_synchronization_window_status() override;
   /**
    * @}
    */

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.h
@@ -123,8 +123,9 @@ public:
    * @{
    */
   carla::rpc::Response<uint64_t> call_tick(
-      carla::rpc::synchronization_client_id_type const &client_id = carla::rpc::ALL_CLIENTS,
-      carla::rpc::synchronization_participant_id_type const &participant_id = carla::rpc::ALL_PARTICIPANTS) override;
+      carla::rpc::synchronization_client_id_type const &client_id,
+      carla::rpc::synchronization_participant_id_type const &participant_id,
+      carla::rpc::SynchronizationTickMode synchronization_tick_mode) override;
   carla::rpc::Response<carla::rpc::synchronization_participant_id_type> call_register_synchronization_participant(
       carla::rpc::synchronization_client_id_type const &client_id,
       carla::rpc::synchronization_participant_id_type const &participant_id_hint = carla::rpc::ALL_PARTICIPANTS) override;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerSynchronization.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/ServerSynchronization.h
@@ -1,0 +1,244 @@
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <map>
+#include <mutex>
+#include "carla/rpc/ServerSynchronizationTypes.h"
+#include "carla/rpc/Response.h"
+#include "carla/Logging.h"
+#include "Carla/Game/CarlaEngine.h"
+
+/// The interface to the CARLA server required from TCP and ROS2 client side.
+/// The parts only required from TPC client side are handled by lambdas directly.
+class ServerSynchronization {
+public:
+  ServerSynchronization() = default;
+  virtual ~ServerSynchronization() = default;
+
+
+  /** @brief Register a synchronization participant
+   *  
+   *  After the first synchronization participant is registered, the server runs in synchronous mode.
+   */
+  carla::rpc::Response<carla::rpc::synchronization_participant_id_type> RegisterSynchronizationParticipant(
+    carla::rpc::synchronization_client_id_type const &ClientId, 
+    carla::rpc::synchronization_participant_id_type const &ParticipantIdHint = carla::rpc::ALL_PARTICIPANTS) {
+    
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+
+    UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::RegisterSynchronizationParticipant[%s:%u] hint"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantIdHint);
+    auto MaxIdIter = ParticipantIdMaxMap.find(ClientId);
+    if ( MaxIdIter==ParticipantIdMaxMap.end()) {
+      auto InsertResult = ParticipantIdMaxMap.insert( {ClientId, carla::rpc::ALL_PARTICIPANTS});
+      MaxIdIter = InsertResult.first;
+    }
+    auto ParticipantId = ParticipantIdHint;
+    if ( ParticipantId==carla::rpc::ALL_PARTICIPANTS ) {
+      ParticipantId = ++(MaxIdIter->second);
+    }
+
+    auto InsertResultIter = SynchronizationWindowMap.insert( { ClientId, {ParticipantId, carla::rpc::NO_SYNC_TARGET_GAME_TIME}});
+    if ( InsertResultIter == SynchronizationWindowMap.end() ) {
+      // collision
+      UE_LOG(LogCarla, Error, TEXT("ServerSynchronization::RegisterSynchronizationParticipant[%s:%u] failed unexpectedly because of id clash"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId);
+      LogSynchronizationMap("Register failed");
+      return carla::rpc::ResponseError("ServerSynchronization::RegisterSynchronizationParticipant failed unexpectedly because of id clash\n");
+    }
+    if (ParticipantId > MaxIdIter->second) {
+      MaxIdIter->second = ParticipantId;
+    }
+    UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::RegisterSynchronizationParticipant[%s:%u]"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId);
+    LogSynchronizationMap("Register end");
+    SyncStateChanged=true;
+    return ParticipantId;
+  }
+
+  bool DeregisterSynchronizationParticipant(carla::rpc::synchronization_client_id_type const &ClientId, 
+    carla::rpc::synchronization_participant_id_type const &ParticipantId) {
+
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::DeregisterSynchronizationParticipant[%s:%u]"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId);
+    LogSynchronizationMap("Deregister start");
+    auto const SynchronizationParticipantEqualRange = SynchronizationWindowMap.equal_range(ClientId);
+    for (auto SynchronizationWindowIter=SynchronizationParticipantEqualRange.first; 
+       SynchronizationWindowIter != SynchronizationParticipantEqualRange.second;
+        /* no iterator update here to support erase */) {
+        if (SynchronizationWindowIter->second.ParticipantId == ParticipantId ) {
+          SynchronizationWindowIter = SynchronizationWindowMap.erase(SynchronizationWindowIter);
+        }
+        else {
+          SynchronizationWindowIter++;
+        }
+    }
+    LogSynchronizationMap("Deregister end");
+    SyncStateChanged=true;
+    return true;
+  }
+
+  void DisconnectClient(carla::rpc::synchronization_client_id_type const &ClientId) {
+    
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    LogSynchronizationMap("Disconnect client start");
+    auto ErasedEntries = SynchronizationWindowMap.erase(ClientId);
+    if ( ErasedEntries > 0u ) {
+      UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::DisconnectClient[%s:ALL]"), UTF8_TO_TCHAR(ClientId.c_str()));
+    }
+    else {
+      UE_LOG(LogCarla, Warning, TEXT("ServerSynchronization::DisconnectClient[%s:ALL] client id not found"), UTF8_TO_TCHAR(ClientId.c_str()));
+      LogSynchronizationMap("Disconnect client not found");
+    }
+    SyncStateChanged=true;
+    LogSynchronizationMap("Disconnect client end");
+  }
+
+  void EnableSynchronousMode(carla::rpc::synchronization_client_id_type const &ClientId, 
+                    carla::rpc::synchronization_participant_id_type const &ParticipantId = carla::rpc::ALL_PARTICIPANTS) {
+
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    for(auto &SynchronizationWindow: SynchronizationWindowMap) {
+      if ( (ClientId == SynchronizationWindow.first) && 
+           (( ParticipantId == carla::rpc::ALL_PARTICIPANTS ) || ( SynchronizationWindow.second.ParticipantId == ParticipantId )) &&
+          (SynchronizationWindow.second.TargetGameTime <= carla::rpc::NO_SYNC_TARGET_GAME_TIME))  {
+        SynchronizationWindow.second.TargetGameTime = carla::rpc::BLOCKING_TARGET_GAME_TIME;
+        SyncStateChanged=true;
+      }
+    }
+    UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::EnableSynchronousMode[%s:%d]"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId);
+  }
+
+  void DisableSynchronousMode(carla::rpc::synchronization_client_id_type const &ClientId, 
+                              carla::rpc::synchronization_participant_id_type const &ParticipantId = carla::rpc::ALL_PARTICIPANTS) {
+
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    for(auto &SynchronizationWindow: SynchronizationWindowMap) {
+      if ( (ClientId == SynchronizationWindow.first) && 
+           (( ParticipantId == carla::rpc::ALL_PARTICIPANTS ) || ( SynchronizationWindow.second.ParticipantId == ParticipantId )) &&
+           (SynchronizationWindow.second.TargetGameTime > carla::rpc::NO_SYNC_TARGET_GAME_TIME))  {
+        SynchronizationWindow.second.TargetGameTime = carla::rpc::NO_SYNC_TARGET_GAME_TIME;
+        SyncStateChanged=true;
+      }
+    }
+    UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::DisableSynchronousMode[%s:%d]"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId);
+  }
+
+  bool IsSynchronousModeActive() const {
+    
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    for(auto const &SynchronizationWindow: SynchronizationWindowMap) {
+      if ( SynchronizationWindow.second.TargetGameTime > carla::rpc::NO_SYNC_TARGET_GAME_TIME)  {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  carla::rpc::synchronization_target_game_time GetTargetSynchronizationTime(double const CurrentGameTime, double const RequestedDltaTime) const {
+    
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    static int LogOncePerFrameCouter = 0;
+    bool LogOutput = false;
+    if (LogOncePerFrameCouter < FCarlaEngine::GetFrameCounter()) {
+      LogOutput = true;
+      LogOncePerFrameCouter = FCarlaEngine::GetFrameCounter();
+    }
+
+    carla::rpc::synchronization_target_game_time TargetGameTime = CurrentGameTime+RequestedDltaTime;
+    for(auto const &SynchronizationWindow: SynchronizationWindowMap) {
+      if ( (SynchronizationWindow.second.TargetGameTime > carla::rpc::NO_SYNC_TARGET_GAME_TIME) && (SynchronizationWindow.second.TargetGameTime < TargetGameTime) ) {
+        if (LogOutput) {
+          UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::GetTargetSynchronizationTime[%s:%u] = %f"), UTF8_TO_TCHAR(SynchronizationWindow.first.c_str()), SynchronizationWindow.second.ParticipantId, SynchronizationWindow.second.TargetGameTime);
+        }
+        TargetGameTime = SynchronizationWindow.second.TargetGameTime;
+      }
+    }
+    if (LogOutput) {
+      UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::GetTargetSynchronizationTime[ALL:ALL] = %f"), TargetGameTime);
+    }
+    return TargetGameTime;
+  }
+
+  carla::rpc::Response<bool> UpdateSynchronizationWindow(
+      carla::rpc::synchronization_client_id_type const &ClientId, 
+      carla::rpc::synchronization_participant_id_type const &ParticipantId,
+     carla::rpc::synchronization_target_game_time const &TargetGameTime) {
+    
+    std::lock_guard<std::mutex> SyncLock(SynchronizationMutex);
+    
+    if ( ClientId != carla::rpc::ALL_CLIENTS ) {
+      auto const SynchronizationParticipantEqualRange = SynchronizationWindowMap.equal_range(ClientId);
+      bool ParticipantFound = false;
+      for (auto SynchronizationWindowIter=SynchronizationParticipantEqualRange.first; 
+        SynchronizationWindowIter != SynchronizationParticipantEqualRange.second;
+          SynchronizationWindowIter++) {
+          if (SynchronizationWindowIter->second.ParticipantId == ParticipantId ) {
+            ParticipantFound=true;
+            SynchronizationWindowIter->second.TargetGameTime = TargetGameTime;
+            UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::UpdateSynchronizationWindow[%s:%u] = %f"), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId, TargetGameTime);
+          }
+      }
+      if ( !ParticipantFound ) {
+        UE_LOG(LogCarla, Error, TEXT("ServerSynchronization::UpdateSynchronizationWindow[%s:%u] = %f failed."), UTF8_TO_TCHAR(ClientId.c_str()), ParticipantId, TargetGameTime);
+        LogSynchronizationMap("Update failed");
+        return carla::rpc::ResponseError("ServerSynchronization::UpdateSynchronizationWindow did not find requested SynchronizationParticipant\n");
+      }
+    }
+    else {
+      for (auto &SynchronizationWindow: SynchronizationWindowMap) {
+        if (SynchronizationWindow.second.TargetGameTime > carla::rpc::NO_SYNC_TARGET_GAME_TIME) {
+          SynchronizationWindow.second.TargetGameTime = TargetGameTime;
+          UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::UpdateSynchronizationWindow[%s:%u] = %f FORCE"), UTF8_TO_TCHAR(SynchronizationWindow.first.c_str()), SynchronizationWindow.second.ParticipantId, TargetGameTime);
+        }
+      }
+    }
+    SyncStateChanged=true;
+    return true;
+  }
+
+  void LogSynchronizationMap(std::string const &Reason) {
+    for (auto &SynchronizationWindow: SynchronizationWindowMap) {
+      UE_LOG(LogCarla, Verbose, TEXT("ServerSynchronization::LogSynchronizationMap[%s:%u] = %f (%s)"), UTF8_TO_TCHAR(SynchronizationWindow.first.c_str()), SynchronizationWindow.second.ParticipantId, SynchronizationWindow.second.TargetGameTime, *FString(Reason.c_str()));
+    }
+  }
+
+  /**
+   * @brief Get the synchronization window participant states and a flag if they have changed since last call.
+  */
+  std::pair<bool, std::vector<carla::rpc::synchronization_window_participant_state> > GetSynchronizationWindowParticipantStates() {
+    std::vector<carla::rpc::synchronization_window_participant_state> SynchronizationWindowParticipantStates;
+    SynchronizationWindowParticipantStates.reserve(SynchronizationWindowMap.size());
+    for (auto &SynchronizationWindow: SynchronizationWindowMap) {
+      carla::rpc::synchronization_window_participant_state ParticipantState {
+        SynchronizationWindow.first,
+        SynchronizationWindow.second.ParticipantId,
+        SynchronizationWindow.second.TargetGameTime
+      };
+      SynchronizationWindowParticipantStates.push_back(ParticipantState);
+    }
+    auto ResultChanged = SyncStateChanged;
+    SyncStateChanged = false;
+    return std::make_pair(ResultChanged, SynchronizationWindowParticipantStates);
+  }
+
+private:
+  mutable std::mutex SynchronizationMutex{};
+
+  struct SynchonizationWindow{
+    carla::rpc::synchronization_participant_id_type ParticipantId;
+    carla::rpc::synchronization_target_game_time TargetGameTime{carla::rpc::NO_SYNC_TARGET_GAME_TIME};
+  };
+
+  std::map<carla::rpc::synchronization_client_id_type, carla::rpc::synchronization_participant_id_type> ParticipantIdMaxMap;
+  std::multimap<carla::rpc::synchronization_client_id_type, SynchonizationWindow> SynchronizationWindowMap;
+  bool SyncStateChanged {false};
+
+};

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -217,7 +217,7 @@ unset BOOST_BASENAME
 # -- Get rpclib and compile it with libc++ and libstdc++ -----------------------
 # ==============================================================================
 
-RPCLIB_PATCH=v2.2.1_c5
+RPCLIB_PATCH=carla-callbacks
 RPCLIB_BASENAME=rpclib-${RPCLIB_PATCH}-${CXX_TAG}
 
 RPCLIB_LIBCXX_INCLUDE=${PWD}/${RPCLIB_BASENAME}-libcxx-install/include

--- a/Util/InstallersWin/install_rpclib.bat
+++ b/Util/InstallersWin/install_rpclib.bat
@@ -40,7 +40,7 @@ rem If not set set the build dir to the current dir
 if "%BUILD_DIR%" == "" set BUILD_DIR=%~dp0
 if not "%BUILD_DIR:~-1%"=="\" set BUILD_DIR=%BUILD_DIR%\
 
-set RPC_VERSION=v2.2.1_c5
+set RPC_VERSION=carla-callbacks
 set RPC_SRC=rpclib-src
 set RPC_SRC_DIR=%BUILD_DIR%%RPC_SRC%\
 set RPC_INSTALL=rpclib-install


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description
This is one of the second steps of the ROS2 extension series.
This one requires #9431 to be merged; until then it's listed as a draft.

Introduced a fine grained ServerSynchronization mechanism, where each
synchonization participant is treated independently and interacts
with the synchronization of the carla-server individually. If a client
is disconnected (or dies) the synchronization state of all participants
registered via that client are dropped, i.e. the server will continue
running in case the participants of that client were the only ones
demanding synchronous mode.

The synchronization interface provides means of a time window, up to
which the server is allowed to run. Like this, every client can prevent
the carla-server to run too fast depending on their individual speed.
There is no sync-master anymore. Every client decides for its own if
it requires synchronization or not.

Drawback of this change: some existing code might have to be changed
(see removal of synchronous_master in generate_traffic.py).

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9450)
<!-- Reviewable:end -->
