### PR TITLE
Add support for CMake 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs/
 .vscode/
+.zed/
 .cache/
 .devcontainer/
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ if (${CMAKE_MINOR_VERSION} GREATER_EQUAL 24)
   cmake_policy (SET CMP0135 NEW)
 endif ()
 
+# CMake 4.x removed support for cmake_minimum_required < 3.5; set the floor
+# so third-party FetchContent dependencies with old requirements still build.
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+  set (CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif ()
+
 set (CARLA_VERSION_MAJOR 0)
 set (CARLA_VERSION_MINOR 10)
 set (CARLA_VERSION_PATCH 0)


### PR DESCRIPTION
Added `cmake_minimum_required < 3.5` if CMake version is 4.0 or newer so third-party FetchContent dependencies with old requirements still build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9690)
<!-- Reviewable:end -->
