### PR TITLE
feat: add detailed logging for TrafficManager vehicle despawn events

### DIFF
--- a/LibCarla/source/carla/road/MapBuilder.cpp
+++ b/LibCarla/source/carla/road/MapBuilder.cpp
@@ -718,25 +718,23 @@ namespace road {
       return result;
     }
 
-    // Completely remade, as the junctions have incoming roads, but not "exitting" ones
-    for (auto con : junction->_connections) {
+    // Use the junction connection table (incoming_road + lane_links) to resolve
+    // lane connectivity. The previous approach matched against the connecting
+    // road's predecessor/successor, which fails when a single connecting road
+    // is shared by multiple incoming roads (common in OSM-derived maps).
+    for (const auto &con : junction->_connections) {
+      if (con.second.incoming_road != road_id) {
+        continue;
+      }
+
       auto conn_road = GetRoad(con.second.connecting_road);
       auto conn_id = conn_road->_id;
 
-      auto road_pred = conn_road->_predecessor;
-      auto road_succ = conn_road->_successor;
-      if (road_id == road_pred) {
-        for (auto lane : conn_road->GetLanesAt(0)){
-          if (lane_id == lane.second->_predecessor){
-            result.push_back(std::make_pair(conn_id, lane.second));
-          }
-        }
-      }
-
-      if (road_id == road_succ) {
-        for (auto lane : conn_road->GetLanesAt(conn_road->GetLength())){
-          if (lane_id == lane.second->_successor){
-            result.push_back(std::make_pair(conn_id, lane.second));
+      for (const auto &lane_link : con.second.lane_links) {
+        if (lane_link.from == lane_id) {
+          Lane *lane = GetEdgeLanePointer(conn_id, lane_link.to);
+          if (lane != nullptr) {
+            result.push_back(std::make_pair(conn_id, lane));
           }
         }
       }

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -58,6 +58,8 @@ void ALSM::Update() {
 
   const ActorIdSet &destroyed_registered = destroyed_actors.first;
   for (const auto &deletion_id: destroyed_registered) {
+    printf("[TM DESPAWN] EXTERNAL_DESTROY (registered) actor_id=%u\n", deletion_id);
+    fflush(stdout);
     RemoveActor(deletion_id, true);
   }
 
@@ -94,6 +96,10 @@ void ALSM::Update() {
   if (IsVehicleStuck(max_idle_time.first)
       && (current_timestamp.elapsed_seconds - elapsed_last_actor_destruction) > DELTA_TIME_BETWEEN_DESTRUCTIONS
       && hero_actors.find(max_idle_time.first) == hero_actors.end()) {
+    double idle_dur = current_timestamp.elapsed_seconds - idle_time.at(max_idle_time.first);
+    printf("[TM DESPAWN] STUCK actor_id=%u idle=%.1fs t=%.1fs\n",
+        max_idle_time.first, idle_dur, current_timestamp.elapsed_seconds);
+    fflush(stdout);
     registered_vehicles.Destroy(max_idle_time.first);
     RemoveActor(max_idle_time.first, true);
     elapsed_last_actor_destruction = current_timestamp.elapsed_seconds;
@@ -102,6 +108,8 @@ void ALSM::Update() {
   // Destorying vehicles for marked for removal by stages.
   if (parameters.GetOSMMode()) {
     for (const ActorId& actor_id: marked_for_removal) {
+      printf("[TM DESPAWN] DEAD_END (OSM) actor_id=%u\n", actor_id);
+      fflush(stdout);
       registered_vehicles.Destroy(actor_id);
       RemoveActor(actor_id, true);
     }

--- a/LibCarla/source/carla/trafficmanager/ALSM.cpp
+++ b/LibCarla/source/carla/trafficmanager/ALSM.cpp
@@ -108,7 +108,13 @@ void ALSM::Update() {
   // Destorying vehicles for marked for removal by stages.
   if (parameters.GetOSMMode()) {
     for (const ActorId& actor_id: marked_for_removal) {
-      printf("[TM DESPAWN] DEAD_END (OSM) actor_id=%u\n", actor_id);
+      if (simulation_state.ContainsActor(actor_id)) {
+        auto loc = simulation_state.GetLocation(actor_id);
+        printf("[TM DESPAWN] DEAD_END (OSM destroy) actor_id=%u vehicle_loc=(%.2f,%.2f,%.2f)\n",
+            actor_id, loc.x, loc.y, loc.z);
+      } else {
+        printf("[TM DESPAWN] DEAD_END (OSM destroy) actor_id=%u vehicle_loc=unknown\n", actor_id);
+      }
       fflush(stdout);
       registered_vehicles.Destroy(actor_id);
       RemoveActor(actor_id, true);

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -203,6 +203,9 @@ void LocalizationStage::Update(const unsigned long index) {
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
+        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
+            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;
       }
@@ -506,6 +509,9 @@ void LocalizationStage::ImportPath(Path &imported_path, Buffer &waypoint_buffer,
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
+        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
+            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;
       }
@@ -569,6 +575,9 @@ void LocalizationStage::ImportRoute(Route &imported_actions, Buffer &waypoint_bu
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
+        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
+            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;
       }

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -203,8 +203,18 @@ void LocalizationStage::Update(const unsigned long index) {
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
-        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
-            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        auto dead_wp = waypoint_buffer.back();
+        auto dead_raw = dead_wp->GetWaypoint();
+        auto dead_loc = dead_wp->GetLocation();
+        auto prev_wps = dead_wp->GetPreviousWaypoint();
+        printf("[TM DESPAWN] DEAD_END actor_id=%u context=random_path osm_mode=%d\n"
+               "  dead_end_wp: road_id=%u section_id=%u lane_id=%d s=%.2f loc=(%.2f,%.2f,%.2f)\n"
+               "  vehicle_loc: (%.2f,%.2f,%.2f) prev_wp_count=%zu buffer_size=%zu\n",
+            actor_id, (int)parameters.GetOSMMode(),
+            dead_raw->GetRoadId(), dead_raw->GetSectionId(), dead_raw->GetLaneId(), dead_raw->GetDistance(),
+            dead_loc.x, dead_loc.y, dead_loc.z,
+            vehicle_location.x, vehicle_location.y, vehicle_location.z,
+            prev_wps.size(), waypoint_buffer.size());
         fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;
@@ -509,8 +519,21 @@ void LocalizationStage::ImportPath(Path &imported_path, Buffer &waypoint_buffer,
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
-        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
-            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        auto dead_wp = waypoint_buffer.back();
+        auto dead_raw = dead_wp->GetWaypoint();
+        auto dead_loc = dead_wp->GetLocation();
+        auto prev_wps = dead_wp->GetPreviousWaypoint();
+        auto imported_loc = imported->GetLocation();
+        printf("[TM DESPAWN] DEAD_END actor_id=%u context=import_path osm_mode=%d\n"
+               "  dead_end_wp: road_id=%u section_id=%u lane_id=%d s=%.2f loc=(%.2f,%.2f,%.2f)\n"
+               "  imported_target: road_id=%u loc=(%.2f,%.2f,%.2f) remaining_path=%zu\n"
+               "  prev_wp_count=%zu buffer_size=%zu\n",
+            actor_id, (int)parameters.GetOSMMode(),
+            dead_raw->GetRoadId(), dead_raw->GetSectionId(), dead_raw->GetLaneId(), dead_raw->GetDistance(),
+            dead_loc.x, dead_loc.y, dead_loc.z,
+            imported->GetWaypoint()->GetRoadId(), imported_loc.x, imported_loc.y, imported_loc.z,
+            imported_path.size(),
+            prev_wps.size(), waypoint_buffer.size());
         fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;
@@ -575,8 +598,19 @@ void LocalizationStage::ImportRoute(Route &imported_actions, Buffer &waypoint_bu
         if (!parameters.GetOSMMode()) {
           std::cout << "This map has dead-end roads, please change the set_open_street_map parameter to true" << std::endl;
         }
-        printf("[TM DESPAWN] DEAD_END actor_id=%u road_id=%u\n",
-            actor_id, waypoint_buffer.back()->GetWaypoint()->GetRoadId());
+        auto dead_wp = waypoint_buffer.back();
+        auto dead_raw = dead_wp->GetWaypoint();
+        auto dead_loc = dead_wp->GetLocation();
+        auto prev_wps = dead_wp->GetPreviousWaypoint();
+        printf("[TM DESPAWN] DEAD_END actor_id=%u context=import_route osm_mode=%d\n"
+               "  dead_end_wp: road_id=%u section_id=%u lane_id=%d s=%.2f loc=(%.2f,%.2f,%.2f)\n"
+               "  next_road_option=%u remaining_actions=%zu\n"
+               "  prev_wp_count=%zu buffer_size=%zu\n",
+            actor_id, (int)parameters.GetOSMMode(),
+            dead_raw->GetRoadId(), dead_raw->GetSectionId(), dead_raw->GetLaneId(), dead_raw->GetDistance(),
+            dead_loc.x, dead_loc.y, dead_loc.z,
+            static_cast<uint8_t>(next_road_option), imported_actions.size(),
+            prev_wps.size(), waypoint_buffer.size());
         fflush(stdout);
         marked_for_removal.push_back(actor_id);
         break;


### PR DESCRIPTION
## Summary

TrafficManager が車両を despawn する際の詳細ログを追加し、despawn 原因の調査を容易にします。また、ジャンクション内レーン接続ロジックの不具合を修正し、DEAD_END の誤判定を低減します。

## Changes

### 1. ALSM.cpp — despawn イベントのログ追加

- **EXTERNAL_DESTROY**: 外部から destroy された registered actor を検知した際に `[TM DESPAWN] EXTERNAL_DESTROY` ログを出力
- **STUCK**: アイドル時間超過により stuck 判定された車両の despawn 時に `[TM DESPAWN] STUCK` ログを出力（アイドル時間・シミュレーション時刻を含む）
- **DEAD_END (OSM destroy)**: OSM モードでのマーク済み車両 destroy 時に `[TM DESPAWN] DEAD_END` ログを出力（車両位置を含む）

### 2. LocalizationStage.cpp — DEAD_END 判定時の詳細ログ追加

以下の3つのコンテキストでの DEAD_END despawn に詳細ログを追加:

- **`context=random_path`**: ランダムパス探索中に行き止まりに到達した場合
- **`context=import_path`**: インポートされたパスを辿る際に行き止まりに到達した場合
- **`context=import_route`**: インポートされたルートを辿る際に行き止まりに到達した場合

各ログには以下の情報を含む:
- `actor_id`, `osm_mode` フラグ
- 行き止まりウェイポイントの `road_id`, `section_id`, `lane_id`, `s` 値, 位置座標
- 車両の現在位置
- `prev_wp_count` (前方ウェイポイント数), `buffer_size`

### 3. MapBuilder.cpp — ジャンクション内レーン接続ロジックの修正

- **修正前**: connecting road の predecessor/successor を照合して接続レーンを解決していたが、1つの connecting road が複数の incoming road に共有される場合（OSM由来マップで頻出）に正しく動作しない
- **修正後**: junction の connection テーブル（`incoming_road` + `lane_links`）を直接参照し、`incoming_road` と `lane_id` の一致で接続レーンを解決するように変更
- この修正により、DEAD_END の誤判定が減少し、despawn ログの正確性が向上

## Test plan

- [ ] OSM マップで TrafficManager を使用した車両走行シナリオを実行し、`[TM DESPAWN]` ログが正しく出力されることを確認
- [ ] ジャンクション内の走行で不正な DEAD_END despawn が発生しないことを確認
- [ ] 既存の非 OSM マップでのリグレッションがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9605)
<!-- Reviewable:end -->
