### PR TITLE
Fix deadlock in RPC server shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Latest Changes
+ * Fix possible RPC Server deadlock on shutdown
  * Change foonathan memory vendor branch to v1.3.1.
  * Improved the way the TrafficManager controls large vehicles at junctions, reducing the frequency of collisions with other elements in the simulation.
  * Improved the turning behavior of vehicles controlled by the TrafficManager, making them smoother.

--- a/LibCarla/source/carla/rpc/Server.h
+++ b/LibCarla/source/carla/rpc/Server.h
@@ -63,6 +63,7 @@ namespace rpc {
 
     /// @warning does not stop the game thread.
     void Stop() {
+      _shutdown_in_progress = true;
       _server.stop();
     }
 
@@ -79,6 +80,7 @@ namespace rpc {
     boost::asio::io_context _sync_io_context;
 
     ::rpc::server _server;
+    bool _shutdown_in_progress{false};
   };
 
   // ===========================================================================
@@ -115,8 +117,8 @@ namespace detail {
     /// I.e., we can use the io_context to run tasks on a specific thread (e.g.
     /// game thread).
     template <typename FuncT>
-    static auto WrapSyncCall(boost::asio::io_context &io, FuncT &&functor) {
-      return [&io, functor=std::forward<FuncT>(functor)](Metadata metadata, Args... args) -> R {
+    static auto WrapSyncCall(bool &shutdown_in_progress, boost::asio::io_context &io, FuncT &&functor) {
+      return [&shutdown_in_progress, &io, functor=std::forward<FuncT>(functor)](Metadata metadata, Args... args) -> R {
         auto const session_id = ::rpc::this_session().id();
         auto task = std::packaged_task<R()>([session_id, functor=std::move(functor), args...]() {
           ::rpc::this_session().set_id(session_id);
@@ -130,7 +132,15 @@ namespace detail {
           // Post task and wait for result.
           auto result = task.get_future();
           boost::asio::post(io, MoveHandler(task));
-          return result.get();
+          std::future_status status;
+          do {
+            status = result.wait_for(std::chrono::seconds(1));
+          } while (!shutdown_in_progress && (status != std::future_status::ready));
+          if (status==std::future_status::ready) {
+            return result.get();
+          } else {
+            return R();
+          }
         }
       };
     }
@@ -164,7 +174,7 @@ namespace detail {
     using Wrapper = detail::FunctionWrapper<FunctorT>;
     _server.bind(
         name,
-        Wrapper::WrapSyncCall(_sync_io_context, std::forward<FunctorT>(functor)));
+        Wrapper::WrapSyncCall(_shutdown_in_progress, _sync_io_context, std::forward<FunctorT>(functor)));
   }
 
   template <typename FunctorT>


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
If there are pending calls which are not yet processed while the CARLA server is stopped, the respective waiting for the future of the sync call result to become ready can block the worker thread from finishing and therefore blocks the join() call on server.stop(). This leads to a deadlock.
With the current change, the thread checks every second if a shutdown was requested and returns an empty response on shutdown. 

Maybe the issue was introduced by the new server synchronization handling, but might have been existing also for longer now. Reproduction on my end was easy.
Start CARLA server, start generate_traffic.py, stop CARLA server which was then blocking...

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...Ubuntu 24.04
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...4.26

#### Possible Drawbacks
None.
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9523)
<!-- Reviewable:end -->
