### PR TITLE
Support pygame source builds on Ubuntu 26.04

### DIFF
--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -66,7 +66,9 @@ sudo apt-get -y install \
     libxkbcommon-dev \
     libgbm-dev \
     libpango1.0-dev \
-    libasound2-dev
+    libasound2-dev \
+    libsdl2-dev \
+    libfreetype-dev
 
 if [ "$python_path" == "python3" ]; then
     sudo apt-get -y install \
@@ -84,7 +86,14 @@ PIP_EXTRA_ARGS=""
 if dpkg --compare-versions "$UBUNTU_VERSION_ID" ge "24.04"; then
     PIP_EXTRA_ARGS="--break-system-packages"
 fi
-$python_path -m pip install --upgrade pip $PIP_EXTRA_ARGS
+if dpkg --compare-versions "$UBUNTU_VERSION_ID" ge "26.04"; then
+    # Ubuntu 26.04's python3-pip package is Debian-managed and cannot be
+    # uninstalled by pip during a self-upgrade. Keep the distro pip and only
+    # install the project requirements.
+    echo "Skipping pip self-upgrade on Ubuntu $UBUNTU_VERSION_ID."
+else
+    $python_path -m pip install --upgrade pip $PIP_EXTRA_ARGS
+fi
 $python_path -m pip install -r requirements.txt $PIP_EXTRA_ARGS
 
 # -- INSTALL CMAKE --

--- a/Util/SetupUtils/InstallPrerequisites.sh
+++ b/Util/SetupUtils/InstallPrerequisites.sh
@@ -86,7 +86,7 @@ PIP_EXTRA_ARGS=""
 if dpkg --compare-versions "$UBUNTU_VERSION_ID" ge "24.04"; then
     PIP_EXTRA_ARGS="--break-system-packages"
 fi
-if dpkg --compare-versions "$UBUNTU_VERSION_ID" ge "26.04"; then
+if dpkg --compare-versions "$UBUNTU_VERSION_ID" eq "26.04"; then
     # Ubuntu 26.04's python3-pip package is Debian-managed and cannot be
     # uninstalled by pip during a self-upgrade. Keep the distro pip and only
     # install the project requirements.


### PR DESCRIPTION
## Summary

This keeps the Ubuntu 26.04 setup path working when `requirements.txt` installs `pygame` under Python 3.14.

Ubuntu 26.04 defaults to Python 3.14, but `pygame==2.6.1` does not currently publish `cp314` wheels on PyPI. As a result, pip falls back to building pygame from source. That source build needs SDL2 and freetype development headers, which were not installed by `InstallPrerequisites.sh`.

This PR also skips pip self-upgrade on Ubuntu 26.04. The distro `python3-pip` package is Debian-managed and fails when pip tries to uninstall it during `pip install --upgrade pip`; the packaged pip is sufficient to build/install the current requirements.

Related to #9706.

## Changes

- Add `libsdl2-dev` and `libfreetype-dev` to Ubuntu prerequisites.
- Skip `python -m pip install --upgrade pip` on Ubuntu >= 26.04.
- Keep the existing `--break-system-packages` behavior for Ubuntu >= 24.04.

## Verification

Ran the prerequisite script in a fresh Ubuntu 26.04 container:

```bash
docker run --rm -v "$PWD:/carla" -w /carla ubuntu:26.04 bash -lc '
  set -euo pipefail
  export DEBIAN_FRONTEND=noninteractive
  apt-get update
  apt-get install -y sudo ca-certificates
  bash -x Util/SetupUtils/InstallPrerequisites.sh --python-path=python3
'
```

Key output:

```text
Skipping pip self-upgrade on Ubuntu 26.04.
Created wheel for pygame: filename=pygame-2.6.1-cp314-cp314-linux_x86_64.whl
Successfully built numpy pygame
Successfully installed ... pygame-2.6.1 ...
DOCKER_PREREQ_EXIT_STATUS=0
```

Also ran:

```bash
bash -n Util/SetupUtils/InstallPrerequisites.sh
```

## Not tested

- Full native `CarlaSetup.sh --interactive` after sudo authentication.
- CARLA content clone.
- Unreal Engine clone/build.
- CARLA CMake configure/build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9709)
<!-- Reviewable:end -->
