### PR TITLE
Fixed sudo issue with UE5 linux build

### DIFF
--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -44,16 +44,14 @@ while true; do
     esac
 done
 
-# Check for root privileges:
+# Check if root is asking for a password:
 if [ -z "$EUID" ]; then
     EUID=$(id -u)
 fi
-if [ "$EUID" -ne 0 ]; then
-    if [ $interactive -eq 0 ]; then
-        if [ $skip_prerequisites -eq 0 ]; then
-            echo "Please run this script as root. Otherwise pass --interactive to be prompted whenever root privileges or Git credentials are needed."
-            exit 1
-        fi
+if [ "$EUID" -ne 0 ] && [ $interactive -eq 0 ] && [ $skip_prerequisites -eq 0 ]; then
+    if ! sudo -n true 2>/dev/null; then
+        echo "Please run 'sudo -v' before running this script, or pass --interactive or --skip-prerequisites."
+        exit 1
     fi
 fi
 

--- a/CarlaSetup.sh
+++ b/CarlaSetup.sh
@@ -76,7 +76,7 @@ if [ $skip_prerequisites -eq 0 ]; then
         python_path=${python_root}/python3
     fi
     echo "Installing prerequisites..."
-    sudo -E bash -x Util/SetupUtils/InstallPrerequisites.sh --python-path=$python_path
+    bash -x Util/SetupUtils/InstallPrerequisites.sh --python-path=$python_path
 else
     echo "Skipping prerequisites install step."
 fi

--- a/Docs/build_linux_ue5.md
+++ b/Docs/build_linux_ue5.md
@@ -30,27 +30,21 @@ The setup script will prompt you for your sudo password, in order to install the
 
 __Building in Linux unattended__:
 
-If you want to run the setup script unattended, your git credentials need to be stored in an environment variable. Add your github credentials to your `.bashrc` file:
+If you want to run the setup script unattended, store your sudo password and your git credentials in an environment variable.
 
 ```sh
-export GIT_LOCAL_CREDENTIALS=username@github_token
+sudo -v   # Used to cache the password for 15 minutes
+export GIT_LOCAL_CREDENTIALS=github_username@github_token 
 ```
 
-Then run the setup script using the following command:
+Then run the setup script without the interactive flag:
 
 ```sh
 cd CarlaUE5
-sudo -E ./CarlaSetup.sh
+./CarlaSetup.sh
 ```
 
 This will download and install Unreal Engine 5.5, install the prerequisites and build CARLA. It may take some time to complete and use a significant amount of disk space.
-
-If you prefer to add the git credentials in the terminal, use the following command:
-
-```sh
-cd CarlaUE5
-sudo -E env GIT_LOCAL_CREDENTIALS=github_username@github_token ./CarlaSetup.sh 
-```
 
 !!! note
     The setup script will install by default Python 3 using apt. If you want to target an existing Python installation, you should use the `--python-root=PATH_TO_PYTHON` argument with the relevant Python installation path. You can use whereis python3 in your chosen environment and strip the `/python3` suffix from the path.

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -38,8 +38,8 @@ fi
 
 # -- INSTALL APT PACKAGES --
 echo "Installing Ubuntu Packages..."
-apt-get update
-apt-get -y install \
+sudo apt-get update
+sudo apt-get -y install \
     build-essential \
     make \
     ninja-build \
@@ -68,6 +68,9 @@ if [ "$python_path" == "python3" ]; then
         python3-dev \
         python3-pip
 fi
+
+# -- CONFIGURE GIT LFS --
+git lfs install
 
 # -- INSTALL PYTHON PACKAGES --
 echo "Installing Python Packages..."

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -27,15 +27,6 @@ while true; do
     esac
 done
 
-if [ -z "$EUID" ]; then
-    EUID=$(id -u)
-fi
-
-if [ "$EUID" -ne 0 ]; then
-    echo "Please run this script as root."
-    exit 1
-fi
-
 # -- INSTALL APT PACKAGES --
 echo "Installing Ubuntu Packages..."
 sudo apt-get update
@@ -63,7 +54,7 @@ sudo apt-get -y install \
     libasound2-dev
 
 if [ "$python_path" == "python3" ]; then
-    apt-get -y install \
+    sudo apt-get -y install \
         python3 \
         python3-dev \
         python3-pip
@@ -107,8 +98,8 @@ else
     echo "Could not find CMake >=$CMAKE_MINIMUM_VERSION."
     echo "Installing CMake 3.28.3..."
     curl -L -O https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz
-    mkdir -p /opt
-    tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
+    sudo mkdir -p /opt
+    sudo tar -xzf cmake-3.28.3-linux-x86_64.tar.gz -C /opt
     if [[ ":$PATH:" != *":/opt/cmake-3.28.3-linux-x86_64/bin:"* ]]; then
         echo -e '\n#CARLA CMake 3.28.3\nPATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH' >> ~/.bashrc
         export PATH=/opt/cmake-3.28.3-linux-x86_64/bin:$PATH


### PR DESCRIPTION
#### Description

The way sudo is used when installing CARLA makes it so that the Build folder and UnrealEngine5 (if installed through the CarlaSetup.sh), have root user. As such, the rest of the pipeline fails due to denied permissions.

This PR changes the sudo to only the install prerequisites, where it is actually used. A `sudo -v` is used to set the password so that the non interactive pipeline still works as intended

#### Where has this been tested?

  * **Platform(s):** ubuntu 22.04
  * **Python version(s):** 3.11
  * **Unreal Engine version(s):** CARLA's UE5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9602)
<!-- Reviewable:end -->
