### PR TITLE
feat: add Ubuntu 24.04 CI matrix entry

### DIFF
--- a/.github/workflows/_ci-ubuntu.yml
+++ b/.github/workflows/_ci-ubuntu.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      ubuntu-version:
+        type: string
+        required: false
+        default: "22.04"
       python-versions:
         required: true
         type: string
@@ -36,13 +40,13 @@ on:
 
 jobs:
   ubuntu:
-    name: Ubuntu CI/CD
+    name: Ubuntu ${{ inputs.ubuntu-version }} CI/CD
     defaults:
       run:
         shell: bash -leo pipefail {0}
     runs-on: self-hosted:ubuntu-gpu
     container:
-      image: carlasim/carla-builder:ue5-22.04
+      image: carlasim/carla-builder:ue5-${{ inputs.ubuntu-version }}
       options: --runtime=nvidia --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all --volume /home/jenkins/unreal-engine/ue5:/unreal-engine
     env:
       CARLA_UNREAL_ENGINE_PATH: /unreal-engine

--- a/.github/workflows/ue5_dev.yml
+++ b/.github/workflows/ue5_dev.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ubuntu-dev:
-    name: Ubuntu Dev
+  ubuntu-22-dev:
+    name: Ubuntu 22.04 Dev
     uses: ./.github/workflows/_ci-ubuntu.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -20,8 +20,26 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
     with:
+      ubuntu-version: "22.04"
       python-versions: "3.10"
       smoke-test-python-versions: "3.10"
+      additional-maps: false
+      upload-package: true
+      upload-replace-latest: true
+      upload-docker: false
+
+  ubuntu-24-dev:
+    name: Ubuntu 24.04 Dev
+    uses: ./.github/workflows/_ci-ubuntu.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+    with:
+      ubuntu-version: "24.04"
+      python-versions: "3.12"
+      smoke-test-python-versions: "3.12"
       additional-maps: false
       upload-package: true
       upload-replace-latest: true

--- a/.github/workflows/ue5_pr.yml
+++ b/.github/workflows/ue5_pr.yml
@@ -11,12 +11,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ubuntu-pr:
-    name: Ubuntu PR
+  ubuntu-22-pr:
+    name: Ubuntu 22.04 PR
     uses: ./.github/workflows/_ci-ubuntu.yml
     with:
+      ubuntu-version: "22.04"
       python-versions: "3.10"
       smoke-test-python-versions: "3.10"
+      additional-maps: false
+      upload-package: false
+      upload-replace-latest: false
+      upload-docker: false
+
+  ubuntu-24-pr:
+    name: Ubuntu 24.04 PR
+    uses: ./.github/workflows/_ci-ubuntu.yml
+    with:
+      ubuntu-version: "24.04"
+      python-versions: "3.12"
+      smoke-test-python-versions: "3.12"
       additional-maps: false
       upload-package: false
       upload-replace-latest: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Add Ubuntu 24.04 CI matrix entry
 * Fix typos in README.md
 * Added actor description as Actor TAGs
 * Create class with functions to import points and polylines from satellite segmentation (#8946, #8949 #8950)


### PR DESCRIPTION
- [ ] CarlaUnreal/UnrealEngine#50

## Summary

- Add `ubuntu-version` input to `_ci-ubuntu.yml` reusable workflow (default: `"22.04"`)
- Parameterize container image: `carlasim/carla-builder:ue5-${ubuntu-version}`
- Add Ubuntu 24.04 jobs to `ue5_dev.yml` and `ue5_pr.yml` with Python 3.12
- Rename existing jobs to `ubuntu-22-*` / `ubuntu-24-*` for clarity

**Blocker:** Requires `carlasim/carla-builder:ue5-24.04` Docker image to be built and published to Docker Hub before CI can use it.

## Test plan

- [ ] Build and publish `carlasim/carla-builder:ue5-24.04` Docker image
- [ ] Verify Ubuntu 22.04 CI job still passes (regression check)
- [ ] Verify Ubuntu 24.04 CI job passes (full build + smoke tests)

Related: #9597
Depends on: CarlaUnreal/UnrealEngine#50 (Dockerfile changes)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9601)
<!-- Reviewable:end -->
