### PR TITLE
Fix segfault on LaneCrossingCalculator nullptr access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  * Added support for parsing offsets from OpenDRIVE using optional offset transforms.
  * Added ad-rss type-stubs for the PythonAPI when building with RSS support
  * Make TrafficManager PID controller use actual delta times to improve robustness to different fixed_delta_seconds
+ * Fix segfault on LaneCrossingCalculator nullptr access
 
 ## CARLA 0.9.16
 

--- a/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
+++ b/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
@@ -38,15 +38,23 @@ namespace element {
 
     if (dest_is_at_right) {
       if (w0_is_offroad) {
-        return { LaneMarking(*w1_marks.second) };
+        if ( w1_marks.second != nullptr ) {
+          return { LaneMarking(*w1_marks.second) };
+        }
       } else {
-        return { LaneMarking(*w0_marks.first) };
+        if ( w0_marks.first != nullptr ) {
+          return { LaneMarking(*w0_marks.first) };
+        }
       }
     } else {
       if (w0_is_offroad) {
-        return { LaneMarking(*w1_marks.first) };
+        if ( w1_marks.first != nullptr ) {
+          return { LaneMarking(*w1_marks.first) };
+        }
       } else {
-        return { LaneMarking(*w0_marks.second) };
+        if ( w0_marks.second != nullptr ) {
+          return { LaneMarking(*w0_marks.second) };
+        }
       }
     }
 


### PR DESCRIPTION
LaneCrossingCalculator tried to create LaneMarking objects without check if the respective information object exists at all.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Running manual_control.py on a custom made map showed segfaults. Debugging lead to a nullptr access on the not existing information from the map. OpenDRIVE maps are valid even without lane marking information (or with a reduced set of it). This change prevents from the segfault an just returns an empty list of markings.  


Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ... Ubuntu 24.04
  * **Python version(s):** ... 3.12
  * **Unreal Engine version(s):** ... 4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9591)
<!-- Reviewable:end -->
