### PR TITLE
fix(sensors): port camera, semantic tag, and bbox fixes from ue4-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed camera fx calculation in ROS2 CameraInfo, large map actor tagging, pedestrian bounding box using skeletal mesh bounds, and camera frame/timestamp consistency (ported from ue4-dev)
 * Fix typos in README.md
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)

--- a/LibCarla/source/carla/ros2/types/CameraInfo.cpp
+++ b/LibCarla/source/carla/ros2/types/CameraInfo.cpp
@@ -53,7 +53,7 @@ m_width(width)
 
     const double cx = static_cast<double>(m_width) / 2.0;
     const double cy = static_cast<double>(m_height) / 2.0;
-    const double fx = static_cast<double>(m_width) / (2.0 * std::tan(fov) * M_PI / 360.0);
+    const double fx = static_cast<double>(m_width) / (2.0 * std::tan(fov * M_PI / 360.0));
     const double fy = fx;
 
     m_d = { 0.0, 0.0, 0.0, 0.0, 0.0 };

--- a/Unreal/CarlaUnreal/Config/DefaultGame.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultGame.ini
@@ -52,7 +52,9 @@ bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/OpenDriveMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Mine_01")
-+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
+; Town15 excluded: UE5 LandscapeTextureStorageProvider assertion crash during cooking
+; (SourceDataBytes == TotalPixels * 4 at LandscapeTextureStorageProvider.cpp:578)
+;+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/GenericMaterials/Licenseplates/Textures")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/Car/4Wheeled/ParkedVehicles")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Blueprints/Walkers")

--- a/Unreal/CarlaUnreal/Config/DefaultGame.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultGame.ini
@@ -52,9 +52,7 @@ bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/OpenDriveMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Mine_01")
-; Town15 excluded: UE5 LandscapeTextureStorageProvider assertion crash during cooking
-; (SourceDataBytes == TotalPixels * 4 at LandscapeTextureStorageProvider.cpp:578)
-;+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
++MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/GenericMaterials/Licenseplates/Textures")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/Car/4Wheeled/ParkedVehicles")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Blueprints/Walkers")

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -908,6 +908,7 @@ void ALargeMapManager::ConvertDormantToActiveActors()
         *((View->GetActor()->GetActorLocation()).ToString()) \
       );
       ActiveActors.Add(Id);
+      ATagger::TagActor(*View->GetActor(), true);
     }
     else
     {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/AsyncDataStream.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/AsyncDataStream.h
@@ -12,6 +12,7 @@
 #include <carla/sensor/SensorRegistry.h>
 #include <carla/sensor/s11n/SensorHeaderSerializer.h>
 #include <carla/streaming/Stream.h>
+#include <carla/rpc/Transform.h>
 #include <util/enable-ue4-macros.h>
 
 
@@ -73,6 +74,36 @@ public:
       {
         carla::log_info("Re-framing sensor type ", HeaderStr->sensor_type, " from ", HeaderStr->frame, " to ", FrameNumber);
         HeaderStr->frame = FrameNumber;
+      }
+    }
+  }
+
+  /// allow to change the timestamp of the header
+  void SetTimestamp(double Timestamp)
+  {
+    carla::sensor::s11n::SensorHeaderSerializer::Header *HeaderStr =
+      reinterpret_cast<carla::sensor::s11n::SensorHeaderSerializer::Header *>(Header.data());
+    if (HeaderStr)
+    {
+      if (HeaderStr->timestamp != Timestamp)
+      {
+        carla::log_info("Re-timestamping sensor type ", HeaderStr->sensor_type, " from ", HeaderStr->timestamp, " to ", Timestamp);
+        HeaderStr->timestamp = Timestamp;
+      }
+    }
+  }
+
+  /// allow to change the transform of the header
+  void SetTransform(carla::rpc::Transform Transform)
+  {
+    carla::sensor::s11n::SensorHeaderSerializer::Header *HeaderStr =
+      reinterpret_cast<carla::sensor::s11n::SensorHeaderSerializer::Header *>(Header.data());
+    if (HeaderStr)
+    {
+      if (HeaderStr->sensor_transform != Transform)
+      {
+        carla::log_info("Re-transforming sensor type ", HeaderStr->sensor_type, " from ", HeaderStr->sensor_transform, " to ", Transform);
+        HeaderStr->sensor_transform = Transform;
       }
     }
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
@@ -111,11 +111,13 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
   Sensor.EnqueueRenderSceneImmediate();
 
   // Enqueue a command in the render-thread that will write the image buffer to
-  // the data stream. The stream is created in the capture thus executed in the
-  // game-thread.
+  // the data stream. We need to get frame, timestamp and the sensor transform in the capture
+  // (thus executed in the game-thread), so that they reflect the current point in time.
+  // Otherwise the asynchronous execution could send a future header to the client.
   ENQUEUE_RENDER_COMMAND(FWritePixels_SendPixelsInRenderThread)
   (
-    [&Sensor, use16BitFormat, Conversor = std::move(Conversor)](auto &InRHICmdList) mutable
+    [&Sensor, use16BitFormat, Conversor = std::move(Conversor), Frame = FCarlaEngine::GetFrameCounter(),
+     Timestamp = Sensor.GetEpisode().GetElapsedGameTime(), Transform = Sensor.GetActorTransform()](auto &InRHICmdList) mutable
     {
       TRACE_CPUPROFILER_EVENT_SCOPE_STR("FWritePixels_SendPixelsInRenderThread");
 
@@ -123,7 +125,7 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
       if (IsValidChecked(&Sensor))
       {
         FPixelReader::Payload FuncForSending =
-          [&Sensor, Frame = FCarlaEngine::GetFrameCounter(), Conversor = std::move(Conversor)]
+          [&Sensor, Frame, Timestamp, Transform, Conversor = std::move(Conversor)]
           (void *LockedData, uint32 Size, uint32 Offset, uint32 ExpectedRowBytes)
           {
             if (!IsValidChecked(&Sensor))
@@ -142,6 +144,8 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
 
             auto Stream = Sensor.GetDataStream(Sensor);
             Stream.SetFrameNumber(Frame);
+            Stream.SetTimestamp(Timestamp);
+            Stream.SetTransform(Transform);
             auto Buffer = Stream.PopBufferFromPool();
 
             uint32 CurrentRowBytes = ExpectedRowBytes;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -51,15 +51,21 @@ FBoundingBox UBoundingBoxCalculator::GetActorBoundingBox(const AActor *Actor, ui
     auto Character = Cast<ACharacter>(Actor);
     if (Character != nullptr)
     {
-      auto Capsule = Character->GetCapsuleComponent();
-      if (Capsule != nullptr)
+      UActorComponent *ActorComp = Character->GetComponentByClass(USkeletalMeshComponent::StaticClass());
+      USkeletalMeshComponent* ParentComp = Cast<USkeletalMeshComponent>(ActorComp);
+
+      if (ParentComp != nullptr)
       {
-        const auto Radius = Capsule->GetScaledCapsuleRadius();
-        const auto HalfHeight = Capsule->GetScaledCapsuleHalfHeight();
-        // Characters have the pivot point centered.
-        FVector Origin = {0.0f, 0.0f, 0.0f};
-        FVector Extent = {Radius, Radius, HalfHeight};
-        return {Origin, Extent};
+        FBoundingBox Box = GetSkeletalMeshBoundingBoxFromComponent(ParentComp);
+
+        if (Character->GetName().Contains("_AB001_G3")
+          || Character->GetName().Contains("_AG001_G3"))
+        {
+          // Hack to center the bbox of Gen3 kids
+          Box.Origin.Z -= Box.Extent.Z * (1.0f / 0.65f - 1.0f);
+        }
+
+        return Box;
       }
     }
     // Traffic sign.
@@ -196,19 +202,15 @@ FBoundingBox UBoundingBoxCalculator::GetCharacterBoundingBox(
   bool FilterByTag = TagQueried == crp::CityObjectLabel::Any ||
                      TagQueried == crp::CityObjectLabel::Pedestrians;
 
-  UCapsuleComponent* Capsule = Character->GetCapsuleComponent();
+  UActorComponent *ActorComp = Character->GetComponentByClass(USkeletalMeshComponent::StaticClass());
+  USkeletalMeshComponent* ParentComp = Cast<USkeletalMeshComponent>(ActorComp);
 
-
-  if (Capsule && FilterByTag)
+  if (ParentComp && FilterByTag)
   {
-    const float Radius = Capsule->GetScaledCapsuleRadius();
-    const float HalfHeight = Capsule->GetScaledCapsuleHalfHeight();
-    FBoundingBox BoundingBox;
-    // Characters have the pivot point centered.
-    BoundingBox.Origin = {0.0f, 0.0f, 0.0f};
-    BoundingBox.Extent = {Radius, Radius, HalfHeight};
-    // Component-to-world transform for this component
-    auto CompToWorldTransform = Capsule->GetComponentTransform();
+    FBoundingBox BoundingBox = GetSkeletalMeshBoundingBoxFromComponent(ParentComp);
+
+    auto& CompToWorldTransform = ParentComp->GetComponentTransform();
+
     BoundingBox = ApplyTransformToBB(BoundingBox, CompToWorldTransform);
 
     return BoundingBox;
@@ -250,6 +252,28 @@ void UBoundingBoxCalculator::GetTrafficLightBoundingBox(
     OutBB.Emplace(BB);
     OutTag.Emplace(Tag);
   }
+}
+
+FBoundingBox UBoundingBoxCalculator::GetSkeletalMeshBoundingBoxFromComponent(
+  const USkeletalMeshComponent* SkeletalMeshComp
+)
+{
+  if(!SkeletalMeshComp || !SkeletalMeshComp->GetSkeletalMeshAsset())
+  {
+    UE_LOG(LogCarla, Error, TEXT("GetSkeletalMeshBoundingBoxFromComponent no SkeletalMeshComponent or SkeletalMesh"));
+    return {};
+  }
+
+  // Force update bounds to current pose
+  const_cast<USkeletalMeshComponent*>(SkeletalMeshComp)->UpdateBounds();
+
+  // Get bounds in component space (already includes current animation pose)
+  FBoxSphereBounds Bounds = SkeletalMeshComp->Bounds;
+
+  FVector Origin = FVector::ZeroVector;
+  FVector Extent = Bounds.BoxExtent;
+
+  return {Origin, Extent};
 }
 
 // TODO: update to calculate current animation pose

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.h
@@ -50,6 +50,9 @@ public:
     uint8 InTagQueried = 0xFF);
 
   UFUNCTION(Category = "Carla Util", BlueprintCallable)
+  static FBoundingBox GetSkeletalMeshBoundingBoxFromComponent(const USkeletalMeshComponent* SkeletalMeshComp);
+
+  UFUNCTION(Category = "Carla Util", BlueprintCallable)
   static FBoundingBox GetSkeletalMeshBoundingBox(const USkeletalMesh* SkeletalMesh);
 
   UFUNCTION(Category = "Carla Util", BlueprintCallable)


### PR DESCRIPTION
- [x] #9595

#### Description

Port 4 sensor and rendering bug fixes from ue4-dev to ue5-dev:

1. **Camera fx calculation** (ref: 86ebadcee) — Fix operator precedence in focal length calculation for ROS2 CameraInfo. `std::tan(fov)` was incorrectly applied before radian conversion
2. **Large map actor tagging** (ref: ff009c8a3) — Tag actors when converting from dormant to active state in large maps
3. **Pedestrian bounding box** (ref: ccc86c6b4, 742113a92) — Use skeletal mesh bounds instead of capsule component for accurate pedestrian bounding boxes, with Gen3 kids bbox centering hack
4. **Camera frame/timestamp** (ref: a095219c7) — Capture frame/timestamp/transform in game thread to ensure consistency with rendered image

Note: Fixes for semantic tag initialization (40ac1f19e) and ObjectRegister (86a1ec101) were skipped — already present or N/A in ue5-dev.

Related #9583 (partial — PR #0c)

#### Where has this been tested?

  * **Platform(s):** Linux (Ubuntu 24.04)
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

The pedestrian bounding box change switches from capsule to skeletal mesh bounds, which may produce slightly different bounding box sizes. The skeletal mesh approach is more accurate but depends on animation pose.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9586)
<!-- Reviewable:end -->