### PR TITLE
fix(streaming): restore ROS2 sensor data flow broken by multistream refactor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest Changes
  * Fixed all 282 compiler warnings in LibCarla across 27 files (unused variables, missing braces, narrowing conversions, implicit casts, initializer order, etc.) establishing a zero-warning baseline for server and client release builds
+ * Fixed ROS2 native sensors not streaming data when no Python client is listening for UE4, caused by a missing ROS2 enablement check in AreClientsListening() after the multistream refactor (PR #9431)
  * Fix possible RPC Server deadlock on shutdown
  * Change foonathan memory vendor branch to v1.3.1.
  * Improved the way the TrafficManager controls large vehicles at junctions, reducing the frequency of collisions with other elements in the simulation.

--- a/LibCarla/source/carla/streaming/detail/MultiStreamState.h
+++ b/LibCarla/source/carla/streaming/detail/MultiStreamState.h
@@ -60,12 +60,12 @@ namespace detail {
     }
 
     void EnableForROS(actor_id_type actor_id) {
-      log_error("MultiStreamState enable for ros. Searching sessions.");
+      log_debug("MultiStreamState enable for ros. Searching sessions.");
       _enable_for_ros.insert(actor_id);
       for (auto &s : _sessions) {
         if (s != nullptr) {
           s->EnableForROS(actor_id);
-          log_error("sensor ", s->get_stream_id(), " enable for ros ");
+          log_debug("sensor ", s->get_stream_id(), " enable for ros ");
         }
       }
     }
@@ -75,7 +75,7 @@ namespace detail {
       for (auto &s : _sessions) {
         if (s != nullptr) {
           s->DisableForROS(actor_id);
-          log_error("sensor ", s->get_stream_id(), " disable for ros ");
+          log_debug("sensor ", s->get_stream_id(), " disable for ros ");
         }
       }
     }
@@ -92,7 +92,7 @@ namespace detail {
     }
 
     bool AreClientsListening() {
-      return (_sessions.size() > 0 || _force_active);
+      return (_sessions.size() > 0 || _force_active || !_enable_for_ros.empty());
     }
 
     void ConnectSession(std::shared_ptr<Session> session) final {


### PR DESCRIPTION
This PR fixes a regression introduced in PR #9431 ("Extend ROS2 support Step 1") to `ue4-dev`.

That refactor changed `EnableForROS` from a simple boolean into a per-actor set, but it also removed the ROS2 enablement check from `AreClientsListening()`. As a result, `Sensor::Tick()` could return early whenever no Python stream client was connected, even if ROS2 publishing had already been enabled for one or more actors.

This caused ROS2-enabled sensors to stop generating data for ROS2 topics unless a regular stream client was also listening.

This PR restores the expected behavior by checking `!_enable_for_ros.empty()` inside `AreClientsListening()`, matching the previous invariant from 0.9.16 where `_enabled_for_ros` kept sensors active for ROS2 publishing.

Additionally, this PR downgrades `log_error` to `log_debug` in `EnableForROS` and `DisableForROS`, since these messages are informational and do not represent actual error conditions.

In summary, this change:

- Restores ROS2 sensor activity when ROS2 publishing is enabled
- Prevents `Sensor::Tick()` from exiting early in ROS2-only scenarios
- Aligns the behavior with the previous 0.9.16 logic
- Reduces misleading log noise by changing informational ROS2 messages from error level to debug level

Fixes #9576

#### Where has this been tested?

* **Platform(s):** Linux Ubuntu 22.04
* **Python version(s):** 3.10 / 3.11 / 3.12
* **Unreal Engine version(s):** UE4

#### Possible Drawbacks

- This change makes sensors remain active when ROS2 publishing is enabled, even if no regular Python stream client is connected. That is the intended behavior, but it may slightly increase sensor work in ROS2-only workflows.
- Lowering these messages from `log_error` to `log_debug` reduces noise, but users relying on those logs at error level will no longer see them as prominent messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9577)
<!-- Reviewable:end -->
