### PR TITLE
refactor(BuildTools, Carla): rename ROS2 middleware CLI flag --dds-middleware= to --rmw=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Latest Changes
  * Added NumPy 2 compatibility to the PythonAPI: replaced removed aliases (`np.bool`, `np.matrix`) in example scripts and upgraded Boost to 1.90.0, which ships the upstream NumPy 2 C ABI fix (boostorg/python#432) so the C extension builds against both NumPy 1.x (>=1.18.4) and NumPy 2.x
  * Fixed North/South latitude inversion in geo-coordinate conversion for Transverse Mercator and UTM projections
- * Decoupled ROS2 DDS middleware from a hard FastDDS dependency to an agnostic strategy-pattern abstraction supporting both FastDDS and CycloneDDS, selectable at runtime via `--dds-middleware=` CLI flag
+ * Decoupled ROS2 DDS middleware from a hard FastDDS dependency to an agnostic strategy-pattern abstraction supporting both FastDDS and CycloneDDS, selectable at runtime via `--rmw=` CLI flag
  * Fixed all 282 compiler warnings in LibCarla across 27 files (unused variables, missing braces, narrowing conversions, implicit casts, initializer order, etc.) establishing a zero-warning baseline for server and client release builds
  * Fixed ROS2 native sensors not streaming data when no Python client is listening for UE4, caused by a missing ROS2 enablement check in AreClientsListening() after the multistream refactor (PR #9431)
  * Fix possible RPC Server deadlock on shutdown

--- a/Docs/ext_quickstart.md
+++ b/Docs/ext_quickstart.md
@@ -17,6 +17,7 @@ There are some configuration options available when launching CARLA and they can
 ```
 
 * `--ros2` - Launch CARLA with the native ROS2 connector enabled
+* `--rmw=<middleware>` - Select the ROS2 middleware (RMW) used by the native connector. Accepted values: `fastdds`, `cyclonedds`. Default: `fastdds`. Only valid together with `--ros2`. CycloneDDS is Linux only; on Windows only `fastdds` is supported.
 * `-carla-rpc-port=N` - Listen for client connections at port `N`. Streaming port is set to `N+1` by default.  
 * `-carla-streaming-port=N` - Specify the port for sensor data streaming. Use 0 to get a random unused port. The second port will be automatically set to `N+1`.  
 * `-quality-level={Low,Epic}` - Change graphics quality level. Find out more in [rendering options](adv_rendering_options.md).  

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
@@ -229,7 +229,7 @@ void FCarlaEngine::NotifyInitGame(const UCarlaSettings &Settings)
     {
       std::string available = carla::ros2::GetAvailableMiddlewareString();
       UE_LOG(LogCarla, Error,
-          TEXT("ROS2: unrecognized --dds-middleware value '%s'. "
+          TEXT("ROS2: unrecognized --rmw value '%s'. "
                "Available: %s. ROS2 is DISABLED for this session."),
           *Settings.DDSMiddlewareName,
           UTF8_TO_TCHAR(available.c_str()));
@@ -240,7 +240,7 @@ void FCarlaEngine::NotifyInitGame(const UCarlaSettings &Settings)
       {
         std::string available = carla::ros2::GetAvailableMiddlewareString();
         UE_LOG(LogCarla, Error,
-            TEXT("ROS2: --dds-middleware='%s' is not compiled into this binary. "
+            TEXT("ROS2: --rmw='%s' is not compiled into this binary. "
                  "Available: %s. ROS2 is DISABLED for this session."),
             *Settings.DDSMiddlewareName,
             UTF8_TO_TCHAR(available.c_str()));

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -159,10 +159,10 @@ void UCarlaSettings::LoadSettings()
     {
       ROS2 = true;
     }
-    FString DDSMiddlewareValue;
-    if (FParse::Value(FCommandLine::Get(), TEXT("-dds-middleware="), DDSMiddlewareValue))
+    FString RmwValue;
+    if (FParse::Value(FCommandLine::Get(), TEXT("-rmw="), RmwValue))
     {
-      DDSMiddlewareName = DDSMiddlewareValue.ToLower();
+      DDSMiddlewareName = RmwValue.ToLower();
     }
   }
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
@@ -169,7 +169,7 @@ public:
   bool ROS2TopicVisibility = true;
 
   /// DDS middleware for ROS2 publishing. Accepted values: "fastdds", "cyclonedds".
-  /// Set via --dds-middleware=<value> on the command line.
+  /// Set via --rmw=<value> on the command line.
   UPROPERTY(Category = "Quality Settings/ROS2",
       BlueprintReadOnly,
       EditAnywhere,

--- a/Util/BuildTools/BuildCarlaUE4.sh
+++ b/Util/BuildTools/BuildCarlaUE4.sh
@@ -19,14 +19,14 @@ USE_PYTORCH=false
 USE_UNITY=true
 USE_ROS2=false
 CHRONO_PATH=""
-DDS_MIDDLEWARE=""
+RMW=""
 
 EDITOR_FLAGS=""
 
 GDB=
 RHI="-vulkan"
 
-OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl,carsim,pytorch,chrono,chrono-path:,ros2,dds-middleware:,no-simready,no-unity,editor-flags: -n 'parse-options' -- "$@"`
+OPTS=`getopt -o h --long help,build,rebuild,launch,clean,hard-clean,gdb,opengl,carsim,pytorch,chrono,chrono-path:,ros2,rmw:,no-simready,no-unity,editor-flags: -n 'parse-options' -- "$@"`
 
 eval set -- "$OPTS"
 
@@ -74,8 +74,8 @@ while [[ $# -gt 0 ]]; do
     --ros2 )
       USE_ROS2=true;
       shift ;;
-    --dds-middleware )
-      DDS_MIDDLEWARE=$2;
+    --rmw )
+      RMW=$2;
       shift 2 ;;
     --no-simready )
       USE_SIMREADY=false
@@ -99,8 +99,8 @@ done
 if ${USE_ROS2} ; then
   EDITOR_FLAGS="${EDITOR_FLAGS} --ros2"
 fi
-if [ -n "${DDS_MIDDLEWARE}" ] ; then
-  EDITOR_FLAGS="${EDITOR_FLAGS} --dds-middleware=${DDS_MIDDLEWARE}"
+if [ -n "${RMW}" ] ; then
+  EDITOR_FLAGS="${EDITOR_FLAGS} --rmw=${RMW}"
 fi
 
 # ==============================================================================


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the `ue4-dev/ue5-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

As I mentioned in other conversations, changing the name of the middleware flag to `--rmw` is a more pertinent name for this flag because it matches the canonical terminology used everywhere else in the ROS 2 ecosystem (`RMW_IMPLEMENTATION`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`) and, more importantly, it does not lock the flag to DDS as the underlying transport. The "RMW" abstraction in ROS 2 (ROS Middleware) sits one level above the wire format, so the same flag can later select a non-DDS middleware (Zenoh, for example) without another rename or a confusing alias. The repository was already using this convention in `PythonAPI/examples/ros2/run_rviz.sh` (`--rmw=fastdds`, `--rmw=cyclonedds`), so this PR brings the server flag in line with that existing usage.

This PR is a strict, end to end rename of the runtime CLI flag from `--dds-middleware=` to `--rmw=`. The deprecated form is removed completely and no alias is kept.

##### What changes

- `Util/BuildTools/BuildCarlaUE4.sh`: the `getopt` long option `dds-middleware:` becomes `rmw:`, the internal variable `DDS_MIDDLEWARE` becomes `RMW`, and the `EDITOR_FLAGS` forward emits `--rmw=${RMW}`.
- `Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp`: `FParse::Value(FCommandLine::Get(), TEXT("-rmw="), ...)` replaces the previous `-dds-middleware=` probe. The parsed value still feeds the existing `DDSMiddlewareName` field, so no UPROPERTY rename and no `.ini` migration is needed.
- `Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h`: the doc comment above `DDSMiddlewareName` is updated to read `Set via --rmw=<value> on the command line.`
- `Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp`: both `UE_LOG(LogCarla, Error, ...)` diagnostic messages now print `--rmw` so the user sees the flag name they actually typed.
- `Docs/ext_quickstart.md`: the command-line options table now documents `--rmw=<middleware>`, listing accepted values (`fastdds`, `cyclonedds`), the default (`fastdds`), and the Linux-only note for `cyclonedds`.
- `CHANGELOG.md`: the existing ROS2 middleware bullet now reads `selectable at runtime via \`--rmw=\` CLI flag`.

##### What is intentionally NOT renamed

- The internal C++ identifiers in `LibCarla` (`carla::ros2::DDSMiddleware` enum, `DDSMiddlewareFactory` class, `IDDSPublisherMiddleware` / `IDDSSubscriberMiddleware` interfaces, the `test_dds_middleware.cpp` suite, and the `UCarlaSettings::DDSMiddlewareName` UPROPERTY) are kept as is. They still describe DDS-specific implementations (FastDDS and CycloneDDS), and renaming the UPROPERTY would change the serialized `.ini` key (`[/Script/Carla.CarlaSettings] DDSMiddlewareName=...`) and break user configs that already pin the value. A future non-DDS RMW would live alongside `DDSMiddleware`, not replace it, so the abstraction layer stays accurate.
- `Util/BuildTools/BuildCarlaUE4.bat` is intentionally not modified. It never accepted `--dds-middleware=` either, so this PR does not regress Windows behavior. Adding `--rmw=` parsing to the `.bat` is deferred to a separate PR that can be validated on a real Windows host.

##### Files by area

| Area | Files |
|------|-------|
| Build script (Linux) | `Util/BuildTools/BuildCarlaUE4.sh` |
| Command-line parsing (UE4) | `Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.{cpp,h}` |
| Diagnostic messages (UE4) | `Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp` |
| Documentation | `Docs/ext_quickstart.md` |
| Release notes | `CHANGELOG.md` |

#### Where has this been tested?

* **Platform(s):** Ubuntu 22.04
* **Python version(s):** 3.12
* **Unreal Engine version(s):** UE4.26

Results:

* `make LibCarla ARGS="--ros2"`: green.
* `make check.LibCarla`: **254 / 254 pass** across all four configs (server release 61, client release 66, server debug 61, client debug 66).
* `make package ARGS="--python-version=3.12 --ros2 --no-zip --target-wheel-platform=manylinux_2_31_x86_64"`: SUCCESS in 443 s, confirming the FParse and UE_LOG changes compile in the UE4 plugin.
* `./CarlaUE4.sh -RenderOffScreen --ros2 --rmw=fastdds -carla-rpc-port=3654` then `python -m nose2 -v smoke.test_ros2` under `carla_py_12`: **5 / 5 pass** in 40.7 s.
* `./CarlaUE4.sh -RenderOffScreen --ros2 --rmw=cyclonedds -carla-rpc-port=3654` then `python -m nose2 -v smoke.test_ros2` under `carla_py_12`: **5 / 5 pass** in 40.0 s.
* Negative check: `make launch ARGS="--ros2 --dds-middleware=cyclonedds"` is rejected by `getopt` with `unrecognized option`, confirming the deprecated flag is gone and not silently accepted.

#### Possible Drawbacks

* This is a breaking change for any external script, CI job, or user documentation that hard codes `--dds-middleware=`. The repository's own CI (`.github/workflows/_ci-ubuntu.yml`) does not pass the flag (it only passes `--ros2`), so this PR does not require a CI workflow update. Anyone running `--dds-middleware=` in their own automation will see `getopt` reject the flag and must rename it to `--rmw=`. The `CHANGELOG.md` entry now points at the new flag name so the breaking change is visible in release notes.
* The Windows `.bat` build script is not modified by this PR, so on Windows `--rmw=` is currently not parsed by `BuildCarlaUE4.bat`. This is consistent with the previous state (the deprecated flag was not parsed there either) and will be addressed in a follow-up PR validated on a real Windows host.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9692)
<!-- Reviewable:end -->
