### PR TITLE
fix(LibCarla/cmake): install ros2/dds/ headers in server cmake for Windows builds

### DIFF
--- a/LibCarla/cmake/server/CMakeLists.txt
+++ b/LibCarla/cmake/server/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(dir ""
             "sensor/" "sensor/data/" "sensor/s11n/"
             "streaming/" "streaming/detail/" "streaming/detail/tcp/" "streaming/low_level/"
             "multigpu/"
-            "ros2/")
+            "ros2/" "ros2/dds/")
 
   file(GLOB headers "${libcarla_source_path}/carla/${dir}*.h")
   install(FILES ${headers} DESTINATION include/carla/${dir})


### PR DESCRIPTION
<!--
  - Merge to `ue4-dev`.
  - README is not updated (no user-facing change).
  - CHANGELOG is not updated (build-system fix only).
  - Compiles correctly: yes (Linux, server + client + ros2).
  - Tests: 114/114 server, 56/56 client.
-->

#### Description

PR #9644 added `#include "carla/ros2/dds/DDSMiddleware.h"` to `ROS2.h` for the new `Enable(bool, DDSMiddleware)` signature, but did not update the server cmake header install list. This breaks the Windows CI build with:

```
carla/ros2/ROS2.h(13): fatal error C1083: cannot open include file:
    'carla/ros2/dds/DDSMiddleware.h': No such file or directory
```

**Why this only affects Windows:** LibCarla headers are installed to `CarlaDependencies/include/` via two different cmake paths:

- **Linux** (`make LibCarla ARGS="--ros2"`): uses the `ros2` build type, which delegates header installation to `cmake/fast_dds/CMakeLists.txt`. That file already installs all `ros2/` subdirectories, including `ros2/dds/`. Working correctly.
- **Windows** (`make LibCarla`, no `--ros2`): uses the `Server` build type, which runs `cmake/server/CMakeLists.txt`. This file contains a manually maintained `foreach` loop that lists every subdirectory whose headers should be installed. It listed `"ros2/"` but not `"ros2/dds/"`.

The UE4 plugin includes `ROS2.h` unconditionally (not behind `#ifdef WITH_ROS2`) from `CarlaEngine.h`, `CarlaEpisode.h`, `ActorROS2Handler.h`, and several sensor `.cpp` files. Before #9644, `ROS2.h` had no subdirectory dependencies, so the missing entry was not a problem.

**Fix:** add `"ros2/dds/"` to the server cmake `foreach` install loop, following the same pattern already used for other nested subdirectories (`"opendrive/parser/"`, `"road/element/"`, `"streaming/detail/tcp/"`, etc.).

**Why this must merge before #9645:** PR [#9645](https://github.com/carla-simulator/carla/pull/9645) (delete legacy FastDDS-generated types) cannot pass Windows CI until this header installation gap is fixed. The error is caused by code already merged in #9644, not by #9645 itself.

#### Where has this been tested?

- **Platform(s):** Ubuntu 22.04
- **Python version(s):** 3.10-3.12
- **Unreal Engine version(s):** 4.26

Tests:

```sh
make LibCarla ARGS="--ros2"    # builds server, client, ros2 targets
make check.LibCarla            # 114/114 server + 56/56 client tests pass
```

Header installation verified:

```
CarlaDependencies/include/carla/ros2/dds/DDSMiddleware.h  (present after build)
```

#### Possible Drawbacks

None. This is a pure addition to the CMake install list. It cannot affect existing installs, only adds previously missing headers. The Linux build path is unaffected because it uses a separate CMake target (`cmake/fast_dds/CMakeLists.txt`) that already installs these headers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9666)
<!-- Reviewable:end -->
