### PR TITLE
fix(sensor): correct IMU gravity direction for ROS 2 coordinate system

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -106,7 +106,7 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(
   // Used to convert from UE4's cm to meters
   constexpr float TO_METERS = 1e-2;
   // Earth's gravitational acceleration is approximately 9.81 m/s^2
-  constexpr float GRAVITY = 9.81f;
+  constexpr float GRAVITY = -9.81f;
 
   // 2nd derivative of the polynomic (quadratic) interpolation
   // using the point in current time and two previous steps:


### PR DESCRIPTION
#### Description

Fix the gravity constant sign in `AInertialMeasurementUnit::ComputeAccelerometer`. https://github.com/carla-simulator/carla/commit/42f95831efc20dcba66e17025d0035138a8d3113 The constant `9.81f` (positive) but should be `-9.81f` (negative) to correctly represent gravitational acceleration in the ROS 2 coordinate system (right-handed, Z up).

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

Existing users relying on the previous (incorrect) gravity sign in ROS 2 IMU output may need to update their processing pipelines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9650)
<!-- Reviewable:end -->
