### PR TITLE
Fix issues with running the cosmos transfer server docker image due to outdate dependencies

### DIFF
--- a/PythonAPI/examples/nvidia/cosmos/server/Dockerfile.server
+++ b/PythonAPI/examples/nvidia/cosmos/server/Dockerfile.server
@@ -17,14 +17,15 @@ WORKDIR /workspace
 RUN rm -rf /usr/lib/python3/dist-packages/blinker-1.7.0.dist-info
 
 # Install Python dependencies from both requirements files
-RUN pip install -v --upgrade --no-build-isolation --no-dependencies sam2==1.1.0 && \
-    pip install transformer-engine[pytorch] && \
-    pip install decord==0.6.0 && \
-    git clone https://github.com/NVIDIA/apex && \
-    pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation \
-        --config-settings "--build-option=--cpp_ext" \
-        --config-settings "--build-option=--cuda_ext" ./apex && \
-    rm -rf apex
+RUN pip install -v --upgrade --no-build-isolation --no-dependencies sam2==1.1.0 &&
+    pip install decord==0.6.0
+
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/apex-0.1+cu128.torch271-cp312-cp312-linux_x86_64.whl
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/flash_attn-2.6.3+cu128.torch271-cp312-cp312-linux_x86_64.whl
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/natten-0.21.0+cu128.torch271-cp312-cp312-linux_x86_64.whl
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/transformer_engine-1.13.0+cu128.torch271-cp312-cp312-linux_x86_64.whl
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/torch-2.7.1+cu128-cp312-cp312-manylinux_2_28_x86_64.whl
+RUN pip install https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.1.0/torchvision-0.22.1+cu128-cp312-cp312-manylinux_2_28_x86_64.whl
 
 
 # Install libmagic

--- a/PythonAPI/examples/nvidia/cosmos/server/make_docker.sh
+++ b/PythonAPI/examples/nvidia/cosmos/server/make_docker.sh
@@ -108,7 +108,7 @@ if [ ! -d "cosmos-transfer1" ]; then
     print_status "Cloning cosmos-transfer1 repository..."
     git clone --recursive https://github.com/nvidia-cosmos/cosmos-transfer1.git
     cd cosmos-transfer1
-    git switch -c transfer1-stable 6f6701d1259bd4021457923e752b1924644dd089
+    git switch -c transfer1-stable dddf6aff7beaa82f81ad972773c152601fd0c934
     
 else
     cd cosmos-transfer1


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

When running the cosmos-transfer-1 docker container after building there are multiple errors as the gradio server tries to start caused by outdated dependencies.
```
File "/workspace/cosmos_transfer1/diffusion/module/attention.py", line 24, in <module> from transformer_engine.pytorch.attention.dot_product_attention.dot_product_attention import DotProductAttention ModuleNotFoundError: No module named 'transformer_engine.pytorch.attention.dot_product_attention'; 'transformer_engine.pytorch.attention' is not a package
```

This commit in the Cosmos-Transfer-1 repository resolves these issues. 
https://github.com/nvidia-cosmos/cosmos-transfer1/commit/dddf6aff7beaa82f81ad972773c152601fd0c934

The Changes I have made:
- Updated carla's modified Dockerfile.server to reflect the changed dockerfile in the commit
- Updated the commit hash in make_docker.sh as a couple changes in there are also related to the fix.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04 LTS
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26
  
  Had issues over multiple days trying to run my built docker images. after this fix it is working

#### Possible Drawbacks

- users who already have the old repository will not get the new one or the updated dockerfile unless they manually copy it or update the repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9456)
<!-- Reviewable:end -->
