### PR TITLE
fix(BuildTools): forward --ros2 and --dds-middleware to UE4 editor command line

### DIFF
--- a/Util/BuildTools/BuildCarlaUE4.bat
+++ b/Util/BuildTools/BuildCarlaUE4.bat
@@ -75,6 +75,11 @@ if not "%1"=="" (
 rem remove quotes from arguments
 set EDITOR_FLAGS=%EDITOR_FLAGS:"=%
 
+rem Forward ROS2 runtime flags to the UE4 editor command line
+if %USE_ROS2% == true (
+    set EDITOR_FLAGS=%EDITOR_FLAGS% --ros2
+)
+
 if %REMOVE_INTERMEDIATE% == false (
     if %LAUNCH_UE4_EDITOR% == false (
         if %BUILD_UE4_EDITOR% == false (

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -19,13 +19,14 @@ USE_PYTORCH=false
 USE_UNITY=true
 USE_ROS2=false
 CHRONO_PATH=""
+DDS_MIDDLEWARE=""
 
 EDITOR_FLAGS=""
 
 GDB=
 RHI="-vulkan"
 
-OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl,carsim,pytorch,chrono,chrono-path:,ros2,no-simready,no-unity,editor-flags: -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl,carsim,pytorch,chrono,chrono-path:,ros2,dds-middleware:,no-simready,no-unity,editor-flags: -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 
@@ -73,6 +74,9 @@ while [[ $# -gt 0 ]]; do
     --ros2 )
       USE_ROS2=true;
       shift ;;
+    --dds-middleware )
+      DDS_MIDDLEWARE=$2;
+      shift 2 ;;
     --no-simready )
       USE_SIMREADY=false
       shift ;;
@@ -88,6 +92,16 @@ while [[ $# -gt 0 ]]; do
       shift ;;
   esac
 done
+
+# Forward ROS2 runtime flags to the UE4 editor command line.
+# --ros2 is consumed above for build-time config (OptionalModules.ini);
+# the editor also needs it as a runtime flag for CarlaSettings.
+if ${USE_ROS2} ; then
+  EDITOR_FLAGS="${EDITOR_FLAGS} --ros2"
+fi
+if [ -n "${DDS_MIDDLEWARE}" ] ; then
+  EDITOR_FLAGS="${EDITOR_FLAGS} --dds-middleware=${DDS_MIDDLEWARE}"
+fi
 
 # ==============================================================================
 # -- Set up environment --------------------------------------------------------


### PR DESCRIPTION
# PR: fix(BuildTools): forward --ros2 and --dds-middleware to UE4 editor command line

**Branch:** `fix/issue-9511-ros2-launch`
**Base:** `ue4-dev`

---

<!-- CARLA contribution checklist -->
<!--
  - [ ] Your branch is up to date with `ue4-dev`
  - [ ] The title is descriptive enough
  - [ ] You have read the CONTRIBUTING docs
  - [ ] Code compiles correctly
  - [ ] Code is tested
-->

#### Description

Fixes #9511

This PR is blocked on #9645.

When running `make launch ARGS="--ros2"`, the `--ros2` flag is consumed by `BuildCarlaUE4.sh`
for build-time configuration (`OptionalModules.ini`) but never forwarded to the UE4 editor
process. At runtime, `CarlaSettings.cpp` checks `FParse::Param(TEXT("-ros2"))` on the command
line, which always fails because the flag is missing.

This PR adds a forwarding block after the argument-parsing loop in both build scripts:

**`BuildCarlaUE4.sh`:**
- New `DDS_MIDDLEWARE` variable and `--dds-middleware` getopt option
- After parsing, appends `--ros2` and `--dds-middleware=<value>` to `EDITOR_FLAGS`

**`BuildCarlaUE4.bat`:**
- After parsing, appends `--ros2` to `EDITOR_FLAGS` when `USE_ROS2` is true
- No `--dds-middleware` on Windows (only FastDDS is supported)

After the fix, `make launch ARGS="--ros2"` produces:

```
UE4Editor CarlaUE4.uproject -vulkan --ros2
```

And `make launch ARGS="--ros2 --dds-middleware=cyclonedds"` produces:

```
UE4Editor CarlaUE4.uproject -vulkan --ros2 --dds-middleware=cyclonedds
```

#### Where has this been tested?

- **Platform:** Ubuntu 22.04
- **ROS2 verification:** `osrf/ros:humble-desktop` container, `ros2 topic list` confirms
  `/clock` and all CARLA topics are published
- **Unreal Engine:** 4.26

Script argument-parsing verified with 6 unit tests covering all flag combinations
(`--ros2` only, `--dds-middleware` only, both, neither, combined with `--editor-flags`).

#### Possible Drawbacks

None. The forwarding is additive and only activates when `--ros2` or `--dds-middleware` is
explicitly passed. Existing workflows without these flags are unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9665)
<!-- Reviewable:end -->
