### PR TITLE
fix(Unreal): remove duplicate include in BoundingBoxCalculator

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Util/BoundingBoxCalculator.cpp
@@ -9,7 +9,6 @@
 #include "Carla/Game/Tagger.h"
 #include "Carla/Traffic/TrafficSignBase.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
-#include "Carla/Game/Tagger.h"
 #include "Carla/Traffic/TrafficLightBase.h"
 #include "Components/CapsuleComponent.h"
 #include "GameFramework/Character.h"


### PR DESCRIPTION
#### Description

Remove duplicate `#include "Carla/Game/Tagger.h"` in `BoundingBoxCalculator.cpp`. The same header is included on both line 9 and line 12.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9656)
<!-- Reviewable:end -->
