### PR TITLE
Updated .gitignore file to include the capability to work locally with the JetBrains suite (PyCharm, CLion).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .vs/
 .vscode/
 .cache/
+.devcontainer/
+.idea/
+cmake-build-*/
 __pycache__/
 
 Build/


### PR DESCRIPTION
Updated `.gitignore` to better support local development environments.

Added ignore rules for JetBrains IDE files (`.idea/`), Dev Container configuration (`.devcontainer/`), and local CMake build directories (`cmake-build-*/`) so these local-only artifacts do not get committed accidentally.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This change updates the root `.gitignore` to cover additional local development artifacts.

The following entries were added:

- `.devcontainer/`
- `.idea/`
- `cmake-build-*/`

These paths are generated by local developer tooling and should not be tracked in the repository. This helps keep commits clean and avoids accidental inclusion of machine-specific configuration or local build outputs.

Fixes #  <!-- N/A -->

#### Where has this been tested?

  * **Platform(s):** N/A
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** N/A

#### Possible Drawbacks

Very low risk. The only impact is that local IDE, devcontainer, and CMake build files matching these patterns will now be ignored by Git.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9613)
<!-- Reviewable:end -->
