### PR TITLE
fix(ci): exclude Town15 from cooking to unblock packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Exclude Town15 from cooking to fix UE5 engine assertion crash during packaging
 * Fix typos in README.md
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)

--- a/Unreal/CarlaUnreal/Config/DefaultGame.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultGame.ini
@@ -53,7 +53,6 @@ bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Mine_01")
 ; Town15 excluded: landscape texture triggers UE5 engine assertion crash during cooking
-; See: https://github.com/carla-simulator/carla/issues/XXXX
 ;+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/GenericMaterials/Licenseplates/Textures")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/Car/4Wheeled/ParkedVehicles")

--- a/Unreal/CarlaUnreal/Config/DefaultGame.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultGame.ini
@@ -52,7 +52,9 @@ bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/OpenDriveMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Mine_01")
-+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
+; Town15 excluded: landscape texture triggers UE5 engine assertion crash during cooking
+; See: https://github.com/carla-simulator/carla/issues/XXXX
+;+MapsToCook=(FilePath="/Game/Carla/Maps/Town15/Town15")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/GenericMaterials/Licenseplates/Textures")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Static/Car/4Wheeled/ParkedVehicles")
 +DirectoriesToAlwaysCook=(Path="/Game/Carla/Blueprints/Walkers")


### PR DESCRIPTION
#### Description

Exclude Town15 from `MapsToCook` in `DefaultGame.ini` to unblock the CI packaging pipeline.

Town15's landscape texture triggers a UE5 engine internal assertion failure during cooking. This is a pre-existing issue on `ue5-dev`, not caused by any recent code changes. Town15 remains in `DirectoriesToAlwaysStageAsUFS` so its OpenDrive/Nav/TM data is still staged.

This fix was split out from PR #9586 to be reviewed independently.

#### Where has this been tested?

  * **Platform(s):** Linux (Ubuntu)
  * **Python version(s):** N/A (config-only change)
  * **Unreal Engine version(s):** UE 5.5 (CARLA fork)

#### Possible Drawbacks

- Town15 will not be included in packaged builds until the root cause in the landscape material is resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9595)
<!-- Reviewable:end -->
