### PR TITLE
fix(geom): Fix Unit test C++, align Vector3D assert message with DEVELOPMENT_ASSERT macro

### DIFF
--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "carla/Debug.h"
 #include "carla/MsgPack.h"
 
 #include <cmath>
@@ -68,6 +69,7 @@ namespace geom {
     }
 
     Vector3D MakeUnitVectorLengthInput(const double length, const float epsilon = 2.0f * std::numeric_limits<float>::epsilon()) const {
+      DEVELOPMENT_ASSERT(length >= epsilon);
       if (length < epsilon) {
         return *this;
       }

--- a/LibCarla/source/test/common/test_vector3D.cpp
+++ b/LibCarla/source/test/common/test_vector3D.cpp
@@ -21,7 +21,7 @@ TEST(vector3D, make_unit_vec) {
 #ifdef LIBCARLA_NO_EXCEPTIONS
   ASSERT_DEATH_IF_SUPPORTED(
       Vector3D().MakeUnitVector(),
-      "length >= 2.0f \\* std::numeric_limits<float>::epsilon()");
+      "length >= epsilon");
 #else
   ASSERT_THROW(
       Vector3D().MakeUnitVector(),


### PR DESCRIPTION
#### Description

This PR fixes the `Vector3D::MakeUnitVector()` death-test expectation so it matches the assertion message generated by `DEVELOPMENT_ASSERT`.

The issue was that `MakeUnitVectorLengthInput` previously relied on an implicit assertion path, while the test was hard-coded to expect the older, fully expanded expression string:

```text
length >= 2.0f * std::numeric_limits<float>::epsilon()
```

After replacing that with `DEVELOPMENT_ASSERT(length >= epsilon)`, the runtime assertion message is now derived from the macro predicate itself via the preprocessor stringify operator. Because the predicate is written as `length >= epsilon`, the emitted message becomes:

```text
length >= epsilon
```

The death-test expectation was still checking for the old string, which caused the test to fail.

This PR makes the precondition explicit and aligns the test with the actual assertion behavior.

Changes included in this PR:

- Added `#include "carla/Debug.h"` in `LibCarla/source/carla/geom/Vector3D.h`
- Added `DEVELOPMENT_ASSERT(length >= epsilon)` at the beginning of `MakeUnitVectorLengthInput`
- Updated the death-test expectation in `LibCarla/source/test/common/test_vector3D.cpp` from the old verbose expression to `length >= epsilon`

This keeps the assertion style consistent with the rest of LibCarla and fixes the failing death test under the relevant build configuration.

Made-with: Cursor

Fixes # <!-- add issue number if applicable -->

#### Where has this been tested?

* **Platform(s):** Linux Ubuntu 22.04
* **Python version(s):** N/A
* **Unreal Engine version(s):** UE4

#### Possible Drawbacks

- This change updates the exact assertion text seen by the death test, so any external tooling or tests that relied on the previous message string would also need to be updated.
- No functional behavior change is expected during normal operation; the assertion only affects invalid zero-length vector inputs in development/assert-enabled scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9578)
<!-- Reviewable:end -->
