### PR TITLE
Made MakeUnitVector() safe

### DIFF
--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -69,7 +69,6 @@ namespace geom {
 
     Vector3D MakeUnitVectorLengthInput(const double length, const float epsilon = 2.0f * std::numeric_limits<float>::epsilon()) const {
       if (length < epsilon) {
-        DEVELOPMENT_ASSERT(length >= 2.0f * std::numeric_limits<float>::epsilon());
         return *this;
       }
       const double k = 1.0 / length;

--- a/PythonAPI/test/unit/test_geom.py
+++ b/PythonAPI/test/unit/test_geom.py
@@ -27,15 +27,6 @@ class TestGeom(unittest.TestCase):
         length = (c_unit.x ** 2 + c_unit.y ** 2 + c_unit.z ** 2) ** 0.5
         self.assertAlmostEqual(length, 1.0)
 
-        # test the behavior of make_unit_vector when the length of the vector is smaller than epsilon
-        with self.assertRaisesRegex(RuntimeError, "length >= 2.0f"):
-            zero = carla.Vector3D(0.0, 0.0, 0.0)
-            zero_unit = zero.make_unit_vector()
-
-        with self.assertRaisesRegex(RuntimeError, "length >= 2.0f"):
-            small = carla.Vector3D(1e-8, 0.0, 0.0)
-            small_unit = small.make_unit_vector(epsilon=1e-6)
-
         large = carla.Vector3D(1e-4, 0.0, 0.0)
         large_unit = large.make_unit_vector(epsilon=1e-6)
         self.assertEqual(large_unit.x, 1.0)


### PR DESCRIPTION
#### Description

PR #9425 changed the MakeSafeUnitVector and MakeUnitVector functions, such that

> Renamed MakeSafeUnitVector->MakeUnitVector (no 'unsafe' variant allowed anymore)

However, the ASSERT from the previous MakeUnitVector was kept, making it still unsafe. This PR removes it.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** CARLA's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9562)
<!-- Reviewable:end -->
