### PR TITLE
[0.9.16-Docs] Update CARLA package version link to 0.9.16 in quickstart guide

### DIFF
--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -43,7 +43,7 @@ python3 -m pip install --upgrade pip
 
 ### Download and extract a CARLA package
 
-Download the desired CARLA package from GitHub using the link provided below. We recommend downloading the Package for the latest release, which is currently [0.9.15](https://github.com/carla-simulator/carla/releases/tag/0.9.15/).
+Download the desired CARLA package from GitHub using the link provided below. We recommend downloading the Package for the latest release, which is currently [0.9.16](https://github.com/carla-simulator/carla/releases/tag/0.9.16/).
 
 <div class="build-buttons">
 <p>


### PR DESCRIPTION
The quickstart guide for carla 0.9.16 pointed to the carla release of 0.9.15 and this commit updates the version to 0.9.16 to keep the documentation up-to-date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9461)
<!-- Reviewable:end -->
