### PR TITLE
docs: add Visual C++ Redistributable prerequisite for Windows install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)
+* Added Visual C++ Redistributable prerequisite and troubleshooting note to Windows quickstart guide (#9560)
 
 ## CARLA 0.10.0
 

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -30,9 +30,12 @@ The following requirements should be fulfilled before installing CARLA:
 >>      pip3 install --upgrade pip
 
 * __Two TCP ports and a good internet connection.__ 2000 and 2001 by default. Make sure that these ports are not blocked by firewalls or any other applications. 
-* __Other requirements.__  CARLA requires some Python dependencies. Install the dependencies according to your operating system:
+* __Other requirements.__  CARLA requires some Python dependencies and platform-specific software. Install the requirements according to your operating system:
 
 ### Windows
+
+!!! important
+    CARLA requires the **Microsoft Visual C++ Redistributable** to run on Windows. Without it, the simulator will fail to launch without any error message. Download and install it from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist). Choose the **x64** version under "Visual Studio 2015, 2017, 2019, and 2022".
 
 ```sh
 pip3 install --user pygame numpy
@@ -90,6 +93,9 @@ Windows:
 cd path/to/carla/root
 CarlaUnreal.exe
 ```
+
+!!! note
+    If CARLA fails to launch on Windows without any error message or log output, ensure that you have installed the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) (x64 version). This is a common issue on fresh Windows installations.
 
 A window containing a view over Town 10 will pop up. This is the _spectator view_. To fly around the city use the mouse and `WASD` keys, holding down the right mouse button to control the direction. 
 


### PR DESCRIPTION
## Summary

- Add a note in the Windows prerequisites section of the quickstart guide stating that the **Microsoft Visual C++ Redistributable** is required to run prebuilt CARLA binaries
- Add a troubleshooting note in the "Running CARLA" section for Windows users who encounter a silent launch failure

## Context

As reported in #9501, CARLA fails to launch on Windows without any error message if the Visual C++ Redistributable is not installed. This is not mentioned anywhere in the quickstart guide for prebuilt binaries, which can be confusing for new users on fresh Windows installations.

Installing the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) (x64 version) resolves the issue.

## Changes

- `Docs/start_quickstart.md`: Added an `!!! important` admonition in the Windows prerequisites section and an `!!! note` admonition in the Running CARLA section

Fixes #9501

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9560)
<!-- Reviewable:end -->
