### PR TITLE
Fix geo latitude inversion unreal coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Latest Changes
+ * Fixed North/South latitude inversion in geo-coordinate conversion for Transverse Mercator and UTM projections
  * Fix possible RPC Server deadlock on shutdown
  * Change foonathan memory vendor branch to v1.3.1.
  * Improved the way the TrafficManager controls large vehicles at junctions, reducing the frequency of collisions with other elements in the simulation.

--- a/LibCarla/source/carla/geom/GeoProjection.cpp
+++ b/LibCarla/source/carla/geom/GeoProjection.cpp
@@ -220,7 +220,11 @@ namespace geom {
         double e6 = e4 * e2;
 
         double x = (location.x - p.x_0) / p.k;
-        double y = (location.y - p.y_0) / p.k;
+        // Fixed: negate Y to account for Unreal left-handed coordinate system
+        // Reason: Unreal uses a left-handed coordinate system; negating the northing
+        // corrects latitude sign for maps without an explicit <offset> in OpenDRIVE.
+        // Applied: 2026-02-13
+        double y = -((location.y - p.y_0) / p.k);
 
         double M = a * ((1.0 - e2 / 4.0 - 3.0 * e4 / 64.0 - 5.0 * e6 / 256.0) * lat_0
             - (3.0 * e2 / 8.0 + 3.0 * e4 / 32.0 + 45.0 * e6 / 1024.0) * std::sin(2.0 * lat_0)
@@ -283,7 +287,11 @@ namespace geom {
 
         //Negate the value of y because of the unreal left hand rule
         double x = (location.x - x_0) / k;
-        double y = (location.y - y_0) / k;
+        // Fixed: negate Y to account for Unreal left-handed coordinate system
+        // Reason: Unreal uses a left-handed coordinate system; negating the northing
+        // corrects latitude sign for maps without an explicit <offset> in OpenDRIVE.
+        // Applied: 2026-02-13
+        double y = -((location.y - y_0) / k);
 
         double mu = y / (a * (1.0 - e2 / 4.0 - 3.0 * e4 / 64.0 - 5.0 * e6 / 256.0));
         double e1 = (1.0 - std::sqrt(1.0 - e2)) / (1.0 + std::sqrt(1.0 - e2));


### PR DESCRIPTION
#### Description

This PR fixes a bug in the geo-coordinate conversion system where latitude values changed incorrectly (inverted sign) when moving north/south in maps using Transverse Mercator (tmerc) or Universal Transverse Mercator (UTM) projections without an explicit `<offset>` tag in the OpenDRIVE file.

**Root Cause:**
Unreal Engine uses a left-handed coordinate system while geographic projections (Transverse Mercator, UTM) assume a right-handed system. The projection inverse transforms did not account for this handedness mismatch, causing the northing (Y) component to have an inverted sign relative to latitude changes.

**Changes Made:**

1. **GeoProjection.cpp**:
   - Modified `TransformToGeoLocationTransverseMercator()` to negate the Y-coordinate: `double y = -((location.y - p.y_0) / p.k);`
   - Modified `TransformToGeoLocationUniversalTransverseMercator()` to negate the Y-coordinate: `double y = -((location.y - y_0) / k);`
   - Added comments documenting the fix and the reasoning (Unreal left-handed coordinate system correction, applied 2026-02-13)

**Behavior Change:**
- **Before:** Moving an actor +Y in CARLA local coordinates produced decreasing latitude (incorrect)
- **After:** Moving an actor +Y in CARLA local coordinates produces increasing latitude (correct)
- Map origin (local 0,0) continues to map correctly to the expected geolocation

#### Fixes #9530 #9389 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 4.26 (CARLA ue4-dev branch)
  * **Test method:** GNSS sensor output validation; confirmed latitude increases when actor moves north

#### Possible Drawbacks

- Maps that explicitly use an `<offset>` transform in OpenDRIVE may need validation to ensure the combined effect (offset negation + projection negation) is correct. However, the offset's OffsetTransform already applies a Y negation, so this change complements existing behavior.
- Any downstream code that relied on the incorrect (inverted) latitude behavior will need adjustment, but the fix aligns the system with correct geographic coordinate semantics.

#### Files Changed

1. `LibCarla/source/carla/geom/GeoProjection.cpp`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9552)
<!-- Reviewable:end -->
