### PR TITLE
fix(LibCarla,plugin): [1/3] pre-existing UE4-era bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cmake-build-*/
 __pycache__/
 
 Build/
+Build-Tests/
 Install/
 Doxygen/
 Dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed pre-existing UE4-era latent bugs in LibCarla and the Carla plugin: LidarData/SemanticLidarData `ResetMemory` boundary, DVSCamera `IsValid` inversion, SceneCaptureCamera profiler gating, `ViewActor` `TObjectPtr` wrap, ImageUtil `ReadImageData` null return, ShaderBasedSensor runtime-safe material loader, and `manual_control.py` sensor teardown drain.
 * Enabled the LibCarla GoogleTest suite (server + client) on ue5-dev and gated both in CI.
 * Fixed Digital Twin Tool crashes on dense metropolitan OSM data, vegetation spawning inside driving lanes on rural maps, and one-way streets being silently excluded from generation (#9565, #9678)
 * Added Ubuntu 24.04 support alongside Ubuntu 22.04

--- a/LibCarla/source/carla/sensor/data/LidarData.h
+++ b/LibCarla/source/carla/sensor/data/LidarData.h
@@ -85,7 +85,7 @@ namespace data {
     ~LidarData() = default;
 
     virtual void ResetMemory(std::vector<uint32_t> points_per_channel) {
-      DEBUG_ASSERT(GetChannelCount() > points_per_channel.size());
+      DEBUG_ASSERT(GetChannelCount() >= points_per_channel.size());
       std::memset(_header.data() + Index::SIZE, 0, sizeof(uint32_t) * GetChannelCount());
 
       uint32_t total_points = static_cast<uint32_t>(

--- a/LibCarla/source/carla/sensor/data/SemanticLidarData.h
+++ b/LibCarla/source/carla/sensor/data/SemanticLidarData.h
@@ -116,7 +116,7 @@ namespace data {
     }
 
     virtual void ResetMemory(std::vector<uint32_t> points_per_channel) {
-      DEBUG_ASSERT(GetChannelCount() > points_per_channel.size());
+      DEBUG_ASSERT(GetChannelCount() >= points_per_channel.size());
       std::memset(_header.data() + Index::SIZE, 0, sizeof(uint32_t) * GetChannelCount());
 
       uint32_t total_points = static_cast<uint32_t>(

--- a/LibCarla/source/test/common/test_lidar_data.cpp
+++ b/LibCarla/source/test/common/test_lidar_data.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "test.h"
+
+#include <carla/sensor/data/LidarData.h>
+#include <carla/sensor/data/SemanticLidarData.h>
+
+#include <vector>
+
+using carla::sensor::data::LidarData;
+using carla::sensor::data::SemanticLidarData;
+
+// {Lidar,SemanticLidar}Data::ResetMemory rejects callers that supply more
+// points-per-channel entries than the configured channel count; the equal
+// count case is valid. These tests pin the boundary so a future tightening
+// to a strict `>` would be caught. DEBUG_ASSERT compiles away under NDEBUG,
+// so the assertion only fires when the suite is built as Debug.
+
+TEST(LidarData, reset_memory_accepts_one_entry_per_channel) {
+  constexpr uint32_t channel_count{4u};
+  LidarData data{channel_count};
+  std::vector<uint32_t> points_per_channel(channel_count, 1u);
+  data.ResetMemory(points_per_channel);
+  EXPECT_EQ(data.GetChannelCount(), channel_count);
+}
+
+TEST(LidarData, reset_memory_accepts_fewer_entries_than_channels) {
+  constexpr uint32_t channel_count{8u};
+  LidarData data{channel_count};
+  std::vector<uint32_t> points_per_channel(channel_count - 2u, 3u);
+  data.ResetMemory(points_per_channel);
+  EXPECT_EQ(data.GetChannelCount(), channel_count);
+}
+
+TEST(SemanticLidarData, reset_memory_accepts_one_entry_per_channel) {
+  constexpr uint32_t channel_count{4u};
+  SemanticLidarData data{channel_count};
+  std::vector<uint32_t> points_per_channel(channel_count, 1u);
+  data.ResetMemory(points_per_channel);
+  EXPECT_EQ(data.GetChannelCount(), channel_count);
+}
+
+TEST(SemanticLidarData, reset_memory_accepts_fewer_entries_than_channels) {
+  constexpr uint32_t channel_count{8u};
+  SemanticLidarData data{channel_count};
+  std::vector<uint32_t> points_per_channel(channel_count - 2u, 3u);
+  data.ResetMemory(points_per_channel);
+  EXPECT_EQ(data.GetChannelCount(), channel_count);
+}

--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -69,6 +69,7 @@ import math
 import random
 import re
 import os
+import time
 import weakref
 
 try:
@@ -1172,6 +1173,12 @@ class CameraManager(object):
             (force_respawn or (self.sensors[index][2] != self.sensors[self.index][2]))
         if needs_respawn:
             if self.sensor is not None:
+                # Drain in-flight callbacks before tearing the actor down.
+                # Bare destroy() races the streaming session and segfaults the
+                # client when the user toggles cameras quickly. stop() detaches
+                # the listener; the short sleep lets queued frames flush.
+                self.sensor.stop()
+                time.sleep(0.4)
                 self.sensor.destroy()
                 self.surface = None
             self.sensor = self._parent.get_world().spawn_actor(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/DVSCamera.cpp
@@ -134,7 +134,7 @@ void ADVSCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTim
   TRACE_CPUPROFILER_EVENT_SCOPE(ADVSCamera::PostPhysTick);
   Super::PostPhysTick(World, TickType, DeltaTime);
   check(CaptureRenderTarget != nullptr);
-  if (!HasActorBegunPlay() || IsValid(this))
+  if (!HasActorBegunPlay() || !IsValid(this) || !AreClientsListening())
   {
     return;
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
@@ -167,7 +167,7 @@ namespace ImageUtil
       RenderTarget.GetSurfaceHeight());
     auto PixelData = MakeUnique<TImagePixelData<FColor>>(Size);
     ReadImageData(RenderTarget, PixelData->Pixels);
-    return TUniquePtr<TImagePixelData<FColor>>();
+    return PixelData;
   }
 
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureCamera.cpp
@@ -52,19 +52,21 @@ void ASceneCaptureCamera::PostPhysTick(UWorld *World, ELevelTick TickType, float
   TRACE_CPUPROFILER_EVENT_SCOPE(ASceneCaptureCamera::PostPhysTick);
   Super::PostPhysTick(World, TickType, DeltaSeconds);
   
+#if STATS || CSV_PROFILER
   ENQUEUE_RENDER_COMMAND(MeasureTime)
   (
     [](auto &InRHICmdList)
     {
-      std::chrono::time_point<std::chrono::high_resolution_clock> Time = 
+      std::chrono::time_point<std::chrono::high_resolution_clock> Time =
           std::chrono::high_resolution_clock::now();
       auto Duration = std::chrono::duration_cast< std::chrono::milliseconds >(Time.time_since_epoch());
       uint64_t Milliseconds = Duration.count();
-      FString ProfilerText = FString("(Render)Frame: ") + FString::FromInt(FCarlaEngine::GetFrameCounter()) + 
+      FString ProfilerText = FString("(Render)Frame: ") + FString::FromInt(FCarlaEngine::GetFrameCounter()) +
           FString(" Time: ") + FString::FromInt(Milliseconds);
       TRACE_CPUPROFILER_EVENT_SCOPE_TEXT(*ProfilerText);
     }
   );
+#endif
 
   if (!AreClientsListening())
       return;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ShaderBasedSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ShaderBasedSensor.cpp
@@ -9,7 +9,7 @@
 #include "Actor/ActorBlueprintFunctionLibrary.h"
 
 #include <util/ue-header-guard-begin.h>
-#include "UObject/ConstructorHelpers.h"
+#include "Materials/Material.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Components/SceneCaptureComponent2D.h"
 #include <util/ue-header-guard-end.h>
@@ -22,12 +22,21 @@ AShaderBasedSensor::AShaderBasedSensor(const FObjectInitializer& ObjectInitializ
 
 bool AShaderBasedSensor::AddPostProcessingMaterial(const FString &Path)
 {
-  ConstructorHelpers::FObjectFinder<UMaterial> Loader(*Path);
-  if (Loader.Succeeded())
+  // ConstructorHelpers::FObjectFinder is documented as constructor-only and
+  // has undefined behavior when used from runtime functions. FSoftObjectPath
+  // is the runtime-safe path resolver; it accepts both plain object paths
+  // and the class-prefixed export-text form ("Material'/Game/.../Foo'") that
+  // FObjectFinder previously normalised internally.
+  UMaterial *Material = Cast<UMaterial>(FSoftObjectPath(Path).TryLoad());
+  if (Material != nullptr)
   {
-    MaterialsFound.Add(Loader.Object);
+    MaterialsFound.Add(Material);
+    return true;
   }
-  return Loader.Succeeded();
+  UE_LOG(LogCarla, Error,
+      TEXT("AShaderBasedSensor::AddPostProcessingMaterial: failed to load material '%s'"),
+      *Path);
+  return false;
 }
 
 void AShaderBasedSensor::SetUpSceneCaptureComponent(USceneCaptureComponent2D &SceneCapture)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/UE4_Overridden/SceneCaptureComponent2D_CARLA.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/UE4_Overridden/SceneCaptureComponent2D_CARLA.h
@@ -23,7 +23,8 @@ public:
 
   USceneCaptureComponent2D_CARLA(const FObjectInitializer& = FObjectInitializer::Get());
 
-  const AActor* ViewActor;
+  UPROPERTY()
+  TObjectPtr<AActor> ViewActor;
 
 	virtual const AActor* GetViewOwner() const override;
 };


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing (LibCarla GoogleTest suite, Debug + Release)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

This PR is the first of a three-PR series aimed at making CARLA on UE5 (0.10.0) usable on graphics cards smaller than the 16 GB announced for the release, without sacrificing the visual quality the project currently ships. Across the series, the goal is bug fixes, refactoring around Unreal Engine resource ownership, and a redesigned scalability tier system that gives users explicit Low / Medium / High / Epic presets with predictable VRAM envelopes.

After the full series, on a 16 GB card in Epic mode the simulator runs at roughly 80 % GPU compute utilisation and averages **~9.5 GB VRAM steady-state** with stable frame pacing, with no sudden spikes that previously crashed the process even on 16 GB cards. Initial testing also suggests that an 8 GB card may be able to run the simulator (likely with a perceptible quality drop in Epic mode), though that is not a guarantee yet and needs broader hardware coverage. Demo run with the full series applied: https://www.youtube.com/watch?v=Z9U6aGwcoBo

<img width="1543" height="836" alt="carla-0 10 0-ue5-refactoring" src="https://github.com/user-attachments/assets/96b44e61-ef2f-4ea0-af10-6d62f50412a3" />

##### PR series overview

| # | PR | Theme | Status |
|---|----|-------|--------|
| **1/3** | **`fix/preexisting-bugs` (this PR)** | **Pre-existing UE4-era latent bugs** | **In review** |
| 2/3 | `refactor/uobject-hardening` | UE5 UObject hardening: `TObjectPtr` migration, factory mesh caches, async heightmap on tile cross, soft-reference catalogs | Pending (stacked on this PR) |
| 3/3 | `feat/render-pipeline-and-tiers` | Sensor pipeline optimisation (`RHIGPUReadbackPool`, lazy GBuffer capture, streaming prewarm), per-camera RT toggle + selective temporal-history opt-in, and ini-first quality tier system via `DeviceProfiles` (Low / Medium / High / Epic presets) | Pending (stacked on PR 2/3) |

This PR (1/3) is the foundation of the chain. It contains independent, small-scope fixes that have **no dependency** on the rendering or scalability work that follows. The rest of the series builds on top of this branch.

##### What this PR (1/3) changes

**LibCarla**
- `LidarData.h` / `SemanticLidarData.h`: relax the boundary check in `ResetMemory` from strict `>` to `>=`. Callers supplying one slot per channel previously tripped the Debug assertion. New `test_lidar_data.cpp` pins both the equality boundary and the under-one-per-channel path.

**Carla plugin (UE5)**
- `Sensor/DVSCamera.cpp`: `PostPhysTick` early-out had the `IsValid(this)` check inverted — it was returning on the live path and ticking the dead path. Flip the condition and gate on `AreClientsListening()` to match every other camera.
- `Sensor/SceneCaptureCamera.cpp`: gate the per-frame `ENQUEUE_RENDER_COMMAND(MeasureTime)` behind `STATS || CSV_PROFILER`. In Shipping builds the command was running every frame for every RGB camera with no observable output and no measurement sink.
- `Sensor/UE4_Overridden/SceneCaptureComponent2D_CARLA.h`: wrap `ViewActor` in `UPROPERTY()` + `TObjectPtr<AActor>`. Currently safe (always assigned `this`), but the raw pointer was a latent foot-gun outside GC's view.
- `Sensor/ImageUtil.cpp`: `ReadImageData` was building a populated `PixelData` and then returning a default-constructed null `TUniquePtr`, throwing the work away. Return the populated pointer.
- `Sensor/ShaderBasedSensor.cpp`: `AddPostProcessingMaterial` used `ConstructorHelpers::FObjectFinder`, which is documented as constructor-only and has undefined behaviour at runtime. Switch to `FSoftObjectPath::TryLoad`, the runtime-safe path resolver, and emit an explicit Error log on load failure so a bad catalog path is observable in `PackageLog` instead of silently swallowed.

**Examples**
- `PythonAPI/examples/manual_control.py`: rapid camera toggles segfaulted the Python client. Bare `sensor.destroy()` races the streaming session while frames are still in flight. Call `sensor.stop()` and sleep briefly before `destroy()` so the listener detaches and queued callbacks drain. Same idiom already used in `visualize_depth.py`.

**Build hygiene**
- `.gitignore`: ignore the `Build-Tests/` directory used by the alternate Debug test build tree (`-DBUILD_LIBCARLA_TESTS=ON` configured in a separate build dir).

##### Possible related issues

This PR may help with the following open issues, though full validation is still pending and broader testing is needed before claiming a definitive fix:

- carla-simulator/carla#8395
- carla-simulator/carla#8481

The `manual_control.py` teardown drain and the `ShaderBasedSensor` runtime material loader are the most likely contributors to a stability improvement on either, but a confirmation from affected users would be welcome.

Fixes #

#### Where has this been tested?

* **Platform(s):** Ubuntu 22.04.
* **Python version(s):** 3.10.
* **Unreal Engine version(s):** UE 5.5.
* **Tested on:** Nvidia GeForce RTX 5070 TI 16GB

#### Possible Drawbacks

- The `SceneCaptureComponent2D_CARLA::ViewActor` `TObjectPtr` wrap forces UHT to regenerate the corresponding generated header. First incremental rebuild after this PR is applied may take longer than usual; subsequent builds are unaffected.
- The `ShaderBasedSensor` runtime material loader switch from `FObjectFinder` to `FSoftObjectPath::TryLoad` changes the failure mode from a silent fall-through to a logged Error. Any consumer that was relying on a silent failure will now see a `LogCarla: Error` line in `PackageLog`. The behaviour itself is the intended one.
- The `DEBUG_ASSERT` boundary relaxation in `LidarData::ResetMemory` is a constraint loosening. The new `test_lidar_data.cpp` covers the boundary so a future tightening back to strict `>` would be caught immediately.
- `manual_control.py` adds a 0.4 s sleep before each sensor `destroy()`. This is a client-side workaround; the underlying race between `Sensor::Stop()` and the streaming `Session` should be fixed properly in LibCarla in a follow-up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9697)
<!-- Reviewable:end -->
