### PR TITLE
feat(LibCarla/ros2): [1/7] add DDS middleware abstraction layer for multi-vendor support

### DIFF
--- a/LibCarla/cmake/fast_dds/CMakeLists.txt
+++ b/LibCarla/cmake/fast_dds/CMakeLists.txt
@@ -9,6 +9,8 @@ file(GLOB libcarla_carla_fastdds_headers
   "${libcarla_source_path}/carla/ros2/subscribers/*.h"
   "${libcarla_source_path}/carla/ros2/listeners/*.h"
   "${libcarla_source_path}/carla/ros2/types/*.h"
+  "${libcarla_source_path}/carla/ros2/dds/*.h"
+  "${libcarla_source_path}/carla/ros2/dds/fastdds/*.h"
   )
 install(FILES ${libcarla_carla_fastdds_headers} DESTINATION include/carla/ros2)
 
@@ -30,6 +32,7 @@ file(GLOB libcarla_fastdds_sources
 if (LIBCARLA_BUILD_RELEASE)
   add_library(carla_fastdds STATIC ${libcarla_fastdds_sources})
 
+  target_compile_definitions(carla_fastdds PRIVATE CARLA_ROS2_DDS_FASTDDS)
   target_compile_options(carla_fastdds PRIVATE -fexceptions)
 
   target_include_directories(carla_fastdds SYSTEM PRIVATE
@@ -48,11 +51,15 @@ if (LIBCARLA_BUILD_DEBUG)
 
   add_library(carla_fastdds_debug STATIC ${libcarla_fastdds_sources})
 
+  target_compile_definitions(carla_fastdds_debug PRIVATE CARLA_ROS2_DDS_FASTDDS)
   target_compile_options(carla_fastdds_debug PRIVATE -fexceptions)
 
   target_include_directories(carla_fastdds_debug SYSTEM PRIVATE
       "${BOOST_INCLUDE_PATH}"
       "${RPCLIB_INCLUDE_PATH}")
+
+  target_include_directories(carla_fastdds_debug PRIVATE "${FASTDDS_INCLUDE_PATH}")
+  target_include_directories(carla_fastdds_debug PRIVATE "${libcarla_source_path}/carla/ros2")
   install(TARGETS carla_fastdds_debug DESTINATION lib)
   set_target_properties(carla_fastdds_debug PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}")
   target_compile_definitions(carla_fastdds_debug PUBLIC -DBOOST_ASIO_ENABLE_BUFFER_DEBUGGING)

--- a/LibCarla/source/carla/ros2/dds/DDSMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/DDSMiddleware.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <string>
+
+namespace carla {
+namespace ros2 {
+
+/// Enumeration of available DDS middleware implementations.
+/// Passed to ROS2::Enable() to select the middleware at startup.
+/// Once set, the middleware cannot be changed without restarting.
+enum class DDSMiddleware {
+  FastDDS
+};
+
+/// Convert a DDSMiddleware enum value to a readable string.
+inline const char* DDSMiddlewareToString(DDSMiddleware middleware) {
+  switch (middleware) {
+    case DDSMiddleware::FastDDS:
+      return "FastDDS";
+  }
+  return "Unknown";
+}
+
+/// Result of parsing a middleware name string.
+struct DDSMiddlewareParseResult {
+  bool valid;
+  DDSMiddleware middleware;
+};
+
+/// Parse a middleware name string (lowercase). Returns {true, middleware} on match,
+/// {false, FastDDS} for unrecognized values.
+inline DDSMiddlewareParseResult DDSMiddlewareFromString(const std::string& name) {
+  if (name == "fastdds") {
+    return {true, DDSMiddleware::FastDDS};
+  }
+  return {false, DDSMiddleware::FastDDS};
+}
+
+/// Return a readable list of middleware implementations compiled into this binary.
+inline std::string GetAvailableMiddlewareString() {
+  std::string result;
+#if defined(CARLA_ROS2_DDS_FASTDDS)
+  result += "FastDDS";
+#endif
+  if (result.empty()) {
+    result = "none";
+  }
+  return result;
+}
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/DDSMiddlewareFactory.h
+++ b/LibCarla/source/carla/ros2/dds/DDSMiddlewareFactory.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "carla/ros2/dds/DDSMiddleware.h"
+#include "carla/ros2/dds/IDDSPublisherMiddleware.h"
+#include "carla/ros2/dds/IDDSSubscriberMiddleware.h"
+#include "carla/Logging.h"
+
+#if defined(CARLA_ROS2_DDS_FASTDDS)
+#  include "carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h"
+#  include "carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h"
+#endif
+
+namespace carla {
+namespace ros2 {
+
+/// Factory that creates DDS publisher/subscriber middleware based on the active middleware selection.
+/// The middleware is set once at startup via SetMiddleware() before any DDS entities are created.
+/// After the first entity is created, changing the middleware has undefined behavior.
+class DDSMiddlewareFactory {
+ public:
+  /// Select the DDS middleware for all subsequent publisher/subscriber creation.
+  /// Must be called before any publisher or subscriber is initialized.
+  static void SetMiddleware(DDSMiddleware middleware) {
+    GetActiveMiddleware() = middleware;
+  }
+
+  /// @return The currently selected DDS middleware.
+  static DDSMiddleware GetMiddleware() {
+    return GetActiveMiddleware();
+  }
+
+  /// Check whether a specific middleware was compiled into this binary.
+  static bool IsMiddlewareAvailable(DDSMiddleware middleware) {
+    switch (middleware) {
+      case DDSMiddleware::FastDDS:
+#if defined(CARLA_ROS2_DDS_FASTDDS)
+        return true;
+#else
+        return false;
+#endif
+    }
+    return false;
+  }
+
+  /// Result of middleware resolution — whether resolution succeeded and which middleware to use.
+  struct MiddlewareResolution {
+    bool success;
+    DDSMiddleware middleware;
+  };
+
+  /// Resolve the requested middleware strictly — no fallback to other middleware.
+  /// Returns {true, requested} if available, {false, requested} otherwise.
+  static MiddlewareResolution ResolveMiddleware(DDSMiddleware requested) {
+    if (IsMiddlewareAvailable(requested)) {
+      return {true, requested};
+    }
+    return {false, requested};
+  }
+
+  /// Return a readable list of middleware implementations compiled into this binary.
+  /// Delegates to the free function in DDSMiddleware.h.
+  static std::string GetAvailableMiddlewareString() {
+    return carla::ros2::GetAvailableMiddlewareString();
+  }
+
+  /// Create a publisher middleware for traits type T.
+  /// T must provide:
+  ///   T::msg_type  — the message type
+  template<typename T>
+  static std::unique_ptr<IDDSPublisherMiddleware> CreatePublisher() {
+    switch (GetActiveMiddleware()) {
+      case DDSMiddleware::FastDDS:
+#if defined(CARLA_ROS2_DDS_FASTDDS)
+        return std::unique_ptr<IDDSPublisherMiddleware>(
+            new FastDDSPublisherMiddleware<T>());
+#else
+        log_error("DDSMiddlewareFactory: FastDDS not compiled in");
+        return nullptr;
+#endif
+    }
+    return nullptr;
+  }
+
+  /// Create a subscriber middleware for traits type S.
+  /// S must provide:
+  ///   S::msg_type  — the message type
+  template<typename S>
+  static std::unique_ptr<IDDSSubscriberMiddleware> CreateSubscriber() {
+    switch (GetActiveMiddleware()) {
+      case DDSMiddleware::FastDDS:
+#if defined(CARLA_ROS2_DDS_FASTDDS)
+        return std::unique_ptr<IDDSSubscriberMiddleware>(
+            new FastDDSSubscriberMiddleware<S>());
+#else
+        log_error("DDSMiddlewareFactory: FastDDS not compiled in");
+        return nullptr;
+#endif
+    }
+    return nullptr;
+  }
+
+ private:
+  /// Returns reference to the active middleware selection
+  /// (function-local static for C++11 thread safety).
+  static DDSMiddleware& GetActiveMiddleware() {
+    static DDSMiddleware active_middleware = DDSMiddleware::FastDDS;
+    return active_middleware;
+  }
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/IDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/IDDSPublisherMiddleware.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <string>
+
+namespace carla {
+namespace ros2 {
+
+/// Type-erased abstract interface for a DDS publisher middleware.
+/// Concrete implementations handle all vendor-specific DDS entity creation,
+/// type registration, and data writing.
+class IDDSPublisherMiddleware {
+ public:
+  virtual ~IDDSPublisherMiddleware() = default;
+
+  /// Initialize DDS entities (participant, publisher, topic, writer).
+  /// @param topic_name  Full DDS topic name including "rt/" prefix.
+  /// @return true on success.
+  virtual bool Init(const std::string& topic_name) = 0;
+
+  /// Serialize and write a message to the DDS network.
+  /// @param message_data  Pointer to the message object (type-erased, cast internally).
+  /// @return true if the write succeeded.
+  virtual bool Publish(void* message_data) = 0;
+
+  /// @return true if at least one subscriber is matched.
+  virtual bool IsAlive() const = 0;
+
+  /// @return The DDS topic name this publisher is bound to.
+  virtual std::string GetTopicName() const = 0;
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/IDDSSubscriberMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/IDDSSubscriberMiddleware.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <string>
+
+namespace carla {
+namespace ros2 {
+
+/// Type-erased abstract interface for a DDS subscriber middleware.
+/// Concrete implementations write received messages directly into the caller-provided
+/// storage (message_ptr / new_message_flag) to avoid an extra copy.
+class IDDSSubscriberMiddleware {
+ public:
+  virtual ~IDDSSubscriberMiddleware() = default;
+
+  /// Initialize DDS entities (participant, subscriber, topic, reader).
+  /// The middleware writes incoming messages to *message_ptr and sets *new_message_flag = true.
+  /// @param topic_name       Full DDS topic name.
+  /// @param message_ptr      Pointer to the message storage owned by SubscriberImpl<S>.
+  /// @param new_message_flag Pointer to the new-message flag owned by SubscriberImpl<S>.
+  /// @return true on success.
+  virtual bool Init(
+      const std::string& topic_name,
+      void* message_ptr,
+      bool* new_message_flag) = 0;
+
+  /// @return true if at least one publisher is matched.
+  virtual bool IsAlive() const = 0;
+
+  /// @return The DDS topic name this subscriber is bound to.
+  virtual std::string GetTopicName() const = 0;
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/ros2/dds/IDDSPublisherMiddleware.h"
+#include "carla/ros2/dds/fastdds/FastDDSTypeMap.h"
+#include "carla/Logging.h"
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/publisher/DataWriterListener.hpp>
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
+#include <fastrtps/attributes/ParticipantAttributes.h>
+#include <fastrtps/qos/QosPolicies.h>
+
+namespace carla {
+namespace ros2 {
+
+namespace efd = eprosima::fastdds::dds;
+using erc = eprosima::fastrtps::types::ReturnCode_t;
+
+/// FastDDS implementation of IDDSPublisherMiddleware.
+/// Parameterized on a traits type T that provides:
+///   T::msg_type  — the message type
+/// Native FastDDS types are resolved via FastDDSTypeMap<T::msg_type>.
+template<typename T>
+class FastDDSPublisherMiddleware
+    : public IDDSPublisherMiddleware,
+      public eprosima::fastdds::dds::DataWriterListener {
+ public:
+  using msg_type = typename T::msg_type;
+  using type_map = FastDDSTypeMap<msg_type>;
+  using fastdds_type = typename type_map::fastdds_type;
+  using fastdds_pubsub_type = typename type_map::fastdds_pubsub_type;
+
+  void on_publication_matched(
+      efd::DataWriter* writer,
+      const efd::PublicationMatchedStatus& info) override {
+    _alive = (info.total_count > 0);
+  }
+
+  ~FastDDSPublisherMiddleware() override {
+    if (_datawriter) {
+      _publisher->delete_datawriter(_datawriter);
+    }
+    if (_publisher) {
+      _participant->delete_publisher(_publisher);
+    }
+    if (_topic) {
+      _participant->delete_topic(_topic);
+    }
+    if (_participant) {
+      efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
+    }
+  }
+
+  bool Init(const std::string& topic_name) override {
+    if (_type == nullptr) {
+      log_error("FastDDSPublisherMiddleware: Invalid TypeSupport");
+      return false;
+    }
+
+    efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
+    auto factory = efd::DomainParticipantFactory::get_instance();
+    _participant = factory->create_participant(0, pqos);
+    if (_participant == nullptr) {
+      log_error("FastDDSPublisherMiddleware: Failed to create DomainParticipant");
+      return false;
+    }
+    _type.register_type(_participant);
+
+    efd::PublisherQos pubqos = efd::PUBLISHER_QOS_DEFAULT;
+    _publisher = _participant->create_publisher(pubqos, nullptr);
+    if (_publisher == nullptr) {
+      log_error("FastDDSPublisherMiddleware: Failed to create Publisher");
+      return false;
+    }
+
+    efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
+    _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    if (_topic == nullptr) {
+      log_error("FastDDSPublisherMiddleware: Failed to create Topic");
+      return false;
+    }
+
+    efd::DataWriterQos wqos = efd::DATAWRITER_QOS_DEFAULT;
+    wqos.endpoint().history_memory_policy =
+        eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    efd::DataWriterListener* listener =
+        static_cast<efd::DataWriterListener*>(this);
+    _datawriter = _publisher->create_datawriter(_topic, wqos, listener);
+    if (_datawriter == nullptr) {
+      log_error("FastDDSPublisherMiddleware: Failed to create DataWriter");
+      return false;
+    }
+
+    _topic_name = topic_name;
+    return true;
+  }
+
+  bool Publish(void* message_data) override {
+    auto* msg = static_cast<msg_type*>(message_data);
+    to_fastdds(*msg, _fastdds_msg);
+    eprosima::fastrtps::rtps::InstanceHandle_t instance_handle;
+    erc rcode = _datawriter->write(&_fastdds_msg, instance_handle);
+    if (rcode == erc::ReturnCodeValue::RETCODE_OK) {
+      return true;
+    }
+    log_error("FastDDSPublisherMiddleware::Publish (",
+        _topic_name, ") failed with code:", rcode());
+    return false;
+  }
+
+  bool IsAlive() const override {
+    return _alive;
+  }
+
+  std::string GetTopicName() const override {
+    return _topic_name;
+  }
+
+ private:
+  efd::DomainParticipant* _participant { nullptr };
+  efd::Publisher*         _publisher   { nullptr };
+  efd::Topic*             _topic       { nullptr };
+  efd::DataWriter*        _datawriter  { nullptr };
+  efd::TypeSupport        _type        { new fastdds_pubsub_type() };
+
+  fastdds_type _fastdds_msg;
+  std::string  _topic_name;
+  bool         _alive { false };
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/ros2/dds/IDDSSubscriberMiddleware.h"
+#include "carla/ros2/dds/fastdds/FastDDSTypeMap.h"
+#include "carla/Logging.h"
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/dds/subscriber/DataReaderListener.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
+#include <fastrtps/attributes/ParticipantAttributes.h>
+#include <fastrtps/qos/QosPolicies.h>
+
+namespace carla {
+namespace ros2 {
+
+namespace efd = eprosima::fastdds::dds;
+using erc = eprosima::fastrtps::types::ReturnCode_t;
+
+/// FastDDS implementation of IDDSSubscriberMiddleware.
+/// Parameterized on traits type S that provides:
+///   S::msg_type  — the message type
+/// Native FastDDS types are resolved via FastDDSTypeMap<S::msg_type>.
+template<typename S>
+class FastDDSSubscriberMiddleware
+    : public IDDSSubscriberMiddleware,
+      public eprosima::fastdds::dds::DataReaderListener {
+ public:
+  using msg_type = typename S::msg_type;
+  using type_map = FastDDSTypeMap<msg_type>;
+  using fastdds_type = typename type_map::fastdds_type;
+  using fastdds_pubsub_type = typename type_map::fastdds_pubsub_type;
+
+  void on_subscription_matched(
+      efd::DataReader* reader,
+      const efd::SubscriptionMatchedStatus& info) override {
+    _alive = (info.total_count > 0);
+  }
+
+  void on_data_available(efd::DataReader* reader) override {
+    efd::SampleInfo info;
+    erc rcode = reader->take_next_sample(&_fastdds_msg, &info);
+    if (rcode == erc::ReturnCodeValue::RETCODE_OK) {
+      from_fastdds(_fastdds_msg, *_message_ptr);
+      *_new_message_ptr = true;
+    } else {
+      log_error("FastDDSSubscriberMiddleware::on_data_available (",
+          _topic_name, ") failed with code:", rcode());
+    }
+  }
+
+  ~FastDDSSubscriberMiddleware() override {
+    if (_datareader) {
+      _subscriber->delete_datareader(_datareader);
+    }
+    if (_subscriber) {
+      _participant->delete_subscriber(_subscriber);
+    }
+    if (_topic) {
+      _participant->delete_topic(_topic);
+    }
+    if (_participant) {
+      efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
+    }
+  }
+
+  bool Init(
+      const std::string& topic_name,
+      void* message_ptr,
+      bool* new_message_flag) override {
+    _message_ptr     = static_cast<msg_type*>(message_ptr);
+    _new_message_ptr = new_message_flag;
+
+    if (_type == nullptr) {
+      log_error("FastDDSSubscriberMiddleware: Invalid TypeSupport");
+      return false;
+    }
+
+    efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
+    auto factory = efd::DomainParticipantFactory::get_instance();
+    _participant = factory->create_participant(0, pqos);
+    if (_participant == nullptr) {
+      log_error("FastDDSSubscriberMiddleware: Failed to create DomainParticipant");
+      return false;
+    }
+    _type.register_type(_participant);
+
+    efd::SubscriberQos subqos = efd::SUBSCRIBER_QOS_DEFAULT;
+    _subscriber = _participant->create_subscriber(subqos, nullptr);
+    if (_subscriber == nullptr) {
+      log_error("FastDDSSubscriberMiddleware: Failed to create Subscriber");
+      return false;
+    }
+
+    efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
+    _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    if (_topic == nullptr) {
+      log_error("FastDDSSubscriberMiddleware: Failed to create Topic");
+      return false;
+    }
+
+    efd::DataReaderQos rqos = efd::DATAREADER_QOS_DEFAULT;
+    efd::DataReaderListener* listener =
+        static_cast<efd::DataReaderListener*>(this);
+    _datareader = _subscriber->create_datareader(_topic, rqos, listener);
+    if (_datareader == nullptr) {
+      log_error("FastDDSSubscriberMiddleware: Failed to create DataReader");
+      return false;
+    }
+
+    _topic_name = topic_name;
+    return true;
+  }
+
+  bool IsAlive() const override {
+    return _alive;
+  }
+
+  std::string GetTopicName() const override {
+    return _topic_name;
+  }
+
+ private:
+  efd::DomainParticipant* _participant { nullptr };
+  efd::Subscriber*        _subscriber  { nullptr };
+  efd::Topic*             _topic       { nullptr };
+  efd::DataReader*        _datareader  { nullptr };
+  efd::TypeSupport        _type        { new fastdds_pubsub_type() };
+
+  fastdds_type _fastdds_msg;
+  msg_type*    _message_ptr     { nullptr };
+  bool*        _new_message_ptr { nullptr };
+
+  std::string _topic_name;
+  bool        _alive { false };
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSTypeMap.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSTypeMap.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+// Identity-mapping version: msg_type IS the FastDDS type, so each
+// specialization maps a type to itself.
+
+#pragma once
+
+// PubSubType headers for type registration
+#include "carla/ros2/types/NavSatFixPubSubTypes.h"
+#include "carla/ros2/types/ImagePubSubTypes.h"
+#include "carla/ros2/types/CameraInfoPubSubTypes.h"
+#include "carla/ros2/types/ImuPubSubTypes.h"
+#include "carla/ros2/types/PointCloud2PubSubTypes.h"
+#include "carla/ros2/types/ClockPubSubTypes.h"
+#include "carla/ros2/types/TFMessagePubSubTypes.h"
+#include "carla/ros2/types/CarlaCollisionEventPubSubTypes.h"
+#include "carla/ros2/types/CarlaEgoVehicleControlPubSubTypes.h"
+#include "carla/ros2/types/AckermannDriveStampedPubSubTypes.h"
+
+namespace carla {
+namespace ros2 {
+
+/// Maps a message type to its FastDDS native type and PubSubType.
+/// Primary template is intentionally undefined — only specializations are valid.
+template<typename MsgType> struct FastDDSTypeMap;
+
+// --- Identity specializations ---
+// In the current codebase, msg_type is already the FastDDS-generated type.
+// Each specialization maps the type to itself and its corresponding PubSubType.
+
+template<> struct FastDDSTypeMap<sensor_msgs::msg::NavSatFix> {
+  using fastdds_type = sensor_msgs::msg::NavSatFix;
+  using fastdds_pubsub_type = sensor_msgs::msg::NavSatFixPubSubType;
+};
+
+template<> struct FastDDSTypeMap<sensor_msgs::msg::Image> {
+  using fastdds_type = sensor_msgs::msg::Image;
+  using fastdds_pubsub_type = sensor_msgs::msg::ImagePubSubType;
+};
+
+template<> struct FastDDSTypeMap<sensor_msgs::msg::CameraInfo> {
+  using fastdds_type = sensor_msgs::msg::CameraInfo;
+  using fastdds_pubsub_type = sensor_msgs::msg::CameraInfoPubSubType;
+};
+
+template<> struct FastDDSTypeMap<sensor_msgs::msg::Imu> {
+  using fastdds_type = sensor_msgs::msg::Imu;
+  using fastdds_pubsub_type = sensor_msgs::msg::ImuPubSubType;
+};
+
+template<> struct FastDDSTypeMap<sensor_msgs::msg::PointCloud2> {
+  using fastdds_type = sensor_msgs::msg::PointCloud2;
+  using fastdds_pubsub_type = sensor_msgs::msg::PointCloud2PubSubType;
+};
+
+template<> struct FastDDSTypeMap<rosgraph::msg::Clock> {
+  using fastdds_type = rosgraph::msg::Clock;
+  using fastdds_pubsub_type = rosgraph::msg::ClockPubSubType;
+};
+
+template<> struct FastDDSTypeMap<tf2_msgs::msg::TFMessage> {
+  using fastdds_type = tf2_msgs::msg::TFMessage;
+  using fastdds_pubsub_type = tf2_msgs::msg::TFMessagePubSubType;
+};
+
+template<> struct FastDDSTypeMap<carla_msgs::msg::CarlaCollisionEvent> {
+  using fastdds_type = carla_msgs::msg::CarlaCollisionEvent;
+  using fastdds_pubsub_type = carla_msgs::msg::CarlaCollisionEventPubSubType;
+};
+
+template<> struct FastDDSTypeMap<carla_msgs::msg::CarlaEgoVehicleControl> {
+  using fastdds_type = carla_msgs::msg::CarlaEgoVehicleControl;
+  using fastdds_pubsub_type = carla_msgs::msg::CarlaEgoVehicleControlPubSubType;
+};
+
+template<> struct FastDDSTypeMap<ackermann_msgs::msg::AckermannDriveStamped> {
+  using fastdds_type = ackermann_msgs::msg::AckermannDriveStamped;
+  using fastdds_pubsub_type = ackermann_msgs::msg::AckermannDriveStampedPubSubType;
+};
+
+/// Identity conversion: copy src to dst when both types are the same.
+/// In the next phase, we will replace these with real POD-to-FastDDS conversions.
+template<typename T>
+inline void to_fastdds(const T& src, T& dst) {
+  dst = src;
+}
+
+template<typename T>
+inline void from_fastdds(const T& src, T& dst) {
+  dst = src;
+}
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
+++ b/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
@@ -5,112 +5,40 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
-#include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
-
-#include <fastdds/dds/topic/Topic.hpp>
-#include <fastdds/dds/topic/TypeSupport.hpp>
-
-#include <fastdds/dds/publisher/Publisher.hpp>
-#include <fastdds/dds/publisher/DataWriter.hpp>
-#include <fastdds/dds/publisher/DataWriterListener.hpp>
-#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-
-#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
-
-#include <fastdds/dds/topic/qos/TopicQos.hpp>
-
-#include <fastrtps/attributes/ParticipantAttributes.h>
-#include <fastrtps/qos/QosPolicies.h>
-
+#include "carla/ros2/dds/DDSMiddlewareFactory.h"
 #include "carla/Logging.h"
 
 namespace carla {
 namespace ros2 {
 
-  namespace efd = eprosima::fastdds::dds;
-  using erc = eprosima::fastrtps::types::ReturnCode_t;
-
   template<typename T>
-  class PublisherImpl : public eprosima::fastdds::dds::DataWriterListener {
+  class PublisherImpl {
   public:
     using msg_type = typename T::msg_type;
-    using msg_pubsub_type = typename T::msg_pubsub_type;
-
-    efd::DomainParticipant* _participant { nullptr };
-    efd::Publisher* _publisher { nullptr };
-    efd::Topic* _topic { nullptr };
-    efd::DataWriter* _datawriter { nullptr };
-    efd::TypeSupport _type { new msg_pubsub_type() };
-
-    void on_publication_matched(efd::DataWriter* /*writer*/, const efd::PublicationMatchedStatus& info) override {
-      _alive = (info.total_count > 0) ? true : false;
-    }
-
-    ~PublisherImpl() {
-      if (_datawriter)
-        _publisher->delete_datawriter(_datawriter);
-
-      if (_publisher)
-        _participant->delete_publisher(_publisher);
-
-      if (_topic)
-        _participant->delete_topic(_topic);
-
-      if (_participant)
-        efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
-    }
 
     bool Init(std::string topic_name) {
-      if (_type == nullptr) {
-        log_error("Invalid TypeSupport");
+      _middleware = DDSMiddlewareFactory::CreatePublisher<T>();
+      if (!_middleware) {
+        log_error("PublisherImpl: Failed to create middleware publisher");
         return false;
       }
-
-      efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
-      auto factory = efd::DomainParticipantFactory::get_instance();
-      _participant = factory->create_participant(0, pqos);
-      if (_participant == nullptr) {
-        log_error("Failed to create DomainParticipant");
-        return false;
-      }
-      _type.register_type(_participant);
-
-      efd::PublisherQos pubqos = efd::PUBLISHER_QOS_DEFAULT;
-      _publisher = _participant->create_publisher(pubqos, nullptr);
-      if (_publisher == nullptr) {
-        log_error("Failed to create Publisher");
-        return false;
-      }
-
-      efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
-      _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
-      if (_topic == nullptr) {
-        log_error("Failed to create Topic");
-        return false;
-      }
-
-      efd::DataWriterQos wqos = efd::DATAWRITER_QOS_DEFAULT;
-      wqos.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-      efd::DataWriterListener* listener = static_cast<efd::DataWriterListener*>(this);
-      _datawriter = _publisher->create_datawriter(_topic, wqos, listener);
-      if (_datawriter == nullptr) {
-        std::cerr << "Failed to create DataWriter" << std::endl;
-        return false;
-      }
-
-      _topic_name = topic_name;
-      return true;
+      return _middleware->Init(topic_name);
     }
 
     std::string GetTopicName() {
-      return _topic_name;
+      if (_middleware) {
+        return _middleware->GetTopicName();
+      }
+      return "";
     }
 
     bool IsAlive() {
-      return _alive;
+      if (_middleware) {
+        return _middleware->IsAlive();
+      }
+      return false;
     }
 
     msg_type* GetMessage() {
@@ -118,20 +46,15 @@ namespace ros2 {
     }
 
     bool Publish() {
-      eprosima::fastrtps::rtps::InstanceHandle_t instance_handle;
-      eprosima::fastrtps::types::ReturnCode_t rcode = _datawriter->write(&_message, instance_handle);
-      if (rcode == eprosima::fastrtps::types::ReturnCode_t::ReturnCodeValue::RETCODE_OK) {
-        return true;
-      } else {
-        log_error("PublisherImpl::Publish (", this->GetTopicName(), ") failed with code:", rcode());
+      if (!_middleware) {
+        log_error("PublisherImpl::Publish called before Init");
         return false;
       }
+      return _middleware->Publish(&_message);
     }
 
   private:
-    std::string _topic_name;
-
-    bool _alive { false };
+    std::unique_ptr<IDDSPublisherMiddleware> _middleware;
     msg_type _message;
   };
 

--- a/LibCarla/source/carla/ros2/subscribers/SubscriberImpl.h
+++ b/LibCarla/source/carla/ros2/subscribers/SubscriberImpl.h
@@ -5,129 +5,41 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "carla/ros2/subscribers/BaseSubscriber.h"
-
-#include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
-
-#include <fastdds/dds/topic/Topic.hpp>
-#include <fastdds/dds/topic/TypeSupport.hpp>
-
-#include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/dds/subscriber/DataReader.hpp>
-#include <fastdds/dds/subscriber/DataReaderListener.hpp>
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
-#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
-#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
-
-#include <fastdds/dds/topic/qos/TopicQos.hpp>
-
-#include <fastrtps/attributes/ParticipantAttributes.h>
-#include <fastrtps/qos/QosPolicies.h>
-
+#include "carla/ros2/dds/DDSMiddlewareFactory.h"
 #include "carla/Logging.h"
 
 namespace carla {
 namespace ros2 {
 
-  namespace efd = eprosima::fastdds::dds;
-  using erc = eprosima::fastrtps::types::ReturnCode_t;
-
   template<typename S>
-  class SubscriberImpl : public eprosima::fastdds::dds::DataReaderListener {
+  class SubscriberImpl {
   public:
     using msg_type = typename S::msg_type;
-    using msg_pubsub_type = typename S::msg_pubsub_type;
 
-    efd::DomainParticipant* _participant { nullptr };
-    efd::Subscriber* _subscriber { nullptr };
-    efd::Topic* _topic { nullptr };
-    efd::DataReader* _datareader { nullptr };
-    efd::TypeSupport _type { new msg_pubsub_type() };
-
-    void on_subscription_matched(efd::DataReader* /*reader*/, const efd::SubscriptionMatchedStatus& info) override {
-      _alive = (info.total_count > 0) ? true : false;
-    }
-
-    void on_data_available(efd::DataReader* reader) override {
-      efd::SampleInfo info;
-      msg_type message;
-
-      eprosima::fastrtps::types::ReturnCode_t rcode = reader->take_next_sample(&_message, &info);
-      if (rcode == eprosima::fastrtps::types::ReturnCode_t::ReturnCodeValue::RETCODE_OK) {
-        // TODO: Process messages directly.
-        _new_message = true;
-      } else {
-        log_error("SubscriberImpl::on_data_available (", this->GetTopicName(), ") failed with code:", rcode());
-      }
-    }
-
-    ~SubscriberImpl() {
-      if (_datareader)
-        _subscriber->delete_datareader(_datareader);
-
-      if (_subscriber)
-        _participant->delete_subscriber(_subscriber);
-
-      if (_topic)
-        _participant->delete_topic(_topic);
-
-      if (_participant)
-        efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
-    }
-
-    // bool Init(std::string topic_name, S *subscriber) {
     bool Init(std::string topic_name) {
-      if (_type == nullptr) {
-        log_error("Invalid TypeSupport");
+      _middleware = DDSMiddlewareFactory::CreateSubscriber<S>();
+      if (!_middleware) {
+        log_error("SubscriberImpl: Failed to create middleware subscriber");
         return false;
       }
-
-      efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
-      auto factory = efd::DomainParticipantFactory::get_instance();
-      _participant = factory->create_participant(0, pqos);
-      if (_participant == nullptr) {
-        log_error("Failed to create DomainParticipant");
-        return false;
-      }
-      _type.register_type(_participant);
-
-      efd::SubscriberQos subqos = efd::SUBSCRIBER_QOS_DEFAULT;
-      _subscriber = _participant->create_subscriber(subqos, nullptr);
-      if (_subscriber == nullptr) {
-        log_error("Failed to create Subscriber");
-        return false;
-      }
-
-      efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
-      _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
-      if (_topic == nullptr) {
-        log_error("Failed to create Topic");
-        return false;
-      }
-
-      efd::DataReaderQos rqos = efd::DATAREADER_QOS_DEFAULT;
-      efd::DataReaderListener* listener = static_cast<efd::DataReaderListener*>(this);
-      _datareader = _subscriber->create_datareader(_topic, rqos, listener);
-      if (_datareader == nullptr) {
-        log_error("Failed to create DataReader");
-        return false;
-      }
-
-      _topic_name = topic_name;
-
-      // _subscriber = subscriber;
-      return true;
+      return _middleware->Init(topic_name, &_message, &_new_message);
     }
 
     std::string GetTopicName() {
-      return _topic_name;
+      if (_middleware) {
+        return _middleware->GetTopicName();
+      }
+      return "";
     }
 
     bool IsAlive() {
-      return _alive;
+      if (_middleware) {
+        return _middleware->IsAlive();
+      }
+      return false;
     }
 
     msg_type GetMessage() {
@@ -138,11 +50,9 @@ namespace ros2 {
     bool HasNewMessage() { return _new_message; }
 
   private:
-    std::string _topic_name;
-
-    bool _alive { false };
-    bool _new_message { false };
+    std::unique_ptr<IDDSSubscriberMiddleware> _middleware;
     msg_type _message;
+    bool _new_message { false };
   };
 
 }  // namespace ros2


### PR DESCRIPTION
Introduce a strategy-pattern abstraction that decouples PublisherImpl and SubscriberImpl from the FastDDS API, enabling future integration of additional DDS middleware implementations (e.g. CycloneDDS).

<img width="2834" height="937" alt="ros2-carla-pr1" src="https://github.com/user-attachments/assets/ee619481-5eda-4e86-98db-6d3deebdc214" />

New abstraction layer (LibCarla/source/carla/ros2/dds/):
- DDSMiddleware enum and string conversion utilities
- IDDSPublisherMiddleware / IDDSSubscriberMiddleware pure virtual interfaces
- DDSMiddlewareFactory with thread-safe middleware selection and creation
- FastDDSPublisherMiddleware<T> / FastDDSSubscriberMiddleware\<S> template implementations behind the new interfaces
- FastDDSTypeMap<T> identity-mapping type traits (to be replaced with real conversions when POD message types are introduced)

Modified files:
- PublisherImpl.h: replaced direct FastDDS inheritance and members with delegation to IDDSPublisherMiddleware via the factory (public API unchanged)
- SubscriberImpl.h: same pattern for subscriber side
- cmake/fast_dds/CMakeLists.txt: added CARLA_ROS2_DDS_FASTDDS compile definition, new header globs, and fixed missing include directories in the debug build target

No behavior change - FastDDS remains the only compiled middleware. Concrete publishers and subscribers are unaffected.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR introduces a DDS middleware abstraction layer that decouples `PublisherImpl` and `SubscriberImpl` from the FastDDS API, laying the groundwork for supporting multiple DDS middleware implementations in CARLA's native ROS2 integration.

This is the first in a series of PRs that incrementally implements the decoupled DDS middleware architecture originally prototyped in draft PR #9589. The end goal is to support multiple DDS backends, starting with CycloneDDS, so users can choose the most appropriate middleware for their deployment.

These changes do not affect current behavior. FastDDS remains the only compiled middleware, and all concrete publishers and subscribers remain unchanged.

### What's new

**Abstraction layer** (`LibCarla/source/carla/ros2/dds/`):
- `DDSMiddleware` - enum and string conversion utilities for middleware selection
- `IDDSPublisherMiddleware` / `IDDSSubscriberMiddleware` - type-erased pure virtual interfaces
- `DDSMiddlewareFactory` - static factory with thread-safe middleware selection and creation via `SetMiddleware()`, `CreatePublisher<T>()`, and `CreateSubscriber<S>()`
- `FastDDSPublisherMiddleware<T>` / `FastDDSSubscriberMiddleware<S>` - FastDDS implementations behind the new interfaces
- `FastDDSTypeMap<T>` - identity-mapping type traits that will be replaced with real conversions when POD message types are introduced in a future PR

**Modified files:**
- `PublisherImpl.h` - removed direct FastDDS inheritance and raw DDS entity members; now delegates to `std::unique_ptr<IDDSPublisherMiddleware>` via the factory while keeping the public API unchanged
- `SubscriberImpl.h` - same delegation pattern for the subscriber side
- `cmake/fast_dds/CMakeLists.txt` - added `CARLA_ROS2_DDS_FASTDDS` compile definition for both release and debug targets, added new header globs for `dds/` and `dds/fastdds/`, and fixed pre-existing missing include directories in the debug build target

### Design decisions

- **"Middleware" naming** instead of "Backend" to align with ROS2 ecosystem terminology (`RMW` = ROS Middleware)
- **Strategy pattern** so middleware can be selected once at startup and instantiated through the factory
- **Identity TypeMap** because `msg_type` is currently already the FastDDS type; this will evolve into real conversion logic once POD message types are introduced
- **No CycloneDDS references in this PR** to keep the scope focused on the abstraction and FastDDS reimplementation only

### PR series

This PR is part of the DDS middleware decoupling series ([#9294](https://github.com/carla-simulator/carla/issues/9294)). Each PR in the chain inherits the commits of all prior PRs. The **Commits** column lists only the commits introduced by that PR, and the **Files** column counts only the files changed by those new commits.

| # | PR | Title | Branch | Commits | Files |
|---|----|-------|--------|---------|-------|
| **1/7** | **[#9608](https://github.com/carla-simulator/carla/pull/9608)** | **DDS middleware abstraction layer (this PR)** | `feature/dds-middleware-abstraction-layer` | `0ab35ee6` | **10** |
| 2/7 | [#9612](https://github.com/carla-simulator/carla/pull/9612) | POD message types, FastDDS conversions, and TypeMap specializations | `feature/ros2-pod-types-and-fastdds-conversions` | `e665d2af` | 39 |
| 3/7 | [#9619](https://github.com/carla-simulator/carla/pull/9619) | Migrate publishers and subscribers to POD message types | `feature/ros2-publishers-pod-types-migration` | `98b6f7aa` | 27 |
| 4/7 | [#9620](https://github.com/carla-simulator/carla/pull/9620) | CycloneDDS enum, factory, stubs, and tests | `feature/ros2-cyclonedds-enum-factory` | `2a4a8db3` | 5 |
| 5/7 | [#9643](https://github.com/carla-simulator/carla/pull/9643) | Unified CDR serialization + `GenericCdrPubSubType` | `feature/ros2-cdr-serialization` | `5a9dd3b4`, `0a9ca585` | 8 |
| 6/7 | [#9644](https://github.com/carla-simulator/carla/pull/9644) | CycloneDDS CDR middleware, UE4 runtime selection, and correctness fixes | `feature/ros2-cyclonedds-cdr-middleware` | `d3f2a45b`, `2d80046b` | 26 |
| 7/7 | [#9645](https://github.com/carla-simulator/carla/pull/9645) | Remove legacy FastDDS-generated type files | `feature/ros2-remove-fastdds-generated-types` | `eea4e0a4` | 125 |

### Related

- Draft PR #9589 - contains the full CycloneDDS implementation as a single large changeset; this PR series replaces that approach with smaller, reviewable incremental PRs

Fixes #9294

#### Where has this been tested?

* **Platform(s):** Linux Ubuntu 22.04
* **Python version(s):** 3.10, 3.11, 3.12
* **Unreal Engine version(s):** UE4

#### Possible Drawbacks

- This PR introduces an additional abstraction layer, which slightly increases architectural complexity.
- The new factory and interface structure adds indirection that may make debugging more involved compared to the previous direct FastDDS coupling.
- At this stage, the abstraction only wraps FastDDS, so the immediate functional benefit is architectural preparation rather than new user-visible functionality.

## Compilation steps

```bash
# 1. Setup all dependencies (FastDDS, CycloneDDS, Chrono, etc.)
make setup ARGS="--python-version=3.10,3.11,3.12 --ros2 --target-wheel-platform=manylinux_2_31_x86_64"

# 2. Build LibCarla (server + client, debug + release, both DDS backends)
make LibCarla ARGS="--python-version=3.10,3.11,3.12 --ros2 --target-wheel-platform=manylinux_2_31_x86_64"

# 3. Build PythonAPI
make PythonAPI ARGS="--python-version=3.10,3.11,3.12 --ros2 --target-wheel-platform=manylinux_2_31_x86_64"

# 4. Build CarlaUE4Editor
make CarlaUE4Editor ARGS="--python-version=3.10,3.11,3.12--ros2 --target-wheel-platform=manylinux_2_31_x86_64"

# 5. Build the final package
make package ARGS="--python-version=3.10,3.11,3.12 --ros2 --target-wheel-platform=manylinux_2_31_x86_64 --no-zip"
```

## Test plan

- [ ] Verify `make LibCarla ARGS="--ros2"` compiles successfully (release build)
- [ ] Verify debug build compiles with the fixed include directories
- [ ] Verify `make check.LibCarla` passes (no regressions)
- [ ] Verify no concrete publisher/subscriber files were modified (only `PublisherImpl.h` and `SubscriberImpl.h`)
- [ ] Verify file count: 10 files changed (7 new + 3 modified)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9608)
<!-- Reviewable:end -->