### PR TITLE
fix(ros2): replace non-standard M_PIf32 with portable alternative

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
@@ -159,9 +159,9 @@ namespace ros2 {
         const float ty = *translation++;
         const float tz = *translation++;
 
-        const float rx = ((*rotation++) * -1.0f) * (M_PIf32 / 180.0f);
-        const float ry = ((*rotation++) * -1.0f) * (M_PIf32 / 180.0f);
-        const float rz = *rotation++ * (M_PIf32 / 180.0f);
+        const float rx = ((*rotation++) * -1.0f) * (static_cast<float>(M_PI) / 180.0f);
+        const float ry = ((*rotation++) * -1.0f) * (static_cast<float>(M_PI) / 180.0f);
+        const float rz = *rotation++ * (static_cast<float>(M_PI) / 180.0f);
 
         const float cr = cosf(rz * 0.5f);
         const float sr = sinf(rz * 0.5f);


### PR DESCRIPTION
#### Description

Replace `M_PIf32` with `static_cast<float>(M_PI)` in `CarlaTransformPublisher.cpp`. `M_PIf32` is a GNU C library extension not defined in ISO C++ or libc++.

Note: The ue4-dev version already uses `float(M_PI)` and does not have this issue.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04
  * **Python version(s):** N/A (C++ only)
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. Functionally identical, improves portability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9658)
<!-- Reviewable:end -->
