### PR TITLE
fix(plugin): default camera post-process profile per active map

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -1424,8 +1424,12 @@ void UActorBlueprintFunctionLibrary::SetCamera(
         MapName = World->GetMapName();
         MapName.RemoveFromStart(World->StreamingLevelsPrefix);
       }
-      const FString MapJsonPath =
-          FPaths::ProjectContentDir() / TEXT("Carla/Config/PostProcess/") + MapName + TEXT(".json");
+      else
+      {
+        UE_LOG(LogCarla, Warning,
+            TEXT("SetCamera: camera has no UWorld; falling back to Default post-process profile."));
+      }
+      const FString MapJsonPath = UPostProcessJsonUtils::GetPostProcessConfigPath(MapName);
       PostProcessProfileName = FPaths::FileExists(MapJsonPath) ? MapName : TEXT("Default");
     }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -411,7 +411,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation post_process_profile;
     post_process_profile.Id = TEXT("post_process_profile");
     post_process_profile.Type = EActorAttributeType::String;
-    post_process_profile.RecommendedValues = {TEXT("default")};
+    post_process_profile.RecommendedValues = {TEXT("Default")};
     post_process_profile.bRestrictToRecommended = false;
 
     Definition.Variations.Append({PostProccess, post_process_profile});
@@ -1407,11 +1407,31 @@ void UActorBlueprintFunctionLibrary::SetCamera(
             Description.Variations["enable_postprocess_effects"],
             true));
 
-    FString PostProcessDefaultName = RetrieveActorAttributeToString("post_process_profile",
-        Description.Variations, TEXT("default"));
+    FString PostProcessProfileName = RetrieveActorAttributeToString(
+        "post_process_profile",
+        Description.Variations,
+        TEXT(""));
+
+    // Empty or the legacy lowercase "default" sentinel means "no preference":
+    // load the profile named after the active map. Case-sensitive so an
+    // explicit "Default" still force-loads Default.json.
+    if (PostProcessProfileName.IsEmpty() || PostProcessProfileName == TEXT("default"))
+    {
+      const UWorld *World = Camera->GetWorld();
+      FString MapName{};
+      if (World != nullptr)
+      {
+        MapName = World->GetMapName();
+        MapName.RemoveFromStart(World->StreamingLevelsPrefix);
+      }
+      const FString MapJsonPath =
+          FPaths::ProjectContentDir() / TEXT("Carla/Config/PostProcess/") + MapName + TEXT(".json");
+      PostProcessProfileName = FPaths::FileExists(MapJsonPath) ? MapName : TEXT("Default");
+    }
+
     UPostProcessJsonUtils::LoadAllPostProcessFromJsonToSceneCapture(
         Camera->GetCaptureComponent(),
-        PostProcessDefaultName);
+        PostProcessProfileName);
   }
 }
 


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing (LibCarla GoogleTest server + client, plus manual repro of issue #9733 against the packaged build)
  - [x] If relevant, update CHANGELOG.md with your changes

-->

#### Description

The RGB camera variation defaults `post_process_profile` to the literal `default`, and the server falls back to that same string when the client does not set the attribute. The matching JSON lives in carla-content as `Carla/Config/PostProcess/Default.json`, which Linux's case-sensitive filesystem does not match against `default`. The load fails silently, the `SceneCapture` keeps the ctor's flags-only zero overrides set by `SetCameraDefaultOverrides`, and Town10HD_Opt renders nearly black except for emissive surfaces (the red and green traffic-light LEDs the user reported on the issue).

Even with the case matched, `Default.json` is calibrated for a much brighter scene than the shipped maps (`AEM_Manual` with ISO 100 and shutter 1/320), so blindly applying it leaves Town10HD_Opt 15 stops underexposed. `manual_control.py` already works around this client side via `get_post_process_profile(map_name)`, but `automatic_control.py` and every third-party script that does not know about the profile system hit the broken default path.

When the client passes no profile (or the legacy lowercase `default` sentinel), the server now picks the JSON named after the active map and falls back to `Default.json` only when no per-map profile is shipped.

Issue: #9733

#### Changes

- `ActorBlueprintFunctionLibrary.cpp`: in the camera setup path under `SetCamera`, treat an empty or `default` (any case) profile as "no preference"; resolve it to `<active map name>.json` if that file exists under `Carla/Config/PostProcess/`, else `Default.json`. Map name is read via `World->GetMapName()` with the standard PIE-prefix strip used elsewhere in the plugin (e.g. `VehicleActorFactory.cpp`).
- `ActorBlueprintFunctionLibrary.cpp`: bump the variation's `RecommendedValues` advertised to clients from `default` to `Default` so the API hint matches the actual filename on case-sensitive filesystems.

#### Where has this been tested?

  * **Platform(s):** Linux Ubuntu 24.04
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 5.5

Built locally (not in the Docker dev container) against the host UE 5.5 and ran the packaged build on `Town10HD_Opt`. Before the patch, stock `automatic_control.py` reproduces the issue: pygame view renders black with only the traffic-light LEDs visible. After the patch, the same unmodified script renders the scene correctly. `manual_control.py`, which already passes an explicit profile, is unaffected.

#### Possible Drawbacks

- Clients that intentionally pass the literal string `default` and rely on the legacy `Default.json` profile being applied regardless of the active map will now get the per-map profile instead. Pass any other explicit profile name to keep the old behavior (e.g. `Default` with a capital `D`); the substring match is case-insensitive only for the legacy `default` sentinel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9736)
<!-- Reviewable:end -->
