### PR TITLE
fix(LibCarla): use double literal in Lane::GetWidth return

### DIFF
--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -61,7 +61,7 @@ namespace road {
     if(width_info != nullptr){
       return width_info->GetPolynomial().Evaluate(s);
     }
-    return 0.0f;
+    return 0.0;
   }
 
   bool Lane::IsStraight() const {


### PR DESCRIPTION
#### Description

`Lane::GetWidth()` returns `double` but the fallback path returned `0.0f` (float literal). Use `0.0` for consistency with the function's return type.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. Eliminates implicit float-to-double conversion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9657)
<!-- Reviewable:end -->
