### PR TITLE
feat(recorder,replayer): port weather recording, follow offset, map override, simultaneous record-and-replay, and stop_replayer flag from ue4-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Added weather recording and replay, simultaneous record-and-replay, `stop_replayer` flag on `start_recorder`, `map_override` and follow-offset arguments on `replay_file`, and traffic-sign follow targets in the replayer (ported from ue4-dev)
 * Enabled the LibCarla GoogleTest suite (server + client) on ue5-dev and gated both in CI.
 * Fixed Digital Twin Tool crashes on dense metropolitan OSM data, vegetation spawning inside driving lanes on rural maps, and one-way streets being silently excluded from generation (#9565, #9678)
 * Added Ubuntu 24.04 support alongside Ubuntu 22.04

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -139,9 +139,11 @@ namespace client {
       return _simulator->ShowRecorderActorsBlocked(name, min_time, min_distance);
     }
 
-    std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
-      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, offset);
+    std::string ReplayFile(
+      std::string name, double start, double duration,
+      uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+      std::string map_override) {
+      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, offset, map_override);
     }
 
     void StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -9,6 +9,7 @@
 #include "carla/client/detail/Simulator.h"
 #include "carla/client/World.h"
 #include "carla/client/Map.h"
+#include "carla/geom/Transform.h"
 #include "carla/PythonUtil.h"
 #include "carla/trafficmanager/TrafficManager.h"
 
@@ -139,8 +140,8 @@ namespace client {
     }
 
     std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors) {
-      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors);
+        uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
+      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, offset);
     }
 
     void StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -140,10 +140,14 @@ namespace client {
     }
 
     std::string ReplayFile(
-      std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
-      std::string map_override) {
-      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, replay_weather, offset, map_override);
+        std::string name, double start, double duration,
+        uint32_t follow_id, bool replay_sensors,
+        bool replay_weather = false,
+        geom::Transform offset = geom::Transform(),
+        std::string map_override = "") {
+      return _simulator->ReplayFile(
+          std::move(name), start, duration, follow_id, replay_sensors,
+          replay_weather, offset, std::move(map_override));
     }
 
     void StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -119,8 +119,8 @@ namespace client {
       return _simulator->GetCurrentEpisode();
     }
 
-    std::string StartRecorder(std::string name, bool additional_data = false) {
-      return _simulator->StartRecorder(name, additional_data);
+    std::string StartRecorder(std::string name, bool additional_data = false, bool stop_replayer = true) {
+      return _simulator->StartRecorder(name, additional_data, stop_replayer);
     }
 
     void StopRecorder(void) {

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -143,7 +143,7 @@ namespace client {
         std::string name, double start, double duration,
         uint32_t follow_id, bool replay_sensors,
         bool replay_weather = false,
-        geom::Transform offset = geom::Transform(),
+        const geom::Transform& offset = geom::Transform(),
         std::string map_override = "") {
       return _simulator->ReplayFile(
           std::move(name), start, duration, follow_id, replay_sensors,

--- a/LibCarla/source/carla/client/Client.h
+++ b/LibCarla/source/carla/client/Client.h
@@ -141,9 +141,9 @@ namespace client {
 
     std::string ReplayFile(
       std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+      uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
       std::string map_override) {
-      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, offset, map_override);
+      return _simulator->ReplayFile(name, start, duration, follow_id, replay_sensors, replay_weather, offset, map_override);
     }
 
     void StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -591,10 +591,10 @@ namespace detail {
 
   std::string Client::ReplayFile(
     std::string name, double start, double duration,
-    uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+    uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
     std::string map_override) {
     return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration,
-        follow_id, replay_sensors, offset, map_override);
+        follow_id, replay_sensors, replay_weather, offset, map_override);
   }
 
   void Client::StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -591,7 +591,7 @@ namespace detail {
 
   std::string Client::ReplayFile(
     std::string name, double start, double duration,
-    uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
+    uint32_t follow_id, bool replay_sensors, bool replay_weather, const geom::Transform& offset,
     std::string map_override) {
     return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration,
         follow_id, replay_sensors, replay_weather, offset, map_override);

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -589,10 +589,12 @@ namespace detail {
     return _pimpl->CallAndWait<std::string>("show_recorder_actors_blocked", name, min_time, min_distance);
   }
 
-  std::string Client::ReplayFile(std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
+  std::string Client::ReplayFile(
+    std::string name, double start, double duration,
+    uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+    std::string map_override) {
     return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration,
-        follow_id, replay_sensors, offset);
+        follow_id, replay_sensors, offset, map_override);
   }
 
   void Client::StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -590,9 +590,9 @@ namespace detail {
   }
 
   std::string Client::ReplayFile(std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors) {
+      uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
     return _pimpl->CallAndWait<std::string>("replay_file", name, start, duration,
-        follow_id, replay_sensors);
+        follow_id, replay_sensors, offset);
   }
 
   void Client::StopReplayer(bool keep_actors) {

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -569,8 +569,8 @@ namespace detail {
     return _pimpl->CallAndWait<return_t>("get_group_traffic_lights", traffic_light);
   }
 
-  std::string Client::StartRecorder(std::string name, bool additional_data) {
-    return _pimpl->CallAndWait<std::string>("start_recorder", name, additional_data);
+  std::string Client::StartRecorder(std::string name, bool additional_data, bool stop_replayer) {
+    return _pimpl->CallAndWait<std::string>("start_recorder", name, additional_data, stop_replayer);
   }
 
   void Client::StopRecorder() {

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -366,7 +366,7 @@ namespace detail {
     std::vector<ActorId> GetGroupTrafficLights(
         rpc::ActorId traffic_light);
 
-    std::string StartRecorder(std::string name, bool additional_data);
+    std::string StartRecorder(std::string name, bool additional_data, bool stop_replayer);
 
     void StopRecorder();
 

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -376,8 +376,10 @@ namespace detail {
 
     std::string ShowRecorderActorsBlocked(std::string name, double min_time, double min_distance);
 
-    std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors, geom::Transform offset);
+    std::string ReplayFile(
+        std::string name, double start, double duration,
+        uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+        std::string map_override);
 
     void SetReplayerTimeFactor(double time_factor);
 

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -377,7 +377,7 @@ namespace detail {
     std::string ShowRecorderActorsBlocked(std::string name, double min_time, double min_distance);
 
     std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors);
+        uint32_t follow_id, bool replay_sensors, geom::Transform offset);
 
     void SetReplayerTimeFactor(double time_factor);
 

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -378,7 +378,7 @@ namespace detail {
 
     std::string ReplayFile(
         std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
+        uint32_t follow_id, bool replay_sensors, bool replay_weather, const geom::Transform& offset,
         std::string map_override);
 
     void SetReplayerTimeFactor(double time_factor);

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -378,7 +378,7 @@ namespace detail {
 
     std::string ReplayFile(
         std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+        uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
         std::string map_override);
 
     void SetReplayerTimeFactor(double time_factor);

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -612,8 +612,8 @@ namespace detail {
     // =========================================================================
     /// @{
 
-    std::string StartRecorder(std::string name, bool additional_data) {
-      return _client.StartRecorder(std::move(name), additional_data);
+    std::string StartRecorder(std::string name, bool additional_data, bool stop_replayer) {
+      return _client.StartRecorder(std::move(name), additional_data, stop_replayer);
     }
 
     void StopRecorder(void) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -634,7 +634,7 @@ namespace detail {
 
     std::string ReplayFile(
       std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
+      uint32_t follow_id, bool replay_sensors, bool replay_weather, const geom::Transform& offset,
       std::string map_override) {
       return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, replay_weather, offset, map_override);
     }

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -633,8 +633,8 @@ namespace detail {
     }
 
     std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors) {
-      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors);
+        uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
+      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, offset);
     }
 
     void SetReplayerTimeFactor(double time_factor) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -632,9 +632,11 @@ namespace detail {
       return _client.ShowRecorderActorsBlocked(std::move(name), min_time, min_distance);
     }
 
-    std::string ReplayFile(std::string name, double start, double duration,
-        uint32_t follow_id, bool replay_sensors, geom::Transform offset) {
-      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, offset);
+    std::string ReplayFile(
+      std::string name, double start, double duration,
+      uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+      std::string map_override) {
+      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, offset, map_override);
     }
 
     void SetReplayerTimeFactor(double time_factor) {

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -634,9 +634,9 @@ namespace detail {
 
     std::string ReplayFile(
       std::string name, double start, double duration,
-      uint32_t follow_id, bool replay_sensors, geom::Transform offset,
+      uint32_t follow_id, bool replay_sensors, bool replay_weather, geom::Transform offset,
       std::string map_override) {
-      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, offset, map_override);
+      return _client.ReplayFile(std::move(name), start, duration, follow_id, replay_sensors, replay_weather, offset, map_override);
     }
 
     void SetReplayerTimeFactor(double time_factor) {

--- a/PythonAPI/carla/src/Client.cpp
+++ b/PythonAPI/carla/src/Client.cpp
@@ -193,10 +193,11 @@ void export_client() {
         double duration, \
         uint32_t follow_id, \
         bool replay_sensors, \
+        bool replay_weather, \
         cg::Transform offset, \
         std::string map_override) { \
       carla::PythonUtil::ReleaseGIL unlock; \
-      return self.fn(name, time_start, duration, follow_id, replay_sensors, offset, map_override); \
+      return self.fn(name, time_start, duration, follow_id, replay_sensors, replay_weather, offset, map_override); \
     }, \
     ( \
       arg("name"), \
@@ -204,6 +205,7 @@ void export_client() {
       arg("duration"), \
       arg("follow_id"), \
       arg("replay_sensors")=false, \
+      arg("replay_weather")=false, \
       arg("offset")=cg::Transform(cg::Location(cg::Vector3D(-10, 0, 5)), cg::Rotation(-25, 0, 0)), \
       arg("map_override")="")
 

--- a/PythonAPI/carla/src/Client.cpp
+++ b/PythonAPI/carla/src/Client.cpp
@@ -11,6 +11,7 @@
 #include <boost/python/stl_iterator.hpp>
 
 namespace ctm = carla::traffic_manager;
+namespace cg = carla::geom;
 
 static void SetTimeout(carla::client::Client &client, double seconds) {
   client.SetTimeout(TimeDurationFromSeconds(seconds));
@@ -185,6 +186,25 @@ void export_client() {
     .def_readwrite("enable_pedestrian_navigation", &rpc::OpendriveGenerationParameters::enable_pedestrian_navigation)
   ;
 
+#define REPLAY_FILE_WITHOUT_GIL(fn) +[]( \
+        cc::Client &self, \
+        std::string name, \
+        double time_start, \
+        double duration, \
+        uint32_t follow_id, \
+        bool replay_sensors, \
+        cg::Transform offset) { \
+      carla::PythonUtil::ReleaseGIL unlock; \
+      return self.fn(name, time_start, duration, follow_id, replay_sensors, offset); \
+    }, \
+    ( \
+      arg("name"), \
+      arg("time_start"), \
+      arg("duration"), \
+      arg("follow_id"), \
+      arg("replay_sensors")=false, \
+      arg("offset")=cg::Transform(cg::Location(cg::Vector3D(-10, 0, 5)), cg::Rotation(-25, 0, 0)))
+
   class_<cc::Client>("Client",
       init<std::string, uint16_t, size_t>((arg("host")="127.0.0.1", arg("port")=2000, arg("worker_threads")=0u)))
     .def("set_timeout", &::SetTimeout, (arg("seconds")))
@@ -206,7 +226,7 @@ void export_client() {
     .def("show_recorder_file_info", CALL_WITHOUT_GIL_2(cc::Client, ShowRecorderFileInfo, std::string, bool), (arg("name"), arg("show_all")))
     .def("show_recorder_collisions", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderCollisions, std::string, char, char), (arg("name"), arg("type1"), arg("type2")))
     .def("show_recorder_actors_blocked", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderActorsBlocked, std::string, double, double), (arg("name"), arg("min_time"), arg("min_distance")))
-    .def("replay_file", CALL_WITHOUT_GIL_5(cc::Client, ReplayFile, std::string, double, double, uint32_t, bool), (arg("name"), arg("time_start"), arg("duration"), arg("follow_id"), arg("replay_sensors")=false))
+    .def("replay_file", REPLAY_FILE_WITHOUT_GIL(ReplayFile))
     .def("stop_replayer", &cc::Client::StopReplayer, (arg("keep_actors")))
     .def("set_replayer_time_factor", &cc::Client::SetReplayerTimeFactor, (arg("time_factor")))
     .def("set_replayer_ignore_hero", &cc::Client::SetReplayerIgnoreHero, (arg("ignore_hero")))

--- a/PythonAPI/carla/src/Client.cpp
+++ b/PythonAPI/carla/src/Client.cpp
@@ -225,7 +225,7 @@ void export_client() {
     .def("generate_opendrive_world", CONST_CALL_WITHOUT_GIL_3(cc::Client, GenerateOpenDriveWorld, std::string,
         rpc::OpendriveGenerationParameters, bool), (arg("opendrive"), arg("parameters")=rpc::OpendriveGenerationParameters(),
         arg("reset_settings")=true))
-    .def("start_recorder", CALL_WITHOUT_GIL_2(cc::Client, StartRecorder, std::string, bool), (arg("name"), arg("additional_data")=false))
+    .def("start_recorder", CALL_WITHOUT_GIL_3(cc::Client, StartRecorder, std::string, bool, bool), (arg("name"), arg("additional_data")=false, arg("stop_replayer")=true))
     .def("stop_recorder", &cc::Client::StopRecorder)
     .def("show_recorder_file_info", CALL_WITHOUT_GIL_2(cc::Client, ShowRecorderFileInfo, std::string, bool), (arg("name"), arg("show_all")))
     .def("show_recorder_collisions", CALL_WITHOUT_GIL_3(cc::Client, ShowRecorderCollisions, std::string, char, char), (arg("name"), arg("type1"), arg("type2")))

--- a/PythonAPI/carla/src/Client.cpp
+++ b/PythonAPI/carla/src/Client.cpp
@@ -193,9 +193,10 @@ void export_client() {
         double duration, \
         uint32_t follow_id, \
         bool replay_sensors, \
-        cg::Transform offset) { \
+        cg::Transform offset, \
+        std::string map_override) { \
       carla::PythonUtil::ReleaseGIL unlock; \
-      return self.fn(name, time_start, duration, follow_id, replay_sensors, offset); \
+      return self.fn(name, time_start, duration, follow_id, replay_sensors, offset, map_override); \
     }, \
     ( \
       arg("name"), \
@@ -203,7 +204,8 @@ void export_client() {
       arg("duration"), \
       arg("follow_id"), \
       arg("replay_sensors")=false, \
-      arg("offset")=cg::Transform(cg::Location(cg::Vector3D(-10, 0, 5)), cg::Rotation(-25, 0, 0)))
+      arg("offset")=cg::Transform(cg::Location(cg::Vector3D(-10, 0, 5)), cg::Rotation(-25, 0, 0)), \
+      arg("map_override")="")
 
   class_<cc::Client>("Client",
       init<std::string, uint16_t, size_t>((arg("host")="127.0.0.1", arg("port")=2000, arg("worker_threads")=0u)))

--- a/PythonAPI/examples/recorder_replay.py
+++ b/PythonAPI/examples/recorder_replay.py
@@ -72,6 +72,9 @@ def main():
         '--follow-ego', action="store_true",
         help='follow the ego vehicle')
     argparser.add_argument(
+        '--top-view', action="store_true",
+        help='enable top-down camera view when following an actor')
+    argparser.add_argument(
         '--factor', default=1, type=float,
         help='Initial recorder factor')
 
@@ -122,8 +125,13 @@ def main():
     if not duration:
         duration = float(file_info.split("Duration: ")[-1].split(" ")[0])
 
+    # set desired offset
+    offset = carla.Transform(carla.Location(-10, 0, 5), carla.Rotation(-25, 0, 0))
+    if args.top_view:
+        offset = carla.Transform(carla.Location(0, 0, 40), carla.Rotation(-90, 0, 0))
+
     print("\033[1m> Starting the replayer\033[0m")
-    client.replay_file(args.file, args.start_time, args.end_time, follow_id)
+    client.replay_file(args.file, args.start_time, args.end_time, follow_id, False, offset)
     client.set_replayer_time_factor(args.factor)
 
     tick(world)

--- a/PythonAPI/examples/recorder_replay.py
+++ b/PythonAPI/examples/recorder_replay.py
@@ -75,6 +75,10 @@ def main():
         '--top-view', action="store_true",
         help='enable top-down camera view when following an actor')
     argparser.add_argument(
+        '-m', '--map-override',
+        type=str,
+        help='The name of the map to load instead of whatever the log file indicates.')
+    argparser.add_argument(
         '--factor', default=1, type=float,
         help='Initial recorder factor')
 
@@ -131,7 +135,14 @@ def main():
         offset = carla.Transform(carla.Location(0, 0, 40), carla.Rotation(-90, 0, 0))
 
     print("\033[1m> Starting the replayer\033[0m")
-    client.replay_file(args.file, args.start_time, args.end_time, follow_id, False, offset)
+    client.replay_file(
+        args.file,
+        args.start_time,
+        args.end_time,
+        follow_id,
+        False,
+        offset,
+        map_override=args.map_override if args.map_override is not None else "")
     client.set_replayer_time_factor(args.factor)
 
     tick(world)

--- a/PythonAPI/examples/recorder_replay.py
+++ b/PythonAPI/examples/recorder_replay.py
@@ -79,6 +79,9 @@ def main():
         type=str,
         help='The name of the map to load instead of whatever the log file indicates.')
     argparser.add_argument(
+        '--replay-weather', action="store_true",
+        help='reapply the weather changes recorded in the log')
+    argparser.add_argument(
         '--factor', default=1, type=float,
         help='Initial recorder factor')
 
@@ -141,6 +144,7 @@ def main():
         args.end_time,
         follow_id,
         False,
+        args.replay_weather,
         offset,
         map_override=args.map_override if args.map_override is not None else "")
     client.set_replayer_time_factor(args.factor)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEpisode.cpp
@@ -399,13 +399,13 @@ void UCarlaEpisode::EndPlay(void)
   }
 }
 
-std::string UCarlaEpisode::StartRecorder(std::string Name, bool AdditionalData)
+std::string UCarlaEpisode::StartRecorder(std::string Name, bool AdditionalData, bool StopReplayer)
 {
   std::string result;
 
   if (Recorder)
   {
-    result = Recorder->Start(Name, MapName, AdditionalData);
+    result = Recorder->Start(Name, MapName, AdditionalData, StopReplayer);
   }
   else
   {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -321,7 +321,7 @@ public:
     return Recorder->GetReplayer();
   }
 
-  std::string StartRecorder(std::string name, bool AdditionalData);
+  std::string StartRecorder(std::string name, bool AdditionalData, bool StopReplayer);
 
   FIntVector GetCurrentMapOrigin() const { return CurrentMapOrigin; }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -140,10 +140,23 @@ void ACarlaGameModeBase::InitGame(
     UE_LOG(LogCarla, Log, TEXT("Existing weather actor. Doing nothing then!"));
     Episode->Weather = static_cast<AWeather*>(WeatherActor);
   }
-  else if (WeatherClass != nullptr) {
-    Episode->Weather = World->SpawnActor<AWeather>(WeatherClass);
-  } else {
-    UE_LOG(LogCarla, Error, TEXT("Missing weather class!"));
+  else {
+    // Fall back to BP_CarlaWeather if WeatherClass is unset on the BP
+    // game mode. Without this, set_weather() RPCs silently no-op because
+    // Episode->Weather stays null and CarlaServer::get_weather_parameters
+    // returns the default-constructed FWeatherParameters{}. Resolved at
+    // runtime (rather than via ConstructorHelpers) so the package cook is
+    // not forced to re-validate the BP asset registry every C++ rebuild.
+    if (WeatherClass == nullptr) {
+      WeatherClass = LoadClass<AWeather>(
+          nullptr,
+          TEXT("/Game/Carla/Blueprints/Weather/BP_CarlaWeather.BP_CarlaWeather_C"));
+    }
+    if (WeatherClass != nullptr) {
+      Episode->Weather = World->SpawnActor<AWeather>(WeatherClass);
+    } else {
+      UE_LOG(LogCarla, Error, TEXT("Missing weather class!"));
+    }
   }
 
   GameInstance->NotifyInitGame();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/FrameData.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/FrameData.cpp
@@ -723,7 +723,7 @@ std::pair<int, FCarlaActor*> FFrameData::CreateOrReuseActor(
   // check type of actor we need
   if (ActorDesc.Id.StartsWith("traffic."))
   {
-    FCarlaActor* CarlaActor = FindTrafficLightAt(Location);
+    FCarlaActor* CarlaActor = FindTrafficSignAt(Location);
     if (CarlaActor != nullptr)
     {
       // reuse that actor
@@ -1173,7 +1173,7 @@ void FFrameData::SetFrameCounter()
   FCarlaEngine::ResetFrameCounter(FrameCounter.FrameCounter);
 }
 
-FCarlaActor *FFrameData::FindTrafficLightAt(FVector Location)
+FCarlaActor *FFrameData::FindTrafficSignAt(FVector Location)
 {
   check(Episode != nullptr);
   auto World = Episode->GetWorld();
@@ -1189,7 +1189,7 @@ FCarlaActor *FFrameData::FindTrafficLightAt(FVector Location)
   for (auto It = Registry.begin(); It != Registry.end(); ++It)
   {
     FCarlaActor* CarlaActor = It.Value().Get();
-    if(CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight)
+    if(CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight || CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficSign)
     {
       FVector vec = CarlaActor->GetActorGlobalLocation();
       int x2 = static_cast<int>(vec.X);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/FrameData.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/FrameData.h
@@ -175,7 +175,7 @@ private:
 
   void SetFrameCounter();
 
-  FCarlaActor* FindTrafficLightAt(FVector Location);
+  FCarlaActor* FindTrafficSignAt(FVector Location);
 
   void AddExistingActors(void);
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -61,10 +61,10 @@ std::string ACarlaRecorder::ShowFileActorsBlocked(std::string Name, double MinTi
 }
 
 std::string ACarlaRecorder::ReplayFile(std::string Name, double TimeStart, double Duration,
-    uint32_t FollowId, bool ReplaySensors)
+    uint32_t FollowId, const FTransform Offset, bool ReplaySensors)
 {
   Stop();
-  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, ReplaySensors);
+  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, Offset, ReplaySensors);
 }
 
 void ACarlaRecorder::SetReplayerTimeFactor(double TimeFactor)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -433,8 +433,12 @@ void ACarlaRecorder::AddActorBones(FCarlaActor *CarlaActor)
 std::string ACarlaRecorder::Start(
   std::string Name,
   FString MapName,
-  bool AdditionalData)
+  bool AdditionalData,
+  bool StopReplayer)
 {
+  // stop replayer if any in course
+  if (StopReplayer && Replayer.IsEnabled())
+    Replayer.Stop();
 
   // stop recording
   Stop();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -468,6 +468,9 @@ std::string ACarlaRecorder::Start(
   Frames.Reset();
   PlatformTime.SetStartTime();
 
+  // reset first-tick flag so the initial weather is captured on every recording session
+  bFirstTick = true;
+
   Enable();
 
   bAdditionalData = AdditionalData;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -157,7 +157,7 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
     // write all data for this frame
     Write(DeltaSeconds);
   }
-  else if (Episode->GetReplayer()->IsEnabled())
+  if (Episode->GetReplayer()->IsEnabled())
   {
     // replayer
     Episode->GetReplayer()->Tick(DeltaSeconds);
@@ -435,9 +435,6 @@ std::string ACarlaRecorder::Start(
   FString MapName,
   bool AdditionalData)
 {
-  // stop replayer if any in course
-  if (Replayer.IsEnabled())
-    Replayer.Stop();
 
   // stop recording
   Stop();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -62,7 +62,7 @@ std::string ACarlaRecorder::ShowFileActorsBlocked(std::string Name, double MinTi
 
 std::string ACarlaRecorder::ReplayFile(
   std::string Name, double TimeStart, double Duration,
-  uint32_t FollowId, const FTransform Offset, bool ReplaySensors, bool ReplayWeather,
+  uint32_t FollowId, const FTransform& Offset, bool ReplaySensors, bool ReplayWeather,
   std::string MapOverride)
 {
   Stop();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -60,11 +60,13 @@ std::string ACarlaRecorder::ShowFileActorsBlocked(std::string Name, double MinTi
   return Query.QueryBlocked(Name, MinTime, MinDistance);
 }
 
-std::string ACarlaRecorder::ReplayFile(std::string Name, double TimeStart, double Duration,
-    uint32_t FollowId, const FTransform Offset, bool ReplaySensors)
+std::string ACarlaRecorder::ReplayFile(
+  std::string Name, double TimeStart, double Duration,
+  uint32_t FollowId, const FTransform Offset, bool ReplaySensors,
+  std::string MapOverride)
 {
   Stop();
-  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, Offset, ReplaySensors);
+  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, Offset, ReplaySensors, MapOverride);
 }
 
 void ACarlaRecorder::SetReplayerTimeFactor(double TimeFactor)
@@ -421,7 +423,10 @@ void ACarlaRecorder::AddActorBones(FCarlaActor *CarlaActor)
   WalkersBones.Add(std::move(Walker));
 }
 
-std::string ACarlaRecorder::Start(std::string Name, FString MapName, bool AdditionalData)
+std::string ACarlaRecorder::Start(
+  std::string Name,
+  FString MapName,
+  bool AdditionalData)
 {
   // stop replayer if any in course
   if (Replayer.IsEnabled())

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.cpp
@@ -62,11 +62,11 @@ std::string ACarlaRecorder::ShowFileActorsBlocked(std::string Name, double MinTi
 
 std::string ACarlaRecorder::ReplayFile(
   std::string Name, double TimeStart, double Duration,
-  uint32_t FollowId, const FTransform Offset, bool ReplaySensors,
+  uint32_t FollowId, const FTransform Offset, bool ReplaySensors, bool ReplayWeather,
   std::string MapOverride)
 {
   Stop();
-  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, Offset, ReplaySensors, MapOverride);
+  return Replayer.ReplayFile(Name, TimeStart, Duration, FollowId, Offset, ReplaySensors, ReplayWeather, MapOverride);
 }
 
 void ACarlaRecorder::SetReplayerTimeFactor(double TimeFactor)
@@ -145,6 +145,13 @@ void ACarlaRecorder::Ticking(float DeltaSeconds)
           AddTrafficLightState(View);
           break;
       }
+    }
+
+    // save the initial weather
+    if (bFirstTick)
+    {
+      AddExistingWeather();
+      bFirstTick = false;
     }
 
     // write all data for this frame
@@ -503,6 +510,7 @@ void ACarlaRecorder::Clear(void)
   DoorVehicles.Clear();
   Wheels.Clear();
   Bikers.Clear();
+  Weathers.Clear();
 }
 
 void ACarlaRecorder::Write(double DeltaSeconds)
@@ -532,6 +540,7 @@ void ACarlaRecorder::Write(double DeltaSeconds)
   LightScenes.Write(File);
   Wheels.Write(File);
   Bikers.Write(File);
+  Weathers.Write(File);
 
   // additional info
   if (bAdditionalData)
@@ -556,6 +565,14 @@ void ACarlaRecorder::AddPosition(const CarlaRecorderPosition &Position)
   if (Enabled)
   {
     Positions.Add(Position);
+  }
+}
+
+void ACarlaRecorder::AddWeather(const CarlaRecorderWeather &Weather)
+{
+  if (Enabled)
+  {
+    Weathers.Add(Weather);
   }
 }
 
@@ -747,6 +764,31 @@ void ACarlaRecorder::AddExistingActors(void)
     }
   }
 
+}
+
+void ACarlaRecorder::AddExistingWeather(void)
+{
+  AWeather *WeatherActor = Episode->GetWeather();
+  if (WeatherActor != nullptr)
+  {
+    CarlaRecorderWeather RecorderWeather;
+    const auto &Params = WeatherActor->GetCurrentWeather();
+    RecorderWeather.Cloudiness              = Params.Cloudiness;
+    RecorderWeather.Precipitation           = Params.Precipitation;
+    RecorderWeather.PrecipitationDeposits   = Params.PrecipitationDeposits;
+    RecorderWeather.WindIntensity           = Params.WindIntensity;
+    RecorderWeather.SunAzimuthAngle         = Params.SunAzimuthAngle;
+    RecorderWeather.SunAltitudeAngle        = Params.SunAltitudeAngle;
+    RecorderWeather.FogDensity              = Params.FogDensity;
+    RecorderWeather.FogDistance             = Params.FogDistance;
+    RecorderWeather.FogFalloff              = Params.FogFalloff;
+    RecorderWeather.Wetness                 = Params.Wetness;
+    RecorderWeather.ScatteringIntensity     = Params.ScatteringIntensity;
+    RecorderWeather.MieScatteringScale      = Params.MieScatteringScale;
+    RecorderWeather.RayleighScatteringScale = Params.RayleighScatteringScale;
+    RecorderWeather.DustStorm               = Params.DustStorm;
+    AddWeather(RecorderWeather);
+  }
 }
 
 void ACarlaRecorder::CreateRecorderEventAdd(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -94,7 +94,10 @@ public:
   void Disable(void);
 
   // start / stop
-  std::string Start(std::string Name, FString MapName, bool AdditionalData = false);
+  std::string Start(
+    std::string Name,
+    FString MapName,
+    bool AdditionalData = false);
 
   void Stop(void);
 
@@ -168,8 +171,10 @@ public:
   std::string ShowFileActorsBlocked(std::string Name, double MinTime = 30, double MinDistance = 10);
 
   // replayer
-  std::string ReplayFile(std::string Name, double TimeStart, double Duration,
-      uint32_t FollowId, const FTransform Offset, bool ReplaySensors);
+  std::string ReplayFile(
+    std::string Name, double TimeStart, double Duration,
+    uint32_t FollowId, const FTransform Offset, bool ReplaySensors,
+    std::string MapOverride);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);
   void SetReplayerIgnoreSpectator(bool IgnoreSpectator);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -178,7 +178,7 @@ public:
   // replayer
   std::string ReplayFile(
     std::string Name, double TimeStart, double Duration,
-    uint32_t FollowId, const FTransform Offset, bool ReplaySensors, bool ReplayWeather,
+    uint32_t FollowId, const FTransform& Offset, bool ReplaySensors, bool ReplayWeather,
     std::string MapOverride);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -169,7 +169,7 @@ public:
 
   // replayer
   std::string ReplayFile(std::string Name, double TimeStart, double Duration,
-      uint32_t FollowId, bool ReplaySensors);
+      uint32_t FollowId, const FTransform Offset, bool ReplaySensors);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);
   void SetReplayerIgnoreSpectator(bool IgnoreSpectator);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -99,7 +99,8 @@ public:
   std::string Start(
     std::string Name,
     FString MapName,
-    bool AdditionalData = false);
+    bool AdditionalData = false,
+    bool StopReplayer = true);
 
   void Stop(void);
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorder.h
@@ -33,6 +33,7 @@
 #include "CarlaRecorderVisualTime.h"
 #include "CarlaRecorderWalkerBones.h"
 #include "CarlaRecorderDoorVehicle.h"
+#include "CarlaRecorderWeather.h"
 #include "CarlaReplayer.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 
@@ -70,7 +71,8 @@ enum class CarlaRecorderPacketId : uint8_t
   VisualTime,
   VehicleDoor,
   AnimVehicleWheels,
-  AnimBiker
+  AnimBiker,
+  Weather
 };
 
 /// Recorder for the simulation
@@ -115,6 +117,8 @@ public:
   void AddCollision(AActor *Actor1, AActor *Actor2);
 
   void AddPosition(const CarlaRecorderPosition &Position);
+
+  void AddWeather(const CarlaRecorderWeather &Weather);
 
   void AddState(const CarlaRecorderStateTrafficLight &State);
 
@@ -173,7 +177,7 @@ public:
   // replayer
   std::string ReplayFile(
     std::string Name, double TimeStart, double Duration,
-    uint32_t FollowId, const FTransform Offset, bool ReplaySensors,
+    uint32_t FollowId, const FTransform Offset, bool ReplaySensors, bool ReplayWeather,
     std::string MapOverride);
   void SetReplayerTimeFactor(double TimeFactor);
   void SetReplayerIgnoreHero(bool IgnoreHero);
@@ -195,6 +199,8 @@ private:
   std::ofstream File;
 
   UCarlaEpisode *Episode = nullptr;
+
+  bool bFirstTick = true;
 
   // structures
   CarlaRecorderInfo Info;
@@ -220,6 +226,7 @@ private:
   CarlaRecorderWalkersBones WalkersBones;
   CarlaRecorderVisualTime VisualTime;
   CarlaRecorderDoorVehicles DoorVehicles;
+  CarlaRecorderWeathers Weathers;
 
   // replayer
   CarlaReplayer Replayer;
@@ -228,6 +235,7 @@ private:
   CarlaRecorderQuery Query;
 
   void AddExistingActors(void);
+  void AddExistingWeather(void);
   void AddActorPosition(FCarlaActor *CarlaActor);
   void AddWalkerAnimation(FCarlaActor *CarlaActor);
   void AddBikerAnimation(FCarlaActor *CarlaActor);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.cpp
@@ -207,6 +207,36 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
       }
       break;
 
+      // weather
+    case static_cast<char>(CarlaRecorderPacketId::Weather):
+      ReadValue<uint16_t>(File, Total);
+      if (Total > 0 && !bFramePrinted)
+      {
+        PrintFrame(Info);
+        bFramePrinted = true;
+      }
+
+      Info << " Weathers: " << Total << std::endl;
+      for (i = 0; i < Total; ++i)
+      {
+        Weather.Read(File);
+        Info << "  Cloudiness: " << Weather.Cloudiness
+            << " Precipitation: " << Weather.Precipitation
+            << " PrecipitationDeposits: " << Weather.PrecipitationDeposits
+            << " WindIntensity: " << Weather.WindIntensity
+            << " SunAzimuthAngle: " << Weather.SunAzimuthAngle
+            << " SunAltitudeAngle: " << Weather.SunAltitudeAngle
+            << " FogDensity: " << Weather.FogDensity
+            << " FogDistance: " << Weather.FogDistance
+            << " FogFalloff: " << Weather.FogFalloff
+            << " Wetness: " << Weather.Wetness
+            << " ScatteringIntensity: " << Weather.ScatteringIntensity
+            << " MieScatteringScale: " << Weather.MieScatteringScale
+            << " RayleighScatteringScale: " << Weather.RayleighScatteringScale
+            << " DustStorm: " << Weather.DustStorm << "\n";
+      }
+      break;
+
       // events del
     case static_cast<char>(CarlaRecorderPacketId::EventDel):
       ReadValue<uint16_t>(File, Total);
@@ -725,7 +755,6 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
               << Bone.Rotation.X << ", " << Bone.Rotation.Y << ", " << Bone.Rotation.Z << ")\n";
           }
         }
-        Info << std::endl;
       }
       else
         SkipPacket();
@@ -733,7 +762,7 @@ std::string CarlaRecorderQuery::QueryInfo(std::string Filename, bool bShowAll)
 
       // frame end
     case static_cast<char>(CarlaRecorderPacketId::FrameEnd):
-      // do nothing, it is empty
+      Info << std::endl;
       break;
 
     default:

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderQuery.h
@@ -27,6 +27,7 @@
 #include "CarlaRecorderState.h"
 #include "CarlaRecorderWalkerBones.h"
 #include "CarlaRecorderDoorVehicle.h"
+#include "CarlaRecorderWeather.h"
 
 class CarlaRecorderQuery
 {
@@ -71,6 +72,7 @@ private:
   CarlaRecorderTrafficLightTime TrafficLightTime;
   CarlaRecorderWalkerBones WalkerBones;
   CarlaRecorderDoorVehicle DoorVehicle;
+  CarlaRecorderWeather Weather;
 
   // read next header packet
   bool ReadHeader(void);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWeather.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWeather.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaRecorderWeather.h"
+#include "CarlaRecorder.h"
+#include "CarlaRecorderHelpers.h"
+
+void CarlaRecorderWeather::Write(std::ostream &OutFile)
+{
+  WriteValue(OutFile, this->Cloudiness);
+  WriteValue(OutFile, this->Precipitation);
+  WriteValue(OutFile, this->PrecipitationDeposits);
+  WriteValue(OutFile, this->WindIntensity);
+  WriteValue(OutFile, this->SunAzimuthAngle);
+  WriteValue(OutFile, this->SunAltitudeAngle);
+  WriteValue(OutFile, this->FogDensity);
+  WriteValue(OutFile, this->FogDistance);
+  WriteValue(OutFile, this->FogFalloff);
+  WriteValue(OutFile, this->Wetness);
+  WriteValue(OutFile, this->ScatteringIntensity);
+  WriteValue(OutFile, this->MieScatteringScale);
+  WriteValue(OutFile, this->RayleighScatteringScale);
+  WriteValue(OutFile, this->DustStorm);
+}
+
+void CarlaRecorderWeather::Read(std::istream &InFile)
+{
+  ReadValue(InFile, this->Cloudiness);
+  ReadValue(InFile, this->Precipitation);
+  ReadValue(InFile, this->PrecipitationDeposits);
+  ReadValue(InFile, this->WindIntensity);
+  ReadValue(InFile, this->SunAzimuthAngle);
+  ReadValue(InFile, this->SunAltitudeAngle);
+  ReadValue(InFile, this->FogDensity);
+  ReadValue(InFile, this->FogDistance);
+  ReadValue(InFile, this->FogFalloff);
+  ReadValue(InFile, this->Wetness);
+  ReadValue(InFile, this->ScatteringIntensity);
+  ReadValue(InFile, this->MieScatteringScale);
+  ReadValue(InFile, this->RayleighScatteringScale);
+  ReadValue(InFile, this->DustStorm);
+}
+
+// ---------------------------------------------
+
+void CarlaRecorderWeathers::Clear(void)
+{
+  Weathers.clear();
+}
+
+void CarlaRecorderWeathers::Add(const CarlaRecorderWeather &InObj)
+{
+  Weathers.push_back(InObj);
+}
+
+void CarlaRecorderWeathers::Write(std::ostream &OutFile)
+{
+  if (Weathers.size() == 0)
+  {
+    return;
+  }
+
+  // write the packet id
+  WriteValue<char>(OutFile, static_cast<char>(CarlaRecorderPacketId::Weather));
+
+  // write the packet size
+  uint32_t Total = 2 + Weathers.size() * sizeof(CarlaRecorderWeather);
+  WriteValue<uint32_t>(OutFile, Total);
+
+  // write total records
+  Total = Weathers.size();
+  WriteValue<uint16_t>(OutFile, Total);
+
+  // write records
+  for (auto& Weather : Weathers)
+  {
+    Weather.Write(OutFile);
+  }
+}

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWeather.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaRecorderWeather.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <sstream>
+#include <vector>
+
+#include "Carla/Weather/WeatherParameters.h"
+
+#pragma pack(push, 1)
+struct CarlaRecorderWeather
+{
+  float Cloudiness;
+  float Precipitation;
+  float PrecipitationDeposits;
+  float WindIntensity;
+  float SunAzimuthAngle;
+  float SunAltitudeAngle;
+  float FogDensity;
+  float FogDistance;
+  float FogFalloff;
+  float Wetness;
+  float ScatteringIntensity;
+  float MieScatteringScale;
+  float RayleighScatteringScale;
+  float DustStorm;
+
+  void Read(std::istream &InFile);
+
+  void Write(std::ostream &OutFile);
+};
+#pragma pack(pop)
+
+class CarlaRecorderWeathers
+{
+public:
+
+  void Add(const CarlaRecorderWeather &InObj);
+
+  void Clear(void);
+
+  void Write(std::ostream &OutFile);
+
+private:
+
+  std::vector<CarlaRecorderWeather> Weathers;
+};

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -110,6 +110,7 @@ std::string CarlaReplayer::ReplayFile(
   uint32_t ThisFollowId,
   const FTransform Offset,
   bool ReplaySensors,
+  bool ReplayWeather,
   std::string MapOverride)
 {
   std::stringstream Info;
@@ -163,6 +164,7 @@ std::string CarlaReplayer::ReplayFile(
     Autoplay.FollowOffset = Offset;
     Autoplay.TimeFactor = TimeFactor;
     Autoplay.ReplaySensors = ReplaySensors;
+    Autoplay.ReplayWeather = ReplayWeather;
   }
 
   // get Total time of recorder
@@ -197,6 +199,7 @@ std::string CarlaReplayer::ReplayFile(
   FollowOffset = Offset;
 
   bReplaySensors = ReplaySensors;
+  bReplayWeather = ReplayWeather;
   // if we don't need to load a new map, then start
   if (!Autoplay.Enabled)
   {
@@ -259,6 +262,7 @@ void CarlaReplayer::CheckPlayAfterMapLoaded(void)
   FollowOffset = Autoplay.FollowOffset;
 
   bReplaySensors = Autoplay.ReplaySensors;
+  bReplayWeather = Autoplay.ReplayWeather;
 
   // apply time factor
   TimeFactor = Autoplay.TimeFactor;
@@ -412,6 +416,11 @@ void CarlaReplayer::ProcessToTime(double Time, bool IsFirstTime)
           ProcessWalkerBones();
         else
           SkipPacket();
+        break;
+
+      // weather
+      case static_cast<char>(CarlaRecorderPacketId::Weather):
+        ProcessWeather();
         break;
 
       // frame end
@@ -684,6 +693,22 @@ void CarlaReplayer::ProcessDoorVehicle(void)
     if (!(IgnoreHero && IsHeroMap[DoorVehicle.DatabaseId]))
     {
       Helper.ProcessReplayerDoorVehicle(DoorVehicle);
+    }
+  }
+}
+
+void CarlaReplayer::ProcessWeather(void)
+{
+  uint16_t Total;
+  CarlaRecorderWeather Weather;
+
+  // read Total weathers
+  ReadValue<uint16_t>(File, Total);
+  for (uint16_t i = 0; i < Total; ++i)
+  {
+    Weather.Read(File);
+    if (bReplayWeather){
+      Helper.ProcessReplayerWeather(Weather);
     }
   }
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -707,7 +707,8 @@ void CarlaReplayer::ProcessWeather(void)
   for (uint16_t i = 0; i < Total; ++i)
   {
     Weather.Read(File);
-    if (bReplayWeather){
+    if (bReplayWeather)
+    {
       Helper.ProcessReplayerWeather(Weather);
     }
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -103,8 +103,14 @@ double CarlaReplayer::GetTotalTime(void)
   return Frame.Elapsed;
 }
 
-std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, double Duration,
-    uint32_t ThisFollowId, const FTransform Offset, bool ReplaySensors)
+std::string CarlaReplayer::ReplayFile(
+  std::string Filename,
+  double TimeStart,
+  double Duration,
+  uint32_t ThisFollowId,
+  const FTransform Offset,
+  bool ReplaySensors,
+  std::string MapOverride)
 {
   std::stringstream Info;
   std::string s;
@@ -132,6 +138,9 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
   // from start
   Rewind();
 
+  if (!MapOverride.empty())
+    RecInfo.Mapfile = UTF8_TO_TCHAR(MapOverride.c_str());
+  
   // check to load map if different
   if (Episode->GetMapName() != RecInfo.Mapfile)
   {
@@ -143,7 +152,7 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
     }
     Info << "Loading map " << TCHAR_TO_UTF8(*RecInfo.Mapfile) << std::endl;
     Info << "Replayer will start after map is loaded..." << std::endl;
-
+  
     // prepare autoplay after map is loaded
     Autoplay.Enabled = true;
     Autoplay.Filename = Filename2;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -108,7 +108,7 @@ std::string CarlaReplayer::ReplayFile(
   double TimeStart,
   double Duration,
   uint32_t ThisFollowId,
-  const FTransform Offset,
+  const FTransform& Offset,
   bool ReplaySensors,
   bool ReplayWeather,
   std::string MapOverride)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 
 // structure to save replaying info when need to load a new map (static member by now)
-CarlaReplayer::PlayAfterLoadMap CarlaReplayer::Autoplay { false, "", "", 0.0, 0.0, 0, 1.0, false };
+CarlaReplayer::PlayAfterLoadMap CarlaReplayer::Autoplay { false, "", "", 0.0, 0.0, 0, FTransform(), 1.0, false };
 
 void CarlaReplayer::Stop(bool bKeepActors)
 {
@@ -104,7 +104,7 @@ double CarlaReplayer::GetTotalTime(void)
 }
 
 std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, double Duration,
-    uint32_t ThisFollowId, bool ReplaySensors)
+    uint32_t ThisFollowId, const FTransform Offset, bool ReplaySensors)
 {
   std::stringstream Info;
   std::string s;
@@ -151,6 +151,7 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
     Autoplay.TimeStart = TimeStart;
     Autoplay.Duration = Duration;
     Autoplay.FollowId = ThisFollowId;
+    Autoplay.FollowOffset = Offset;
     Autoplay.TimeFactor = TimeFactor;
     Autoplay.ReplaySensors = ReplaySensors;
   }
@@ -182,8 +183,9 @@ std::string CarlaReplayer::ReplayFile(std::string Filename, double TimeStart, do
   if (IgnoreSpectator)
     Info << "Ignoring Spectator camera" << std::endl;
 
-  // set the follow Id
+  // set the follow Id and offset
   FollowId = ThisFollowId;
+  FollowOffset = Offset;
 
   bReplaySensors = ReplaySensors;
   // if we don't need to load a new map, then start
@@ -243,8 +245,9 @@ void CarlaReplayer::CheckPlayAfterMapLoaded(void)
   else
     TimeToStop = TotalTime;
 
-  // set the follow Id
+  // set the follow Id and offset
   FollowId = Autoplay.FollowId;
+  FollowOffset = Autoplay.FollowOffset;
 
   bReplaySensors = Autoplay.ReplaySensors;
 
@@ -790,13 +793,12 @@ void CarlaReplayer::UpdatePositions(double Per, double DeltaTime)
         InterpolatePosition(Pos, Pos, 0.0, DeltaTime);
       }
     }
+  }
 
-    // move the camera to follow this actor if required
-    if (NewFollowId != 0)
-    {
-      if (NewFollowId == Pos.DatabaseId)
-        Helper.SetCameraPosition(NewFollowId, FVector(-1000, 0, 500), FQuat::MakeFromEuler({0, -25, 0}));
-    }
+  // move the camera to follow the desired actor
+  if (NewFollowId != 0)
+  {
+    Helper.SetCameraPosition(NewFollowId, FollowOffset.GetTranslation(), FollowOffset.GetRotation());
   }
 }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -54,7 +54,8 @@ public:
   ~CarlaReplayer() { Stop(); };
 
   std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f,
-      uint32_t FollowId = 0, const FTransform Offset = FTransform(),  bool ReplaySensors = false);
+      uint32_t FollowId = 0, const FTransform Offset = FTransform(),  bool ReplaySensors = false,
+      std::string MapOverride = "");
 
   // void Start(void);
   void Stop(bool KeepActors = false);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -43,6 +43,7 @@ public:
     double TimeStart;
     double Duration;
     uint32_t FollowId;
+    FTransform FollowOffset;
     double TimeFactor;
     bool ReplaySensors;
   };
@@ -53,7 +54,7 @@ public:
   ~CarlaReplayer() { Stop(); };
 
   std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f,
-      uint32_t FollowId = 0, bool ReplaySensors = false);
+      uint32_t FollowId = 0, const FTransform Offset = FTransform(),  bool ReplaySensors = false);
 
   // void Start(void);
   void Stop(bool KeepActors = false);
@@ -121,6 +122,8 @@ private:
   CarlaReplayerHelper Helper;
   // follow camera
   uint32_t FollowId;
+  // follow camera offset
+  FTransform FollowOffset;
   // speed (time factor)
   double TimeFactor { 1.0 };
   // ignore hero vehicles

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -46,6 +46,7 @@ public:
     FTransform FollowOffset;
     double TimeFactor;
     bool ReplaySensors;
+    bool ReplayWeather;
   };
 
   static PlayAfterLoadMap Autoplay;
@@ -55,7 +56,7 @@ public:
 
   std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f,
       uint32_t FollowId = 0, const FTransform Offset = FTransform(),  bool ReplaySensors = false,
-      std::string MapOverride = "");
+      bool ReplayWeather = false, std::string MapOverride = "");
 
   // void Start(void);
   void Stop(bool KeepActors = false);
@@ -104,6 +105,7 @@ private:
 
   bool Enabled;
   bool bReplaySensors = false;
+  bool bReplayWeather = false;
   UCarlaEpisode *Episode = nullptr;
   // binary file reader
   std::ifstream File;
@@ -165,6 +167,8 @@ private:
   void ProcessDoorVehicle(void);
 
   void ProcessWalkerBones(void);
+
+  void ProcessWeather(void);
 
   // positions
   void UpdatePositions(double Per, double DeltaTime);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayer.h
@@ -55,7 +55,7 @@ public:
   ~CarlaReplayer() { Stop(); };
 
   std::string ReplayFile(std::string Filename, double TimeStart = 0.0f, double Duration = 0.0f,
-      uint32_t FollowId = 0, const FTransform Offset = FTransform(),  bool ReplaySensors = false,
+      uint32_t FollowId = 0, const FTransform& Offset = FTransform(),  bool ReplaySensors = false,
       bool ReplayWeather = false, std::string MapOverride = "");
 
   // void Start(void);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -52,7 +52,7 @@ std::pair<int, FCarlaActor*>CarlaReplayerHelper::TryToCreateReplayerActor(
   // check type of actor we need
   if (ActorDesc.Id.StartsWith("traffic."))
   {
-    FCarlaActor* CarlaActor = FindTrafficLightAt(Location);
+    FCarlaActor* CarlaActor = FindTrafficSignAt(Location);
     if (CarlaActor != nullptr)
     {
       // reuse that actor
@@ -112,7 +112,7 @@ std::pair<int, FCarlaActor*>CarlaReplayerHelper::TryToCreateReplayerActor(
   }
 }
 
-FCarlaActor *CarlaReplayerHelper::FindTrafficLightAt(FVector Location)
+FCarlaActor *CarlaReplayerHelper::FindTrafficSignAt(FVector Location)
 {
   check(Episode != nullptr);
   auto World = Episode->GetWorld();
@@ -128,7 +128,7 @@ FCarlaActor *CarlaReplayerHelper::FindTrafficLightAt(FVector Location)
   for (auto It = Registry.begin(); It != Registry.end(); ++It)
   {
     FCarlaActor* CarlaActor = It.Value().Get();
-    if(CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight)
+    if(CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight || CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficSign)
     {
       FVector vec = CarlaActor->GetActorGlobalLocation();
       int x2 = static_cast<int>(vec.X);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -129,7 +129,8 @@ FCarlaActor *CarlaReplayerHelper::FindTrafficSignAt(FVector Location)
   for (auto It = Registry.begin(); It != Registry.end(); ++It)
   {
     FCarlaActor* CarlaActor = It.Value().Get();
-    if(CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight || CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficSign)
+    if (CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficLight ||
+        CarlaActor->GetActorType() == FCarlaActor::ActorType::TrafficSign)
     {
       FVector vec = CarlaActor->GetActorGlobalLocation();
       int x2 = static_cast<int>(vec.X);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.cpp
@@ -24,6 +24,7 @@
 #include "Carla/Vehicle/WheeledVehicleAIController.h"
 #include "Carla/Walker/WalkerControl.h"
 #include "Carla/Walker/WalkerController.h"
+#include "Carla/Weather/Weather.h"
 
 #include <util/ue-header-guard-begin.h>
 #include "Components/BoxComponent.h"
@@ -450,6 +451,32 @@ void CarlaReplayerHelper::ProcessReplayerLightVehicle(CarlaRecorderLightVehicle 
   {
     carla::rpc::VehicleLightState LightState(LightVehicle.State);
     CarlaActor->SetVehicleLightState(FVehicleLightState(LightState));
+  }
+}
+
+void CarlaReplayerHelper::ProcessReplayerWeather(const CarlaRecorderWeather &Weather)
+{
+  check(Episode != nullptr);
+
+  AWeather *WeatherActor = Episode->GetWeather();
+  if (WeatherActor != nullptr)
+  {
+    FWeatherParameters Params;
+    Params.Cloudiness              = Weather.Cloudiness;
+    Params.Precipitation           = Weather.Precipitation;
+    Params.PrecipitationDeposits   = Weather.PrecipitationDeposits;
+    Params.WindIntensity           = Weather.WindIntensity;
+    Params.SunAzimuthAngle         = Weather.SunAzimuthAngle;
+    Params.SunAltitudeAngle        = Weather.SunAltitudeAngle;
+    Params.FogDensity              = Weather.FogDensity;
+    Params.FogDistance             = Weather.FogDistance;
+    Params.FogFalloff              = Weather.FogFalloff;
+    Params.Wetness                 = Weather.Wetness;
+    Params.ScatteringIntensity     = Weather.ScatteringIntensity;
+    Params.MieScatteringScale      = Weather.MieScatteringScale;
+    Params.RayleighScatteringScale = Weather.RayleighScatteringScale;
+    Params.DustStorm               = Weather.DustStorm;
+    WeatherActor->ApplyWeather(Params);
   }
 }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -106,7 +106,7 @@ private:
     uint32_t DesiredId,
     bool SpawnSensors);
 
-  FCarlaActor* FindTrafficLightAt(FVector Location);
+  FCarlaActor* FindTrafficSignAt(FVector Location);
 
   // enable / disable physics for an actor
   bool SetActorSimulatePhysics(FCarlaActor *CarlaActor, bool bEnabled);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Recorder/CarlaReplayerHelper.h
@@ -15,8 +15,9 @@
 #include "CarlaRecorderAnimVehicleWheels.h"
 #include "CarlaRecorderLightVehicle.h"
 #include "CarlaRecorderLightScene.h"
-#include "CarlaRecorderDoorVehicle.h"	
+#include "CarlaRecorderDoorVehicle.h"
 #include "CarlaRecorderWalkerBones.h"
+#include "CarlaRecorderWeather.h"
 
 #include <unordered_map>
 
@@ -81,6 +82,9 @@ public:
   // set walker bones
   void ProcessReplayerWalkerBones(const CarlaRecorderWalkerBones &Walker);
 
+  // set weather
+  void ProcessReplayerWeather(const CarlaRecorderWeather &Weather);
+  
   // replay finish
   bool ProcessReplayerFinish(bool bApplyAutopilot, bool bIgnoreHero, std::unordered_map<uint32_t, bool> &IsHero);
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2476,7 +2476,8 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       double start,
       double duration,
       uint32_t follow_id,
-      bool replay_sensors) -> R<std::string>
+      bool replay_sensors,
+      const cr::Transform offset) -> R<std::string>
   {
     REQUIRE_CARLA_EPISODE();
     return R<std::string>(Episode->GetRecorder()->ReplayFile(
@@ -2484,6 +2485,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
         start,
         duration,
         follow_id,
+        offset,
         replay_sensors));
   };
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2478,7 +2478,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       uint32_t follow_id,
       bool replay_sensors,
       bool replay_weather,
-      const cr::Transform offset,
+      const cr::Transform& offset,
       std::string map_override) -> R<std::string>
   {
     REQUIRE_CARLA_EPISODE();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2424,10 +2424,10 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
 
   // ~~ Logging and playback ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  BIND_SYNC(start_recorder) << [this](std::string name, bool AdditionalData) -> R<std::string>
+  BIND_SYNC(start_recorder) << [this](std::string name, bool AdditionalData, bool StopReplayer) -> R<std::string>
   {
     REQUIRE_CARLA_EPISODE();
-    return R<std::string>(Episode->StartRecorder(name, AdditionalData));
+    return R<std::string>(Episode->StartRecorder(name, AdditionalData, StopReplayer));
   };
 
   BIND_SYNC(stop_recorder) << [this]() -> R<void>

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2477,6 +2477,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       double duration,
       uint32_t follow_id,
       bool replay_sensors,
+      bool replay_weather,
       const cr::Transform offset,
       std::string map_override) -> R<std::string>
   {
@@ -2488,6 +2489,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
         follow_id,
         offset,
         replay_sensors,
+        replay_weather,
         map_override));
   };
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -2477,7 +2477,8 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
       double duration,
       uint32_t follow_id,
       bool replay_sensors,
-      const cr::Transform offset) -> R<std::string>
+      const cr::Transform offset,
+      std::string map_override) -> R<std::string>
   {
     REQUIRE_CARLA_EPISODE();
     return R<std::string>(Episode->GetRecorder()->ReplayFile(
@@ -2486,7 +2487,8 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
         duration,
         follow_id,
         offset,
-        replay_sensors));
+        replay_sensors,
+        map_override));
   };
 
   BIND_SYNC(set_replayer_time_factor) << [this](double time_factor) -> R<void>

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
@@ -79,7 +79,6 @@ void AWeather::ApplyWeather(const FWeatherParameters& InWeather)
     // Call the blueprint that actually changes the weather.
     RefreshWeather(Weather);
 
-    UE_LOG(LogCarla, Log, TEXT("Changing weather!!!!!!!!!!"));
     // record the weather event
     ACarlaRecorder *Recorder = UCarlaStatics::GetRecorder(GetWorld());
     if (Recorder && Recorder->IsEnabled())

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
@@ -6,6 +6,9 @@
 
 #include "Carla/Weather/Weather.h"
 #include "Carla.h"
+#include "Carla/Game/CarlaStatics.h"
+#include "Carla/Recorder/CarlaRecorder.h"
+#include "Carla/Recorder/CarlaRecorderWeather.h"
 #include "Carla/Sensor/SceneCaptureCamera.h"
 
 #include <util/ue-header-guard-begin.h>
@@ -75,6 +78,29 @@ void AWeather::ApplyWeather(const FWeatherParameters& InWeather)
 
     // Call the blueprint that actually changes the weather.
     RefreshWeather(Weather);
+
+    UE_LOG(LogCarla, Log, TEXT("Changing weather!!!!!!!!!!"));
+    // record the weather event
+    ACarlaRecorder *Recorder = UCarlaStatics::GetRecorder(GetWorld());
+    if (Recorder && Recorder->IsEnabled())
+    {
+        CarlaRecorderWeather RecorderWeather;
+        RecorderWeather.Cloudiness              = InWeather.Cloudiness;
+        RecorderWeather.Precipitation           = InWeather.Precipitation;
+        RecorderWeather.PrecipitationDeposits   = InWeather.PrecipitationDeposits;
+        RecorderWeather.WindIntensity           = InWeather.WindIntensity;
+        RecorderWeather.SunAzimuthAngle         = InWeather.SunAzimuthAngle;
+        RecorderWeather.SunAltitudeAngle        = InWeather.SunAltitudeAngle;
+        RecorderWeather.FogDensity              = InWeather.FogDensity;
+        RecorderWeather.FogDistance             = InWeather.FogDistance;
+        RecorderWeather.FogFalloff              = InWeather.FogFalloff;
+        RecorderWeather.Wetness                 = InWeather.Wetness;
+        RecorderWeather.ScatteringIntensity     = InWeather.ScatteringIntensity;
+        RecorderWeather.MieScatteringScale      = InWeather.MieScatteringScale;
+        RecorderWeather.RayleighScatteringScale = InWeather.RayleighScatteringScale;
+        RecorderWeather.DustStorm               = InWeather.DustStorm;
+        Recorder->AddWeather(RecorderWeather);
+    }
 }
 
 void AWeather::NotifyWeather(ASensor* Sensor)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the `ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing (LibCarla GoogleTest suite, Debug + Release)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

Port of five upstream `ue4-dev` recorder/replayer commits to `ue5-dev`, plus one fix that unblocks the weather feature on the packaged build. The work was tracked under [Discussion #9581 (Category 3)](https://github.com/carla-simulator/carla/discussions/9581) and [Issue #9628](https://github.com/carla-simulator/carla/issues/9628).

The recorder gains the ability to capture weather changes and replay them later, the replayer gains a follow offset, a map-override argument, traffic-sign attach, and a `stop_replayer` flag that lets a recording start while a replay is still playing back. Paths and example scripts are adapted to the ue5-dev tree (`CarlaUE4` -> `CarlaUnreal`, `start_replaying.py` + `start_recording.py` merged into `recorder_replay.py`).

##### Source SHAs ported

| ue4-dev SHA | Subject |
|---|---|
| `fd6c4e0bf` | Allow attach spectator to traffic sign and traffic light actors in the replayer (#9076) |
| `70bee19db` | Add `map_override` argument to `replay_file` (#9265) |
| `df0161e87` | Added weather to recorder and replayer |
| `be60694b7` | Added simultaneous record and replay |
| `5ab7c76ea` | Added `stop_replayer` flag to `start_recorder` |

##### What this PR changes

**Replayer follow + offset (port of `fd6c4e0bf` / #9076)**
- `FFrameData::FindTrafficLightAt` is renamed to `FindTrafficSignAt` and now matches `ActorType::TrafficLight` **or** `ActorType::TrafficSign`, so attaching the spectator to a stop / yield / unknown sign no longer silently falls through.
- `replay_file` accepts a `Transform offset` argument (default `Location(-10, 0, 5) / Rotation(-25, 0, 0)`), plumbed through `cc::Client`, `Simulator`, `CarlaServer`, `ACarlaRecorder::ReplayFile`, `CarlaReplayer::ReplayFile`, and `CarlaReplayerHelper`.
- The Python binding is exposed via a new `REPLAY_FILE_WITHOUT_GIL` macro (the `CALL_WITHOUT_GIL_<N>` family doesn't compose with `cg::Transform` defaults).
- `recorder_replay.py` exposes `--top-view`, which swaps the offset to `Location(0, 0, 40) / Rotation(-90, 0, 0)`.

**`replay_file` map override (port of `70bee19db` / #9265)**
- `replay_file` accepts an optional `MapOverride` string. When non-empty the replayer skips its own `LoadMap` step and replays into whatever map the server is currently running.
- Plumbed end-to-end (`cc::Client`, `Simulator`, RPC handler, `ACarlaRecorder::ReplayFile`, `CarlaReplayer::ReplayFile`).
- `recorder_replay.py` exposes `-m / --map-override`.

**Weather recording and replay (port of `df0161e87`)**
- New `Weather` packet id appended to `CarlaRecorderPacketId`, with `CarlaRecorderWeather.{cpp,h}` defining the wire format.
- `ACarlaRecorder` gains `AddWeather` (per-event) and `AddExistingWeather` (called once on the first recording tick to capture the initial state), plus `Weathers.Write` / `Clear` wiring.
- `AWeather::ApplyWeather` records the weather event after the blueprint refresh fires, so any client `set_weather` is captured.
- `CarlaRecorderQuery` decodes the `Weather` packet and emits a `Weathers: N` block with all 14 fields. The `FrameEnd` handler now emits the trailing newline (moved from the `WalkerBones` case so frames without bones still terminate cleanly).
- `CarlaReplayer::ReplayFile` accepts a new `bool ReplayWeather`, and `ProcessLookAheadEvents` invokes a fresh `ProcessReplayerWeather` helper that calls `AWeather::ApplyWeather` on the cached weather actor.
- `recorder_replay.py` exposes `--replay-weather`.

**Weather actor BP fallback (cherry-picked from `fix/carla-vram-needed-performance` `fe39ff9d4`)**
- Required to make the weather port actually exercisable on the packaged ue5-dev `Town10HD_Opt` build. Without this hunk, neither a placed `BP_CarlaWeather` actor nor a non-null `WeatherClass` exists on the BP game mode, so `ACarlaGameModeBase::InitGame` logs `"Missing weather class!"` and `Episode->Weather` stays null. `set_weather` is an `AsyncCall` on the client, so the server's `RESPOND_ERROR` never propagates; `get_weather` returns the default-constructed `FWeatherParameters{}`, masking the issue.
- `InitGame` now `LoadClass<AWeather>(/Game/Carla/Blueprints/Weather/BP_CarlaWeather.BP_CarlaWeather_C)` as a runtime fallback when `WeatherClass` is null. Resolved at runtime (rather than via `ConstructorHelpers::FClassFinder`) so the package cook is not forced to re-validate the BP asset registry on every C++ rebuild.

**Simultaneous record and replay (port of `be60694b7`)**
- `ACarlaRecorder::Ticking` swaps `else if (Replayer.IsEnabled())` for an unconditional `if`, so the recorder begins writing on the same tick the replayer halts. A fresh `start_recorder` call now captures from frame 1 and concurrent record-while-replay scenarios stop losing data on the boundary tick. `Start` also drops its implicit `Replayer.Stop()` since `stop_replayer` (next commit) makes it caller-controlled.

**`stop_replayer` flag on `start_recorder` (port of `5ab7c76ea`)**
- `start_recorder` accepts a `stop_replayer` boolean (default `true`, preserving legacy behaviour). When `false`, the recorder no longer halts an active replayer on start, which combined with the previous commit unlocks the "simultaneous record and replay" use case end-to-end.
- Plumbed through `cc::Client`, `Simulator`, the Python binding (`CALL_WITHOUT_GIL_3`), `UCarlaEpisode::StartRecorder`, `ACarlaRecorder::Start`, and the RPC handler.

##### Commit shape

Six commits, one per ported SHA plus the cherry-picked weather fallback:

```
feat(replayer): allow follow on traffic signs/lights, add spectator offset       (port of fd6c4e0bf / #9076)
feat(replayer): add map_override argument to replay_file                         (port of 70bee19db / #9265)
feat(recorder): record and replay weather changes                                (port of df0161e87)
fix(weather):  spawn AWeather via runtime fallback when BP class is unset        (cherry-pick fe39ff9d4)
fix(recorder): allow simultaneous record and replay                              (port of be60694b7)
feat(recorder): add stop_replayer flag to start_recorder                         (port of 5ab7c76ea)
```

The weather BP fallback is intentionally committed between the weather port and the simultaneous-record/replay change so a reader gets "feature -> fix that makes feature testable -> next feature" in sequence.

Fixes #9628

#### Where has this been tested?

* **Platform(s):** Ubuntu 22.04.
* **Python version(s):** 3.10.
* **Unreal Engine version(s):** UE 5.5.
* **Tested on:** NVIDIA GeForce RTX 5070 Ti 16GB.

Manual smoke recipe followed against the packaged `Build/Package/Carla-0.10.0-Linux-Shipping/Linux/CarlaUnreal.sh -RenderOffScreen -carla-rpc-port=2000 -quality-level=Epic`:

| Step | Result |
|---|---|
| `start_recorder` + `set_weather(80,70,30)` + `stop_recorder` | Log captured (176 KB, `Town10HD_Opt`); `is_weather_enabled() = True`, `get_weather()` mutates `30/0/10 -> 80/70/30`. |
| `show_recorder_file_info(..., True)` for `Weathers:` packets | **2 packets**: initial `Cloudiness: 30 Precipitation: 0 SunAlt: 10` and post-`set_weather` `Cloudiness: 80 Precipitation: 70 SunAlt: 30` (matches `df0161e87` expectations). |
| `replay_file(..., replay_weather=False)` | Live weather not overwritten by recorded values. |
| `replay_file(..., replay_weather=True)` | Live weather flips to `80/70` mid-replay. |
| `replay_file(..., offset=Transform(Location(0,0,40), Rotation(-90,0,0)))` | Top-view offset accepted, replay runs, no crash. |
| `replay_file(..., map_override='Town10HD_Opt')` | No map reload triggered (same-map case). |
| `replay_file(...)` then `start_recorder('/tmp/test2.log', stop_replayer=False)` while replay active | `/tmp/test2.log` 71 KB well-formed; replayer kept running; server alive afterward. |

LibCarla GoogleTest suite (Debug, in `Build-Tests/`):
- `libcarla_test_server`: 44/44 passed.
- `libcarla_test_client`: 58/58 passed.

Compiler audit on the post-split build (`AutomationTool ExitCode=0`, `cmake --build Build --target package` green inside the docker):
- The only diagnostic touching a PR1 file is the pre-existing `CarlaServer.cpp:495 GetNamesOfAllActors` deprecation introduced upstream in commit `6a6acd9a8 Rename CarlaUE4 -> CarlaUnreal`. Our hunks in that file are at lines 2424 / 2477 / 2487, far outside the deprecated call site.
- No new warnings introduced by any of the six commits.

#### Possible Drawbacks

- **Recorder log binary format change.** The new `Weather` packet id (`23`) and the trailing-newline relocation in `CarlaRecorderQuery` mean logs produced by an older `ue5-dev` build can still be replayed by this PR (older logs simply don't contain `Weather` packets, the case statement is skipped), but logs produced by this PR can NOT be replayed by an older client / server: an older `CarlaRecorderQuery` would hit `default:` on the unknown packet id and abort the show / reuse step. This is a one-way bump intrinsic to the upstream feature port.
- **Weather BP fallback path is hard-coded.** `LoadClass<AWeather>` looks for `/Game/Carla/Blueprints/Weather/BP_CarlaWeather.BP_CarlaWeather_C`. This matches the asset path shipped with the ue5-dev `Town10HD_Opt` package; downstream forks that move or rename the BP would lose the fallback. The pre-existing `FClassFinder`-via-game-mode path still wins when configured, so the only regression is for installs that have no `BP_CarlaWeather` and no game-mode binding (i.e., the same case that already silently broke before this PR).
- **Visible weather response is not fixed by this PR.** `BP_CarlaWeather::RefreshWeather` is a `BlueprintImplementableEvent` graph that is not fully wired to drive the directional light and sky sphere in the shipped maps. The recorder/replayer state machine and the `set_weather` round-trip both work, but the visual result of the weather change can be muted on the current packaged build. Tracking under a separate ticket; out of scope here.
- **`recorder_replay.py` consolidates the ue4 example surface into one script.** Users who scripted against ue4's `start_replaying.py` / `start_recording.py` need to update flag names accordingly. The new flags are `--top-view`, `-m / --map-override`, `--replay-weather`, plus the existing `-f / --file`, `--start-time`, `--end-time`, `--follow-id`, `--follow-ego`, `--factor`. The change is in the example script only; the C++ / Python API surface is additive.
- **`stop_replayer` defaults to `true`.** Existing callers see no behavioural change. New callers that opt into `stop_replayer=False` get the simultaneous-record-and-replay path; combined with the `else if -> if` tick-loop fix from `be60694b7`, this is the prerequisite for the use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9708)
<!-- Reviewable:end -->
