### PR TITLE
Update the foonathan to match the version of CMake

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Carla.Build.cs
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Carla.Build.cs
@@ -175,7 +175,7 @@ public class Carla :
       string CarlaPluginSourcePath = Path.GetFullPath(ModuleDirectory);
       string CarlaPluginBinariesLinuxPath = Path.Combine(CarlaPluginSourcePath, "..", "..", "Binaries", "Linux");
       AddDynamicLibrary(Path.Combine(CarlaPluginBinariesLinuxPath, "libcarla-ros2-native.so"));
-      RuntimeDependencies.Add(Path.Combine(CarlaPluginBinariesLinuxPath, "libfoonathan_memory-0.7.3.so"));
+      RuntimeDependencies.Add(Path.Combine(CarlaPluginBinariesLinuxPath, "libfoonathan_memory-0.7.4.so"));
       RuntimeDependencies.Add(Path.Combine(CarlaPluginBinariesLinuxPath, "libfastcdr.so"));
       RuntimeDependencies.Add(Path.Combine(CarlaPluginBinariesLinuxPath, "libfastcdr.so.1"));
       RuntimeDependencies.Add(Path.Combine(CarlaPluginBinariesLinuxPath, "libfastcdr.so.1.1.0"));


### PR DESCRIPTION
Fix libfoonathan_memory version mismatch in packaging

  Carla.Build.cs referenced libfoonathan_memory-0.7.3.so as a runtime dependency, but the foonathan_memory_vendor CMake   build (from its master branch) now produces version 0.7.4. This caused the packaging step to fail when trying to
  stage the file.
  Updated the hardcoded version in Carla.Build.cs from 0.7.3 to 0.7.4 to match the built library name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9603)
<!-- Reviewable:end -->
