### PR TITLE
fix(LibCarla/ros2): add REP-2011 type hashes and shared FastDDS participant for Jazzy compatibility

### DIFF
--- a/Docs/ros2/adding_message_types.md
+++ b/Docs/ros2/adding_message_types.md
@@ -316,9 +316,33 @@ Also add an `#include` for the new header at the top of `CdrTopicInfo.h`.
 **`type_name()`:** follows the DDS mangled name convention used by ROS 2 RMWs:
 `<package>::msg::dds_::<TypeName>_` (note the trailing underscore).
 
-**`type_hash()`:** paste the `RIHS01_...` string from Step 4. For
-CARLA-specific types whose hash depends on a `carla_msgs` version that may
-vary across installations, return `nullptr` to skip setting `USER_DATA`.
+**`type_hash()`:** the REP-2011 type hash, published by every writer and
+reader in the `USER_DATA` QoS field (REP-2016 payload
+`typehash=RIHS01_<hex>;`). Peer ROS 2 RMWs read this during discovery to
+perform type-hash-based endpoint matching and, on Jazzy and newer, to
+suppress the `Failed to parse type hash for topic ...` warning.
+
+Paste the `RIHS01_...` string from Step 4. The hash is pinned per message
+definition; update it if the `.msg` definition ever changes.
+
+```cpp
+// Typical case: pin the hash computed from the .msg definition.
+static const char* type_hash() {
+  return "RIHS01_7d9a00ff...";  // 64 hex chars after "RIHS01_"
+}
+```
+
+Return `nullptr` only when no canonical hash can be computed for the type
+(for example, a custom payload with no `.msg` counterpart). The middleware
+then emits an empty `USER_DATA` payload for that endpoint; peers will log
+the missing-type-hash warning on Jazzy but the connection still forms.
+
+```cpp
+// Fallback: no canonical .msg exists for this type.
+static const char* type_hash() {
+  return nullptr;
+}
+```
 
 **`max_serialized_size()`:** a preallocation hint in bytes, excluding the
 4-byte DDS encapsulation header. For fixed types, sum the byte sizes of all

--- a/Docs/ros2/adding_message_types.md
+++ b/Docs/ros2/adding_message_types.md
@@ -1,0 +1,390 @@
+# Adding a new ROS 2 message type to CARLA
+
+CARLA publishes ROS 2 data by serializing hand-written C++ POD structs directly
+into CDR byte buffers using Fast-CDR. There is no IDL compiler or code-generation
+step at build time. As a result, supporting a new message type is a manual
+7-step process. This guide walks through each step.
+
+## Prerequisites
+
+- Docker installed and running (needed only for Step 4).
+- The `.msg` file for the type you want to add. Standard ROS 2 types (e.g.
+  `sensor_msgs/msg/NavSatFix`) already have one in any ROS 2 installation.
+  If you are defining a new `carla_msgs` type, write it first (see Step 1).
+
+---
+
+## Step 1 - Write the `.msg` file (skip for standard ROS 2 types)
+
+If the type already exists in a standard ROS 2 package, skip this step and
+use the existing `.msg` file in Step 4.
+
+For a new `carla_msgs` type, create a `.msg` file following the
+[ROS 2 interface definition format](https://design.ros2.org/articles/legacy_interface_definition.html).
+Each line is either a field declaration or a comment (`# ...`):
+
+```
+# carla_msgs/msg/CarlaSpeedometer.msg
+std_msgs/Header header
+float32 speed   # m/s
+```
+
+Field type names for nested types use `pkg_name/TypeName` (no `msg/` in the
+field line itself). Supported primitives: `bool`, `int8`, `uint8`, `int16`,
+`uint16`, `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`, `string`.
+Fixed arrays use `type[N]`; unbounded sequences use `type[]`.
+
+---
+
+## Step 2 - Create the C++ POD struct
+
+Create `LibCarla/source/carla/ros2/types/msg/MyType.h`. Rules:
+
+- The struct lives in `namespace carla::ros2::msg`.
+- Include only `<array>`, `<vector>`, `<string>`, `<cstdint>`, and sibling
+  `msg/*.h` headers - no DDS or Fast-CDR includes.
+- Initialize primitive fields to zero with `= 0` or `= 0.0`.
+- Use `std::array<T, N>` for fixed-length arrays, `std::vector<T>` for
+  unbounded sequences.
+- Nest other message types by value.
+
+**Leaf type** (all fields are primitives):
+
+```cpp
+// LibCarla/source/carla/ros2/types/msg/MyLeaf.h
+#pragma once
+#include <cstdint>
+
+namespace carla { namespace ros2 { namespace msg {
+
+struct MyLeaf {
+  float speed = 0.0f;
+  uint32_t count = 0u;
+};
+
+}}} // namespace carla::ros2::msg
+```
+
+**Composite type** (nested message, fixed array, string):
+
+```cpp
+// LibCarla/source/carla/ros2/types/msg/MyComposite.h
+#pragma once
+#include <array>
+#include <string>
+#include "carla/ros2/types/msg/Header.h"
+#include "carla/ros2/types/msg/Vector3.h"
+
+namespace carla { namespace ros2 { namespace msg {
+
+struct MyComposite {
+  Header header;
+  std::string frame_id;
+  Vector3 velocity;
+  std::array<double, 9> covariance = {};   // fixed 3x3 matrix
+};
+
+}}} // namespace carla::ros2::msg
+```
+
+**Type with a sequence** (variable-length vector):
+
+```cpp
+// LibCarla/source/carla/ros2/types/msg/MyList.h
+#pragma once
+#include <vector>
+#include "carla/ros2/types/msg/SomeElement.h"
+
+namespace carla { namespace ros2 { namespace msg {
+
+struct MyList {
+  std::vector<SomeElement> items;
+};
+
+}}} // namespace carla::ros2::msg
+```
+
+### Side-by-side example: `.msg` to POD
+
+Full translation of `sensor_msgs/msg/Imu.msg` into its equivalent POD struct.
+Every `.msg` line maps to exactly one C++ field in the same order; nested types
+are resolved to the corresponding `msg::*` struct and included by header.
+
+`sensor_msgs/msg/Imu.msg`:
+
+```
+# sensor_msgs/msg/Imu.msg
+std_msgs/Header header
+geometry_msgs/Quaternion orientation
+float64[9] orientation_covariance
+geometry_msgs/Vector3 angular_velocity
+float64[9] angular_velocity_covariance
+geometry_msgs/Vector3 linear_acceleration
+float64[9] linear_acceleration_covariance
+```
+
+`LibCarla/source/carla/ros2/types/msg/Imu.h`:
+
+```cpp
+// LibCarla/source/carla/ros2/types/msg/Imu.h
+#pragma once
+#include <array>
+#include "carla/ros2/types/msg/Header.h"
+#include "carla/ros2/types/msg/Quaternion.h"
+#include "carla/ros2/types/msg/Vector3.h"
+
+namespace carla { namespace ros2 { namespace msg {
+
+struct Imu {
+  Header header;
+  Quaternion orientation;
+  std::array<double, 9> orientation_covariance = {};
+  Vector3 angular_velocity;
+  std::array<double, 9> angular_velocity_covariance = {};
+  Vector3 linear_acceleration;
+  std::array<double, 9> linear_acceleration_covariance = {};
+};
+
+}}} // namespace carla::ros2::msg
+```
+
+Mapping rules used above:
+
+| `.msg` token                   | C++ field                                |
+| ------------------------------ | ---------------------------------------- |
+| `std_msgs/Header header`       | `Header header;` (nested by value)       |
+| `geometry_msgs/Quaternion q`   | `Quaternion q;` (nested by value)        |
+| `float64[9] covariance`        | `std::array<double, 9> covariance = {};` |
+| `float64 x`                    | `double x = 0.0;`                        |
+| `string frame_id`              | `std::string frame_id;`                  |
+| `type[] items`                 | `std::vector<type> items;`               |
+
+Note: the `dds_::Imu_` mangling in `type_name()` (Step 5) and the DDS wire
+format are derived automatically from this POD layout via Fast-CDR; there is
+no separate IDL definition to maintain.
+
+---
+
+## Step 3 - Register CDR serialization
+
+Open `LibCarla/source/carla/ros2/types/CdrSerialization.h` and add:
+
+1. An `#include` for your new header alongside the others at the top.
+2. A `serialize_cdr` / `deserialize_cdr` overload pair.
+
+**Placement:** add the overloads after the overloads of any types your struct
+depends on (the file is ordered least-to-most dependent to avoid forward
+declarations).
+
+**Leaf type example** (primitives only - use `cdr <<` / `cdr >>`):
+
+```cpp
+inline void serialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, const msg::MyLeaf& m) {
+  cdr << m.speed;
+  cdr << m.count;
+}
+
+inline void deserialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, msg::MyLeaf& m) {
+  cdr >> m.speed;
+  cdr >> m.count;
+}
+```
+
+**Composite type example** (nested types call their own overload; strings and
+`std::array` serialize directly via `cdr <<`):
+
+```cpp
+inline void serialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, const msg::MyComposite& m) {
+  serialize_cdr(cdr, m.header);   // nested msg:: type
+  cdr << m.frame_id;              // std::string
+  serialize_cdr(cdr, m.velocity); // nested msg:: type
+  cdr << m.covariance;            // std::array<double, 9>
+}
+
+inline void deserialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, msg::MyComposite& m) {
+  deserialize_cdr(cdr, m.header);
+  cdr >> m.frame_id;
+  deserialize_cdr(cdr, m.velocity);
+  cdr >> m.covariance;
+}
+```
+
+**Sequence example** (`std::vector` of structs - write length manually):
+
+```cpp
+inline void serialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, const msg::MyList& m) {
+  // CDR sequence length is uint32_t per DDS-XTypes 1.3 clause 7.4.1.1.
+  cdr << static_cast<uint32_t>(m.items.size());
+  for (const auto& item : m.items) {
+    serialize_cdr(cdr, item);
+  }
+}
+
+inline void deserialize_cdr(
+    eprosima::fastcdr::Cdr& cdr, msg::MyList& m) {
+  uint32_t n{0u};
+  cdr >> n;
+  if (n > kMaxCdrSequenceElements) {
+    throw eprosima::fastcdr::exception::BadParamException(
+        "MyList::items length exceeds sane CDR sequence cap");
+  }
+  m.items.resize(static_cast<size_t>(n));
+  for (auto& item : m.items) {
+    deserialize_cdr(cdr, item);
+  }
+}
+```
+
+For `std::vector<uint8_t>` (byte arrays, e.g. `Image::data`) FastCDR handles
+the length prefix automatically via `cdr << m.data` - no manual loop needed.
+
+---
+
+## Step 4 - Compute the RIHS01 type hash
+
+ROS 2 Iron and later check a type hash in the DDS `USER_DATA` QoS field when
+two nodes discover each other. If the hash is absent, each endpoint logs:
+
+```
+[WARN] [rmw_cyclonedds_cpp]: Failed to parse type hash for topic 'rt/...'
+```
+
+CARLA embeds a hardcoded RIHS01 hash in `CdrTopicInfo<T>::type_hash()` for
+every message type. Use `Util/ros2/compute_type_hash.sh` to get the correct
+hash for a type. Docker is the only requirement - no local ROS 2 installation.
+
+**Standard ROS 2 type** (the `.msg` is already installed inside the container):
+
+```sh
+# Extract Imu.msg from the container first, then compute:
+docker run --rm osrf/ros:jazzy-desktop \
+    cat /opt/ros/jazzy/share/sensor_msgs/msg/Imu.msg > /tmp/Imu.msg
+
+Util/ros2/compute_type_hash.sh sensor_msgs/msg/Imu /tmp/Imu.msg
+# Output: RIHS01_7d9a00ff...
+```
+
+**New `carla_msgs` type** (provide your own `.msg` file):
+
+```sh
+Util/ros2/compute_type_hash.sh \
+    carla_msgs/msg/CarlaSpeedometer \
+    /path/to/carla_msgs/msg/CarlaSpeedometer.msg
+# Output: RIHS01_<64 hex chars>
+```
+
+The script prints a single line to stdout:
+
+```
+RIHS01_<64 lowercase hex digits>
+```
+
+Paste this value into `CdrTopicInfo.h` in Step 5.
+
+**Troubleshooting:** if `colcon build` fails inside Docker, the most common
+cause is a `.msg` dependency that is not in the standard `jazzy` install. Add
+the missing package to the `rosidl_generate_interfaces` workspace or, for
+bleeding-edge packages, switch to a newer `osrf/ros` tag.
+
+---
+
+## Step 5 - Register in `CdrTopicInfo.h`
+
+Add a specialization to
+`LibCarla/source/carla/ros2/types/CdrTopicInfo.h`:
+
+```cpp
+template<> struct CdrTopicInfo<msg::MyComposite> {
+  static const char* type_name() {
+    // DDS mangled name: <package>::msg::dds_::<TypeName>_
+    return "my_pkg::msg::dds_::MyComposite_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_<hash from Step 4>";
+  }
+  static size_t max_serialized_size() { return <byte count>u; }
+};
+```
+
+Also add an `#include` for the new header at the top of `CdrTopicInfo.h`.
+
+**`type_name()`:** follows the DDS mangled name convention used by ROS 2 RMWs:
+`<package>::msg::dds_::<TypeName>_` (note the trailing underscore).
+
+**`type_hash()`:** paste the `RIHS01_...` string from Step 4. For
+CARLA-specific types whose hash depends on a `carla_msgs` version that may
+vary across installations, return `nullptr` to skip setting `USER_DATA`.
+
+**`max_serialized_size()`:** a preallocation hint in bytes, excluding the
+4-byte DDS encapsulation header. For fixed types, sum the byte sizes of all
+fields. For variable-length types, choose a reasonable upper bound. This is
+only a hint; the actual payload is sized dynamically.
+
+Quick sizing guide:
+- `bool`, `uint8`, `int8`: 1 byte
+- `uint16`, `int16`: 2 bytes
+- `uint32`, `int32`, `float32`: 4 bytes
+- `uint64`, `int64`, `float64`, `double`: 8 bytes
+- `std::string`: 4 (length) + capacity estimate in bytes
+- `std::array<double, 9>`: 72 bytes
+- Nested struct: sum its fields recursively
+
+---
+
+## Step 6 - Add a test
+
+Open `LibCarla/source/test/server/test_type_hash.cpp` and add:
+
+1. One `CHECK_HASH(MyComposite)` call inside `TEST(TypeHash, FormatAllTypes)`.
+2. One `CdrTopicInfo<msg::MyComposite>::type_hash()` entry in the `hashes`
+   vector inside `TEST(TypeHash, UniqueAcrossAllTypes)`.
+
+These two tests verify that the hash string matches the `RIHS01_<64 hex>`
+format and is unique across all registered types.
+
+---
+
+## Step 7 - Build and verify
+
+```sh
+docker exec carla-development-ue4-20.04 make LibCarla ARGS="--ros2"
+docker exec carla-development-ue4-20.04 make check.LibCarla
+```
+
+All tests must pass. The new `CHECK_HASH` entry will fail if the hash is
+malformed or duplicated.
+
+---
+
+## FAQ
+
+**Why are hashes hardcoded?**
+CARLA has no IDL compiler (`rosidl`, `idlc`) running at build time. Computing
+RIHS01 hashes correctly requires `rosidl_generator_type_description`, which
+only runs inside a ROS 2 build environment. Hardcoding the values from a
+one-time Docker build is zero-dependency and correct because standard message
+definitions are stable per distro.
+
+**Are hashes the same on Humble and Jazzy?**
+Yes, for any message whose definition has not changed between the two distros
+(all messages in `std_msgs`, `geometry_msgs`, `sensor_msgs`, `nav_msgs`,
+`builtin_interfaces`, `tf2_msgs`, `rosgraph_msgs`, `ackermann_msgs`). Compute
+the hash against Jazzy - it will match on Humble too.
+
+**What is the wire format?**
+Classic CDR, encoding version 1, little-endian (CDR_LE). Defined in:
+- OMG DDSI-RTPS v2.5 Section 10 (encapsulation header)
+- DDS-XTypes 1.3 clause 7.4.1.1 (sequence/string encoding)
+- [REP-2011](https://ros.org/reps/rep-2011.html) (RIHS01 hash algorithm)
+- [REP-2016](https://ros.org/reps/rep-2016.html) (USER_DATA KV format)
+
+---
+
+## References
+
+- [OMG DDSI-RTPS v2.5 specification (PDF)](https://www.omg.org/spec/DDSI-RTPS/2.5/PDF)

--- a/LibCarla/cmake/fast_dds/CMakeLists.txt
+++ b/LibCarla/cmake/fast_dds/CMakeLists.txt
@@ -27,6 +27,7 @@ install(DIRECTORY "${FASTDDS_INCLUDE_PATH}/fastcdr"   DESTINATION include)
 install(DIRECTORY "${FASTDDS_INCLUDE_PATH}/fastdds"   DESTINATION include)
 install(DIRECTORY "${FASTDDS_INCLUDE_PATH}/fastrtps"  DESTINATION include)
 
-# Note: dds/fastdds/ contains only header-only templates (no .cpp sources).
-# All compiled ros2 code is in cmake/ros2/ (carla_ros2), compiled once with
-# both CARLA_ROS2_DDS_FASTDDS and CARLA_ROS2_DDS_CYCLONEDDS defined.
+# Note: dds/fastdds/ headers are installed here.  The one .cpp source
+# (FastDDSSharedParticipant.cpp) is compiled via cmake/ros2/ (carla_ros2),
+# together with all other ros2 sources, once with both
+# CARLA_ROS2_DDS_FASTDDS and CARLA_ROS2_DDS_CYCLONEDDS defined.

--- a/LibCarla/cmake/ros2/CMakeLists.txt
+++ b/LibCarla/cmake/ros2/CMakeLists.txt
@@ -14,6 +14,7 @@ file(GLOB libcarla_ros2_sources
   "${libcarla_source_path}/carla/ros2/subscribers/*.cpp"
   "${libcarla_source_path}/carla/ros2/listeners/*.cpp"
   "${libcarla_source_path}/carla/ros2/types/*.cpp"
+  "${libcarla_source_path}/carla/ros2/dds/fastdds/*.cpp"
   "${libcarla_source_path}/carla/ros2/dds/cyclonedds/*.cpp")
 
 # ==============================================================================

--- a/LibCarla/source/carla/multigpu/listener.cpp
+++ b/LibCarla/source/carla/multigpu/listener.cpp
@@ -7,6 +7,7 @@
 #include "carla/multigpu/listener.h"
 #include "carla/multigpu/primary.h"
 
+#include <boost/asio/error.hpp>
 #include <boost/asio/post.hpp>
 
 #include "carla/Logging.h"
@@ -48,7 +49,8 @@ namespace multigpu {
     auto handle_query = [on_opened, on_closed, on_response, session, self](const error_code &ec) {
     if (!ec) {
       session->Open(std::move(on_opened), std::move(on_closed), std::move(on_response));
-    } else {
+    } else if (ec != boost::asio::error::operation_aborted) {
+      // operation_aborted is the normal shutdown path (Listener::Stop -> cancel()).
       log_error("Secondary server:", ec.message());
     }
   };

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -471,12 +471,16 @@ void ROS2::ProcessDataFromCollisionSensor(
 
 void ROS2::Shutdown() {
   std::lock_guard<std::recursive_mutex> lock(_mutex);
+  // Destroy publishers first so DataWriter unregister-dispose messages are
+  // sent while the shared DomainParticipant is still alive, then clear
+  // subscribers.  Order matters: the FastDDS shared participant is refcounted;
+  // destroying all endpoints (publishers and subscribers) drives the refcount
+  // to zero and triggers delete_contained_entities() + delete_participant().
   _publishers.clear();
-  _subscribers.clear();
-
   _tf_publishers.clear();
-
   _clock_publisher.reset();
+
+  _subscribers.clear();
 
   _enabled = false;
 }

--- a/LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSPublisherMiddleware.h
@@ -8,6 +8,7 @@
 #include "carla/ros2/dds/cyclonedds/CycloneDDSSertype.h"
 #include "carla/ros2/types/CdrSerialization.h"
 #include "carla/ros2/types/CdrTopicInfo.h"
+#include "carla/ros2/types/UserDataFormat.h"
 #include "carla/Logging.h"
 
 #include <atomic>
@@ -75,6 +76,12 @@ class CycloneDDSPublisherMiddleware : public IDDSPublisherMiddleware {
     dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
                          DDS_SECS(1));
     dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, 1);
+    // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
+    // to the REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
+    auto ud = build_user_data_for<msg_type>();
+    if (!ud.empty()) {
+      dds_qset_userdata(qos, ud.data(), ud.size());
+    }
     dds_listener_t* listener = dds_create_listener(this);
     dds_lset_publication_matched(listener, carla_on_publication_matched);
 

--- a/LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSSubscriberMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSSubscriberMiddleware.h
@@ -8,6 +8,7 @@
 #include "carla/ros2/dds/cyclonedds/CycloneDDSSertype.h"
 #include "carla/ros2/types/CdrSerialization.h"
 #include "carla/ros2/types/CdrTopicInfo.h"
+#include "carla/ros2/types/UserDataFormat.h"
 #include "carla/Logging.h"
 
 #include <atomic>
@@ -83,6 +84,12 @@ class CycloneDDSSubscriberMiddleware : public IDDSSubscriberMiddleware {
     dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
                          DDS_SECS(1));
     dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, 1);
+    // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
+    // to the REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
+    auto ud = build_user_data_for<msg_type>();
+    if (!ud.empty()) {
+      dds_qset_userdata(qos, ud.data(), ud.size());
+    }
     dds_listener_t* listener = dds_create_listener(this);
     dds_lset_subscription_matched(listener, carla_on_subscription_matched);
     dds_lset_data_available(listener, carla_on_data_available);

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include "carla/ros2/dds/IDDSPublisherMiddleware.h"
+#include "carla/ros2/dds/fastdds/FastDDSSharedParticipant.h"
 #include "carla/ros2/dds/fastdds/GenericCdrPubSubType.h"
+#include "carla/ros2/types/UserDataFormat.h"
 #include "carla/Logging.h"
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
@@ -34,6 +34,16 @@ using erc = eprosima::fastrtps::types::ReturnCode_t;
 /// Parameterized on a traits type T that provides:
 ///   T::msg_type  — the message type (a carla::ros2::msg::* POD struct)
 /// Serialization is handled by GenericCdrPubSubType<msg_type> via CdrSerialization.h.
+///
+/// Uses FastDDSSharedParticipant for a single refcounted DomainParticipant
+/// across all FastDDS endpoints, mirroring CycloneDDS's shared-participant
+/// model.  This avoids the discovery storm that occurred when N independent
+/// participants were destroyed back-to-back on ROS2::Shutdown().
+///
+/// Sets USER_DATA QoS on the DataWriter to the REP-2016 KV payload
+/// "typehash=RIHS01_<hex>;" (PID_USER_DATA = 0x002c in DDSI-RTPS v2.5
+/// §9.6.2.2.2) so that Jazzy rmw_cyclonedds_cpp and rmw_fastrtps_cpp can
+/// perform REP-2011 type-hash-based endpoint matching without warning.
 template<typename T>
 class FastDDSPublisherMiddleware
     : public IDDSPublisherMiddleware,
@@ -65,7 +75,11 @@ class FastDDSPublisherMiddleware
       _participant->delete_topic(_topic);
     }
     if (_participant) {
-      efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
+      // Release the per-type refcount so unregister_type() fires when the last
+      // user of this TypeSupport goes away, before the shared participant drops.
+      FastDDSSharedParticipant::release_type(_type->getName());
+      FastDDSSharedParticipant::release();
+      _participant = nullptr;
     }
   }
 
@@ -75,14 +89,14 @@ class FastDDSPublisherMiddleware
       return false;
     }
 
-    efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
-    auto factory = efd::DomainParticipantFactory::get_instance();
-    _participant = factory->create_participant(0, pqos);
+    _participant = FastDDSSharedParticipant::acquire();
     if (_participant == nullptr) {
-      log_error("FastDDSPublisherMiddleware: Failed to create DomainParticipant");
+      log_error("FastDDSPublisherMiddleware: Shared participant unavailable");
       return false;
     }
+
     _type.register_type(_participant);
+    FastDDSSharedParticipant::retain_type(_type->getName());
 
     efd::PublisherQos pubqos = efd::PUBLISHER_QOS_DEFAULT;
     _publisher = _participant->create_publisher(pubqos, nullptr);
@@ -91,8 +105,17 @@ class FastDDSPublisherMiddleware
       return false;
     }
 
-    efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
-    _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    // Multiple endpoints may share the same topic on the shared participant
+    // (e.g. every actor publishes on rt/tf). FastDDS's create_topic rejects a
+    // duplicate name, so probe first and reuse via find_topic if it already
+    // exists; find_topic increments an internal refcount that the matching
+    // delete_topic in the destructor balances.
+    if (_participant->lookup_topicdescription(topic_name) != nullptr) {
+      _topic = _participant->find_topic(topic_name, eprosima::fastrtps::Duration_t{0, 0});
+    } else {
+      efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
+      _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    }
     if (_topic == nullptr) {
       log_error("FastDDSPublisherMiddleware: Failed to create Topic");
       return false;
@@ -101,6 +124,16 @@ class FastDDSPublisherMiddleware
     efd::DataWriterQos wqos = efd::DATAWRITER_QOS_DEFAULT;
     wqos.endpoint().history_memory_policy =
         eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
+    // to the REP-2011/REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
+    // Jazzy rmw_cyclonedds_cpp / rmw_fastrtps_cpp parse this during SEDP
+    // endpoint discovery to verify type compatibility.
+    auto ud = build_user_data_for<msg_type>();
+    if (!ud.empty()) {
+      wqos.user_data().data_vec(ud);
+    }
+
     efd::DataWriterListener* listener =
         static_cast<efd::DataWriterListener*>(this);
     _datawriter = _publisher->create_datawriter(_topic, wqos, listener);

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSharedParticipant.cpp
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSharedParticipant.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef CARLA_ROS2_DDS_TESTING
+
+#include "carla/ros2/dds/fastdds/FastDDSSharedParticipant.h"
+#include "carla/Logging.h"
+
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+
+namespace carla {
+namespace ros2 {
+
+namespace efd = eprosima::fastdds::dds;
+
+// Static member definitions
+std::mutex                                      FastDDSSharedParticipant::_mutex;
+efd::DomainParticipant*                         FastDDSSharedParticipant::_participant { nullptr };
+uint32_t                                        FastDDSSharedParticipant::_refcount { 0u };
+std::unordered_map<std::string, uint32_t>       FastDDSSharedParticipant::_type_refcounts;
+
+efd::DomainParticipant* FastDDSSharedParticipant::acquire() {
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (_refcount == 0u) {
+    efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
+    _participant =
+        efd::DomainParticipantFactory::get_instance()->create_participant(0, pqos);
+    if (_participant == nullptr) {
+      log_error("FastDDSSharedParticipant: Failed to create DomainParticipant");
+      return nullptr;
+    }
+  }
+  ++_refcount;
+  return _participant;
+}
+
+void FastDDSSharedParticipant::release() {
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (_refcount == 0u) {
+    log_error("FastDDSSharedParticipant::release() called with refcount already 0");
+    return;
+  }
+  --_refcount;
+  if (_refcount == 0u && _participant != nullptr) {
+    // delete_contained_entities() drains all Topics and TypeSupports still
+    // owned by the participant before the participant itself is deleted.
+    // Without this call, TypeSupport objects registered with register_type()
+    // but not explicitly unregistered could be leaked or double-freed.
+    _participant->delete_contained_entities();
+    efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
+    _participant = nullptr;
+    _type_refcounts.clear();
+  }
+}
+
+void FastDDSSharedParticipant::retain_type(const std::string& type_name) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  ++_type_refcounts[type_name];
+}
+
+void FastDDSSharedParticipant::release_type(const std::string& type_name) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _type_refcounts.find(type_name);
+  if (it == _type_refcounts.end() || it->second == 0u) {
+    return;
+  }
+  --it->second;
+  if (it->second == 0u) {
+    // Unregister the type from the shared participant so the TypeSupport
+    // refcount inside FastDDS reaches zero cleanly.
+    if (_participant != nullptr) {
+      _participant->unregister_type(type_name);
+    }
+    _type_refcounts.erase(it);
+  }
+}
+
+} // namespace ros2
+} // namespace carla
+
+#endif // !CARLA_ROS2_DDS_TESTING

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSharedParticipant.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSharedParticipant.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#ifndef CARLA_ROS2_DDS_TESTING
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace carla {
+namespace ros2 {
+
+/// Refcounted singleton DomainParticipant shared across all FastDDS
+/// publishers and subscribers in the process.
+///
+/// Using one DomainParticipant per publisher (the previous approach) caused a
+/// discovery storm on ROS2::Shutdown() when all N participants were destroyed
+/// back-to-back, triggering intermittent segfaults in remote rmw_fastrtps_cpp
+/// and rmw_cyclonedds_cpp clients.  CycloneDDS already uses a
+/// process-lifetime shared participant (CycloneDDSSertype::carla_cdr_get_participant);
+/// this class mirrors that model for FastDDS.
+///
+/// Thread-safety: all methods acquire an internal mutex.
+class FastDDSSharedParticipant {
+ public:
+  /// Increment the refcount and return the shared DomainParticipant.
+  /// Creates the participant on the first call.  Returns nullptr on failure.
+  static eprosima::fastdds::dds::DomainParticipant* acquire();
+
+  /// Decrement the refcount.  Destroys the participant when count reaches 0.
+  /// Must be called exactly once for every successful acquire().
+  static void release();
+
+  /// Notify the singleton that one more endpoint is using type_name so that
+  /// unregister_type() is deferred until the last user releases it.
+  static void retain_type(const std::string& type_name);
+
+  /// Release one use of type_name.  Calls participant->unregister_type() when
+  /// the count for that name drops to 0 (and the participant is still alive).
+  static void release_type(const std::string& type_name);
+
+ private:
+  FastDDSSharedParticipant() = delete;
+
+  static std::mutex                       _mutex;
+  static eprosima::fastdds::dds::DomainParticipant* _participant;
+  static uint32_t                         _refcount;
+  static std::unordered_map<std::string, uint32_t>  _type_refcounts;
+};
+
+} // namespace ros2
+} // namespace carla
+
+#endif // !CARLA_ROS2_DDS_TESTING

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include "carla/ros2/dds/IDDSSubscriberMiddleware.h"
+#include "carla/ros2/dds/fastdds/FastDDSSharedParticipant.h"
 #include "carla/ros2/dds/fastdds/GenericCdrPubSubType.h"
+#include "carla/ros2/types/UserDataFormat.h"
 #include "carla/Logging.h"
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
@@ -35,6 +35,9 @@ using erc = eprosima::fastrtps::types::ReturnCode_t;
 /// Parameterized on traits type S that provides:
 ///   S::msg_type  — the message type (a carla::ros2::msg::* POD struct)
 /// Deserialization is handled by GenericCdrPubSubType<msg_type> via CdrSerialization.h.
+///
+/// Uses FastDDSSharedParticipant for a single refcounted DomainParticipant
+/// across all FastDDS endpoints.  See FastDDSPublisherMiddleware.h for the
 template<typename S>
 class FastDDSSubscriberMiddleware
     : public IDDSSubscriberMiddleware,
@@ -77,7 +80,9 @@ class FastDDSSubscriberMiddleware
       _participant->delete_topic(_topic);
     }
     if (_participant) {
-      efd::DomainParticipantFactory::get_instance()->delete_participant(_participant);
+      FastDDSSharedParticipant::release_type(_type->getName());
+      FastDDSSharedParticipant::release();
+      _participant = nullptr;
     }
   }
 
@@ -93,14 +98,14 @@ class FastDDSSubscriberMiddleware
       return false;
     }
 
-    efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
-    auto factory = efd::DomainParticipantFactory::get_instance();
-    _participant = factory->create_participant(0, pqos);
+    _participant = FastDDSSharedParticipant::acquire();
     if (_participant == nullptr) {
-      log_error("FastDDSSubscriberMiddleware: Failed to create DomainParticipant");
+      log_error("FastDDSSubscriberMiddleware: Shared participant unavailable");
       return false;
     }
+
     _type.register_type(_participant);
+    FastDDSSharedParticipant::retain_type(_type->getName());
 
     efd::SubscriberQos subqos = efd::SUBSCRIBER_QOS_DEFAULT;
     _subscriber = _participant->create_subscriber(subqos, nullptr);
@@ -109,14 +114,29 @@ class FastDDSSubscriberMiddleware
       return false;
     }
 
-    efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
-    _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    // Reuse an existing topic on the shared participant when present: FastDDS
+    // rejects duplicate create_topic for the same name. find_topic bumps the
+    // participant's topic refcount, balanced by delete_topic in the destructor.
+    if (_participant->lookup_topicdescription(topic_name) != nullptr) {
+      _topic = _participant->find_topic(topic_name, eprosima::fastrtps::Duration_t{0, 0});
+    } else {
+      efd::TopicQos tqos = efd::TOPIC_QOS_DEFAULT;
+      _topic = _participant->create_topic(topic_name, _type->getName(), tqos);
+    }
     if (_topic == nullptr) {
       log_error("FastDDSSubscriberMiddleware: Failed to create Topic");
       return false;
     }
 
     efd::DataReaderQos rqos = efd::DATAREADER_QOS_DEFAULT;
+
+    // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
+    // to the REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
+    auto ud = build_user_data_for<msg_type>();
+    if (!ud.empty()) {
+      rqos.user_data().data_vec(ud);
+    }
+
     efd::DataReaderListener* listener =
         static_cast<efd::DataReaderListener*>(this);
     _datareader = _subscriber->create_datareader(_topic, rqos, listener);

--- a/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
+++ b/LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h
@@ -37,7 +37,12 @@ using erc = eprosima::fastrtps::types::ReturnCode_t;
 /// Deserialization is handled by GenericCdrPubSubType<msg_type> via CdrSerialization.h.
 ///
 /// Uses FastDDSSharedParticipant for a single refcounted DomainParticipant
-/// across all FastDDS endpoints.  See FastDDSPublisherMiddleware.h for the
+/// across all FastDDS endpoints. See FastDDSPublisherMiddleware.h for the rationale.
+///
+/// Sets USER_DATA QoS on the DataReader to the REP-2016 KV payload
+/// "typehash=RIHS01_<hex>;" (PID_USER_DATA = 0x002c in DDSI-RTPS v2.5
+/// §9.6.2.2.2) so that Jazzy rmw_cyclonedds_cpp and rmw_fastrtps_cpp can
+/// perform REP-2011 type-hash-based endpoint matching without warning.
 template<typename S>
 class FastDDSSubscriberMiddleware
     : public IDDSSubscriberMiddleware,

--- a/LibCarla/source/carla/ros2/types/CdrTopicInfo.h
+++ b/LibCarla/source/carla/ros2/types/CdrTopicInfo.h
@@ -47,6 +47,22 @@ namespace ros2 {
 ///                         registering the type with a DomainParticipant.
 ///                         Follows the "pkg::msg::dds_::TypeName_" pattern.
 ///
+/// type_hash()           — REP-2011 RIHS01 type hash string, placed in the
+///                         DDS endpoint USER_DATA QoS policy (PID_USER_DATA,
+///                         0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2).
+///                         Format: "RIHS01_<64 lowercase hex>" (71 chars).
+///                         Consumed by UserDataFormat.h to build the
+///                         REP-2016 KV payload "typehash=RIHS01_<hex>;".
+///                         Hashes sourced from ros-jazzy installed packages
+///                         via rosidl_generator_type_description (stable per
+///                         message definition across Humble and Jazzy).
+///                         Returns nullptr for CARLA-specific types whose
+///                         canonical hash depends on the carla_msgs package
+///                         IDL version — callers must skip setting user_data.
+///                         To compute the hash for a new type, use
+///                         Util/ros2/compute_type_hash.sh (Docker required).
+///                         Full workflow: Docs/ros2/adding_message_types.md.
+///
 /// max_serialized_size() — Initial preallocation hint for the CDR payload size
 ///                         in bytes, excluding the 4-byte DDS encapsulation
 ///                         header. Used by FastDDS to pre-allocate payload
@@ -67,12 +83,18 @@ template<> struct CdrTopicInfo<msg::AckermannDrive> {
   static const char* type_name() {
     return "ackermann_msgs::msg::dds_::AckermannDrive_";
   }
+  static const char* type_hash() {
+    return "RIHS01_acf287a224a947dd1b0b87d6d76cdb73f497b0237b8fc73be2173b2ebbb82c99";
+  }
   static size_t max_serialized_size() { return 20u; }
 };
 
 template<> struct CdrTopicInfo<msg::AckermannDriveStamped> {
   static const char* type_name() {
     return "ackermann_msgs::msg::dds_::AckermannDriveStamped_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_48ca7612a08d3bb72744fd98b71b7cf2ea24c6ad50fa4e1aa0bbad963c90d8cf";
   }
   static size_t max_serialized_size() { return 288u; }
 };
@@ -81,12 +103,18 @@ template<> struct CdrTopicInfo<msg::CameraInfo> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::CameraInfo_";
   }
+  static const char* type_hash() {
+    return "RIHS01_b3dfd68ff46c9d56c80fd3bd4ed22c7a4ddce8c8348f2f59c299e73118e7e275";
+  }
   static size_t max_serialized_size() { return 3793u; }
 };
 
 template<> struct CdrTopicInfo<msg::CarlaCollisionEvent> {
   static const char* type_name() {
     return "carla_msgs::msg::dds_::CarlaCollisionEvent_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_d77acb472c5effb98998bfb2e176ae3ffac0a84ce33a79f90e999544e3fcfeff";
   }
   static size_t max_serialized_size() { return 296u; }
 };
@@ -95,6 +123,9 @@ template<> struct CdrTopicInfo<msg::CarlaEgoVehicleControl> {
   static const char* type_name() {
     return "carla_msgs::msg::dds_::CarlaEgoVehicleControl_";
   }
+  static const char* type_hash() {
+    return "RIHS01_4f251fa2a554e8ed996f77eb1d5b65515af1369eceb04d5122cb5761f7801be3";
+  }
   static size_t max_serialized_size() { return 289u; }
 };
 
@@ -102,12 +133,18 @@ template<> struct CdrTopicInfo<msg::CarlaLineInvasion> {
   static const char* type_name() {
     return "carla_msgs::msg::dds_::LaneInvasionEvent_";
   }
+  static const char* type_hash() {
+    return "RIHS01_1d81c780738761101e1b4cb165af96ed32b8aa5cd523713c9b28d1ee95af719b";
+  }
   static size_t max_serialized_size() { return 672u; }
 };
 
 template<> struct CdrTopicInfo<msg::Clock> {
   static const char* type_name() {
     return "rosgraph_msgs::msg::dds_::Clock_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_692f7a66e93a3c83e71765d033b60349ba68023a8c689a79e48078bcb5c58564";
   }
   // Clock holds one Time (8 bytes = 2 × int32).
   static size_t max_serialized_size() { return 8u; }
@@ -117,12 +154,18 @@ template<> struct CdrTopicInfo<msg::Float32> {
   static const char* type_name() {
     return "std_msgs::msg::dds_::Float32_";
   }
+  static const char* type_hash() {
+    return "RIHS01_7170d3d8f841f7be3172ce5f4f59f3a4d7f63b0447e8b33327601ad64d83d6e2";
+  }
   static size_t max_serialized_size() { return 4u; }
 };
 
 template<> struct CdrTopicInfo<msg::Header> {
   static const char* type_name() {
     return "std_msgs::msg::dds_::Header_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_f49fb3ae2cf070f793645ff749683ac6b06203e41c891e17701b1cb597ce6a01";
   }
   static size_t max_serialized_size() { return 268u; }
 };
@@ -131,12 +174,18 @@ template<> struct CdrTopicInfo<msg::Image> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::Image_";
   }
+  static const char* type_hash() {
+    return "RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47";
+  }
   static size_t max_serialized_size() { return 648u; }
 };
 
 template<> struct CdrTopicInfo<msg::Imu> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::Imu_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_7d9a00ff131080897a5ec7e26e315954b8eae3353c3f995c55faf71574000b5b";
   }
   static size_t max_serialized_size() { return 568u; }
 };
@@ -145,12 +194,18 @@ template<> struct CdrTopicInfo<msg::NavSatFix> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::NavSatFix_";
   }
+  static const char* type_hash() {
+    return "RIHS01_62223ab3fe210a15976021da7afddc9e200dc9ec75231c1b6a557fc598a65404";
+  }
   static size_t max_serialized_size() { return 369u; }
 };
 
 template<> struct CdrTopicInfo<msg::NavSatStatus> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::NavSatStatus_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_d1ed3befa628e09571bd273b888ba1c1fd187c9a5e0006b385d7e5e9095a3204";
   }
   static size_t max_serialized_size() { return 4u; }
 };
@@ -159,12 +214,18 @@ template<> struct CdrTopicInfo<msg::Odometry> {
   static const char* type_name() {
     return "nav_msgs::msg::dds_::Odometry_";
   }
+  static const char* type_hash() {
+    return "RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0";
+  }
   static size_t max_serialized_size() { return 1208u; }
 };
 
 template<> struct CdrTopicInfo<msg::Point> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Point_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_6963084842a9b04494d6b2941d11444708d892da2f4b09843b9c43f42a7f6881";
   }
   static size_t max_serialized_size() { return 24u; }
 };
@@ -173,12 +234,18 @@ template<> struct CdrTopicInfo<msg::Point32> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Point32_";
   }
+  static const char* type_hash() {
+    return "RIHS01_2fc4db7cae16a4582c79a56b66173a8d48d52c7dc520ddc55a0d4bcf2a4bfdbc";
+  }
   static size_t max_serialized_size() { return 12u; }
 };
 
 template<> struct CdrTopicInfo<msg::PointCloud2> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::PointCloud2_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_9198cabf7da3796ae6fe19c4cb3bdd3525492988c70522628af5daa124bae2b5";
   }
   static size_t max_serialized_size() { return 27597u; }
 };
@@ -187,12 +254,18 @@ template<> struct CdrTopicInfo<msg::PointField> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::PointField_";
   }
+  static const char* type_hash() {
+    return "RIHS01_5c6a4750728c2bcfbbf7037225b20b02d4429634732146b742dee1726637ef01";
+  }
   static size_t max_serialized_size() { return 272u; }
 };
 
 template<> struct CdrTopicInfo<msg::Pose> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Pose_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_d501954e9476cea2996984e812054b68026ae0bfae789d9a10b23daf35cc90fa";
   }
   static size_t max_serialized_size() { return 56u; }
 };
@@ -201,12 +274,18 @@ template<> struct CdrTopicInfo<msg::PoseWithCovariance> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::PoseWithCovariance_";
   }
+  static const char* type_hash() {
+    return "RIHS01_9a7c0fd234b7f45c6098745ecccd773ca1085670e64107135397aee31c02e1bb";
+  }
   static size_t max_serialized_size() { return 344u; }
 };
 
 template<> struct CdrTopicInfo<msg::Quaternion> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Quaternion_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_8a765f66778c8ff7c8ab94afcc590a2ed5325a1d9a076ffff38fbce36f458684";
   }
   static size_t max_serialized_size() { return 32u; }
 };
@@ -215,12 +294,18 @@ template<> struct CdrTopicInfo<msg::RegionOfInterest> {
   static const char* type_name() {
     return "sensor_msgs::msg::dds_::RegionOfInterest_";
   }
+  static const char* type_hash() {
+    return "RIHS01_ad16bcba5f9131dcdba6fbded19f726f5440e3c513b4fb586dd3027eeed8abb1";
+  }
   static size_t max_serialized_size() { return 17u; }
 };
 
 template<> struct CdrTopicInfo<msg::String> {
   static const char* type_name() {
     return "std_msgs::msg::dds_::String_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18";
   }
   static size_t max_serialized_size() { return 260u; }
 };
@@ -229,12 +314,18 @@ template<> struct CdrTopicInfo<msg::TF2Error> {
   static const char* type_name() {
     return "tf2_msgs::msg::dds_::TF2Error_";
   }
+  static const char* type_hash() {
+    return "RIHS01_db2485e7d6a0ec75bf087e058ee45df682acc3a621ca7780503d10aac141809a";
+  }
   static size_t max_serialized_size() { return 264u; }
 };
 
 template<> struct CdrTopicInfo<msg::TFMessage> {
   static const char* type_name() {
     return "tf2_msgs::msg::dds_::TFMessage_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_e369d0f05a23ae52508854b66f6aa0437f3449d652e8cbf22d5abe85d020f087";
   }
   static size_t max_serialized_size() { return 58408u; }
 };
@@ -243,12 +334,18 @@ template<> struct CdrTopicInfo<msg::Time> {
   static const char* type_name() {
     return "builtin_interfaces::msg::dds_::Time_";
   }
+  static const char* type_hash() {
+    return "RIHS01_b106235e25a4c5ed35098aa0a61a3ee9c9b18d197f398b0e4206cea9acf9c197";
+  }
   static size_t max_serialized_size() { return 8u; }
 };
 
 template<> struct CdrTopicInfo<msg::Transform> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Transform_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_beb83fbe698636351461f6f35d1abb20010c43d55374d81bd041f1ba2581fddc";
   }
   static size_t max_serialized_size() { return 56u; }
 };
@@ -257,12 +354,18 @@ template<> struct CdrTopicInfo<msg::TransformStamped> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::TransformStamped_";
   }
+  static const char* type_hash() {
+    return "RIHS01_0a241f87d04668d94099cbb5ba11691d5ad32c2f29682e4eb5653424bd275206";
+  }
   static size_t max_serialized_size() { return 584u; }
 };
 
 template<> struct CdrTopicInfo<msg::Twist> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Twist_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_9c45bf16fe0983d80e3cfe750d6835843d265a9a6c46bd2e609fcddde6fb8d2a";
   }
   static size_t max_serialized_size() { return 48u; }
 };
@@ -271,12 +374,18 @@ template<> struct CdrTopicInfo<msg::TwistWithCovariance> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::TwistWithCovariance_";
   }
+  static const char* type_hash() {
+    return "RIHS01_49f574f033f095d8b6cd1beaca5ca7925e296e84af1716d16c89d38b059c8c18";
+  }
   static size_t max_serialized_size() { return 336u; }
 };
 
 template<> struct CdrTopicInfo<msg::Vector3> {
   static const char* type_name() {
     return "geometry_msgs::msg::dds_::Vector3_";
+  }
+  static const char* type_hash() {
+    return "RIHS01_cc12fe83e4c02719f1ce8070bfd14aecd40f75a96696a67a2a1f37f7dbb0765d";
   }
   static size_t max_serialized_size() { return 24u; }
 };

--- a/LibCarla/source/carla/ros2/types/CdrTopicInfo.h
+++ b/LibCarla/source/carla/ros2/types/CdrTopicInfo.h
@@ -53,12 +53,11 @@ namespace ros2 {
 ///                         Format: "RIHS01_<64 lowercase hex>" (71 chars).
 ///                         Consumed by UserDataFormat.h to build the
 ///                         REP-2016 KV payload "typehash=RIHS01_<hex>;".
-///                         Hashes sourced from ros-jazzy installed packages
-///                         via rosidl_generator_type_description (stable per
-///                         message definition across Humble and Jazzy).
-///                         Returns nullptr for CARLA-specific types whose
-///                         canonical hash depends on the carla_msgs package
-///                         IDL version — callers must skip setting user_data.
+///                         The hash is pinned per message definition and is
+///                         stable across ROS 2 distributions. A specialization
+///                         may return nullptr when no hash is available for the
+///                         type; UserDataFormat.h then emits an empty user_data
+///                         payload and callers skip setting the QoS field.
 ///                         To compute the hash for a new type, use
 ///                         Util/ros2/compute_type_hash.sh (Docker required).
 ///                         Full workflow: Docs/ros2/adding_message_types.md.

--- a/LibCarla/source/carla/ros2/types/UserDataFormat.h
+++ b/LibCarla/source/carla/ros2/types/UserDataFormat.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/ros2/types/CdrTopicInfo.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace carla {
+namespace ros2 {
+
+/// Builds the REP-2016 endpoint USER_DATA payload encoding a REP-2011 type
+/// hash.
+///
+/// Per OMG DDSI-RTPS v2.5 §9.6.2.2.2, PID_USER_DATA (0x002c) carries the
+/// DDS UserDataQosPolicy octet sequence.  ROS 2 REP-2016 defines the payload
+/// as a set of ASCII key=value pairs separated by semicolons, e.g.:
+///
+///   typehash=RIHS01_<64 lowercase hex>;
+///
+/// rmw_cyclonedds_cpp and rmw_fastrtps_cpp on Iron / Jazzy parse this string
+/// from PID_USER_DATA during SEDP endpoint discovery to perform REP-2011
+/// type-hash-based matching.  When it is absent (null), Jazzy rmws emit:
+///   [WARN] Failed to parse type hash ... from USER_DATA '(null)'.
+///
+/// This helper is vendor-agnostic; the resulting byte vector is fed to:
+///   FastDDS : DataWriterQos::user_data().data_vec()
+///             DataReaderQos::user_data().data_vec()
+///   CycloneDDS: dds_qset_userdata(qos, data, size)
+///
+/// If type_hash is nullptr (used for types whose hash is unknown), an empty
+/// vector is returned and user_data should NOT be set.
+inline std::vector<uint8_t> build_user_data(const char* type_hash) {
+  if (type_hash == nullptr) {
+    return {};
+  }
+  // Payload: "typehash=<hash>;"  (no null terminator — DDS carries length)
+  static const char prefix[] = "typehash=";
+  static const char suffix[] = ";";
+  const size_t hash_len  = std::strlen(type_hash);
+  const size_t total_len = sizeof(prefix) - 1u + hash_len + sizeof(suffix) - 1u;
+
+  std::vector<uint8_t> payload;
+  payload.reserve(total_len);
+  for (const char* p = prefix; *p; ++p) payload.push_back(static_cast<uint8_t>(*p));
+  for (size_t i = 0u; i < hash_len; ++i) payload.push_back(static_cast<uint8_t>(type_hash[i]));
+  for (const char* p = suffix; *p; ++p) payload.push_back(static_cast<uint8_t>(*p));
+  return payload;
+}
+
+/// Convenience: build user_data from the CdrTopicInfo<T>::type_hash() of T.
+/// Returns an empty vector (and the caller must skip setting user_data) when
+/// CdrTopicInfo<T>::type_hash() returns nullptr.
+template<typename T>
+inline std::vector<uint8_t> build_user_data_for() {
+  return build_user_data(CdrTopicInfo<T>::type_hash());
+}
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/test/server/test_type_hash.cpp
+++ b/LibCarla/source/test/server/test_type_hash.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+// Tests for REP-2011 type hash values embedded in CdrTopicInfo<T>::type_hash().
+// Verifies format RIHS01_[0-9a-f]{64} for all 31 specializations and
+// uniqueness across the set.
+
+#define CARLA_ROS2_DDS_TESTING
+#include "test.h"
+
+#include <carla/ros2/types/CdrTopicInfo.h>
+#include <carla/ros2/types/UserDataFormat.h>
+
+#include <cstring>
+#include <regex>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace carla::ros2;
+
+// ---------------------------------------------------------------------------
+// Format tests
+// ---------------------------------------------------------------------------
+
+static void check_hash(const char* hash, const std::string& type_label) {
+  ASSERT_NE(hash, nullptr) << "type_hash() is nullptr for " << type_label;
+  const std::string s(hash);
+  ASSERT_EQ(s.size(), 71u) << "type_hash length != 71 for " << type_label
+                              << " (got " << s.size() << "): " << s;
+  const std::regex pattern("^RIHS01_[0-9a-f]{64}$");
+  EXPECT_TRUE(std::regex_match(s, pattern))
+      << "type_hash format mismatch for " << type_label << ": " << s;
+}
+
+#define CHECK_HASH(MsgType) \
+  check_hash(CdrTopicInfo<msg::MsgType>::type_hash(), #MsgType)
+
+TEST(TypeHash, FormatAllTypes) {
+  CHECK_HASH(AckermannDrive);
+  CHECK_HASH(AckermannDriveStamped);
+  CHECK_HASH(CameraInfo);
+  CHECK_HASH(CarlaCollisionEvent);
+  CHECK_HASH(CarlaEgoVehicleControl);
+  CHECK_HASH(CarlaLineInvasion);
+  CHECK_HASH(Clock);
+  CHECK_HASH(Float32);
+  CHECK_HASH(Header);
+  CHECK_HASH(Image);
+  CHECK_HASH(Imu);
+  CHECK_HASH(NavSatFix);
+  CHECK_HASH(NavSatStatus);
+  CHECK_HASH(Odometry);
+  CHECK_HASH(Point);
+  CHECK_HASH(Point32);
+  CHECK_HASH(PointCloud2);
+  CHECK_HASH(PointField);
+  CHECK_HASH(Pose);
+  CHECK_HASH(PoseWithCovariance);
+  CHECK_HASH(Quaternion);
+  CHECK_HASH(RegionOfInterest);
+  CHECK_HASH(String);
+  CHECK_HASH(TF2Error);
+  CHECK_HASH(TFMessage);
+  CHECK_HASH(Time);
+  CHECK_HASH(Transform);
+  CHECK_HASH(TransformStamped);
+  CHECK_HASH(Twist);
+  CHECK_HASH(TwistWithCovariance);
+  CHECK_HASH(Vector3);
+}
+
+TEST(TypeHash, UniqueAcrossAllTypes) {
+  std::vector<std::string> hashes = {
+    CdrTopicInfo<msg::AckermannDrive>::type_hash(),
+    CdrTopicInfo<msg::AckermannDriveStamped>::type_hash(),
+    CdrTopicInfo<msg::CameraInfo>::type_hash(),
+    CdrTopicInfo<msg::CarlaCollisionEvent>::type_hash(),
+    CdrTopicInfo<msg::CarlaEgoVehicleControl>::type_hash(),
+    CdrTopicInfo<msg::CarlaLineInvasion>::type_hash(),
+    CdrTopicInfo<msg::Clock>::type_hash(),
+    CdrTopicInfo<msg::Float32>::type_hash(),
+    CdrTopicInfo<msg::Header>::type_hash(),
+    CdrTopicInfo<msg::Image>::type_hash(),
+    CdrTopicInfo<msg::Imu>::type_hash(),
+    CdrTopicInfo<msg::NavSatFix>::type_hash(),
+    CdrTopicInfo<msg::NavSatStatus>::type_hash(),
+    CdrTopicInfo<msg::Odometry>::type_hash(),
+    CdrTopicInfo<msg::Point>::type_hash(),
+    CdrTopicInfo<msg::Point32>::type_hash(),
+    CdrTopicInfo<msg::PointCloud2>::type_hash(),
+    CdrTopicInfo<msg::PointField>::type_hash(),
+    CdrTopicInfo<msg::Pose>::type_hash(),
+    CdrTopicInfo<msg::PoseWithCovariance>::type_hash(),
+    CdrTopicInfo<msg::Quaternion>::type_hash(),
+    CdrTopicInfo<msg::RegionOfInterest>::type_hash(),
+    CdrTopicInfo<msg::String>::type_hash(),
+    CdrTopicInfo<msg::TF2Error>::type_hash(),
+    CdrTopicInfo<msg::TFMessage>::type_hash(),
+    CdrTopicInfo<msg::Time>::type_hash(),
+    CdrTopicInfo<msg::Transform>::type_hash(),
+    CdrTopicInfo<msg::TransformStamped>::type_hash(),
+    CdrTopicInfo<msg::Twist>::type_hash(),
+    CdrTopicInfo<msg::TwistWithCovariance>::type_hash(),
+    CdrTopicInfo<msg::Vector3>::type_hash(),
+  };
+  std::set<std::string> unique_set(hashes.begin(), hashes.end());
+  EXPECT_EQ(unique_set.size(), hashes.size())
+      << "Duplicate type hash detected across CdrTopicInfo specializations";
+}
+
+// ---------------------------------------------------------------------------
+// UserDataFormat tests
+// ---------------------------------------------------------------------------
+
+TEST(UserDataFormat, BuildPayloadFormat) {
+  const char* hash = "RIHS01_acf287a224a947dd1b0b87d6d76cdb73f497b0237b8fc73be2173b2ebbb82c99";
+  auto ud = build_user_data(hash);
+  const std::string payload(ud.begin(), ud.end());
+  // REP-2016 KV format: "typehash=<hash>;"
+  const std::string expected = std::string("typehash=") + hash + ";";
+  EXPECT_EQ(payload, expected);
+}
+
+TEST(UserDataFormat, NullHashReturnsEmpty) {
+  auto ud = build_user_data(nullptr);
+  EXPECT_TRUE(ud.empty());
+}
+
+TEST(UserDataFormat, BuildForTemplateImu) {
+  auto ud = build_user_data_for<msg::Imu>();
+  EXPECT_FALSE(ud.empty());
+  const std::string payload(ud.begin(), ud.end());
+  EXPECT_EQ(payload.substr(0, 9), "typehash=");
+  EXPECT_EQ(payload.back(), ';');
+  // Confirm the embedded hash matches type_hash()
+  const std::string expected_hash = CdrTopicInfo<msg::Imu>::type_hash();
+  EXPECT_NE(payload.find(expected_hash), std::string::npos);
+}
+
+TEST(UserDataFormat, PayloadHasNoNullTerminator) {
+  auto ud = build_user_data_for<msg::Clock>();
+  // The last byte should be ';', not '\0'
+  EXPECT_FALSE(ud.empty());
+  EXPECT_EQ(static_cast<char>(ud.back()), ';');
+}

--- a/Util/ros2/compute_type_hash.sh
+++ b/Util/ros2/compute_type_hash.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+# Compute the REP-2011 RIHS01 type hash for a ROS 2 message type by building
+# the .msg file inside an osrf/ros:jazzy-desktop Docker container.
+# No local ROS 2 installation is required.
+#
+# Usage:
+#   compute_type_hash.sh <pkg/msg/TypeName> <path/to/TypeName.msg>
+#
+# Arguments:
+#   <pkg/msg/TypeName>      Full ROS 2 type name, e.g. sensor_msgs/msg/Imu
+#   <path/to/TypeName.msg>  Path to the .msg file on the host
+#
+# Output (stdout):
+#   RIHS01_<64 hex chars>  ready to paste into CdrTopicInfo.h
+#
+# Exit codes:
+#   0  hash printed to stdout
+#   1  invalid arguments, file not found, or build failure
+#
+# Requirements:
+#   Docker must be installed and running.
+#
+# Package dependencies (std_msgs, geometry_msgs, ...) are detected
+# automatically from field type declarations in the .msg file.
+#
+# Examples:
+#   # Standard ROS 2 type (hash matches what is already in CdrTopicInfo.h):
+#   ./compute_type_hash.sh sensor_msgs/msg/Imu \
+#       /opt/ros/jazzy/share/sensor_msgs/msg/Imu.msg
+#
+#   # New carla_msgs type:
+#   ./compute_type_hash.sh carla_msgs/msg/CarlaStatus \
+#       /path/to/carla_msgs/msg/CarlaStatus.msg
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'EOF'
+Usage: compute_type_hash.sh <pkg/msg/TypeName> <path/to/TypeName.msg>
+
+Arguments:
+  <pkg/msg/TypeName>      Full ROS 2 type name, e.g. sensor_msgs/msg/Imu
+  <path/to/TypeName.msg>  Path to the .msg file on the host
+
+Output (stdout):
+  RIHS01_<64 hex chars>  ready to paste into CdrTopicInfo.h
+
+Requirements:
+  Docker must be installed and running.
+
+EOF
+    exit "${1:-0}"
+}
+
+if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
+    usage 0
+fi
+
+[[ $# -ne 2 ]] && usage 1
+
+ROS_TYPE="$1"
+MSG_FILE="$2"
+
+# ---------------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------------
+if ! [[ "$ROS_TYPE" =~ ^[a-zA-Z_][a-zA-Z0-9_]*/msg/[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "ERROR: type must be 'pkg/msg/TypeName', got: $ROS_TYPE" >&2
+    exit 1
+fi
+
+if [[ ! -f "$MSG_FILE" ]]; then
+    echo "ERROR: .msg file not found: $MSG_FILE" >&2
+    exit 1
+fi
+
+PKG_NAME="${ROS_TYPE%%/msg/*}"
+TYPE_NAME="${ROS_TYPE##*/}"
+
+# ---------------------------------------------------------------------------
+# Create a temporary colcon workspace
+# ---------------------------------------------------------------------------
+WS=$(mktemp -d)
+trap 'rm -rf "$WS"' EXIT
+
+PKG_DIR="$WS/src/$PKG_NAME"
+mkdir -p "$PKG_DIR/msg"
+cp "$MSG_FILE" "$PKG_DIR/msg/${TYPE_NAME}.msg"
+
+# Generate package.xml and CMakeLists.txt.
+# Dependencies are detected by scanning the .msg file for "pkg/TypeName" field
+# type declarations (e.g. "std_msgs/Header header").
+python3 - "$MSG_FILE" "$PKG_NAME" "$TYPE_NAME" "$PKG_DIR" <<'PYEOF'
+import re, sys, os
+
+msg_file, pkg_name, type_name, pkg_dir = sys.argv[1:]
+
+with open(msg_file) as f:
+    content = f.read()
+
+deps = set()
+for line in content.splitlines():
+    line = line.strip().split('#')[0].strip()   # strip inline comments
+    # Match "pkg_name/TypeName[optional_array] field_name"
+    m = re.match(r'^([a-zA-Z_][a-zA-Z0-9_]*)/[a-zA-Z_][a-zA-Z0-9_]*(\[.*?\])?\s+\w', line)
+    if m:
+        dep = m.group(1)
+        if dep != pkg_name:
+            deps.add(dep)
+
+deps = sorted(deps)
+
+xml_depends = '\n'.join(f'  <depend>{d}</depend>' for d in deps)
+
+with open(os.path.join(pkg_dir, 'package.xml'), 'w') as f:
+    f.write(f"""<?xml version="1.0"?>
+<package format="3">
+  <name>{pkg_name}</name>
+  <version>0.0.1</version>
+  <description>Temporary package for RIHS01 hash computation</description>
+  <maintainer email="tmp@tmp.com">tmp</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rosidl_default_generators</depend>
+{xml_depends}
+  <member_of_group>rosidl_interface_packages</member_of_group>
+</package>
+""")
+
+find_pkgs = '\n'.join(f'find_package({d} REQUIRED)' for d in deps)
+rosidl_deps = ('  DEPENDENCIES ' + ' '.join(deps)) if deps else ''
+
+with open(os.path.join(pkg_dir, 'CMakeLists.txt'), 'w') as f:
+    f.write(f"""cmake_minimum_required(VERSION 3.8)
+project({pkg_name})
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+{find_pkgs}
+rosidl_generate_interfaces(${{PROJECT_NAME}}
+  "msg/{type_name}.msg"
+{rosidl_deps}
+)
+ament_package()
+""")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Build inside Docker and extract the hash
+# ---------------------------------------------------------------------------
+echo "[hash] Building ${ROS_TYPE} inside osrf/ros:jazzy-desktop ..." >&2
+
+docker run --rm \
+    --volume="${WS}:/ws" \
+    osrf/ros:jazzy-desktop \
+    bash -c "
+        set -euo pipefail
+        source /opt/ros/jazzy/setup.bash
+        cd /ws
+        colcon build \
+            --packages-select ${PKG_NAME} \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release \
+            --log-base /tmp/colcon-log \
+            > /tmp/colcon-out.txt 2>&1 \
+        || { echo 'ERROR: colcon build failed:' >&2; cat /tmp/colcon-out.txt >&2; exit 1; }
+        JSON_FILE=/ws/install/${PKG_NAME}/share/${PKG_NAME}/msg/${TYPE_NAME}.json
+        if [[ ! -f \"\$JSON_FILE\" ]]; then
+            echo 'ERROR: generated JSON not found: '\"\$JSON_FILE\" >&2
+            exit 1
+        fi
+        jq -re --arg t '${ROS_TYPE}' \
+            '.type_hashes[] | select(.type_name == \$t) | .hash_string' \
+            \"\$JSON_FILE\" \
+        || { echo \"ERROR: '${ROS_TYPE}' not found in \$JSON_FILE\" >&2; exit 1; }
+    "


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.

Checklist:

  - [x] Your branch is up-to-date with the `ue4-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Fixes two ROS 2 Jazzy interoperability problems in the native DDS integration.

##### 1. Missing REP-2011 type hash on every topic (#9674)

ROS 2 Iron and later RMWs (`rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`) parse the DDS `USER_DATA` QoS field during SEDP/PDP endpoint discovery and expect a REP-2016 KV payload of the form `typehash=RIHS01_<64-hex>;`. When the payload is absent, the RMW logs for every discovered endpoint:

```
[WARN] [rmw_cyclonedds_cpp]: Failed to parse type hash for topic 'rt/...'
```

CARLA did not set `USER_DATA` on any of its 31 message types, so running a Jazzy subscriber (rviz2, any `ros2 topic echo`, any autonomy stack) against a CARLA server produced a warning per topic per endpoint, and prevented future strict type-hash-based endpoint matching.

Fix: hardcode a REP-2011 RIHS01 hash per message type in `CdrTopicInfo<T>::type_hash()` and attach it via a new `UserDataFormat.h::build_user_data_for<T>()` helper on every `DataWriter` and `DataReader` QoS in both FastDDS and CycloneDDS middlewares. Hashes are hardcoded because CARLA has no IDL code-generation step at build time and recomputing RIHS01 correctly requires `rosidl_generator_type_description` inside a ROS 2 build environment. The values are stable per distro for every standard message (`std_msgs`, `geometry_msgs`, `sensor_msgs`, `nav_msgs`, `builtin_interfaces`, `tf2_msgs`, `rosgraph_msgs`, `ackermann_msgs`) and match on Humble and Jazzy.

A helper script `Util/ros2/compute_type_hash.sh` computes the RIHS01 hash for any message type using only Docker, so adding a new type needs no local ROS 2 install.

##### 2. FastDDS `rt/tf` duplicate-topic crash (#9675)

Since the shared `DomainParticipant` was introduced, multiple sensor publishers on the same actor (or multiple hero actors) all call `create_topic("rt/tf", ...)` on the same participant. FastDDS rejects duplicate topic creation and aborts the server:

```
Topic with name : rt/tf already exists -> Function create_topic
ERROR: FastDDSPublisherMiddleware: Failed to create Topic
WARNING: CarlaTransformPublisher: Init failed for topic: rt/tf
Signal 11 caught.
```

Fix: introduce `FastDDSSharedParticipant`, a refcounted shared `DomainParticipant` with per-type registration refcount, and route duplicate topic names through `lookup_topicdescription` + `find_topic` so the second and later endpoints reuse the existing topic (balanced by `delete_topic` in the destructor, which decrements FastDDS's internal topic refcount). CycloneDDS is unaffected (it tolerates duplicate `dds_create_topic` when types match) but the shared-participant lifetime now drives both middlewares for parity.

The shutdown order in `ROS2::Shutdown()` also changes: publishers and TF publishers are destroyed before subscribers so `DataWriter` unregister/dispose messages are sent while the shared participant is still alive.

##### 3. Additional hardening

- `carla/multigpu/listener.cpp`: treat `boost::asio::error::operation_aborted` as the normal shutdown path instead of logging `Secondary server: Operation canceled.` Every graceful CARLA shutdown previously emitted that spurious line.

- `Docs/ros2/adding_message_types.md`: 7-step guide covering `.msg` to POD, CDR serialization, RIHS01 computation, `CdrTopicInfo` registration, and regression tests. Includes a worked `sensor_msgs/msg/Imu` side-by-side example of the `.msg` and its POD struct.

##### Files by area

| Area | Files |
|------|-------|
| REP-2011 type hashes | `LibCarla/source/carla/ros2/types/CdrTopicInfo.h`, `LibCarla/source/carla/ros2/types/UserDataFormat.h` |
| FastDDS shared participant | `LibCarla/source/carla/ros2/dds/fastdds/FastDDSSharedParticipant.{h,cpp}`, `LibCarla/source/carla/ros2/dds/fastdds/FastDDSPublisherMiddleware.h`, `LibCarla/source/carla/ros2/dds/fastdds/FastDDSSubscriberMiddleware.h` |
| USER_DATA on CycloneDDS | `LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSPublisherMiddleware.h`, `LibCarla/source/carla/ros2/dds/cyclonedds/CycloneDDSSubscriberMiddleware.h` |
| Shutdown order | `LibCarla/source/carla/ros2/ROS2.cpp` |
| Asio shutdown log | `LibCarla/source/carla/multigpu/listener.cpp` |
| Build wiring | `LibCarla/cmake/ros2/CMakeLists.txt`, `LibCarla/cmake/fast_dds/CMakeLists.txt` |
| Tests | `LibCarla/source/test/server/test_type_hash.cpp` (format, uniqueness, USER_DATA payload) |
| Tooling and docs | `Util/ros2/compute_type_hash.sh`, `Docs/ros2/adding_message_types.md` |

Fixes #9674
Fixes #9675

#### Where has this been tested?

* **Platform(s):** Ubuntu 22.04
* **Python version(s):** 3.12
* **Unreal Engine version(s):** UE4.26

Results:

* `make LibCarla ARGS="--ros2"`: clean, zero warnings in changed files.
* `libcarla_test_server_release`: **120 / 120 pass** (includes 4 `UserDataFormat.*` tests and 2 `TypeHash.*` tests).
* `libcarla_test_server_debug`: **120 / 120 pass**.
* `libcarla_test_client_release`: **56 / 56 pass**.
* `smoke.test_ros2` on port 3654 with `--dds-middleware=fastdds` and `--dds-middleware=cyclonedds`: **5 / 5 pass** each. FastDDS log is clean of `rt/tf already exists`, `Failed to create Topic`, and `Signal 11`. CycloneDDS log is clean of `Secondary server: Operation canceled`.
* rviz2 Jazzy (`osrf/ros:jazzy-desktop`) with `RMW_IMPLEMENTATION=rmw_fastrtps_cpp` and `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, against CARLA running either middleware: topics discover, type hashes parse, no `Failed to parse type hash` warnings.

#### Possible Drawbacks

* Adding a new ROS 2 message type now requires a one-time RIHS01 hash computation through `Util/ros2/compute_type_hash.sh`. The 7-step workflow is documented in `Docs/ros2/adding_message_types.md`. No runtime dependency on ROS 2 or `rosidl` is introduced.

* Hashes are hardcoded per message definition. If a standard ROS 2 message definition ever changes between distros (none of the types currently in CARLA have changed between Humble and Jazzy), the hash for that type must be updated in `CdrTopicInfo.h`. `test_type_hash.cpp` validates format and uniqueness but cannot catch a stale value versus an upstream redefinition.

* The refcounted shared participant is FastDDS-only; CycloneDDS uses its own shared participant via `dds_create_participant`. The two are independent and neither affects the other.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9681)
<!-- Reviewable:end -->
