### PR TITLE
Fix for Instanced Static Mesh Segmentation Appearance Bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  * Improved V2X sensor capabilities: send complex custom user-defined data, support V2I sensors not attached to a vehicle
  * Introduced fine grained ServerSynchronization mechanism: each client decides for its own if it requires synchronization or not and provides its own synchronization window.
    Be aware: some existing code using master/slave sync mechanism might need rework. See also generate_traffic.py.
+ * Fixed issue with disabled environment objects (ISMs) appearing in segmentation and depth images.
 
 ## CARLA 0.9.16
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ObjectRegister.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Util/ObjectRegister.cpp
@@ -12,6 +12,7 @@
 #include "Carla/Traffic/TrafficSignBase.h"
 #include "Carla/Game/CarlaStatics.h"
 #include "Carla/MapGen/LargeMapManager.h"
+#include "Carla/Game/TaggedComponent.h"
 
 #include "InstancedFoliageActor.h"
 #include "GameFramework/Character.h"
@@ -443,5 +444,19 @@ void UObjectRegister::EnableISMComp(FEnvironmentObject& EnvironmentObject, bool 
   UStaticMeshComponent* SMComp = const_cast<UStaticMeshComponent*>(ObjectComps[0]);
   UInstancedStaticMeshComponent* ISMComp = Cast<UInstancedStaticMeshComponent>(SMComp);
   bool Result = ISMComp->UpdateInstanceTransform(Index, InstanceTransform, true, true);
+
+  TArray<USceneComponent*> ChildComponents;
+  ISMComp->GetChildrenComponents(false, ChildComponents);
+  
+  for (USceneComponent* Child : ChildComponents)
+  {
+    UTaggedComponent* TaggedComp = Cast<UTaggedComponent>(Child);
+    
+    if (TaggedComp)
+    {
+      TaggedComp->MarkRenderStateDirty();
+      break;
+    }
+  }
 
 }


### PR DESCRIPTION
#### Description

Fixes #8750 , #9470 . When setting the transform of an ISM element the scene proxy should be updated so the change is reflected in the segmentation and depth images.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26

#### Possible Drawbacks

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9471)
<!-- Reviewable:end -->
