### PR TITLE
fix: retry traffic light state when vehicle controller is not yet available

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -182,6 +182,15 @@ void UTrafficLightComponent::OnBeginOverlapTriggerBox(UPrimitiveComponent *Overl
       Vehicles.Add(VehicleController);
       VehicleController->SetTrafficLight(Cast<ATrafficLightBase>(GetOwner()));
     }
+    else
+    {
+      // Controller not yet available (vehicle spawned inside the trigger
+      // box before set_autopilot was called).  Queue for deferred retry.
+      PendingVehicles.AddUnique(Vehicle);
+      GetWorld()->GetTimerManager().SetTimerForNextTick(
+          FTimerDelegate::CreateUObject(this,
+              &UTrafficLightComponent::RetryPendingVehicles));
+    }
   }
 }
 
@@ -193,6 +202,7 @@ void UTrafficLightComponent::OnEndOverlapTriggerBox(UPrimitiveComponent *Overlap
   ACarlaWheeledVehicle * Vehicle = Cast<ACarlaWheeledVehicle>(OtherActor);
   if (Vehicle)
   {
+    PendingVehicles.Remove(Vehicle);
     AWheeledVehicleAIController* VehicleController =
         Cast<AWheeledVehicleAIController>(Vehicle->GetController());
     if (VehicleController)
@@ -200,6 +210,35 @@ void UTrafficLightComponent::OnEndOverlapTriggerBox(UPrimitiveComponent *Overlap
       VehicleController->SetTrafficLightState(ETrafficLightState::Green);
       VehicleController->SetTrafficLight(nullptr);
       Vehicles.Remove(VehicleController);
+    }
+  }
+}
+
+void UTrafficLightComponent::RetryPendingVehicles()
+{
+  for (int32 i = PendingVehicles.Num() - 1; i >= 0; --i)
+  {
+    ACarlaWheeledVehicle* Vehicle = PendingVehicles[i];
+    if (!IsValid(Vehicle))
+    {
+      PendingVehicles.RemoveAt(i);
+      continue;
+    }
+    AWheeledVehicleAIController* VehicleController =
+        Cast<AWheeledVehicleAIController>(Vehicle->GetController());
+    if (VehicleController)
+    {
+      VehicleController->SetTrafficLightState(LightState);
+      Vehicles.Add(VehicleController);
+      VehicleController->SetTrafficLight(Cast<ATrafficLightBase>(GetOwner()));
+      PendingVehicles.RemoveAt(i);
+    }
+    else
+    {
+      // Still no controller — retry next tick
+      GetWorld()->GetTimerManager().SetTimerForNextTick(
+          FTimerDelegate::CreateUObject(this,
+              &UTrafficLightComponent::RetryPendingVehicles));
     }
   }
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.h
@@ -12,6 +12,7 @@
 #include "Carla/Vehicle/WheeledVehicleAIController.h"
 #include "TrafficLightComponent.generated.h"
 
+class ACarlaWheeledVehicle;
 class ATrafficLightManager;
 class ATrafficLightGroup;
 class UTrafficLightController;
@@ -94,4 +95,11 @@ private:
   UPROPERTY()
   TArray<AWheeledVehicleAIController*> Vehicles;
 
+  /// Vehicles that entered the trigger box before their AI controller
+  /// was available (e.g. spawned inside the box before set_autopilot).
+  /// Re-checked on the next tick via a timer.
+  UPROPERTY()
+  TArray<ACarlaWheeledVehicle*> PendingVehicles;
+
+  void RetryPendingVehicles();
 };


### PR DESCRIPTION
## Summary

車両がトリガーボックス内にスポーンされた際に、AIコントローラーがまだ設定されていない場合に信号状態が適用されない問題を修正します。

## Problem

`OnBeginOverlapTriggerBox` で車両がトリガーボックスに進入した際、`Vehicle->GetController()` で `AWheeledVehicleAIController` を取得しますが、車両がトリガーボックス内にスポーンされてから `set_autopilot` が呼ばれるまでの間はコントローラーが `nullptr` になります。この場合、信号状態が車両に適用されず、車両が赤信号を無視して走行する原因となっていました。

## Changes

### TrafficLightComponent.h

- `ACarlaWheeledVehicle` の前方宣言を追加
- `PendingVehicles` 配列を追加: コントローラー未設定の車両を一時的に保持
- `RetryPendingVehicles()` メソッドを追加

### TrafficLightComponent.cpp

#### `OnBeginOverlapTriggerBox` の変更
- コントローラーが取得できなかった場合、車両を `PendingVehicles` に追加
- `SetTimerForNextTick` で次のティックに `RetryPendingVehicles` を呼び出すタイマーを設定

#### `OnEndOverlapTriggerBox` の変更
- 車両がトリガーボックスから出た際に `PendingVehicles` からも削除するように変更（リトライ対象から除外）

#### `RetryPendingVehicles()` (新規メソッド)
- `PendingVehicles` を逆順にイテレートし、各車両のコントローラーを再取得
- コントローラーが利用可能になった場合:
  - `SetTrafficLightState` で信号状態を適用
  - `Vehicles` 配列に追加
  - `SetTrafficLight` でオーナーの信号アクターを設定
  - `PendingVehicles` から削除
- コントローラーがまだ利用不可の場合: 次のティックに再度リトライをスケジュール
- 無効になった車両は自動的にリストから除去（`IsValid` チェック）

## Test plan

- [ ] トリガーボックス内に車両をスポーンし、`set_autopilot(True)` を呼び出した後に信号状態が正しく適用されることを確認
- [ ] 通常の走行でトリガーボックスに進入した車両の動作にリグレッションがないことを確認
- [ ] トリガーボックスから出た車両が `PendingVehicles` からクリーンアップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9606)
<!-- Reviewable:end -->
