### PR TITLE
fix(‎LibCarla): add buffer_map guard to prevent segfault on destroyed vehicles

### DIFF
--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -341,6 +341,9 @@ SimpleWaypointPtr LocalizationStage::AssignLaneChange(const ActorId actor_id,
   SimpleWaypointPtr change_over_point = nullptr;
 
   // Retrieve waypoint buffer for current vehicle.
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return change_over_point;
+  }
   const Buffer &waypoint_buffer = buffer_map.at(actor_id);
 
   // Check buffer is not empty.
@@ -592,6 +595,9 @@ void LocalizationStage::ImportRoute(Route &imported_actions, Buffer &waypoint_bu
 }
 
 Action LocalizationStage::ComputeNextAction(const ActorId& actor_id) {
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return std::make_pair(RoadOption::Void, nullptr);
+  }
   auto waypoint_buffer = buffer_map.at(actor_id);
   auto next_action = std::make_pair(RoadOption::LaneFollow, waypoint_buffer.back()->GetWaypoint());
   bool is_lane_change = false;
@@ -626,8 +632,11 @@ Action LocalizationStage::ComputeNextAction(const ActorId& actor_id) {
 
 ActionBuffer LocalizationStage::ComputeActionBuffer(const ActorId& actor_id) {
 
-  auto waypoint_buffer = buffer_map.at(actor_id);
   ActionBuffer action_buffer;
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return action_buffer;
+  }
+  auto waypoint_buffer = buffer_map.at(actor_id);
   Action lane_change;
   bool is_lane_change = false;
   SimpleWaypointPtr buffer_front = waypoint_buffer.front();

--- a/PythonAPI/carla/src/TrafficManager.cpp
+++ b/PythonAPI/carla/src/TrafficManager.cpp
@@ -55,8 +55,10 @@ void InterSetImportedRoute(carla::traffic_manager::TrafficManager& self, const A
 boost::python::list InterGetNextAction(carla::traffic_manager::TrafficManager& self, const ActorPtr &actor_ptr) {
   boost::python::list l;
   auto next_action = self.GetNextAction(actor_ptr->GetId());
-  l.append(RoadOptionToString(next_action.first));
-  l.append(next_action.second);
+  if (next_action.second != nullptr) {
+    l.append(RoadOptionToString(next_action.first));
+    l.append(next_action.second);
+  }
   return l;
 }
 


### PR DESCRIPTION
#### Description

Port of ue4-dev [`fb5f61269`](https://github.com/carla-simulator/carla/commit/fb5f61269) — Fix segfault in traffic manager when trying to access not available vehicles (#8553).

Add `buffer_map.find()` guards before `buffer_map.at(actor_id)` calls in three methods of `LocalizationStage.cpp`:
- `AssignLaneChange` — return nullptr if actor not in buffer
- `ComputeNextAction` — return `RoadOption::Void` if actor not in buffer
- `ComputeActionBuffer` — return empty buffer if actor not in buffer

Without these guards, destroyed vehicles cause `std::out_of_range` exceptions (segfaults) when the traffic manager tries to access their waypoint buffers.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. Defensive null checks only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9651)
<!-- Reviewable:end -->
