### PR TITLE
Use full path for carla cache dir, make CTPC (file) CARLA_CACHE_DIR-aware.

### DIFF
--- a/LibCarla/source/carla/FileSystem.cpp
+++ b/LibCarla/source/carla/FileSystem.cpp
@@ -19,7 +19,7 @@ namespace carla {
     fs::path path(filepath);
     if (!ext.empty() && path.extension() != ext)
       path.replace_extension(ext);
-    auto parent = path.parent_path();
+    auto parent = fs::absolute(path.parent_path());
     if (!fs::exists(parent))
       fs::create_directories(parent);
     filepath = path.string();

--- a/LibCarla/source/carla/client/FileTransfer.cpp
+++ b/LibCarla/source/carla/client/FileTransfer.cpp
@@ -27,7 +27,7 @@ namespace carla::client {
       return fs::path(override_path);
     fs::path path = std::getenv(HomePathEV);
     path /= "carlaCache";
-    return path;
+    return fs::absolute(path);
   }();
 
   bool FileTransfer::SetFilesBaseFolder(std::string_view path) {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CustomTerrainPhysicsComponent.cpp
@@ -57,6 +57,7 @@
 // #include <carla/pytorch/pytorch.h>
 #include <util/enable-ue4-macros.h>
 
+#include <filesystem>
 #include <algorithm>
 #include <fstream>
 #include <thread>
@@ -64,18 +65,28 @@
 
 #undef CreateDirectory
 
-
+namespace fs = std::filesystem;
 
 constexpr float MToCM = 100.f;
 constexpr float CMToM = 0.01f;
  
 const int CacheExtraRadius = 10;
 
+static std::string CachePath = [] {
+  constexpr char OverridePathEV[] = "CARLA_CACHE_DIR";
+  constexpr char HomePathEV[] =
 #ifdef _WIN32
-      std::string _filesBaseFolder = std::string(getenv("USERPROFILE")) + "/carlaCache/";
+      "USERPROFILE";
 #else
-      std::string _filesBaseFolder = std::string(getenv("HOME")) + "/carlaCache/";
+      "HOME";
 #endif
+  const char* override_path = std::getenv(OverridePathEV);
+  if (override_path != NULL)
+    return fs::path(override_path).string();
+  fs::path path = std::getenv(HomePathEV);
+  path /= "carlaCache";
+  return fs::absolute(path).string();
+}();
 
 FVector SIToUEFrame(const FVector& In)
 {
@@ -1298,7 +1309,7 @@ void UCustomTerrainPhysicsComponent::BeginPlay()
   FString LevelName = GetWorld()->GetMapName();
   LevelName.RemoveFromStart(GetWorld()->StreamingLevelsPrefix);
   
-  SavePath = FString(_filesBaseFolder.c_str()) + LevelName + "_Terrain/";
+  SavePath = FString(CachePath.c_str()) + LevelName + "_Terrain/";
   SparseMap.SavePath = SavePath;
   // Creating the FileManager
   IPlatformFile& FileManager = FPlatformFileManager::Get().GetPlatformFile();


### PR DESCRIPTION
#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.13
  * **Unreal Engine version(s):** UE5-CARLA

#### Possible Drawbacks

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9486)
<!-- Reviewable:end -->
