### PR TITLE
fix(streaming): make ServerSession::CloseNow idempotent (one client drop no longer stalls others)

### DIFF
--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -135,6 +135,16 @@ namespace tcp {
   }
 
   void ServerSession::CloseNow(boost::system::error_code ec) {
+    // Guard against double-close. CloseNow() can be reached more than once for
+    // the same session: the deadline timer firing, an async read/write
+    // completing with an error, and an explicit Close() can all race. Without
+    // this guard the session invokes _on_closed twice, which calls
+    // DisconnectSession twice on the stream state, tripping the DEBUG_ASSERT in
+    // MultiStreamState::DisconnectSession (and corrupting session bookkeeping
+    // in release builds).
+    if (_is_closed.exchange(true)) {
+      return;
+    }
     _deadline.cancel();
     if (!ec)
     {

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
@@ -22,6 +22,8 @@
 #  pragma clang diagnostic pop
 #endif
 
+#include <atomic>
+
 namespace carla {
 namespace streaming {
 namespace detail {
@@ -81,6 +83,8 @@ namespace tcp {
     callback_function_type _on_closed;
 
     bool _is_writing = false;
+
+    std::atomic_bool _is_closed{false};
   };
 
 } // namespace tcp


### PR DESCRIPTION
**Setup**

  * CARLA version: 0.9.15 (UE4 / `ue4-dev`)
  * Platform: Windows (Win64, Shipping)
  * Python version: 3.7 (reproduction client)

**Describe the bug**

`tcp::ServerSession::CloseNow()` is not idempotent. The inactivity-deadline timer, an async read/write erroring, and an explicit `Close()` can each enter it for the same session, so `_on_closed()` → `Dispatcher::DeregisterSession` → `MultiStreamState::DisconnectSession` runs twice.

A lone double-disconnect is harmless, but with **two sessions on a stream**, one session disconnecting twice evicts the **other** one:

```
_sessions = [V, A]
DisconnectSession(A)  # erase A -> [V], size==1 -> _session = V
DisconnectSession(A)  # size==1 branch -> _session = null; _sessions.clear()  -> V evicted
```

The world-snapshot stream (every client subscribes to it) is the everyday victim: when two clients are connected and one drops abruptly while a snapshot write is in flight, the survivor's broadcast goes silent and `world.wait_for_tick()` hangs.

**Expected behavior**

One client closing or dropping — even abruptly — should not stop other clients on the same stream from receiving data.

**Steps to reproduce**

Two clients on the world-snapshot stream; hard-kill one so its socket RSTs with a read and a snapshot write in flight. Reproduction script `reproduce_min.py` (one persistent client + one client connected and killed each round), with a fast tick so a write is in flight:

```
python reproduce_min.py --host 127.0.0.1 --port 3000 --rounds 30
```

  * **stock 0.9.15:** the survivor stops receiving ticks on cycle 1
  * **with this fix:** the survivor keeps ticking 30/30

**The fix** (2 files, ~14 lines, no API/ABI change)

Guard `CloseNow()` with an `std::atomic_bool _is_closed` so the close path runs exactly once:

```cpp
void ServerSession::CloseNow(boost::system::error_code ec) {
  if (_is_closed.exchange(true)) return;   // first caller wins; the rest return
  ...
}
```

**Other information**

  * Tested on Windows only (Win64, Shipping). The change is platform-independent `LibCarla` C++; a Linux `make check` from CI would be welcome.
  * Scope: deeper multi-session teardown races under an extreme burst of simultaneous disconnects are out of scope — this is the minimal, low-risk fix for the common case.
  * Prepared with AI assistance (see `Co-Authored-By` on the commit); the analysis was reviewed and the before/after results were measured on real 0.9.15 Win64 binaries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9740)
<!-- Reviewable:end -->
