### PR TITLE
fix(LibCarla): port core bug fixes from ue4-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed RPC server deadlock on shutdown, overly strict Vector3D assert, OpenDrive lane width for center lanes, busy-wait yield() calls, and strict RELEASE_ASSERTs in road Map (ported from ue4-dev)
 * Fix typos in README.md
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -21,6 +21,7 @@
 #include "carla/trafficmanager/TrafficManager.h"
 #include "carla/sensor/Deserializer.h"
 
+#include <chrono>
 #include <exception>
 #include <thread>
 
@@ -50,7 +51,7 @@ namespace detail {
     bool result = true;
     auto start = std::chrono::system_clock::now();
     while (frame > episode.GetState()->GetTimestamp().frame) {
-      std::this_thread::yield();
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
       auto end = std::chrono::system_clock::now();
       auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
       if(timeout.to_chrono() < diff) {

--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -66,6 +66,9 @@ namespace geom {
 
     inline Vector3D MakeUnitVector() const {
       const float length = Length();
+      if (length <= 0.0f) {
+        return Vector3D(0.0f, 0.0f, 0.0f);
+      }
       const float k = 1.0f / length;
       return Vector3D(x * k, y * k, z * k);
     }

--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -66,7 +66,6 @@ namespace geom {
 
     inline Vector3D MakeUnitVector() const {
       const float length = Length();
-      DEVELOPMENT_ASSERT(length > 2.0f * std::numeric_limits<float>::epsilon());
       const float k = 1.0f / length;
       return Vector3D(x * k, y * k, z * k);
     }

--- a/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
+++ b/LibCarla/source/carla/opendrive/parser/LaneParser.cpp
@@ -38,10 +38,12 @@ namespace parser {
         map_builder.CreateLaneWidth(lane, s_offset + s, a, b, c, d);
         width_count++;
       }
-      if (width_count == 0 && lane->GetId() != 0) {
+      if (width_count == 0) {
         map_builder.CreateLaneWidth(lane, s, 0.0, 0.0, 0.0, 0.0);
-        std::cout << "WARNING: In road " << lane->GetRoad()->GetId() << " lane " << lane->GetId() <<
-        " no \"<width>\" parameter found under \"<lane>\" tag. Using default values." << std::endl;
+        if (lane->GetId() != 0) {
+          std::cout << "WARNING: In road " << lane->GetRoad()->GetId() << " lane " << lane->GetId() <<
+          " no \"<width>\" parameter found under \"<lane>\" tag. Using default values." << std::endl;
+        }
       }
 
       // Lane Border

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -521,13 +521,21 @@ namespace road {
     std::vector<Waypoint> result;
     result.reserve(next_lanes.size());
     for (auto *next_lane : next_lanes) {
-      RELEASE_ASSERT(next_lane != nullptr);
+      if (next_lane == nullptr) {
+        continue;
+      }
       const auto lane_id = next_lane->GetId();
-      RELEASE_ASSERT(lane_id != 0);
+      if (lane_id == 0) {
+        continue;
+      }
       const auto *section = next_lane->GetLaneSection();
-      RELEASE_ASSERT(section != nullptr);
+      if (section == nullptr) {
+        continue;
+      }
       const auto *road = next_lane->GetRoad();
-      RELEASE_ASSERT(road != nullptr);
+      if (road == nullptr) {
+        continue;
+      }
       const auto distance = GetDistanceAtStartOfLane(*next_lane);
       result.emplace_back(Waypoint{road->GetId(), section->GetId(), lane_id, distance});
     }
@@ -539,13 +547,21 @@ namespace road {
     std::vector<Waypoint> result;
     result.reserve(prev_lanes.size());
     for (auto *next_lane : prev_lanes) {
-      RELEASE_ASSERT(next_lane != nullptr);
+      if (next_lane == nullptr) {
+        continue;
+      }
       const auto lane_id = next_lane->GetId();
-      RELEASE_ASSERT(lane_id != 0);
+      if (lane_id == 0) {
+        continue;
+      }
       const auto *section = next_lane->GetLaneSection();
-      RELEASE_ASSERT(section != nullptr);
+      if (section == nullptr) {
+        continue;
+      }
       const auto *road = next_lane->GetRoad();
-      RELEASE_ASSERT(road != nullptr);
+      if (road == nullptr) {
+        continue;
+      }
       const auto distance = GetDistanceAtEndOfLane(*next_lane);
       result.emplace_back(Waypoint{road->GetId(), section->GetId(), lane_id, distance});
     }

--- a/LibCarla/source/carla/rpc/Server.h
+++ b/LibCarla/source/carla/rpc/Server.h
@@ -16,6 +16,7 @@
 
 #include <rpc/server.h>
 
+#include <atomic>
 #include <future>
 
 namespace carla {
@@ -62,6 +63,7 @@ namespace rpc {
 
     /// @warning does not stop the game thread.
     void Stop() {
+      _shutdown_in_progress = true;
       _server.stop();
     }
 
@@ -70,6 +72,7 @@ namespace rpc {
     boost::asio::io_context _sync_io_context;
 
     ::rpc::server _server;
+    std::atomic_bool _shutdown_in_progress{false};
   };
 
   // ===========================================================================
@@ -106,8 +109,8 @@ namespace detail {
     /// I.e., we can use the io_context to run tasks on a specific thread (e.g.
     /// game thread).
     template <typename FuncT>
-    static auto WrapSyncCall(boost::asio::io_context &io, FuncT &&functor) {
-      return [&io, functor=std::forward<FuncT>(functor)](Metadata metadata, Args... args) -> R {
+    static auto WrapSyncCall(std::atomic_bool &shutdown_in_progress, boost::asio::io_context &io, FuncT &&functor) {
+      return [&shutdown_in_progress, &io, functor=std::forward<FuncT>(functor)](Metadata metadata, Args... args) -> R {
         auto task = std::packaged_task<R()>([functor=std::move(functor), args...]() {
           return functor(args...);
         });
@@ -119,7 +122,15 @@ namespace detail {
           // Post task and wait for result.
           auto result = task.get_future();
           boost::asio::post(io, MoveHandler(task));
-          return result.get();
+          std::future_status status;
+          do {
+            status = result.wait_for(std::chrono::milliseconds(100));
+          } while (!shutdown_in_progress && (status != std::future_status::ready));
+          if (status==std::future_status::ready) {
+            return result.get();
+          } else {
+            return R();
+          }
         }
       };
     }
@@ -153,7 +164,7 @@ namespace detail {
     using Wrapper = detail::FunctionWrapper<FunctorT>;
     _server.bind(
         name,
-        Wrapper::WrapSyncCall(_sync_io_context, std::forward<FunctorT>(functor)));
+        Wrapper::WrapSyncCall(_shutdown_in_progress, _sync_io_context, std::forward<FunctorT>(functor)));
   }
 
   template <typename FunctorT>

--- a/LibCarla/source/carla/rpc/Server.h
+++ b/LibCarla/source/carla/rpc/Server.h
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <atomic>
 #include <future>
+#include <stdexcept>
 
 namespace carla {
 namespace rpc {
@@ -127,10 +128,10 @@ namespace detail {
           do {
             status = result.wait_for(std::chrono::milliseconds(100));
           } while (!shutdown_in_progress && (status != std::future_status::ready));
-          if (status==std::future_status::ready) {
+          if (status == std::future_status::ready) {
             return result.get();
           } else {
-            return R();
+            throw std::runtime_error("RPC server is shutting down");
           }
         }
       };

--- a/LibCarla/source/carla/rpc/Server.h
+++ b/LibCarla/source/carla/rpc/Server.h
@@ -16,6 +16,7 @@
 
 #include <rpc/server.h>
 
+#include <chrono>
 #include <atomic>
 #include <future>
 

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -16,6 +16,7 @@
 #include <boost/asio/post.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <thread>
 
 namespace carla {
@@ -86,7 +87,7 @@ namespace tcp {
       if (_server.IsSynchronousMode()) {
         // wait until previous message has been sent
         while (_is_writing) {
-          std::this_thread::yield();
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
         }
       } else {
         // ignore this message

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
@@ -15,7 +15,8 @@
 #include <RHIGPUReadback.h>
 #include <util/ue-header-guard-end.h>
 
-
+#include <chrono>
+#include <thread>
 
 template <typename F>
 class ScopedCallback
@@ -255,7 +256,7 @@ namespace ImageUtil
       Self = std::move(Self)]() mutable
     {
       while (!Self.Readback->IsReady())
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
       ReadImageDataEnd(Self);
     });
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -15,6 +15,9 @@
 #include "RHIGPUReadback.h"
 #include <util/ue-header-guard-end.h>
 
+#include <chrono>
+#include <thread>
+
 // =============================================================================
 // -- FPixelReader -------------------------------------------------------------
 // =============================================================================
@@ -63,7 +66,7 @@ void FPixelReader::WritePixelsToBuffer(
       TRACE_CPUPROFILER_EVENT_SCOPE_STR("Wait GPU transfer");
       while (!Readback->IsReady())
       {
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
       }
     }
 


### PR DESCRIPTION
- [x] #9595

#### Description

Port 5 core bug fixes from ue4-dev to ue5-dev:

1. **RPC server deadlock fix** (ref: 0c477d65c) — Add atomic shutdown flag and timeout loop in `Server::WrapSyncCall` to prevent deadlock on shutdown
2. **Vector3D assert removal** (ref: 7b2ef1d94) — Remove overly strict `DEVELOPMENT_ASSERT` in `MakeUnitVector()` that could crash on small vectors
3. **OpenDrive lane width** (ref: 3b3b890ae) — Always create lane width attribute (including center lanes) to prevent missing width data
4. **yield() → sleep_for()** (ref: 4c49a741d) — Replace unreliable `std::this_thread::yield()` with `sleep_for(100us)` for proper CPU scheduling
5. **Assert relaxation** (ref: 5161fb09e) — Replace strict `RELEASE_ASSERT` in road Map with graceful skip logic

Note: Fixes 4 (GeoReferenceParser) and 5 (TrafficManager NaN) from the original plan were skipped — the ue5-dev codebase has completely different code in those areas.

Related #9583 (partial — PR #0a)

#### Where has this been tested?

  * **Platform(s):** Linux (Ubuntu 24.04)
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None expected. All fixes are well-understood ports from the stable ue4-dev branch. The assert relaxation changes error behavior from crash to skip, which is more forgiving but could mask issues in rare edge cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9585)
<!-- Reviewable:end -->
