### PR TITLE
fix: use lane travel direction for traffic light trigger box offset

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightComponent.cpp
@@ -71,7 +71,17 @@ void UTrafficLightComponent::InitializeSign(const carla::road::Map &Map)
         double LaneLength = Map.GetLane(signal_waypoint).GetLength();
         double LaneDistance = Map.GetLane(signal_waypoint).GetDistance();
         float AdditionalDistance = 1.5f;
-        if(lane < 0)
+        // Place the trigger box upstream of the signal (before the stop line
+        // in the direction of travel).  The travel direction depends on the
+        // road's traffic rule (RHT/LHT) and the lane-id sign, which is
+        // captured by Lane::IsPositiveDirection().
+        //   +s travel → upstream is -s  (subtract offset)
+        //   -s travel → upstream is +s  (add offset)
+        // The previous code used the lane-id sign alone, which only works for
+        // RHT roads.  On LHT roads with positive lane ids the offset was
+        // applied in the wrong direction, pushing the box past the road end
+        // and causing vehicles to miss the trigger volume entirely.
+        if(Map.GetLane(signal_waypoint).IsPositiveDirection())
         {
           signal_waypoint.s = FMath::Clamp(signal_waypoint.s - (BoxLength + AdditionalDistance),
               LaneDistance + epsilon, LaneDistance + LaneLength - epsilon);


### PR DESCRIPTION
## Summary

左側通行（LHT）の道路でトリガーボックスのオフセット方向が誤っていた問題を修正します。

## Problem

`UTrafficLightComponent::InitializeSign` において、信号のトリガーボックスを停止線の手前（走行方向上流側）に配置するためのオフセット計算で、`lane < 0` という条件でオフセット方向を決定していました。

- **右側通行（RHT）** の場合: 負のレーンID = 正のs方向に走行 → `lane < 0` で正しくオフセットが計算される
- **左側通行（LHT）** の場合: 正のレーンID でも正のs方向に走行するケースがあり、`lane < 0` 条件では逆方向にオフセットが適用される

この結果、LHT道路ではトリガーボックスが道路の終端を超えた位置に配置され、車両がトリガーボリュームを検知できず信号を無視する現象が発生していました。

## Changes

### TrafficLightComponent.cpp

- **修正前**: `if(lane < 0)` — レーンIDの符号でオフセット方向を判定
- **修正後**: `if(Map.GetLane(signal_waypoint).IsPositiveDirection())` — レーンの実際の走行方向（s値の増加方向に走行するか）でオフセット方向を判定

`Lane::IsPositiveDirection()` は道路の交通ルール（RHT/LHT）とレーンIDの符号の両方を考慮して走行方向を返すため、RHT・LHT の両方で正しく動作します:

| 走行方向 | オフセット |
|---|---|
| +s 方向に走行 (`IsPositiveDirection() == true`) | s を減算（上流側へ） |
| -s 方向に走行 (`IsPositiveDirection() == false`) | s を加算（上流側へ） |

## Test plan

- [ ] RHT マップ（デフォルトの Carla マップ）でトリガーボックスの位置が変わらないことを確認
- [ ] LHT マップでトリガーボックスが正しく停止線の手前に配置されることを確認
- [ ] LHT マップで車両が信号を正しく検知して停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9607)
<!-- Reviewable:end -->
