### PR TITLE
ROS2: Correct CameraInfo intrinsic computation (degrees→radians)

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaCameraPublisher.cpp
@@ -21,7 +21,7 @@ bool CarlaCameraPublisher::WriteCameraInfo(int32_t seconds, uint32_t nanoseconds
 
   const double cx = static_cast<double>(width) / 2.0;
   const double cy = static_cast<double>(height) / 2.0;
-  const double fx = static_cast<double>(width) / (2.0 * std::tan(fov) * M_PI / 360.0);
+  const double fx = static_cast<double>(width) / (2.0 * std::tan(fov * M_PI / 360.0));
   const double fy = fx;
 
   _impl_camera_info->GetMessage()->height(height);


### PR DESCRIPTION
#### Description
The ROS2 camera intrinsic matrix (sensor_msgs::CameraInfo K) previously computed focal length incorrectly by passing a degree FOV directly into std::tan(). This yielded unrealistically large focal values (e.g. ~289307 for width=1616, fov=60). The corrected formula converts FOV from degrees to radians before tan:

Before:
```
fx = width / (2.0 * tan(fov) * π / 360.0)
```
After:
```
fx = width / (2.0 * tan(fov * π / 360.0))
```
Resulting example (width=1616, height=1240, fov=60):
```
K = [1399.4970525, 0, 808,
     0, 1399.4970525, 620,
     0, 0, 1]
```
`fy` set equal to `fx` assuming square pixels and horizontal FOV source.

Fixes #  I did not find any issue related <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Linux x86_64
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

No drawbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9462)
<!-- Reviewable:end -->
