### PR TITLE
fix(test): update MakeUnitVector test for zero-length vector behavior

### DIFF
--- a/LibCarla/source/test/common/test_vector3D.cpp
+++ b/LibCarla/source/test/common/test_vector3D.cpp
@@ -5,7 +5,6 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "test.h"
-#include "gtest/gtest-death-test.h"
 
 #include <carla/geom/Vector3D.h>
 #include <carla/geom/Math.h>
@@ -18,13 +17,7 @@ TEST(vector3D, make_unit_vec) {
   ASSERT_EQ(Vector3D(0,10,0).MakeUnitVector(), Vector3D(0,1,0));
   ASSERT_EQ(Vector3D(0,0,512).MakeUnitVector(), Vector3D(0,0,1));
   ASSERT_NE(Vector3D(0,1,512).MakeUnitVector(), Vector3D(0,0,1));
-#ifdef LIBCARLA_NO_EXCEPTIONS
-  ASSERT_DEATH_IF_SUPPORTED(
-      Vector3D().MakeUnitVector(),
-      "length > 2.0f \\* std::numeric_limits<float>::epsilon()");
-#else
-  ASSERT_THROW(
-      Vector3D().MakeUnitVector(),
-      std::runtime_error);
-#endif // LIBCARLA_NO_EXCEPTIONS
+
+  // MakeUnitVector returns zero vector for zero-length input
+  ASSERT_EQ(Vector3D().MakeUnitVector(), Vector3D(0,0,0));
 }


### PR DESCRIPTION
#### Description

Update the C++ unit test for `Vector3D::MakeUnitVector()` to match the current implementation. PR #9585 changed `MakeUnitVector()` to return `Vector3D(0,0,0)` for zero-length vectors instead of asserting/throwing, but the C++ test was not updated.

Port of ue4-dev [`e75378b62`](https://github.com/carla-simulator/carla/commit/e75378b62) #9575.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. Aligns test expectations with actual implementation behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9655)
<!-- Reviewable:end -->
