### PR TITLE
Fix C++ unit tests

### DIFF
--- a/LibCarla/source/test/common/test_vector3D.cpp
+++ b/LibCarla/source/test/common/test_vector3D.cpp
@@ -18,13 +18,7 @@ TEST(vector3D, make_unit_vec) {
   ASSERT_EQ(Vector3D(0,10,0).MakeUnitVector(), Vector3D(0,1,0));
   ASSERT_EQ(Vector3D(0,0,512).MakeUnitVector(), Vector3D(0,0,1));
   ASSERT_NE(Vector3D(0,1,512).MakeUnitVector(), Vector3D(0,0,1));
-#ifdef LIBCARLA_NO_EXCEPTIONS
-  ASSERT_DEATH_IF_SUPPORTED(
-      Vector3D().MakeUnitVector(),
-      "length >= 2.0f \\* std::numeric_limits<float>::epsilon()");
-#else
-  ASSERT_THROW(
-      Vector3D().MakeUnitVector(),
-      std::runtime_error);
-#endif // LIBCARLA_NO_EXCEPTIONS
+
+  // The following test is to check that the MakeUnitVector doesn't fail on zero-length vectors
+  ASSERT_EQ(Vector3D().MakeUnitVector(), Vector3D(0,0,0));
 }


### PR DESCRIPTION
After 7b2ef1d94a54124349cc90a5226095469c1f25d6 only the python unit tests were adapted. This commit adapts the C++ tests to the changed behavior.

Interestingly, this missing adaption wasn't detected by the CI run: When looking into the respective run, I only found that the make check.PythonAPI is called and the C++ ones seem to be switched off...


<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9575)
<!-- Reviewable:end -->
