### PR TITLE
Fix OSM renderer build by pinning lunasvg, linking boost_system, and enabling parallel make

### DIFF
--- a/Util/BuildTools/BuildOSMRenderer.sh
+++ b/Util/BuildTools/BuildOSMRenderer.sh
@@ -39,7 +39,7 @@ cd ${LIBOSMSCOUT_BUILD_FOLDER}
 cmake ${LIBOSMSCOUT_SOURCE_FOLDER} \
     -DCMAKE_INSTALL_PREFIX=${INSTALLATION_PATH}
 
-make
+make -j$(nproc)
 make install
 
 # ==============================================================================
@@ -47,7 +47,7 @@ make install
 # ==============================================================================
 echo "Cloning luna-svg"
 if [ ! -d ${LUNASVG_SOURCE_FOLDER} ] ; then
-  git clone ${LUNASVG_REPO} ${LUNASVG_SOURCE_FOLDER}
+  git clone -b v2.3.8 --depth 1 ${LUNASVG_REPO} ${LUNASVG_SOURCE_FOLDER}
 fi
 
 mkdir -p ${LUNASVG_BUILD_FOLDER}
@@ -56,7 +56,7 @@ cd ${LUNASVG_BUILD_FOLDER}
 cmake ${LUNASVG_SOURCE_FOLDER} \
     -DCMAKE_INSTALL_PREFIX=${INSTALLATION_PATH}
 
-make
+make -j$(nproc)
 make install
 
 
@@ -69,7 +69,8 @@ mkdir -p ${OSM_RENDERER_BUILD}
 cd ${OSM_RENDERER_BUILD}
 
 cmake -DCMAKE_CXX_FLAGS="-std=c++17 -g -pthread -I${CARLA_BUILD_FOLDER}/boost-1.84.0-c10-install/include" \
+-DCMAKE_EXE_LINKER_FLAGS="-L${CARLA_BUILD_FOLDER}/boost-1.84.0-c10-install/lib -lboost_system" \
     ${OSM_RENDERER_SOURCE}
-make
+make -j$(nproc)
 
 echo "SUCCESS! Finishing setting up renderer."


### PR DESCRIPTION
#### Description

This PR improves the OSM renderer build process in `Util/BuildTools/BuildOSMRenderer.sh` to make it more reliable and faster.

The following changes were introduced:

- Replaced `make` with `make -j$(nproc)` in all build steps to enable parallel compilation and reduce build time.
- Pinned `lunasvg` to `v2.3.8` using a shallow clone:
  - `git clone -b v2.3.8 --depth 1 ${LUNASVG_REPO} ${LUNASVG_SOURCE_FOLDER}`
- Added explicit Boost linker flags when building the OSM renderer:
  - `-DCMAKE_EXE_LINKER_FLAGS="-L${CARLA_BUILD_FOLDER}/boost-1.84.0-c10-install/lib -lboost_system"`

These changes are intended to improve reproducibility and reduce build failures in the OSM renderer toolchain.

The `lunasvg` change avoids pulling the latest upstream state, which may introduce incompatibilities over time. Pinning a known release makes the dependency more stable and predictable.

The Boost linker flag was added to address build/link errors reported by the community when compiling the OSM renderer.

Using parallel `make` also improves developer experience by reducing compilation time during setup.

Fixes #6913

#### Where has this been tested?

* **Platform(s):** Linux
* **Python version(s):** N/A
* **Unreal Engine version(s):** UE4

#### Possible Drawbacks

- Using `make -j$(nproc)` increases CPU usage during compilation and may be too aggressive on low-memory systems.
- Pinning `lunasvg` to a fixed release reduces exposure to upstream regressions, but it also means future fixes in newer versions will not be picked up automatically unless the version is updated manually.
- Adding explicit linker flags may need adjustment in the future if the Boost build layout changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9573)
<!-- Reviewable:end -->
