### PR TITLE
fix(LibCarla): eliminate compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed compiler warnings across 20 LibCarla files including signed/unsigned conversions, pessimizing moves, deep copies in range-for loops, and C-style casts (ported from ue4-dev)
 * Fix typos in README.md
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)

--- a/LibCarla/source/carla/Exception.h
+++ b/LibCarla/source/carla/Exception.h
@@ -62,7 +62,7 @@ namespace boost
   }
 
   BOOST_NORETURN
-  inline void throw_exception(const std::exception &e, boost::source_location const& loc)
+  inline void throw_exception(const std::exception &e, boost::source_location const& /*loc*/)
   {
     throw_exception(e);
   }

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -161,7 +161,8 @@ EpisodeProxy Simulator::GetCurrentEpisode() {
       std::string map_name;
       std::string map_base_path;
       bool fill_base_string = false;
-      for (int i = map_info.name.size() - 1; i >= 0; --i) {
+      for (size_t ri = map_info.name.size(); ri > 0; --ri) {
+        size_t i = ri - 1;
         if (fill_base_string == false && map_info.name[i] != '/') {
           map_name += map_info.name[i];
         } else {

--- a/LibCarla/source/carla/geom/Mesh.cpp
+++ b/LibCarla/source/carla/geom/Mesh.cpp
@@ -309,8 +309,9 @@ namespace geom {
       rhs.GetNormals().begin(),
       rhs.GetNormals().end());
 
-    const size_t vertex_to_start_concating = v_num - num_vertices_to_link;
-    for( size_t i = 1; i < num_vertices_to_link; ++i ) {
+    const size_t vertices_to_link = static_cast<size_t>(num_vertices_to_link);
+    const size_t vertex_to_start_concating = v_num - vertices_to_link;
+    for( size_t i = 1; i < vertices_to_link; ++i ) {
       _indexes.push_back( vertex_to_start_concating + i );
       _indexes.push_back( vertex_to_start_concating + i  + 1 );
       _indexes.push_back( v_num + i );

--- a/LibCarla/source/carla/geom/Simplification.cpp
+++ b/LibCarla/source/carla/geom/Simplification.cpp
@@ -32,7 +32,7 @@ namespace geom {
 
     // Reduce to the X% of the polys
     float target_size = static_cast<float>(Simplification.triangles.size());
-    Simplification.simplify_mesh((target_size * simplification_percentage));
+    Simplification.simplify_mesh(static_cast<int>(target_size * simplification_percentage));
 
     pmesh->GetVertices().clear();
     pmesh->GetIndexes().clear();
@@ -46,9 +46,9 @@ namespace geom {
     }
 
     for (size_t i = 0; i < Simplification.triangles.size(); ++i) {
-      pmesh->GetIndexes().push_back((Simplification.triangles[i].v[0]) + 1);
-      pmesh->GetIndexes().push_back((Simplification.triangles[i].v[1]) + 1);
-      pmesh->GetIndexes().push_back((Simplification.triangles[i].v[2]) + 1);
+      pmesh->GetIndexes().push_back(static_cast<size_t>((Simplification.triangles[i].v[0]) + 1));
+      pmesh->GetIndexes().push_back(static_cast<size_t>((Simplification.triangles[i].v[1]) + 1));
+      pmesh->GetIndexes().push_back(static_cast<size_t>((Simplification.triangles[i].v[2]) + 1));
     }
   }
 

--- a/LibCarla/source/carla/multigpu/primary.cpp
+++ b/LibCarla/source/carla/multigpu/primary.cpp
@@ -76,14 +76,12 @@ namespace multigpu {
         return;
       }
 
-      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
+      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t) {
         auto self = weak.lock();
         if (!self) return;
         if (ec) {
           log_error("session ", self->_session_id, ": error sending data: ", ec.message());
           self->CloseNow(ec);
-        } else {
-          // DEBUG_ASSERT_EQ(bytes, sizeof(message_size_type) + message->size());
         }
       };
 
@@ -106,7 +104,7 @@ namespace multigpu {
 
       // sent first size buffer
       self->_deadline.expires_from_now(self->_timeout);
-      int this_size = text.size();
+      int this_size = static_cast<int>(text.size());
       boost::asio::async_write(
           self->_socket,
           boost::asio::buffer(&this_size, sizeof(this_size)),
@@ -146,7 +144,7 @@ namespace multigpu {
 
       auto handle_read_header = [weak, message, handle_read_data](
           boost::system::error_code ec,
-          size_t DEBUG_ONLY(bytes)) {
+          size_t) {
         auto self = weak.lock();
         if (!self) return;
         if (!ec && (message->size() > 0u)) {

--- a/LibCarla/source/carla/multigpu/primaryCommands.cpp
+++ b/LibCarla/source/carla/multigpu/primaryCommands.cpp
@@ -56,7 +56,7 @@ token_type PrimaryCommands::SendGetToken(stream_id sensor_id) {
 // send to know if a connection is alive
 void PrimaryCommands::SendIsAlive() {
   std::string msg("Are you alive?");
-  carla::Buffer buf(reinterpret_cast<unsigned char *>(const_cast<char *>(msg.c_str())), static_cast<size_t>(msg.size()));
+  carla::Buffer buf(reinterpret_cast<const unsigned char *>(msg.c_str()), static_cast<size_t>(msg.size()));
   log_info("sending is alive command");
   auto fut = _router->WriteToNext(MultiGPUCommand::YOU_ALIVE, std::move(buf));
   auto response = fut.get();

--- a/LibCarla/source/carla/multigpu/primaryCommands.cpp
+++ b/LibCarla/source/carla/multigpu/primaryCommands.cpp
@@ -36,7 +36,7 @@ void PrimaryCommands::SendFrameData(carla::Buffer buffer) {
 
 // broadcast to all secondary servers the map to load
 void PrimaryCommands::SendLoadMap(std::string map) {
-  carla::Buffer buf(reinterpret_cast<unsigned char *>(const_cast<char *>(map.c_str())), static_cast<size_t>(map.size() + 1));
+  carla::Buffer buf(reinterpret_cast<const unsigned char *>(map.c_str()), static_cast<size_t>(map.size() + 1));
   _router->Write(MultiGPUCommand::LOAD_MAP, std::move(buf));
 }
 

--- a/LibCarla/source/carla/multigpu/primaryCommands.cpp
+++ b/LibCarla/source/carla/multigpu/primaryCommands.cpp
@@ -36,15 +36,15 @@ void PrimaryCommands::SendFrameData(carla::Buffer buffer) {
 
 // broadcast to all secondary servers the map to load
 void PrimaryCommands::SendLoadMap(std::string map) {
-  carla::Buffer buf((unsigned char *) map.c_str(), (size_t) map.size() + 1);
+  carla::Buffer buf(reinterpret_cast<unsigned char *>(const_cast<char *>(map.c_str())), static_cast<size_t>(map.size() + 1));
   _router->Write(MultiGPUCommand::LOAD_MAP, std::move(buf));
 }
 
 // send to who the router wants the request for a token
 token_type PrimaryCommands::SendGetToken(stream_id sensor_id) {
   log_info("asking for a token");
-  carla::Buffer buf((carla::Buffer::value_type *) &sensor_id,
-                    (size_t) sizeof(stream_id));
+  carla::Buffer buf(reinterpret_cast<carla::Buffer::value_type *>(&sensor_id),
+                    static_cast<size_t>(sizeof(stream_id)));
   auto fut = _router->WriteToNext(MultiGPUCommand::GET_TOKEN, std::move(buf));
 
   auto response = fut.get();
@@ -56,7 +56,7 @@ token_type PrimaryCommands::SendGetToken(stream_id sensor_id) {
 // send to know if a connection is alive
 void PrimaryCommands::SendIsAlive() {
   std::string msg("Are you alive?");
-  carla::Buffer buf((unsigned char *) msg.c_str(), (size_t) msg.size());
+  carla::Buffer buf(reinterpret_cast<unsigned char *>(const_cast<char *>(msg.c_str())), static_cast<size_t>(msg.size()));
   log_info("sending is alive command");
   auto fut = _router->WriteToNext(MultiGPUCommand::YOU_ALIVE, std::move(buf));
   auto response = fut.get();
@@ -67,12 +67,11 @@ void PrimaryCommands::SendEnableForROS(stream_id sensor_id) {
   // search if the sensor has been activated in any secondary server
   auto it = _servers.find(sensor_id);
   if (it != _servers.end()) {
-    carla::Buffer buf((carla::Buffer::value_type *) &sensor_id,
-                      (size_t) sizeof(stream_id));
+    carla::Buffer buf(reinterpret_cast<carla::Buffer::value_type *>(&sensor_id),
+                      static_cast<size_t>(sizeof(stream_id)));
     auto fut = _router->WriteToOne(it->second, MultiGPUCommand::ENABLE_ROS, std::move(buf));
 
-    auto response = fut.get();
-    bool res = (*reinterpret_cast<bool *>(response.buffer.data()));
+    fut.get();
   } else {
     log_error("enable_for_ros for sensor", sensor_id, " not found on any server");
   }
@@ -82,12 +81,11 @@ void PrimaryCommands::SendDisableForROS(stream_id sensor_id) {
   // search if the sensor has been activated in any secondary server
   auto it = _servers.find(sensor_id);
   if (it != _servers.end()) {
-    carla::Buffer buf((carla::Buffer::value_type *) &sensor_id,
-                      (size_t) sizeof(stream_id));
+    carla::Buffer buf(reinterpret_cast<carla::Buffer::value_type *>(&sensor_id),
+                      static_cast<size_t>(sizeof(stream_id)));
     auto fut = _router->WriteToOne(it->second, MultiGPUCommand::DISABLE_ROS, std::move(buf));
 
-    auto response = fut.get();
-    bool res = (*reinterpret_cast<bool *>(response.buffer.data()));
+    fut.get();
   } else {
     log_error("disable_for_ros for sensor", sensor_id, " not found on any server");
   }
@@ -97,8 +95,8 @@ bool PrimaryCommands::SendIsEnabledForROS(stream_id sensor_id) {
   // search if the sensor has been activated in any secondary server
   auto it = _servers.find(sensor_id);
   if (it != _servers.end()) {
-    carla::Buffer buf((carla::Buffer::value_type *) &sensor_id,
-                      (size_t) sizeof(stream_id));
+    carla::Buffer buf(reinterpret_cast<carla::Buffer::value_type *>(&sensor_id),
+                      static_cast<size_t>(sizeof(stream_id)));
     auto fut = _router->WriteToOne(it->second, MultiGPUCommand::IS_ENABLED_ROS, std::move(buf));
 
     auto response = fut.get();

--- a/LibCarla/source/carla/multigpu/router.cpp
+++ b/LibCarla/source/carla/multigpu/router.cpp
@@ -114,7 +114,7 @@ void Router::Write(MultiGPUCommand id, Buffer &&buffer) {
   CommandHeader header;
   header.id = id;
   header.size = buffer.size();
-  Buffer buf_header((uint8_t *) &header, sizeof(header));
+  Buffer buf_header(reinterpret_cast<uint8_t *>(&header), sizeof(header));
 
   auto view_header = carla::BufferView::CreateFrom(std::move(buf_header));
   auto view_data = carla::BufferView::CreateFrom(std::move(buffer));
@@ -134,7 +134,7 @@ std::future<SessionInfo> Router::WriteToNext(MultiGPUCommand id, Buffer &&buffer
   CommandHeader header;
   header.id = id;
   header.size = buffer.size();
-  Buffer buf_header((uint8_t *) &header, sizeof(header));
+  Buffer buf_header(reinterpret_cast<uint8_t *>(&header), sizeof(header));
 
   auto view_header = carla::BufferView::CreateFrom(std::move(buf_header));
   auto view_data = carla::BufferView::CreateFrom(std::move(buffer));
@@ -166,7 +166,7 @@ std::future<SessionInfo> Router::WriteToOne(std::weak_ptr<Primary> server, Multi
   CommandHeader header;
   header.id = id;
   header.size = buffer.size();
-  Buffer buf_header((uint8_t *) &header, sizeof(header));
+  Buffer buf_header(reinterpret_cast<uint8_t *>(&header), sizeof(header));
 
   auto view_header = carla::BufferView::CreateFrom(std::move(buf_header));
   auto view_data = carla::BufferView::CreateFrom(std::move(buffer));

--- a/LibCarla/source/carla/multigpu/secondary.cpp
+++ b/LibCarla/source/carla/multigpu/secondary.cpp
@@ -142,7 +142,7 @@ namespace multigpu {
         return;
       }
 
-      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
+      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t) {
         auto self = weak.lock();
         if (!self) return;
         if (ec) {
@@ -172,7 +172,7 @@ namespace multigpu {
         return;
       }
 
-      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
+      auto handle_sent = [weak, message](const boost::system::error_code &ec, size_t) {
         auto self = weak.lock();
         if (!self) return;
         if (ec) {
@@ -197,7 +197,7 @@ namespace multigpu {
         return;
       }
 
-      auto handle_sent = [weak](const boost::system::error_code &ec, size_t DEBUG_ONLY(bytes)) {
+      auto handle_sent = [weak](const boost::system::error_code &ec, size_t) {
         auto self = weak.lock();
         if (!self) return;
         if (ec) {
@@ -207,7 +207,7 @@ namespace multigpu {
 
       // _deadline.expires_from_now(_timeout);
       // sent first size buffer
-      int this_size = text.size();
+      int this_size = static_cast<int>(text.size());
       boost::asio::async_write(
           self->_socket,
           boost::asio::buffer(&this_size, sizeof(this_size)),

--- a/LibCarla/source/carla/multigpu/secondary.cpp
+++ b/LibCarla/source/carla/multigpu/secondary.cpp
@@ -207,7 +207,7 @@ namespace multigpu {
 
       // _deadline.expires_from_now(_timeout);
       // sent first size buffer
-      int this_size = static_cast<int>(text.size());
+      uint32_t this_size = static_cast<uint32_t>(text.size());
       boost::asio::async_write(
           self->_socket,
           boost::asio::buffer(&this_size, sizeof(this_size)),

--- a/LibCarla/source/carla/road/Deformation.h
+++ b/LibCarla/source/carla/road/Deformation.h
@@ -43,17 +43,17 @@ namespace deformation {
     float constraintX = 17.0f;
     float constraintY = 12.0f;
 
-    float BumpX = std::ceil(posx / constraintX);
-    float BumpY = std::floor(posy / constraintY);
+    float BumpX = static_cast<float>(std::ceil(posx / constraintX));
+    float BumpY = static_cast<float>(std::floor(posy / constraintY));
 
     BumpX *= constraintX;
     BumpY *= constraintY;
 
-    float DistanceToBumpOrigin = sqrt(pow(BumpX - posx, 2) + pow(BumpY - posy, 2) );
-    float MaxDistance = 2.0;
+    float DistanceToBumpOrigin = static_cast<float>(sqrt(pow(BumpX - posx, 2) + pow(BumpY - posy, 2)));
+    float MaxDistance = 2.0f;
 
     if (DistanceToBumpOrigin <= MaxDistance) {
-      bumpsoffset = sin(DistanceToBumpOrigin);
+      bumpsoffset = static_cast<float>(sin(DistanceToBumpOrigin));
     }
 
     return A3 * bumpsoffset;

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -1181,7 +1181,7 @@ namespace road {
       std::thread neworker(
         [this, &write_mutex, &mesh_factory, &RoadsIDToGenerate, &road_out_mesh_list, i, num_roads_per_thread]() {
         std::map<road::Lane::LaneType, std::vector<std::unique_ptr<geom::Mesh>>> Current =
-          std::move(GenerateRoadsMultithreaded(mesh_factory, RoadsIDToGenerate,i, num_roads_per_thread ));
+          GenerateRoadsMultithreaded(mesh_factory, RoadsIDToGenerate,i, num_roads_per_thread );
         std::scoped_lock<std::mutex> guard(write_mutex);
         for ( auto&& pair : Current ) {
           if (road_out_mesh_list.find(pair.first) != road_out_mesh_list.end()) {
@@ -1323,7 +1323,7 @@ namespace road {
       }
     }
 
-    return std::move(LineMarks);
+    return LineMarks;
   }
 
   std::vector<carla::geom::BoundingBox> Map::GetJunctionsBoundingBoxes() const {
@@ -1354,7 +1354,7 @@ namespace road {
     size_t endoffset = (index+1) * number_of_roads_per_thread;
     size_t end = RoadsId.size();
 
-    for (int i = start; i < endoffset && i < end; ++i) {
+    for (size_t i = start; i < endoffset && i < end; ++i) {
       const auto& road = _data.GetRoads().at(RoadsId[i]);
       if (!road.IsJunction()) {
         mesh_factory.GenerateAllOrderedWithMaxLen(road, out);
@@ -1365,7 +1365,7 @@ namespace road {
   }
 
   void Map::GenerateJunctions(const carla::geom::MeshFactory& mesh_factory,
-    const rpc::OpendriveGenerationParameters& params,
+    const rpc::OpendriveGenerationParameters& /*params*/,
     const geom::Vector3D& minpos,
     const geom::Vector3D& maxpos,
     std::map<road::Lane::LaneType,
@@ -1374,7 +1374,6 @@ namespace road {
     std::vector<JuncId> JunctionsToGenerate = FilterJunctionsByPosition(minpos, maxpos);
     size_t num_junctions = JunctionsToGenerate.size();
     std::cout << "Generating " << std::to_string(num_junctions) << " junctions" << std::endl;
-    size_t junctionindex = 0;
     size_t num_junctions_per_thread = 5;
     size_t num_threads = (num_junctions / num_junctions_per_thread) + 1;
     num_threads = num_threads > 1 ? num_threads : 1;
@@ -1466,20 +1465,16 @@ namespace road {
   }
 
   std::unique_ptr<geom::Mesh> Map::SDFToMesh(const road::Junction& jinput,
-    const std::vector<geom::Vector3D>& sdfinput,
-    int grid_cells_per_dim) const {
+    const std::vector<geom::Vector3D>& /*sdfinput*/,
+    int /*grid_cells_per_dim*/) const {
 
-    int junctionid = jinput.GetId();
     float box_extraextension_factor = 1.2f;
     const double CubeSize = 0.5;
     carla::geom::BoundingBox bb = jinput.GetBoundingBox();
     carla::geom::Vector3D MinOffset = bb.location - geom::Location(bb.extent * box_extraextension_factor);
-    carla::geom::Vector3D MaxOffset = bb.location + geom::Location(bb.extent * box_extraextension_factor);
-    carla::geom::Vector3D OffsetPerCell = ( bb.extent * box_extraextension_factor * 2 ) / grid_cells_per_dim;
-
-    auto junctionsdf = [this, OffsetPerCell, CubeSize, MinOffset, junctionid](MeshReconstruction::Vec3 const& pos)
+    auto junctionsdf = [this, CubeSize](MeshReconstruction::Vec3 const& pos)
     {
-      geom::Vector3D worldloc(pos.x, pos.y, pos.z);
+      geom::Vector3D worldloc(static_cast<float>(pos.x), static_cast<float>(pos.y), static_cast<float>(pos.z));
       std::optional<element::Waypoint> CheckingWaypoint = GetWaypoint(geom::Location(worldloc), 0x1 << 1);
       if (CheckingWaypoint) {
         if ( pos.z < 0.2) {
@@ -1492,7 +1487,7 @@ namespace road {
       geom::Transform InRoadWPTransform = ComputeTransform(*InRoadWaypoint);
 
       geom::Vector3D director = geom::Location(worldloc) - (InRoadWPTransform.location);
-      geom::Vector3D laneborder = InRoadWPTransform.location + geom::Location(director.MakeUnitVector() * GetLaneWidth(*InRoadWaypoint) * 0.5f);
+      geom::Vector3D laneborder = InRoadWPTransform.location + geom::Location(director.MakeUnitVector() * static_cast<float>(GetLaneWidth(*InRoadWaypoint) * 0.5));
 
       geom::Vector3D Distance = laneborder - worldloc;
       if (Distance.Length2D() < CubeSize * 1.1 && pos.z < 0.2) {
@@ -1501,30 +1496,27 @@ namespace road {
       return Distance.Length() * -1.0;
     };
 
-    double gridsizeindouble = grid_cells_per_dim;
     MeshReconstruction::Rect3 domain;
     domain.min = { MinOffset.x, MinOffset.y, MinOffset.z };
     domain.size = { bb.extent.x * box_extraextension_factor * 2, bb.extent.y * box_extraextension_factor * 2, 0.4 };
 
     MeshReconstruction::Vec3 cubeSize{ CubeSize, CubeSize, 0.2 };
     auto mesh = MeshReconstruction::MarchCube(junctionsdf, domain, cubeSize );
-    carla::geom::Rotation inverse = bb.rotation;
-    carla::geom::Vector3D trasltation = bb.location;
     geom::Mesh out_mesh;
 
     for (auto& cv : mesh.vertices) {
       geom::Vector3D newvertex;
-      newvertex.x = cv.x;
-      newvertex.y = cv.y;
-      newvertex.z = cv.z;
+      newvertex.x = static_cast<float>(cv.x);
+      newvertex.y = static_cast<float>(cv.y);
+      newvertex.z = static_cast<float>(cv.z);
       out_mesh.AddVertex(newvertex);
     }
 
     auto finalvertices = out_mesh.GetVertices();
     for (auto ct : mesh.triangles) {
-      out_mesh.AddIndex(ct[1] + 1);
-      out_mesh.AddIndex(ct[0] + 1);
-      out_mesh.AddIndex(ct[2] + 1);
+      out_mesh.AddIndex(static_cast<size_t>(ct[1] + 1));
+      out_mesh.AddIndex(static_cast<size_t>(ct[0] + 1));
+      out_mesh.AddIndex(static_cast<size_t>(ct[2] + 1));
     }
 
     for (auto& cv : out_mesh.GetVertices() ) {
@@ -1535,7 +1527,7 @@ namespace road {
         geom::Transform InRoadWPTransform = ComputeTransform(*InRoadWaypoint);
 
         geom::Vector3D director = geom::Location(cv) - (InRoadWPTransform.location);
-        geom::Vector3D laneborder = InRoadWPTransform.location + geom::Location(director.MakeUnitVector() * GetLaneWidth(*InRoadWaypoint) * 0.5f);
+        geom::Vector3D laneborder = InRoadWPTransform.location + geom::Location(director.MakeUnitVector() * static_cast<float>(GetLaneWidth(*InRoadWaypoint) * 0.5));
         cv = laneborder;
       }
     }
@@ -1564,7 +1556,7 @@ namespace road {
               const auto& lane = lane_pair.second;
               if ( lane.GetType() == road::Lane::LaneType::Sidewalk ) {
                 std::optional<element::Waypoint> sw =
-                  GetWaypoint(road.GetId(), lane_pair.first, lane.GetDistance() + (lane.GetLength() * 0.5f));
+                  GetWaypoint(road.GetId(), lane_pair.first, static_cast<float>(lane.GetDistance() + (lane.GetLength() * 0.5)));
                 if (!GetWaypoint(ComputeTransform(*sw).location).has_value()){
                   sidewalk_lane_meshes.push_back(mesh_factory.GenerateSidewalk(lane));
                 }

--- a/LibCarla/source/carla/road/MapBuilder.cpp
+++ b/LibCarla/source/carla/road/MapBuilder.cpp
@@ -290,7 +290,7 @@ namespace road {
       const double roll) {
     std::unique_ptr<Signal> &signal = _temp_signal_container[signal_id];
     signal->_using_inertial_position = true;
-    geom::Location location = geom::Location(x, -y, z);
+    geom::Location location = geom::Location(static_cast<float>(x), static_cast<float>(-y), static_cast<float>(z));
     signal->_transform = geom::Transform (location, geom::Rotation(
         geom::Math::ToDegrees(static_cast<float>(pitch)),
         geom::Math::ToDegrees(static_cast<float>(-hdg)),
@@ -1132,7 +1132,7 @@ void MapBuilder::CreateController(
 
           geom::Vector3D displacement = 1.f*(road_transform.GetRightVector()) *
               static_cast<float>(abs(lane_width))*0.2f;
-          signal_position += (displacement * displacement_direction);
+          signal_position += (displacement * static_cast<float>(displacement_direction));
           signal_rotation = road_transform.rotation;
           closest_waypoint_to_signal =
               map.GetClosestWaypointOnRoad(signal_position,

--- a/LibCarla/source/carla/road/MeshFactory.cpp
+++ b/LibCarla/source/carla/road/MeshFactory.cpp
@@ -125,8 +125,8 @@ namespace geom {
 
     std::vector<geom::Vector3D> vertices;
     // Ensure minimum vertices in width are two
-    const int vertices_in_width = road_param.vertex_width_resolution >= 2 ? road_param.vertex_width_resolution : 2;
-    const int segments_number = vertices_in_width - 1;
+    const size_t vertices_in_width = road_param.vertex_width_resolution >= 2 ? static_cast<size_t>(road_param.vertex_width_resolution) : size_t{2};
+    const size_t segments_number = vertices_in_width - 1;
 
     std::vector<geom::Vector2D> uvs;
     int uvx = 0;
@@ -135,11 +135,11 @@ namespace geom {
     do {
       // Get the location of the edges of the current lane at the current waypoint
       std::pair<geom::Vector3D, geom::Vector3D> edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
-      const geom::Vector3D segments_size = ( edges.second - edges.first ) / segments_number;
+      const geom::Vector3D segments_size = ( edges.second - edges.first ) / static_cast<float>(segments_number);
       geom::Vector3D current_vertex = edges.first;
       uvx = 0;
-      for (int i = 0; i < vertices_in_width; ++i) {
-        uvs.push_back(geom::Vector2D(uvx, uvy));
+      for (size_t i = 0; i < vertices_in_width; ++i) {
+        uvs.push_back(geom::Vector2D(static_cast<float>(uvx), static_cast<float>(uvy)));
         vertices.push_back(current_vertex);
         current_vertex = current_vertex + segments_size;
         uvx++;
@@ -155,12 +155,12 @@ namespace geom {
     if (s_end - (s_current - road_param.resolution) > EPSILON) {
       std::pair<carla::geom::Vector3D, carla::geom::Vector3D> edges =
         lane.GetCornerPositions(s_end - MESH_EPSILON, road_param.extra_lane_width);
-      const geom::Vector3D segments_size = (edges.second - edges.first) / segments_number;
+      const geom::Vector3D segments_size = (edges.second - edges.first) / static_cast<float>(segments_number);
       geom::Vector3D current_vertex = edges.first;
       uvx = 0;
-      for (int i = 0; i < vertices_in_width; ++i)
+      for (size_t i = 0; i < vertices_in_width; ++i)
       {
-        uvs.push_back(geom::Vector2D(uvx, uvy));
+        uvs.push_back(geom::Vector2D(static_cast<float>(uvx), static_cast<float>(uvy)));
         vertices.push_back(current_vertex);
         current_vertex = current_vertex + segments_size;
         uvx++;
@@ -195,15 +195,15 @@ namespace geom {
     const road::LaneSection &lane_section,
     std::map<carla::road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>>& result) const {
 
-    const int vertices_in_width = road_param.vertex_width_resolution >= 2 ? road_param.vertex_width_resolution : 2;
+    const size_t vertices_in_width = road_param.vertex_width_resolution >= 2 ? static_cast<size_t>(road_param.vertex_width_resolution) : size_t{2};
     std::vector<size_t> redirections;
     for (auto &&lane_pair : lane_section.GetLanes()) {
-      auto it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+      auto it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
       if ( it == redirections.end() ) {
-        redirections.push_back(lane_pair.first);
-        it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+        redirections.push_back(static_cast<size_t>(lane_pair.first));
+        it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
       }
-      size_t PosToAdd = it - redirections.begin();
+      size_t PosToAdd = static_cast<size_t>(it - redirections.begin());
 
       Mesh out_mesh;
       if(lane_pair.second.GetType() == road::Lane::LaneType::Driving ){
@@ -217,13 +217,13 @@ namespace geom {
       } else {
         uint32_t verticesinwidth  = 0;
         if(lane_pair.second.GetType() == road::Lane::LaneType::Driving) {
-          verticesinwidth = vertices_in_width;
+          verticesinwidth = static_cast<uint32_t>(vertices_in_width);
         }else if(lane_pair.second.GetType() == road::Lane::LaneType::Sidewalk){
           verticesinwidth = 6;
         }else{
           verticesinwidth = 2;
         }
-        (result[lane_pair.second.GetType()][PosToAdd])->ConcatMesh(out_mesh, verticesinwidth);
+        (result[lane_pair.second.GetType()][PosToAdd])->ConcatMesh(out_mesh, static_cast<int>(verticesinwidth));
       }
     }
   }
@@ -261,8 +261,7 @@ namespace geom {
 
     std::vector<geom::Vector3D> vertices;
     // Ensure minimum vertices in width are two
-    const int vertices_in_width = 6;
-    const int segments_number = vertices_in_width - 1;
+    const size_t vertices_in_width = 6;
     std::vector<geom::Vector2D> uvs;
     int uvy = 0;
 
@@ -275,22 +274,22 @@ namespace geom {
       geom::Vector3D low_vertex_first = edges.first - geom::Vector3D(0,0,1);
       geom::Vector3D low_vertex_second = edges.second - geom::Vector3D(0,0,1);
       vertices.push_back(low_vertex_first);
-      uvs.push_back(geom::Vector2D(0, uvy));
+      uvs.push_back(geom::Vector2D(0.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.first);
-      uvs.push_back(geom::Vector2D(1, uvy));
+      uvs.push_back(geom::Vector2D(1.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.first);
-      uvs.push_back(geom::Vector2D(1, uvy));
+      uvs.push_back(geom::Vector2D(1.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.second);
-      uvs.push_back(geom::Vector2D(2, uvy));
+      uvs.push_back(geom::Vector2D(2.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.second);
-      uvs.push_back(geom::Vector2D(2, uvy));
+      uvs.push_back(geom::Vector2D(2.0f, static_cast<float>(uvy)));
 
       vertices.push_back(low_vertex_second);
-      uvs.push_back(geom::Vector2D(3, uvy));
+      uvs.push_back(geom::Vector2D(3.0f, static_cast<float>(uvy)));
 
       // Update the current waypoint's "s"
       s_current += road_param.resolution;
@@ -308,22 +307,22 @@ namespace geom {
       geom::Vector3D low_vertex_second = edges.second - geom::Vector3D(0,0,1);
 
       vertices.push_back(low_vertex_first);
-      uvs.push_back(geom::Vector2D(0, uvy));
+      uvs.push_back(geom::Vector2D(0.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.first);
-      uvs.push_back(geom::Vector2D(1, uvy));
+      uvs.push_back(geom::Vector2D(1.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.first);
-      uvs.push_back(geom::Vector2D(1, uvy));
+      uvs.push_back(geom::Vector2D(1.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.second);
-      uvs.push_back(geom::Vector2D(2, uvy));
+      uvs.push_back(geom::Vector2D(2.0f, static_cast<float>(uvy)));
 
       vertices.push_back(edges.second);
-      uvs.push_back(geom::Vector2D(2, uvy));
+      uvs.push_back(geom::Vector2D(2.0f, static_cast<float>(uvy)));
 
       vertices.push_back(low_vertex_second);
-      uvs.push_back(geom::Vector2D(3, uvy));
+      uvs.push_back(geom::Vector2D(3.0f, static_cast<float>(uvy)));
 
     }
 
@@ -333,7 +332,7 @@ namespace geom {
     out_mesh.AddMaterial(
       lane.GetType() == road::Lane::LaneType::Sidewalk ? "sidewalk" : "road");
 
-    const int number_of_rows = (vertices.size() / vertices_in_width);
+    const size_t number_of_rows = (vertices.size() / vertices_in_width);
 
     for (size_t i = 0; i < (number_of_rows - 1); ++i) {
       for (size_t j = 0; j < vertices_in_width - 1; ++j) {
@@ -534,7 +533,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
   std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory::GenerateOrderedWithMaxLen(
     const road::LaneSection &lane_section) const {
-      const int vertices_in_width = road_param.vertex_width_resolution >= 2 ? road_param.vertex_width_resolution : 2;
+      const size_t vertices_in_width = road_param.vertex_width_resolution >= 2 ? static_cast<size_t>(road_param.vertex_width_resolution) : size_t{2};
       std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> mesh_uptr_list;
 
       if (lane_section.GetLength() < road_param.max_road_len) {
@@ -554,25 +553,25 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
               lane_section_mesh += *GenerateSidewalk(lane_pair.second, s_current, s_until);
             }
 
-            auto it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+            auto it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
             if (it == redirections.end()) {
-              redirections.push_back(lane_pair.first);
-              it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+              redirections.push_back(static_cast<size_t>(lane_pair.first));
+              it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
             }
 
-            size_t PosToAdd = it - redirections.begin();
+            size_t PosToAdd = static_cast<size_t>(it - redirections.begin());
             if (mesh_uptr_list[lane_pair.second.GetType()].size() <= PosToAdd) {
               mesh_uptr_list[lane_pair.second.GetType()].push_back(std::make_unique<Mesh>(lane_section_mesh));
             } else {
               uint32_t verticesinwidth  = 0;
               if(lane_pair.second.GetType() == road::Lane::LaneType::Driving) {
-                verticesinwidth = vertices_in_width;
+                verticesinwidth = static_cast<uint32_t>(vertices_in_width);
               }else if(lane_pair.second.GetType() == road::Lane::LaneType::Sidewalk){
                 verticesinwidth = 6;
               }else{
                 verticesinwidth = 2;
               }
-              (mesh_uptr_list[lane_pair.second.GetType()][PosToAdd])->ConcatMesh(lane_section_mesh, verticesinwidth);
+              (mesh_uptr_list[lane_pair.second.GetType()][PosToAdd])->ConcatMesh(lane_section_mesh, static_cast<int>(verticesinwidth));
             }
           }
           s_current = s_until;
@@ -586,20 +585,20 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
               lane_section_mesh += *GenerateSidewalk(lane_pair.second, s_current, s_end);
             }
 
-            auto it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+            auto it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
             if (it == redirections.end()) {
-              redirections.push_back(lane_pair.first);
-              it = std::find(redirections.begin(), redirections.end(), lane_pair.first);
+              redirections.push_back(static_cast<size_t>(lane_pair.first));
+              it = std::find(redirections.begin(), redirections.end(), static_cast<size_t>(lane_pair.first));
             }
 
-            size_t PosToAdd = it - redirections.begin();
+            size_t PosToAdd = static_cast<size_t>(it - redirections.begin());
 
             if (mesh_uptr_list[lane_pair.second.GetType()].size() <= PosToAdd) {
               mesh_uptr_list[lane_pair.second.GetType()].push_back(std::make_unique<Mesh>(lane_section_mesh));
             } else {
               uint32_t verticesinwidth  = 0;
               if(lane_pair.second.GetType() == road::Lane::LaneType::Driving) {
-                verticesinwidth = vertices_in_width;
+                verticesinwidth = static_cast<uint32_t>(vertices_in_width);
               }else if(lane_pair.second.GetType() == road::Lane::LaneType::Sidewalk){
                 verticesinwidth = 6;
               }else{
@@ -743,7 +742,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
     const road::LaneSection& lane_section,
     const road::Lane& lane,
     std::vector<std::unique_ptr<Mesh>>& inout,
-    std::vector<std::string>& outinfo ) const {
+    std::vector<std::string>& /*outinfo*/ ) const {
     Mesh out_mesh;
     const double s_start = lane_section.GetDistance();
     const double s_end = lane_section.GetDistance() + lane_section.GetLength();
@@ -765,7 +764,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             geom::Vector3D director = edges.second - edges.first;
             director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * lane_mark_info.width;
+            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(endmarking);
@@ -789,7 +788,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             geom::Vector3D director = edges.second - edges.first;
             director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * lane_mark_info.width;
+            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(endmarking);
@@ -803,7 +802,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             director = edges.second - edges.first;
             director /= director.Length();
-            endmarking = edges.first + director * lane_mark_info.width;
+            endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(endmarking);
@@ -867,7 +866,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
         std::pair<geom::Vector3D, geom::Vector3D> edges = lane.GetCornerPositions(s_end, 0);
         geom::Vector3D director = edges.second - edges.first;
         director /= director.Length();
-        geom::Vector3D endmarking = edges.first + director * lane_mark_info.width;
+        geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
         out_mesh.AddVertex(edges.first);
         out_mesh.AddVertex(endmarking);
@@ -881,7 +880,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
     const road::LaneSection& lane_section,
     const road::Lane& lane,
     std::vector<std::unique_ptr<Mesh>>& inout,
-    std::vector<std::string>& outinfo ) const
+    std::vector<std::string>& /*outinfo*/ ) const
   {
     Mesh out_mesh;
     const double s_start = lane_section.GetDistance();
@@ -903,8 +902,8 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             carla::road::element::DirectedPoint rightpoint = road.GetDirectedPointIn(s_current);
             carla::road::element::DirectedPoint leftpoint = rightpoint;
 
-            rightpoint.ApplyLateralOffset(lane_mark_info.width * 0.5);
-            leftpoint.ApplyLateralOffset(lane_mark_info.width * -0.5);
+            rightpoint.ApplyLateralOffset(static_cast<float>(lane_mark_info.width * 0.5));
+            leftpoint.ApplyLateralOffset(static_cast<float>(lane_mark_info.width * -0.5));
 
             // Unreal's Y axis hack
             rightpoint.location.y *= -1;
@@ -932,7 +931,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             geom::Vector3D director = edges.second - edges.first;
             director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * lane_mark_info.width;
+            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(endmarking);
@@ -946,7 +945,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
 
             director = edges.second - edges.first;
             director /= director.Length();
-            endmarking = edges.first + director * lane_mark_info.width;
+            endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(endmarking);
@@ -1011,8 +1010,8 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
         carla::road::element::DirectedPoint rightpoint = road.GetDirectedPointIn(s_current);
         carla::road::element::DirectedPoint leftpoint = rightpoint;
 
-        rightpoint.ApplyLateralOffset(lane_mark_info.width * 0.5f);
-        leftpoint.ApplyLateralOffset(lane_mark_info.width * -0.5f);
+        rightpoint.ApplyLateralOffset(static_cast<float>(lane_mark_info.width * 0.5));
+        leftpoint.ApplyLateralOffset(static_cast<float>(lane_mark_info.width * -0.5));
 
         // Unreal's Y axis hack
         rightpoint.location.y *= -1;

--- a/LibCarla/source/carla/road/element/Geometry.cpp
+++ b/LibCarla/source/carla/road/element/Geometry.cpp
@@ -190,7 +190,7 @@ namespace element {
     constexpr double interval_size = 0.5;
     size_t number_intervals =
         std::max(static_cast<size_t>(_length / interval_size), size_t(5));
-    double delta_p = 1.0 / number_intervals;
+    double delta_p = 1.0 / static_cast<double>(number_intervals);
     if (_arcLength) {
         delta_p *= _length;
     }

--- a/LibCarla/source/test/client/test_image.cpp
+++ b/LibCarla/source/test/client/test_image.cpp
@@ -80,7 +80,7 @@ TEST(image, depth) {
           get_color(p_bgra8, red_t()) = static_cast<uint8_t>(r);
           get_color(p_bgra8, green_t()) = static_cast<uint8_t>(g);
           get_color(p_bgra8, blue_t()) = static_cast<uint8_t>(b);
-          const float depth = r + (g * 256) + (b  * 256 * 256);
+          const float depth = static_cast<float>(r + (g * 256) + (b  * 256 * 256));
           const float normalized = depth / static_cast<float>(256 * 256 * 256 - 1);
           p_gray8[0] = static_cast<uint8_t>(255.0 * normalized);
 

--- a/LibCarla/source/test/client/test_opendrive.cpp
+++ b/LibCarla/source/test/client/test_opendrive.cpp
@@ -369,7 +369,7 @@ TEST(road, iterate_waypoints) {
         }
       }
       ASSERT_GT(count, 0u);
-      float seconds = 1e-3f * stop_watch.GetElapsedTime();
+      float seconds = 1e-3f * static_cast<float>(stop_watch.GetElapsedTime());
       carla::logging::log(file, "done in", seconds, "seconds.");
     }));
   }
@@ -416,7 +416,7 @@ TEST(road, get_waypoint) {
           ASSERT_EQ(right->s, wp.s);
         }
       }
-      float seconds = 1e-3f * stop_watch.GetElapsedTime();
+      float seconds = 1e-3f * static_cast<float>(stop_watch.GetElapsedTime());
       carla::logging::log(file, "done in", seconds, "seconds.");
     }));
   }

--- a/LibCarla/source/test/server/test_benchmark_streaming.cpp
+++ b/LibCarla/source/test/server/test_benchmark_streaming.cpp
@@ -130,7 +130,7 @@ private:
 
 static size_t get_max_concurrency() {
   size_t concurrency = std::thread::hardware_concurrency() / 2u;
-  return std::max((size_t) 2u, concurrency);
+  return std::max(static_cast<size_t>(2u), concurrency);
 }
 
 static void benchmark_image(

--- a/LibCarla/source/third-party/marchingcube/Cube.h
+++ b/LibCarla/source/third-party/marchingcube/Cube.h
@@ -69,9 +69,9 @@ namespace MeshReconstruction
 
     struct Edge
     {
-      int edgeFlag : 12; // flag: 1, 2, 4, ... 2048
-      int vert0;         // 0-7
-      int vert1;         // 0-7
+      unsigned edgeFlag : 12; // flag: 1, 2, 4, ... 2048
+      int vert0;              // 0-7
+      int vert1;              // 0-7
     };
 
     const Edge edges[12] =
@@ -163,7 +163,7 @@ namespace MeshReconstruction
     IntersectInfo intersect;
     intersect.signConfig = SignConfig(iso);
 
-    for (auto e = 0; e < 12; ++e)
+    for (size_t e = 0; e < 12; ++e)
     {
       if (signConfigToIntersectedEdges[intersect.signConfig] & edges[e].edgeFlag)
       {

--- a/LibCarla/source/third-party/marchingcube/MeshReconstruction.h
+++ b/LibCarla/source/third-party/marchingcube/MeshReconstruction.h
@@ -28,11 +28,10 @@ namespace MeshReconstruction
       Fun3v sdfGrad = nullptr);
 }
 
-using namespace MeshReconstruction;
-using namespace std;
-
 // Adapted from here: http://paulbourke.net/geometry/polygonise/
 
+namespace MeshReconstruction
+{
 namespace
 {
   Vec3 NumGrad(Fun3s const &f, Vec3 const &p)
@@ -46,7 +45,7 @@ namespace
   }
 }
 
-Mesh MeshReconstruction::MarchCube(Fun3s const &sdf, Rect3 const &domain)
+Mesh MarchCube(Fun3s const &sdf, Rect3 const &domain)
 {
   auto const NumCubes = 50;
   auto cubeSize = domain.size * (1.0 / NumCubes);
@@ -54,14 +53,13 @@ Mesh MeshReconstruction::MarchCube(Fun3s const &sdf, Rect3 const &domain)
   return MarchCube(sdf, domain, cubeSize);
 }
 
-Mesh MeshReconstruction::MarchCube(
+Mesh MarchCube(
     Fun3s const &sdf,
     Rect3 const &domain,
     Vec3 const &cubeSize,
     double isoLevel,
     Fun3v sdfGrad)
 {
-  // Default value.
   sdfGrad = sdfGrad == nullptr
                 ? [&sdf](Vec3 const &p)
   { return NumGrad(sdf, p); }
@@ -104,3 +102,4 @@ Mesh MeshReconstruction::MarchCube(
 
   return mesh;
 }
+} // namespace MeshReconstruction

--- a/LibCarla/source/third-party/marchingcube/Triangulation.h
+++ b/LibCarla/source/third-party/marchingcube/Triangulation.h
@@ -289,9 +289,9 @@ void MeshReconstruction::Triangulate(
 
   for (auto i = 0; tri[i] != -1; i += 3)
   {
-    auto const &v0 = intersect.edgeVertIndices[tri[i]];
-    auto const &v1 = intersect.edgeVertIndices[tri[i + 1]];
-    auto const &v2 = intersect.edgeVertIndices[tri[i + 2]];
+    auto const &v0 = intersect.edgeVertIndices[static_cast<size_t>(tri[i])];
+    auto const &v1 = intersect.edgeVertIndices[static_cast<size_t>(tri[i + 1])];
+    auto const &v2 = intersect.edgeVertIndices[static_cast<size_t>(tri[i + 2])];
 
     mesh.vertices.push_back(v0);
     mesh.vertices.push_back(v1);

--- a/LibCarla/source/third-party/simplify/Simplify.h
+++ b/LibCarla/source/third-party/simplify/Simplify.h
@@ -23,10 +23,9 @@
 #include <math.h>
 #include <float.h> //FLT_EPSILON, DBL_EPSILON
 
-#define loopi(start_l, end_l) for (int i = start_l; i < end_l; ++i)
-#define loopi(start_l, end_l) for (int i = start_l; i < end_l; ++i)
-#define loopj(start_l, end_l) for (int j = start_l; j < end_l; ++j)
-#define loopk(start_l, end_l) for (int k = start_l; k < end_l; ++k)
+#define loopi(start_l, end_l) for (size_t i = static_cast<size_t>(start_l); i < static_cast<size_t>(end_l); ++i)
+#define loopj(start_l, end_l) for (size_t j = static_cast<size_t>(start_l); j < static_cast<size_t>(end_l); ++j)
+#define loopk(start_l, end_l) for (size_t k = static_cast<size_t>(start_l); k < static_cast<size_t>(end_l); ++k)
 
 struct vector3
 {
@@ -39,8 +38,7 @@ struct vec3f
 
   inline vec3f(void) {}
 
-  // inline vec3f operator =( vector3 a )
-  // { vec3f b ; b.x = a.x; b.y = a.y; b.z = a.z; return b;}
+  inline vec3f(const vec3f &a) : x(a.x), y(a.y), z(a.z) {}
 
   inline vec3f(vector3 a)
   {
@@ -137,7 +135,7 @@ struct vec3f
       input = -1;
     if (input > 1)
       input = 1;
-    return (double)acos(input);
+    return acos(input);
   }
 
   inline double angle2(const vec3f &v, const vec3f &w)
@@ -152,9 +150,9 @@ struct vec3f
     plane.cross(b, w);
 
     if (plane.x * a.x + plane.y * a.y + plane.z * a.z > 0)
-      return (double)-acos(dot / len);
+      return -acos(dot / len);
 
-    return (double)acos(dot / len);
+    return acos(dot / len);
   }
 
   inline vec3f rot_x(double a)
@@ -221,19 +219,12 @@ struct vec3f
 
   inline double length() const
   {
-    return (double)sqrt(x * x + y * y + z * z);
+    return sqrt(x * x + y * y + z * z);
   }
 
-  inline vec3f normalize(double desired_length = 1)
+  inline vec3f normalize(double /*desired_length*/ = 1)
   {
     double square = sqrt(x * x + y * y + z * z);
-    /*
-    if (square <= 0.00001f )
-    {
-      x=1;y=0;z=0;
-      return *this;
-    }*/
-    // double len = desired_length / square;
     x /= square;
     y /= square;
     z /= square;
@@ -251,15 +242,15 @@ struct vec3f
   double random_double_01(double a)
   {
     double rnf = a * 14.434252 + a * 364.2343 + a * 4213.45352 + a * 2341.43255 + a * 254341.43535 + a * 223454341.3523534245 + 23453.423412;
-    int rni = ((int)rnf) % 100000;
+    int rni = static_cast<int>(rnf) % 100000;
     return double(rni) / (100000.0f - 1.0f);
   }
 
   vec3f random01_fxyz()
   {
-    x = (double)random_double_01(x);
-    y = (double)random_double_01(y);
-    z = (double)random_double_01(z);
+    x = random_double_01(x);
+    y = random_double_01(y);
+    z = random_double_01(z);
     return *this;
   }
 };
@@ -484,9 +475,9 @@ namespace Simplify
           {
 
             int i0 = t.v[j];
-            Vertex &v0 = vertices[i0];
+            Vertex &v0 = vertices[static_cast<size_t>(i0)];
             int i1 = t.v[(j + 1) % 3];
-            Vertex &v1 = vertices[i1];
+            Vertex &v1 = vertices[static_cast<size_t>(i1)];
             // Border check
             if (v0.border || v1.border)
               continue;
@@ -494,8 +485,8 @@ namespace Simplify
             // Compute vertex to collapse to
             vec3f p;
             calculate_error(i0, i1, p);
-            deleted0.resize(v0.tcount); // normals temporarily
-            deleted1.resize(v1.tcount); // normals temporarily
+            deleted0.resize(static_cast<size_t>(v0.tcount)); // normals temporarily
+            deleted1.resize(static_cast<size_t>(v1.tcount)); // normals temporarily
             // don't remove if flipped
             if (flipped(p, i0, i1, v0, v1, deleted0))
               continue;
@@ -512,18 +503,18 @@ namespace Simplify
             // not flipped, so remove edge
             v0.p = p;
             v0.q = v1.q + v0.q;
-            int tstart = refs.size();
+            int tstart = static_cast<int>(refs.size());
 
             update_triangles(i0, v0, deleted0, deleted_triangles);
             update_triangles(i0, v1, deleted1, deleted_triangles);
 
-            int tcount = refs.size() - tstart;
+            int tcount = static_cast<int>(refs.size()) - tstart;
 
             if (tcount <= v0.tcount)
             {
               // save ram
               if (tcount)
-                memcpy(&refs[v0.tstart], &refs[tstart], tcount * sizeof(Ref));
+                memcpy(&refs[static_cast<size_t>(v0.tstart)], &refs[static_cast<size_t>(tstart)], static_cast<size_t>(tcount) * sizeof(Ref));
             }
             else
               // append
@@ -584,9 +575,9 @@ namespace Simplify
           loopj(0, 3) if (t.err[j] < threshold)
           {
             int i0 = t.v[j];
-            Vertex &v0 = vertices[i0];
+            Vertex &v0 = vertices[static_cast<size_t>(i0)];
             int i1 = t.v[(j + 1) % 3];
-            Vertex &v1 = vertices[i1];
+            Vertex &v1 = vertices[static_cast<size_t>(i1)];
 
             // Border check
             if (v0.border != v1.border)
@@ -596,8 +587,8 @@ namespace Simplify
             vec3f p;
             calculate_error(i0, i1, p);
 
-            deleted0.resize(v0.tcount); // normals temporarily
-            deleted1.resize(v1.tcount); // normals temporarily
+            deleted0.resize(static_cast<size_t>(v0.tcount)); // normals temporarily
+            deleted1.resize(static_cast<size_t>(v1.tcount)); // normals temporarily
 
             // don't remove if flipped
             if (flipped(p, i0, i1, v0, v1, deleted0))
@@ -614,18 +605,18 @@ namespace Simplify
             // not flipped, so remove edge
             v0.p = p;
             v0.q = v1.q + v0.q;
-            int tstart = refs.size();
+            int tstart = static_cast<int>(refs.size());
 
             update_triangles(i0, v0, deleted0, deleted_triangles);
             update_triangles(i0, v1, deleted1, deleted_triangles);
 
-            int tcount = refs.size() - tstart;
+            int tcount = static_cast<int>(refs.size()) - tstart;
 
             if (tcount <= v0.tcount)
             {
               // save ram
               if (tcount)
-                memcpy(&refs[v0.tstart], &refs[tstart], tcount * sizeof(Ref));
+                memcpy(&refs[static_cast<size_t>(v0.tstart)], &refs[static_cast<size_t>(tstart)], static_cast<size_t>(tcount) * sizeof(Ref));
             }
             else
               // append
@@ -645,16 +636,16 @@ namespace Simplify
 
     // Check if a triangle flips when this edge is removed
 
-    bool flipped(vec3f p, int i0, int i1, Vertex &v0, Vertex &v1, std::vector<int> &deleted)
+    bool flipped(vec3f p, int /*i0*/, int i1, Vertex &v0, Vertex &/*v1*/, std::vector<int> &deleted)
     {
 
-      loopk(0, v0.tcount)
+      loopk(0, static_cast<size_t>(v0.tcount))
       {
-        Triangle &t = triangles[refs[v0.tstart + k].tid];
+        Triangle &t = triangles[static_cast<size_t>(refs[static_cast<size_t>(v0.tstart) + k].tid)];
         if (t.deleted)
           continue;
 
-        int s = refs[v0.tstart + k].tvertex;
+        int s = refs[static_cast<size_t>(v0.tstart) + k].tvertex;
         int id1 = t.v[(s + 1) % 3];
         int id2 = t.v[(s + 2) % 3];
 
@@ -664,9 +655,9 @@ namespace Simplify
           deleted[k] = 1;
           continue;
         }
-        vec3f d1 = vertices[id1].p - p;
+        vec3f d1 = vertices[static_cast<size_t>(id1)].p - p;
         d1.normalize();
-        vec3f d2 = vertices[id2].p - p;
+        vec3f d2 = vertices[static_cast<size_t>(id2)].p - p;
         d2.normalize();
         if (fabs(d1.dot(d2)) > 0.999)
           return true;
@@ -682,20 +673,20 @@ namespace Simplify
 
     // update_uvs
 
-    void update_uvs(int i0, const Vertex &v, const vec3f &p, std::vector<int> &deleted)
+    void update_uvs(int /*i0*/, const Vertex &v, const vec3f &p, std::vector<int> &deleted)
     {
-      loopk(0, v.tcount)
+      loopk(0, static_cast<size_t>(v.tcount))
       {
-        Ref &r = refs[v.tstart + k];
-        Triangle &t = triangles[r.tid];
+        Ref &r = refs[static_cast<size_t>(v.tstart) + k];
+        Triangle &t = triangles[static_cast<size_t>(r.tid)];
         if (t.deleted)
           continue;
         if (deleted[k])
           continue;
-        vec3f p1 = vertices[t.v[0]].p;
-        vec3f p2 = vertices[t.v[1]].p;
-        vec3f p3 = vertices[t.v[2]].p;
-        t.uvs[r.tvertex] = interpolate(p, p1, p2, p3, t.uvs);
+        vec3f p1 = vertices[static_cast<size_t>(t.v[0])].p;
+        vec3f p2 = vertices[static_cast<size_t>(t.v[1])].p;
+        vec3f p3 = vertices[static_cast<size_t>(t.v[2])].p;
+        t.uvs[static_cast<size_t>(r.tvertex)] = interpolate(p, p1, p2, p3, t.uvs);
       }
     }
 
@@ -704,10 +695,10 @@ namespace Simplify
     void update_triangles(int i0, Vertex &v, std::vector<int> &deleted, int &deleted_triangles)
     {
       vec3f p;
-      loopk(0, v.tcount)
+      loopk(0, static_cast<size_t>(v.tcount))
       {
-        Ref &r = refs[v.tstart + k];
-        Triangle &t = triangles[r.tid];
+        Ref &r = refs[static_cast<size_t>(v.tstart) + k];
+        Triangle &t = triangles[static_cast<size_t>(r.tid)];
         if (t.deleted)
           continue;
         if (deleted[k])
@@ -716,7 +707,7 @@ namespace Simplify
           deleted_triangles++;
           continue;
         }
-        t.v[r.tvertex] = i0;
+        t.v[static_cast<size_t>(r.tvertex)] = i0;
         t.dirty = 1;
         t.err[0] = calculate_error(t.v[0], t.v[1], p);
         t.err[1] = calculate_error(t.v[1], t.v[2], p);
@@ -732,7 +723,7 @@ namespace Simplify
     {
       if (iteration > 0) // compact triangles
       {
-        int dst = 0;
+        size_t dst = 0;
         loopi(0, triangles.size()) if (!triangles[i].deleted)
         {
           triangles[dst++] = triangles[i];
@@ -751,7 +742,7 @@ namespace Simplify
       loopi(0, triangles.size())
       {
         Triangle &t = triangles[i];
-        loopj(0, 3) vertices[t.v[j]].tcount++;
+        loopj(0, 3) vertices[static_cast<size_t>(t.v[j])].tcount++;
       }
       int tstart = 0;
       loopi(0, vertices.size())
@@ -769,9 +760,9 @@ namespace Simplify
         Triangle &t = triangles[i];
         loopj(0, 3)
         {
-          Vertex &v = vertices[t.v[j]];
-          refs[v.tstart + v.tcount].tid = i;
-          refs[v.tstart + v.tcount].tvertex = j;
+          Vertex &v = vertices[static_cast<size_t>(t.v[j])];
+          refs[static_cast<size_t>(v.tstart + v.tcount)].tid = static_cast<int>(i);
+          refs[static_cast<size_t>(v.tstart + v.tcount)].tvertex = static_cast<int>(j);
           v.tcount++;
         }
       }
@@ -797,13 +788,14 @@ namespace Simplify
           Vertex &v = vertices[i];
           vcount.clear();
           vids.clear();
-          loopj(0, v.tcount)
+          loopj(0, static_cast<size_t>(v.tcount))
           {
-            int k = refs[v.tstart + j].tid;
-            Triangle &t = triangles[k];
+            int k = refs[static_cast<size_t>(v.tstart) + j].tid;
+            Triangle &t = triangles[static_cast<size_t>(k)];
             loopk(0, 3)
             {
-              int ofs = 0, id = t.v[k];
+              size_t ofs = 0;
+              int id = t.v[k];
               while (ofs < vcount.size())
               {
                 if (vids[ofs] == id)
@@ -820,7 +812,7 @@ namespace Simplify
             }
           }
           loopj(0, vcount.size()) if (vcount[j] == 1)
-              vertices[vids[j]]
+              vertices[static_cast<size_t>(vids[j])]
                   .border = 1;
         }
         // initialize errors
@@ -832,12 +824,12 @@ namespace Simplify
         {
           Triangle &t = triangles[i];
           vec3f n, p[3];
-          loopj(0, 3) p[j] = vertices[t.v[j]].p;
+          loopj(0, 3) p[j] = vertices[static_cast<size_t>(t.v[j])].p;
           n.cross(p[1] - p[0], p[2] - p[0]);
           n.normalize();
           t.n = n;
-          loopj(0, 3) vertices[t.v[j]].q =
-              vertices[t.v[j]].q + SymetricMatrix(n.x, n.y, n.z, -n.dot(p[0]));
+          loopj(0, 3) vertices[static_cast<size_t>(t.v[j])].q =
+              vertices[static_cast<size_t>(t.v[j])].q + SymetricMatrix(n.x, n.y, n.z, -n.dot(p[0]));
         }
         loopi(0, triangles.size())
         {
@@ -854,7 +846,7 @@ namespace Simplify
 
     void compact_mesh()
     {
-      int dst = 0;
+      size_t dst = 0;
       loopi(0, vertices.size())
       {
         vertices[i].tcount = 0;
@@ -863,20 +855,20 @@ namespace Simplify
       {
         Triangle &t = triangles[i];
         triangles[dst++] = t;
-        loopj(0, 3) vertices[t.v[j]].tcount = 1;
+        loopj(0, 3) vertices[static_cast<size_t>(t.v[j])].tcount = 1;
       }
       triangles.resize(dst);
       dst = 0;
       loopi(0, vertices.size()) if (vertices[i].tcount)
       {
-        vertices[i].tstart = dst;
+        vertices[i].tstart = static_cast<int>(dst);
         vertices[dst].p = vertices[i].p;
         dst++;
       }
       loopi(0, triangles.size())
       {
         Triangle &t = triangles[i];
-        loopj(0, 3) t.v[j] = vertices[t.v[j]].tstart;
+        loopj(0, 3) t.v[j] = vertices[static_cast<size_t>(t.v[j])].tstart;
       }
       vertices.resize(dst);
     }
@@ -894,8 +886,8 @@ namespace Simplify
     {
       // compute interpolated vertex
 
-      SymetricMatrix q = vertices[id_v1].q + vertices[id_v2].q;
-      bool border = vertices[id_v1].border & vertices[id_v2].border;
+      SymetricMatrix q = vertices[static_cast<size_t>(id_v1)].q + vertices[static_cast<size_t>(id_v2)].q;
+      bool border = vertices[static_cast<size_t>(id_v1)].border & vertices[static_cast<size_t>(id_v2)].border;
       double error = 0;
       double det = q.det(0, 1, 2, 1, 4, 5, 2, 5, 7);
       if (det != 0 && !border)
@@ -911,8 +903,8 @@ namespace Simplify
       else
       {
         // det = 0 -> try to find best result
-        vec3f p1 = vertices[id_v1].p;
-        vec3f p2 = vertices[id_v2].p;
+        vec3f p1 = vertices[static_cast<size_t>(id_v1)].p;
+        vec3f p2 = vertices[static_cast<size_t>(id_v2)].p;
         vec3f p3 = (p1 + p2) / 2;
         double error1 = vertex_error(q, p1.x, p1.y, p1.z);
         double error2 = vertex_error(q, p2.x, p2.y, p2.z);
@@ -933,7 +925,7 @@ namespace Simplify
       char *end;
 
       // Trim leading space
-      while (isspace((unsigned char)*str))
+      while (isspace(static_cast<unsigned char>(*str)))
         str++;
 
       if (*str == 0) // All spaces?
@@ -941,7 +933,7 @@ namespace Simplify
 
       // Trim trailing space
       end = str + strlen(str) - 1;
-      while (end > str && isspace((unsigned char)*end))
+      while (end > str && isspace(static_cast<unsigned char>(*end)))
         end--;
 
       // Write new null terminator
@@ -959,7 +951,7 @@ namespace Simplify
       FILE *fn;
       if (filename == NULL)
         return;
-      if ((char)filename[0] == 0)
+      if (static_cast<char>(filename[0]) == 0)
         return;
       if ((fn = fopen(filename, "rb")) == NULL)
       {
@@ -988,7 +980,7 @@ namespace Simplify
           std::string usemtl = trimwhitespace(&line[7]);
           if (material_map.find(usemtl) == material_map.end())
           {
-            material_map[usemtl] = materials.size();
+            material_map[usemtl] = static_cast<int>(materials.size());
             materials.push_back(usemtl);
           }
           material = material_map[usemtl];
@@ -997,6 +989,7 @@ namespace Simplify
         if (line[0] == 'v' && line[1] == 't')
         {
           if (line[2] == ' ')
+          {
             if (sscanf(line, "vt %lf %lf",
                        &uv.x, &uv.y) == 2)
             {
@@ -1008,6 +1001,7 @@ namespace Simplify
             {
               uvs.push_back(uv);
             }
+          }
         }
         else if (line[0] == 'v')
         {
@@ -1098,7 +1092,7 @@ namespace Simplify
         {
           loopj(0, 3)
               triangles[i]
-                  .uvs[j] = uvs[uvMap[i][j]];
+                  .uvs[j] = uvs[static_cast<size_t>(uvMap[i][j])];
         }
       }
 
@@ -1112,7 +1106,6 @@ namespace Simplify
     void write_obj(const char *filename)
     {
       FILE *file = fopen(filename, "w");
-      int cur_material = -1;
       bool has_uv = (triangles.size() && (triangles[0].attr & TEXCOORD) == TEXCOORD);
 
       if (!file)


### PR DESCRIPTION
#### Description

Eliminate compiler warnings across LibCarla to achieve clean builds.

Based on ue4-dev commit d179041f4, this PR fixes compiler warnings across 20 files including:
- Unnecessary deep copies in range-for loops (`auto const` → `const auto&`)
- Pessimizing moves preventing NRVO
- Signed/unsigned implicit conversions
- Double-to-float narrowing conversions
- C-style casts replaced with `static_cast`/`reinterpret_cast`
- Unused parameter annotations (`/*name*/`)
- Unused variables and lambda captures removed
- Third-party header fixes (namespace pollution, bitfield sign, duplicate macros)

Files skipped (already fixed or N/A in ue5-dev):
- `FIleTransfer.cpp` — Renamed to `FileTransfer.cpp` and rewritten with `std::filesystem`
- `GeoReferenceParser.cpp` — Completely different implementation
- `GeometryParser.cpp`, `RoadParser.cpp` — Already fixed
- `ALSM.cpp`, `LocalizationStage.cpp` — `large_vehicles` member doesn't exist
- `test_geom.cpp` — Quaternion test doesn't exist

Fixes #9583 (partial — PR #0d)

#### Where has this been tested?

  * **Platform(s):** Linux (Ubuntu 24.04)
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

Pure code quality improvements with no behavioral changes. Some third-party header fixes may need to be re-applied if those headers are regenerated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9587)
<!-- Reviewable:end -->
