### PR TITLE
Fix ScenarioRunner documentation links

### DIFF
--- a/Docs/adv_traffic_manager.md
+++ b/Docs/adv_traffic_manager.md
@@ -530,7 +530,7 @@ If more than one TM is set to synchronous mode, synchrony will fail. Follow thes
 
 - In a __[multiclient](#multiclient)__ situation, only the __TM-Server__ should be set to synchronous mode.
 - In a __[multiTM](#multitm)__ situation, only __one TM-Server__ should be set to synchronous mode.
-- The __[ScenarioRunner module](https://carla-scenariorunner.readthedocs.io/en/latest/)__ runs a TM automatically. The TM inside ScenarioRunner will automatically be the one set to sync mode.
+- The __[ScenarioRunner module](https://scenario-runner.readthedocs.io/en/latest/)__ runs a TM automatically. The TM inside ScenarioRunner will automatically be the one set to sync mode.
 
 !!! Warning
     Disable synchronous mode (for both the world and TM) in your script managing ticks before it finishes to prevent the server blocking, waiting forever for a tick.

--- a/Docs/ts_traffic_simulation_overview.md
+++ b/Docs/ts_traffic_simulation_overview.md
@@ -29,20 +29,20 @@ Go to Traffic Manager</a>
 
 ## Scenario Runner and OpenScenario
 
-Scenario Runner provides [predefined traffic scenarios](https://carla-scenariorunner.readthedocs.io/en/latest/list_of_scenarios/) out of the box and also allows users to [define their own](https://carla-scenariorunner.readthedocs.io/en/latest/creating_new_scenario/) scenarios using either Python or the [OpenSCENARIO 1.0 standard](https://releases.asam.net/OpenSCENARIO/1.0.0/ASAM_OpenSCENARIO_BS-1-2_User-Guide_V1-0-0.html#_foreword).
+Scenario Runner provides [predefined traffic scenarios](https://scenario-runner.readthedocs.io/en/latest/list_of_scenarios/) out of the box and also allows users to [define their own](https://scenario-runner.readthedocs.io/en/latest/creating_new_scenario/) scenarios using either Python or the [OpenSCENARIO 1.0 standard](https://releases.asam.net/OpenSCENARIO/1.0.0/ASAM_OpenSCENARIO_BS-1-2_User-Guide_V1-0-0.html#_foreword).
 
-The primary use of OpenSCENARIO is the description of complex maneuvers that involve multiple vehicles. Users can see which features of OpenSCENARIO are supported by Scenario Runner [here](https://carla-scenariorunner.readthedocs.io/en/latest/openscenario_support/). These features include Maneuvers, Actions, Conditions, Stories and the Storyboard. 
+The primary use of OpenSCENARIO is the description of complex maneuvers that involve multiple vehicles. Users can see which features of OpenSCENARIO are supported by Scenario Runner [here](https://scenario-runner.readthedocs.io/en/latest/openscenario_support/). These features include Maneuvers, Actions, Conditions, Stories and the Storyboard.
 
 Scenario Runner has to be installed [separately](https://github.com/carla-simulator/scenario_runner) from the main CARLA package.
 
 __Useful for:__
 
 - Creating complex traffic scenarios and routes to prepare AD agents for evaluation in the [CARLA leaderboard](https://leaderboard.carla.org/).
-- Defining bespoke [metrics](https://carla-scenariorunner.readthedocs.io/en/latest/metrics_module/) that can be run against recordings of the scenario simulation, foregoing the need to run simulations repeatedly.
+- Defining bespoke [metrics](https://scenario-runner.readthedocs.io/en/latest/metrics_module/) that can be run against recordings of the scenario simulation, foregoing the need to run simulations repeatedly.
 
 <div class="build-buttons">
 <p>
-<a href="https://carla-scenariorunner.readthedocs.io" target="_blank" class="btn btn-neutral" title="Go to Scenario Runner">
+<a href="https://scenario-runner.readthedocs.io" target="_blank" class="btn btn-neutral" title="Go to Scenario Runner">
 Go to Scenario Runner</a>
 </p>
 </div>


### PR DESCRIPTION
﻿This addresses #9719.

The ScenarioRunner docs moved from `carla-scenariorunner.readthedocs.io` to `scenario-runner.readthedocs.io`. The old domain now returns 404 for the linked pages in the traffic simulation docs.

This updates the ScenarioRunner links in the traffic simulation overview and the related traffic manager page to use the current Read the Docs domain.

Verified with:
- `rg -n "carla-scenariorunner\.readthedocs\.io|scenario-runner\.readthedocs\.io" Docs/ts_traffic_simulation_overview.md Docs/adv_traffic_manager.md`
- `git diff --check`
- `curl -L -s -o NUL -w "%{http_code} %{url_effective}"` for the updated ScenarioRunner links

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9720)
<!-- Reviewable:end -->
