### PR TITLE
fix(ros2): correct PointField descriptors in DVS camera publisher

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
@@ -489,10 +489,10 @@ namespace ros2 {
     descriptor3.datatype(sensor_msgs::msg::PointField__FLOAT64);
     descriptor3.count(1);
     sensor_msgs::msg::PointField descriptor4;
-    descriptor3.name("pol");
-    descriptor3.offset(12);
-    descriptor3.datatype(sensor_msgs::msg::PointField__INT8);
-    descriptor3.count(1);
+    descriptor4.name("pol");
+    descriptor4.offset(12);
+    descriptor4.datatype(sensor_msgs::msg::PointField__INT8);
+    descriptor4.count(1);
 
     const size_t point_size = sizeof(carla::sensor::data::DVSEvent);
     _point_cloud->_pc.width(width);


### PR DESCRIPTION
#### Description

Fix a copy-paste bug in `CarlaDVSCameraPublisher::SetPointCloudData` where `descriptor4` (for the `pol` field) was incorrectly assigned using `descriptor3`, causing:
  1. `descriptor3` (`t` field) to be overwritten with `pol` field values
  2. `descriptor4` to remain uninitialized

The PointCloud2 message published by the DVS camera sensor had incorrect field metadata, making it unusable by downstream ROS 2 consumers. I found it in the https://github.com/carla-simulator/carla/pull/9638#discussion_r3029474170.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. This is a straightforward bug fix with no behavioral change beyond correcting the PointField metadata.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9649)
<!-- Reviewable:end -->
