### PR TITLE
fix(LibCarla): resolve compile-time warnings in ROS2 integration

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -246,6 +246,7 @@ std::shared_ptr<BasePublisher> ROS2::GetOrCreateSensor(int type, void* actor) {
     case ESensors::HSSLidar:
       return create_and_register(std::make_shared<CarlaLidarPublisher>(topic_name, frame_id));
   }
+  return nullptr;
 }
 
 void ROS2::ProcessDataFromCamera(
@@ -254,7 +255,7 @@ void ROS2::ProcessDataFromCamera(
     const carla::SharedBufferView buffer,
     void *actor) {
 
-  auto base_publisher = GetOrCreateSensor(sensor_type, actor);
+  auto base_publisher = GetOrCreateSensor(static_cast<int>(sensor_type), actor);
   auto sensor_publisher = std::dynamic_pointer_cast<CarlaCameraPublisher>(base_publisher);
   auto transform_publisher = GetOrCreateTransformPublisher(actor);
 
@@ -264,7 +265,7 @@ void ROS2::ProcessDataFromCamera(
     return;
 
   sensor_publisher->WriteCameraInfo(_seconds, _nanoseconds, 0, 0, header->height, header->width, header->fov_angle, true);
-  sensor_publisher->WriteImage(_seconds, _nanoseconds, header->height, header->width, (const uint8_t*) (buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
+  sensor_publisher->WriteImage(_seconds, _nanoseconds, header->height, header->width, reinterpret_cast<const uint8_t*>(buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
   sensor_publisher->Publish();
 
   if (transform_publisher) {
@@ -274,7 +275,7 @@ void ROS2::ProcessDataFromCamera(
 }
 
 void ROS2::ProcessDataFromGNSS(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     const carla::geom::GeoLocation &data,
     void *actor) {
@@ -293,7 +294,7 @@ void ROS2::ProcessDataFromGNSS(
 }
 
 void ROS2::ProcessDataFromIMU(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     carla::geom::Vector3D accelerometer,
     carla::geom::Vector3D gyroscope,
@@ -314,7 +315,7 @@ void ROS2::ProcessDataFromIMU(
 }
 
 void ROS2::ProcessDataFromDVS(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     const carla::SharedBufferView buffer,
     void *actor) {
@@ -332,9 +333,9 @@ void ROS2::ProcessDataFromDVS(
   const size_t im_width = header->width;
   const size_t im_height = header->height;
 
-  sensor_publisher->WriteCameraInfo(_seconds, _nanoseconds, 0, 0, im_height, im_width, header->fov_angle, true);
-  sensor_publisher->WriteImage(_seconds, _nanoseconds, elements, header->height, header->width, (const uint8_t*) (buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
-  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, 1, elements, (uint8_t*) (buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
+  sensor_publisher->WriteCameraInfo(_seconds, _nanoseconds, 0, 0, static_cast<uint32_t>(im_height), static_cast<uint32_t>(im_width), header->fov_angle, true);
+  sensor_publisher->WriteImage(_seconds, _nanoseconds, static_cast<uint32_t>(elements), header->height, header->width, reinterpret_cast<const uint8_t*>(buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
+  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, 1, static_cast<uint32_t>(elements), const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset)));
   sensor_publisher->Publish();
 
   if (transform_publisher) {
@@ -344,7 +345,7 @@ void ROS2::ProcessDataFromDVS(
 }
 
 void ROS2::ProcessDataFromLidar(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     carla::sensor::data::LidarData &data,
     void *actor) {
@@ -356,9 +357,9 @@ void ROS2::ProcessDataFromLidar(
   // The lidar returns a flat list of floats rather than structured detection points.
   // Each lidar detection consists of 4 floats: x, y, z, and intensity.
   // Divide the total number of floats by 4 to get the number of lidar detections.
-  size_t width = data._points.size() / 4;
-  size_t height = 1;
-  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, (uint8_t*)data._points.data());
+  const uint32_t width = static_cast<uint32_t>(data._points.size() / 4);
+  const uint32_t height = 1;
+  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, reinterpret_cast<uint8_t*>(data._points.data()));
   sensor_publisher->Publish();
 
   if (transform_publisher) {
@@ -368,7 +369,7 @@ void ROS2::ProcessDataFromLidar(
 }
 
 void ROS2::ProcessDataFromSemanticLidar(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     carla::sensor::data::SemanticLidarData &data,
     void *actor) {
@@ -377,9 +378,9 @@ void ROS2::ProcessDataFromSemanticLidar(
   auto sensor_publisher = std::dynamic_pointer_cast<CarlaSemanticLidarPublisher>(base_publisher);
   auto transform_publisher = GetOrCreateTransformPublisher(actor);
 
-  size_t width = data._ser_points.size();
-  size_t height = 1;
-  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, (uint8_t*)data._ser_points.data());
+  const uint32_t width = static_cast<uint32_t>(data._ser_points.size());
+  const uint32_t height = 1;
+  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, reinterpret_cast<uint8_t*>(data._ser_points.data()));
   sensor_publisher->Publish();
 
   if (transform_publisher) {
@@ -389,7 +390,7 @@ void ROS2::ProcessDataFromSemanticLidar(
 }
 
 void ROS2::ProcessDataFromRadar(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     const carla::sensor::data::RadarData &data,
     void *actor) {
@@ -398,9 +399,9 @@ void ROS2::ProcessDataFromRadar(
   auto sensor_publisher = std::dynamic_pointer_cast<CarlaRadarPublisher>(base_publisher);
   auto transform_publisher = GetOrCreateTransformPublisher(actor);
 
-  size_t width = data.GetDetectionCount();
-  size_t height = 1;
-  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, (uint8_t*)data._detections.data());
+  const uint32_t width = static_cast<uint32_t>(data.GetDetectionCount());
+  const uint32_t height = 1;
+  sensor_publisher->WritePointCloud(_seconds, _nanoseconds, height, width, reinterpret_cast<uint8_t*>(const_cast<carla::sensor::data::RadarDetection*>(data._detections.data())));
   sensor_publisher->Publish();
 
   if (transform_publisher) {
@@ -411,16 +412,16 @@ void ROS2::ProcessDataFromRadar(
 
 void ROS2::ProcessDataFromObstacleDetection(
     uint64_t sensor_type,
-    const carla::geom::Transform sensor_transform,
-    AActor *first_ctor,
-    AActor *second_actor,
+    const carla::geom::Transform /*sensor_transform*/,
+    AActor * /*first_ctor*/,
+    AActor * /*second_actor*/,
     float distance,
-    void *actor) {
+    void * /*actor*/) {
   log_info("Sensor ObstacleDetector to ROS data: frame.", _frame, "sensor.", sensor_type, "distance.", distance);
 }
 
 void ROS2::ProcessDataFromCollisionSensor(
-    uint64_t sensor_type,
+    uint64_t /*sensor_type*/,
     const carla::geom::Transform sensor_transform,
     uint32_t other_actor,
     carla::geom::Vector3D impulse,

--- a/LibCarla/source/carla/ros2/publishers/BasePublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/BasePublisher.h
@@ -26,18 +26,19 @@ namespace ros2 {
         _base_topic_name(base_topic_name),
         _frame_id(frame_id) {}
 
-      const std::string GetBaseTopicName() {return _base_topic_name; }
-      const std::string GetFrameId() { return _frame_id; }
+      virtual ~BasePublisher() = default;
+
+      std::string GetBaseTopicName() { return _base_topic_name; }
+      std::string GetFrameId() { return _frame_id; }
 
       virtual bool Publish() = 0;
 
       void* GetActor() { return _actor; }
 
     protected:
-      std::string _frame_id = "";
-      std::string _base_topic_name = "";
-
       void* _actor { nullptr };
+      std::string _base_topic_name = "";
+      std::string _frame_id = "";
   };
 
 }  // namespace ros2

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSPublisher.cpp
@@ -9,7 +9,7 @@
 namespace carla {
 namespace ros2 {
 
-const size_t CarlaDVSPointCloudPublisher::GetPointSize() {
+size_t CarlaDVSPointCloudPublisher::GetPointSize() {
   return sizeof(sensor::data::DVSEvent);
 }
 
@@ -44,7 +44,7 @@ std::vector<uint8_t> CarlaDVSPointCloudPublisher::ComputePointCloud(uint32_t hei
   sensor::data::DVSEvent* events = reinterpret_cast<sensor::data::DVSEvent*>(data);
   const size_t total_points = height * width;
   for (size_t i = 0; i < total_points; ++i) {
-    events[i].y *= -1.0f;
+    events[i].y = static_cast<std::uint16_t>(static_cast<float>(events[i].y) * -1.0f);
   }
 
   const size_t total_bytes = total_points * sizeof(sensor::data::DVSEvent);

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
         CarlaPointCloudPublisher(base_topic_name, frame_id) {}
 
     private:
-      const size_t GetPointSize() override;
+      size_t GetPointSize() override;
       std::vector<sensor_msgs::msg::PointField> GetFields() override;
 
       std::vector<uint8_t> ComputePointCloud(uint32_t height, uint32_t width, uint8_t *data) override;
@@ -64,7 +64,7 @@ namespace ros2 {
         const carla::sensor::data::DVSEvent* events = reinterpret_cast<const carla::sensor::data::DVSEvent*>(data);
         for (size_t i = 0; i < elements; ++i) {
           const auto& event = events[i];
-          size_t index = (event.y * im_width + event.x) * 3 + (static_cast<int>(event.pol) * 2);
+          size_t index = (event.y * im_width + event.x) * 3u + (event.pol ? 2u : 0u);
           im_data[index] = 255;
         }
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.cpp
@@ -9,7 +9,7 @@
 namespace carla {
 namespace ros2 {
 
-const size_t CarlaLidarPublisher::GetPointSize() {
+size_t CarlaLidarPublisher::GetPointSize() {
   return sizeof(sensor::data::LidarDetection);
 }
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.h
@@ -17,7 +17,7 @@ namespace ros2 {
         CarlaPointCloudPublisher(base_topic_name, frame_id) {}
 
     private:
-      const size_t GetPointSize() override;
+      size_t GetPointSize() override;
       std::vector<sensor_msgs::msg::PointField> GetFields() override;
 
       std::vector<uint8_t> ComputePointCloud(uint32_t height, uint32_t width, uint8_t *data) override;

--- a/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.cpp
@@ -20,8 +20,8 @@ bool CarlaPointCloudPublisher::WritePointCloud(int32_t seconds, uint32_t nanosec
   _impl->GetMessage()->height(height);
   _impl->GetMessage()->is_bigendian(false);
   _impl->GetMessage()->fields(fields);
-  _impl->GetMessage()->point_step(point_size);
-  _impl->GetMessage()->row_step(width * point_size);
+  _impl->GetMessage()->point_step(static_cast<uint32_t>(point_size));
+  _impl->GetMessage()->row_step(static_cast<uint32_t>(width * point_size));
   _impl->GetMessage()->is_dense(false); // True if there are not invalid points
   _impl->GetMessage()->data(std::move(data));
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.h
@@ -39,7 +39,7 @@ namespace ros2 {
       bool WritePointCloud(int32_t seconds, uint32_t nanoseconds, uint32_t height, uint32_t width, std::vector<uint8_t> data);
 
     private:
-      virtual const size_t GetPointSize() = 0;
+      virtual size_t GetPointSize() = 0;
       virtual std::vector<sensor_msgs::msg::PointField> GetFields() = 0;
 
       virtual std::vector<uint8_t> ComputePointCloud(uint32_t height, uint32_t width, uint8_t *data) = 0;

--- a/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.cpp
@@ -16,7 +16,7 @@ struct RadarDetectionWithPosition {
   carla::sensor::data::RadarDetection detection;
 };
 
-const size_t CarlaRadarPublisher::GetPointSize() {
+size_t CarlaRadarPublisher::GetPointSize() {
   return sizeof(RadarDetectionWithPosition);
 }
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.h
@@ -18,7 +18,7 @@ namespace ros2 {
         CarlaPointCloudPublisher(base_topic_name, frame_id) {}
 
     private:
-      const size_t GetPointSize() override;
+      size_t GetPointSize() override;
       std::vector<sensor_msgs::msg::PointField> GetFields() override;
 
       std::vector<uint8_t> ComputePointCloud(uint32_t height, uint32_t width, uint8_t *data) override;

--- a/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.cpp
@@ -9,7 +9,7 @@
 namespace carla {
 namespace ros2 {
 
-const size_t CarlaSemanticLidarPublisher::GetPointSize() {
+size_t CarlaSemanticLidarPublisher::GetPointSize() {
   return sizeof(sensor::data::SemanticLidarDetection);
 }
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.h
@@ -18,7 +18,7 @@ namespace ros2 {
         CarlaPointCloudPublisher(base_topic_name, frame_id) {}
 
     private:
-      const size_t GetPointSize() override;
+      size_t GetPointSize() override;
       std::vector<sensor_msgs::msg::PointField> GetFields() override;
 
       std::vector<uint8_t> ComputePointCloud(uint32_t height, uint32_t width, uint8_t *data) override;

--- a/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
@@ -15,7 +15,8 @@ geometry_msgs::msg::Transform CarlaTransformPublisher::ComputeTransform(std::str
   // This is common for static sensors that are typically attached to other actors.
   auto it = _last_transforms.find(frame_id);
   if (it != _last_transforms.end()) {
-    const auto& [last_transform, last_tf] = it->second;
+    const auto& last_transform = it->second.first;
+    const auto& last_tf = it->second.second;
 
     // Do not use operator== directly on transforms.
     // Floating-point errors can cause two transforms that are equal to compare as different.

--- a/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
+++ b/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
@@ -45,7 +45,7 @@ namespace ros2 {
     efd::DataWriter* _datawriter { nullptr };
     efd::TypeSupport _type { new msg_pubsub_type() };
 
-    void on_publication_matched(efd::DataWriter* writer, const efd::PublicationMatchedStatus& info) override {
+    void on_publication_matched(efd::DataWriter* /*writer*/, const efd::PublicationMatchedStatus& info) override {
       _alive = (info.total_count > 0) ? true : false;
     }
 
@@ -94,7 +94,7 @@ namespace ros2 {
 
       efd::DataWriterQos wqos = efd::DATAWRITER_QOS_DEFAULT;
       wqos.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-      efd::DataWriterListener* listener = (efd::DataWriterListener*)(this);
+      efd::DataWriterListener* listener = static_cast<efd::DataWriterListener*>(this);
       _datawriter = _publisher->create_datawriter(_topic, wqos, listener);
       if (_datawriter == nullptr) {
         std::cerr << "Failed to create DataWriter" << std::endl;

--- a/LibCarla/source/carla/ros2/subscribers/BaseSubscriber.h
+++ b/LibCarla/source/carla/ros2/subscribers/BaseSubscriber.h
@@ -30,8 +30,10 @@ namespace ros2 {
         _base_topic_name(base_topic_name),
         _frame_id(frame_id) {}
 
-      const std::string GetBaseTopicName() {return _base_topic_name; }
-      const std::string GetFrameId() { return _frame_id; }
+      virtual ~BaseSubscriber() = default;
+
+      std::string GetBaseTopicName() { return _base_topic_name; }
+      std::string GetFrameId() { return _frame_id; }
 
       virtual ROS2CallbackData GetMessage() = 0;
       virtual void ProcessMessages(ActorCallback callback) = 0;
@@ -39,10 +41,9 @@ namespace ros2 {
       void* GetActor() { return _actor; }
 
     protected:
-      std::string _frame_id = "";
-      std::string _base_topic_name = "";
-
       void* _actor { nullptr };
+      std::string _base_topic_name = "";
+      std::string _frame_id = "";
   };
 
 }  // namespace ros2

--- a/LibCarla/source/carla/ros2/subscribers/SubscriberImpl.h
+++ b/LibCarla/source/carla/ros2/subscribers/SubscriberImpl.h
@@ -47,7 +47,7 @@ namespace ros2 {
     efd::DataReader* _datareader { nullptr };
     efd::TypeSupport _type { new msg_pubsub_type() };
 
-    void on_subscription_matched(efd::DataReader* reader, const efd::SubscriptionMatchedStatus& info) override {
+    void on_subscription_matched(efd::DataReader* /*reader*/, const efd::SubscriptionMatchedStatus& info) override {
       _alive = (info.total_count > 0) ? true : false;
     }
 
@@ -109,7 +109,7 @@ namespace ros2 {
       }
 
       efd::DataReaderQos rqos = efd::DATAREADER_QOS_DEFAULT;
-      efd::DataReaderListener* listener = (efd::DataReaderListener*)(this);
+      efd::DataReaderListener* listener = static_cast<efd::DataReaderListener*>(this);
       _datareader = _subscriber->create_datareader(_topic, rqos, listener);
       if (_datareader == nullptr) {
         log_error("Failed to create DataReader");

--- a/LibCarla/source/carla/ros2/types/AckermannDrivePubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/AckermannDrivePubSubTypes.h
@@ -63,7 +63,7 @@ namespace ackermann_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr AckermannDrive_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/Float32PubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/Float32PubSubTypes.h
@@ -59,7 +59,7 @@ namespace std_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Float32_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/NavSatStatusPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/NavSatStatusPubSubTypes.h
@@ -60,7 +60,7 @@ namespace sensor_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr NavSatStatus_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/Point32PubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/Point32PubSubTypes.h
@@ -60,7 +60,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Point32_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/PointPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/PointPubSubTypes.h
@@ -60,7 +60,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Point_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/PosePubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/PosePubSubTypes.h
@@ -63,7 +63,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Pose_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/PoseWithCovariancePubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/PoseWithCovariancePubSubTypes.h
@@ -63,7 +63,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr PoseWithCovariance_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/QuaternionPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/QuaternionPubSubTypes.h
@@ -61,7 +61,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Quaternion_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/RegionOfInterestPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/RegionOfInterestPubSubTypes.h
@@ -61,7 +61,7 @@ namespace sensor_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr RegionOfInterest_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/TransformPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/TransformPubSubTypes.h
@@ -64,7 +64,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Transform_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/TwistPubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/TwistPubSubTypes.h
@@ -63,7 +63,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Twist_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/TwistWithCovariancePubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/TwistWithCovariancePubSubTypes.h
@@ -63,7 +63,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr TwistWithCovariance_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif

--- a/LibCarla/source/carla/ros2/types/Vector3PubSubTypes.h
+++ b/LibCarla/source/carla/ros2/types/Vector3PubSubTypes.h
@@ -61,7 +61,7 @@ namespace geometry_msgs
 
             template <typename T, typename Tag>
             inline size_t constexpr Vector3_offset_of() {
-                return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+                return reinterpret_cast<::size_t>(&reinterpret_cast<char const volatile&>((static_cast<T*>(nullptr)->*get(Tag()))));
             }
         }
         #endif


### PR DESCRIPTION
#### Description

This PR fixes compile-time warnings in the LibCarla ROS2 module by applying targeted, warning-focused changes across the ROS2 bridge, publishers, subscribers, and generated PubSub type headers.

The goal of this PR is to improve build hygiene and compatibility with stricter compiler settings without changing runtime behavior or public APIs.

Main changes included in this PR:

- Added a missing return path in `GetOrCreateSensor()` to fix `-Wreturn-type`
- Added virtual destructors to `BasePublisher` and `BaseSubscriber`
- Replaced old-style C casts with `static_cast` and `reinterpret_cast`
- Added explicit conversions to fix integer narrowing warnings
- Marked unused parameters to silence `-Wunused-parameter`
- Removed redundant `const` qualifiers from by-value return types
- Reordered members in base classes to match constructor initialization order

More specifically:

- `LibCarla/source/carla/ros2/ROS2.cpp`
  - Added `return nullptr;` at the end of `GetOrCreateSensor()`
  - Replaced C-style pointer casts with explicit C++ casts
  - Added explicit `static_cast` conversions for sensor type and width/height values
  - Marked several unused parameters in sensor processing functions

- `LibCarla/source/carla/ros2/publishers/BasePublisher.h`
  - Added `virtual ~BasePublisher() = default;`
  - Removed redundant `const` from by-value getters
  - Reordered protected members to match constructor initialization order

- `LibCarla/source/carla/ros2/subscribers/BaseSubscriber.h`
  - Added `virtual ~BaseSubscriber() = default;`
  - Removed redundant `const` from by-value getters
  - Reordered protected members to match constructor initialization order

- `LibCarla/source/carla/ros2/publishers/PublisherImpl.h`
  - Replaced listener cast with `static_cast`
  - Marked unused callback parameter

- `LibCarla/source/carla/ros2/subscribers/SubscriberImpl.h`
  - Replaced listener cast with `static_cast`
  - Marked unused callback parameter

- `LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp`
  - Replaced structured binding syntax with a C++14-compatible alternative

- `LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.cpp`
  - Added explicit casts for `point_step` and `row_step`

- `LibCarla/source/carla/ros2/publishers/CarlaDVSPublisher.cpp`
  - Removed redundant `const` from `GetPointSize()`
  - Added explicit conversion in DVS event point-cloud generation

- `LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.*`
- `LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.*`
- `LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.*`
- `LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.h`
  - Removed redundant `const` from `GetPointSize()` return types

- `LibCarla/source/carla/ros2/types/*PubSubTypes.h`
  - Replaced old-style casts in offset helper templates with explicit C++ casts

These changes are intended to be mechanical and warning-oriented only. No ROS2 message schema, public interface, or expected runtime data flow was intentionally changed.

Fixes # 

#### Where has this been tested?

* **Platform(s):** Linux Ubuntu 22.04
* **Python version(s):** N/A
* **Unreal Engine version(s):** UE4

#### Possible Drawbacks

- This PR touches multiple ROS2-related files, including generated PubSub type headers, so future upstream syncs in these files may require reapplying or reconciling some of these warning fixes.
- Although the changes are intended to be behavior-preserving, any warning cleanup involving casts or base class definitions should still be reviewed carefully in case a downstream component depended on previous implicit behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9582)
<!-- Reviewable:end -->
