### PR TITLE
Update ROS2 Example

### DIFF
--- a/PythonAPI/examples/ros2/Dockerfile
+++ b/PythonAPI/examples/ros2/Dockerfile
@@ -1,0 +1,15 @@
+ARG ROS_DISTRO=humble
+FROM osrf/ros:${ROS_DISTRO}-desktop
+
+ARG ROS_DISTRO=humble
+ARG RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+
+# Install CycloneDDS middleware package when selected; FastDDS is already in the base image
+RUN if [ "$RMW_IMPLEMENTATION" = "rmw_cyclonedds_cpp" ]; then \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}

--- a/PythonAPI/examples/ros2/config/cyclonedds.xml
+++ b/PythonAPI/examples/ros2/config/cyclonedds.xml
@@ -6,5 +6,8 @@
         <SharedMemory>
             <Enable>false</Enable>
         </SharedMemory>
+        <General>
+            <Transport>udp</Transport>
+        </General>
     </Domain>
 </CycloneDDS>

--- a/PythonAPI/examples/ros2/config/cyclonedds.xml
+++ b/PythonAPI/examples/ros2/config/cyclonedds.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://cdds.io/config https://cdds.io/schema/cyclonedds.xsd">
+    <Domain id="any">
+        <SharedMemory>
+            <Enable>false</Enable>
+        </SharedMemory>
+    </Domain>
+</CycloneDDS>

--- a/PythonAPI/examples/ros2/run_rviz.sh
+++ b/PythonAPI/examples/ros2/run_rviz.sh
@@ -1,24 +1,98 @@
 #!/bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-function transfer_x11_permissions() {
-    # store X11 access rights in temp file to be passed into docker container
-    XAUTH=/tmp/.docker.xauth
-    touch $XAUTH
-    xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+# --- Defaults ---
+DISTRO="humble"
+RMW="fastdds"
+
+# --- Argument parsing ---
+usage() {
+    cat <<EOF
+Usage: $0 [--distro=<distro>] [--rmw=<middleware>]
+
+Options:
+  --distro    ROS 2 distribution to use. Supported: humble, jazzy  (default: humble)
+  --rmw       DDS middleware to use. Supported: fastdds, cyclonedds  (default: fastdds)
+
+Examples:
+  $0 --distro=humble --rmw=fastdds
+  $0 --distro=jazzy  --rmw=cyclonedds
+EOF
+    exit 1
 }
 
-transfer_x11_permissions
+for arg in "$@"; do
+    case "$arg" in
+        --distro=*) DISTRO="${arg#*=}" ;;
+        --rmw=*)    RMW="${arg#*=}" ;;
+        --help|-h)  usage ;;
+        *) echo "Unknown argument: $arg"; usage ;;
+    esac
+done
+
+# --- Validate ---
+case "$DISTRO" in
+    humble|jazzy) ;;
+    *) echo "Unsupported distro '${DISTRO}'. Supported values: humble, jazzy"; exit 1 ;;
+esac
+
+case "$RMW" in
+    fastdds|cyclonedds) ;;
+    *) echo "Unsupported RMW '${RMW}'. Supported values: fastdds, cyclonedds"; exit 1 ;;
+esac
+
+# Map short names to ROS RMW implementation identifiers
+if [ "$RMW" = "cyclonedds" ]; then
+    RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
+else
+    RMW_IMPLEMENTATION="rmw_fastrtps_cpp"
+fi
+
+IMAGE_NAME="carla-rviz-${DISTRO}-${RMW}"
+
+# --- Build ---
+function build_image() {
+    echo "[RViz] Building Docker image '${IMAGE_NAME}' (distro=${DISTRO}, rmw=${RMW})..."
+    docker build \
+        --build-arg ROS_DISTRO="${DISTRO}" \
+        --build-arg RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION}" \
+        --file "${SCRIPT_DIR}/Dockerfile" \
+        --tag "${IMAGE_NAME}" \
+        "${SCRIPT_DIR}"
+}
+
+if ! docker image inspect "${IMAGE_NAME}" &>/dev/null; then
+    build_image
+fi
+
+# --- X11 permissions ---
+XAUTH=/tmp/.docker.xauth
+touch "$XAUTH"
+xauth nlist "$DISPLAY" | sed -e 's/^..../ffff/' | xauth -f "$XAUTH" nmerge -
+
+# --- RMW-specific environment variables ---
+EXTRA_ENV=()
+if [ "$RMW" = "cyclonedds" ]; then
+    EXTRA_ENV+=(--env="CYCLONEDDS_URI=/config/cyclonedds.xml")
+else
+    EXTRA_ENV+=(--env="FASTRTPS_DEFAULT_PROFILES_FILE=/config/fastrtps-profile.xml")
+fi
+
+# --- Run ---
+echo "[RViz] Launching RViz2 (distro=${DISTRO}, rmw=${RMW})..."
 docker run \
     --rm \
     --net=host \
     --env="DISPLAY=$DISPLAY" \
     --env="XAUTHORITY=$XAUTH" \
-    --env="FASTRTPS_DEFAULT_PROFILES_FILE=/config/fastrtps-profile.xml" \
+    --env="RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}" \
+    "${EXTRA_ENV[@]}" \
     --volume="${SCRIPT_DIR}/config:/config:ro" \
     --volume="${SCRIPT_DIR}/rviz:/rviz:rw" \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     --volume="$XAUTH:$XAUTH" \
-    osrf/ros:humble-desktop \
+    "${IMAGE_NAME}" \
     ros2 run rviz2 rviz2 -d /rviz/ros2_native.rviz


### PR DESCRIPTION
Summary

  - Replaces the hardcoded `osrf/ros:humble-desktop` image and `rmw_cyclonedds_cpp middleware` in the ROS2 RViz example with configurable `--distro` and `--rmw` arguments.
  - Adds a unified parametrized Dockerfile that builds the correct image for any supported distro/RMW combination
  - Supported distros: humble, jazzy
  - Supported middlewares: fastdds, cyclonedds

  Usage

  # Default: humble + fastdds
  `./PythonAPI/examples/ros2/run_rviz.sh`

  # Explicit combination
  `./PythonAPI/examples/ros2/run_rviz.sh --distro=jazzy --rmw=cyclonedds`

  Each distro/RMW combination builds and caches a separate image (carla-rviz-<distro>-<rmw>), so switching between them doesn't require a rebuild.


Related Issues:
During the testing of the new example I've noticed 3 issues
- https://github.com/carla-simulator/carla/issues/9673
- https://github.com/carla-simulator/carla/issues/9674
- https://github.com/carla-simulator/carla/issues/9675

@JesusAnaya have you ever seen any of these?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9672)
<!-- Reviewable:end -->
