### PR TITLE
fix(ros2): [1/8] correct IMU compass yaw and reorder actor disposal

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "carla/ros2/publishers/ImuMath.h"
 #include "carla/ros2/types/ImuPubSubTypes.h"
 #include "carla/ros2/listeners/CarlaListener.h"
 
@@ -170,23 +171,13 @@ namespace ros2 {
     header.stamp(std::move(time));
     header.frame_id(_frame_id);
 
+    const auto q = OrientationFromCompass(compass);
+
     geometry_msgs::msg::Quaternion orientation;
-
-    const float rx = 0.0f;                           // pitch
-    const float ry = (float(M_PI_2) / 2.0f) - compass;  // yaw
-    const float rz = 0.0f;                           // roll
-
-    const float cr = cosf(rz * 0.5f);
-    const float sr = sinf(rz * 0.5f);
-    const float cp = cosf(rx * 0.5f);
-    const float sp = sinf(rx * 0.5f);
-    const float cy = cosf(ry * 0.5f);
-    const float sy = sinf(ry * 0.5f);
-
-    orientation.w(cr * cp * cy + sr * sp * sy);
-    orientation.x(sr * cp * cy - cr * sp * sy);
-    orientation.y(cr * sp * cy + sr * cp * sy);
-    orientation.z(cr * cp * sy - sr * sp * cy);
+    orientation.w(q[0]);
+    orientation.x(q[1]);
+    orientation.y(q[2]);
+    orientation.z(q[3]);
 
     _impl->_imu.header(std::move(header));
     _impl->_imu.orientation(orientation);

--- a/LibCarla/source/carla/ros2/publishers/ImuMath.h
+++ b/LibCarla/source/carla/ros2/publishers/ImuMath.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+
+namespace carla {
+namespace ros2 {
+
+// Returns a yaw-only quaternion (w, x, y, z) corresponding to converting a
+// magnetic compass heading (radians, clockwise from North) into ROS REP-103
+// yaw (radians, counter-clockwise from East): yaw = pi/2 - compass.
+//
+// M_PI is used here, not std::numbers::pi_v, because this header is consumed
+// by the carla-ros2-native ExternalProject in Ros2Native/, which does not
+// configure CMAKE_CXX_STANDARD and therefore defaults to C++17 where
+// <numbers> is unavailable.
+inline std::array<float, 4> OrientationFromCompass(float compass) {
+  const float yaw = static_cast<float>(M_PI) / 2.0f - compass;
+  const float c = std::cos(yaw * 0.5f);
+  const float s = std::sin(yaw * 0.5f);
+  return {c, 0.0f, 0.0f, s};
+}
+
+}  // namespace ros2
+}  // namespace carla

--- a/LibCarla/source/test/common/test_imu_compass.cpp
+++ b/LibCarla/source/test/common/test_imu_compass.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "test.h"
+
+#include <carla/ros2/publishers/ImuMath.h>
+
+#include <cmath>
+
+namespace {
+
+constexpr float kEps = 1e-5f;
+
+// Recover yaw (radians, REP-103) from a (w, x, y, z) quaternion that is known
+// to be yaw-only (x == y == 0).
+float YawFrom(const std::array<float, 4> &q) {
+  return 2.0f * std::atan2(q[3], q[0]);
+}
+
+}  // namespace
+
+TEST(ImuMath, north_is_pi_over_two) {
+  // Compass = 0 means the vehicle faces magnetic North. REP-103 yaw measured
+  // counter-clockwise from East should be +pi/2.
+  const auto q = carla::ros2::OrientationFromCompass(0.0f);
+
+  ASSERT_NEAR(q[1], 0.0f, kEps);
+  ASSERT_NEAR(q[2], 0.0f, kEps);
+  ASSERT_NEAR(q[0], std::cos(static_cast<float>(M_PI) / 4.0f), kEps);
+  ASSERT_NEAR(q[3], std::sin(static_cast<float>(M_PI) / 4.0f), kEps);
+  ASSERT_NEAR(YawFrom(q), static_cast<float>(M_PI) / 2.0f, kEps);
+}
+
+TEST(ImuMath, east_is_zero_yaw) {
+  // Compass = pi/2 means the vehicle faces magnetic East. REP-103 yaw = 0.
+  const auto q = carla::ros2::OrientationFromCompass(static_cast<float>(M_PI) / 2.0f);
+
+  ASSERT_NEAR(q[1], 0.0f, kEps);
+  ASSERT_NEAR(q[2], 0.0f, kEps);
+  ASSERT_NEAR(q[0], 1.0f, kEps);
+  ASSERT_NEAR(q[3], 0.0f, kEps);
+  ASSERT_NEAR(YawFrom(q), 0.0f, kEps);
+}
+
+TEST(ImuMath, south_is_negative_pi_over_two) {
+  // Compass = pi means the vehicle faces magnetic South. REP-103 yaw = -pi/2.
+  const auto q = carla::ros2::OrientationFromCompass(static_cast<float>(M_PI));
+
+  ASSERT_NEAR(q[1], 0.0f, kEps);
+  ASSERT_NEAR(q[2], 0.0f, kEps);
+  ASSERT_NEAR(YawFrom(q), -static_cast<float>(M_PI) / 2.0f, kEps);
+}
+
+TEST(ImuMath, west_is_pi) {
+  // Compass = 3*pi/2 means the vehicle faces magnetic West. REP-103 yaw is
+  // pi/2 - 3*pi/2 = -pi (equivalently +pi); compare on |yaw| to avoid the
+  // atan2 wrap-around at the +/-pi seam.
+  const auto q = carla::ros2::OrientationFromCompass(
+      3.0f * static_cast<float>(M_PI) / 2.0f);
+
+  ASSERT_NEAR(q[1], 0.0f, kEps);
+  ASSERT_NEAR(q[2], 0.0f, kEps);
+  ASSERT_NEAR(std::abs(YawFrom(q)), static_cast<float>(M_PI), kEps);
+}
+
+TEST(ImuMath, is_not_the_regressed_pi_over_four) {
+  // Regression guard: the spelling shipped on ue5-dev before this fix
+  // returned pi/4 - compass instead of pi/2 - compass. With compass = 0 the
+  // buggy yaw is pi/4. Verify the helper does not produce that anymore.
+  const auto q = carla::ros2::OrientationFromCompass(0.0f);
+  ASSERT_GT(std::abs(YawFrom(q) - static_cast<float>(M_PI) / 4.0f), 1e-3f);
+}

--- a/PythonAPI/examples/ros2/ros2_native.py
+++ b/PythonAPI/examples/ros2/ros2_native.py
@@ -68,6 +68,7 @@ def main(args):
     world = None
     vehicle = None
     sensors = []
+    traffic_manager = None
     original_settings = None
     synchronous_master = False
 
@@ -126,8 +127,15 @@ def main(args):
         print('\nCancelled by user. Bye!')
 
     finally:
-        if synchronous_master and original_settings:
-            world.apply_settings(original_settings)
+        # Only the synchronous master that took ownership of the clock should
+        # release it: drop Traffic Manager back to async and restore the world
+        # settings. If another client (e.g. generate_traffic.py) owns the clock
+        # we leave its synchronous mode untouched.
+        if synchronous_master:
+            if traffic_manager:
+                traffic_manager.set_synchronous_mode(False)
+            if original_settings:
+                world.apply_settings(original_settings)
 
         for sensor in sensors:
             sensor.destroy()

--- a/PythonAPI/examples/ros2/ros2_native.py
+++ b/PythonAPI/examples/ros2/ros2_native.py
@@ -69,6 +69,7 @@ def main(args):
     vehicle = None
     sensors = []
     original_settings = None
+    synchronous_master = False
 
     try:
         client = carla.Client(args.host, args.port)
@@ -78,12 +79,27 @@ def main(args):
 
         original_settings = world.get_settings()
         settings = world.get_settings()
-        settings.synchronous_mode = True
-        settings.fixed_delta_seconds = 0.05
-        world.apply_settings(settings)
 
-        traffic_manager = client.get_trafficmanager()
-        traffic_manager.set_synchronous_mode(True)
+        traffic_manager = client.get_trafficmanager(args.tm_port)
+        if not args.asynch:
+            traffic_manager.set_synchronous_mode(True)
+
+        # A synchronous world must have exactly one client ticking it. By
+        # default we only take ownership of the clock (become the synchronous
+        # master) if no other client already runs the world synchronously
+        # (e.g. generate_traffic.py); otherwise we would double-step the
+        # simulation and destabilise Traffic Manager control of the autopilot
+        # vehicle. --force-sync overrides this, --asynch opts out entirely.
+        if args.force_sync and settings.synchronous_mode:
+            logging.warning(
+                "--force-sync: the world is already in synchronous mode; "
+                "ticking it from a second client may double-step the simulation.")
+
+        if not args.asynch and (args.force_sync or not settings.synchronous_mode):
+            synchronous_master = True
+            settings.synchronous_mode = True
+            settings.fixed_delta_seconds = args.delta
+            world.apply_settings(settings)
 
         with open(args.file) as f:
             config = json.load(f)
@@ -91,20 +107,26 @@ def main(args):
         vehicle = _setup_vehicle(world, config)
         sensors = _setup_sensors(world, vehicle, config.get("sensors", []))
 
-        _ = world.tick()
+        if synchronous_master:
+            world.tick()
+        else:
+            world.wait_for_tick()
 
-        vehicle.set_autopilot(True)
+        vehicle.set_autopilot(True, args.tm_port)
 
         logging.info("Running...")
 
         while True:
-            _ = world.tick()
+            if synchronous_master:
+                world.tick()
+            else:
+                world.wait_for_tick()
 
     except KeyboardInterrupt:
         print('\nCancelled by user. Bye!')
 
     finally:
-        if original_settings:
+        if synchronous_master and original_settings:
             world.apply_settings(original_settings)
 
         for sensor in sensors:
@@ -120,6 +142,11 @@ if __name__ == '__main__':
     argparser.add_argument('--port', metavar='P', default=2000, type=int, help='TCP port of CARLA Simulator (default: 2000)')
     argparser.add_argument('-f', '--file', default='', required=True, help='File to be executed')
     argparser.add_argument('-v', '--verbose', action='store_true', dest='debug', help='print debug information')
+    argparser.add_argument('--tm-port', metavar='P', default=8000, type=int, help='Port of the Traffic Manager to register the autopilot vehicle with (default: 8000). Must match the port used by generate_traffic.py.')
+    argparser.add_argument('--delta', metavar='S', default=0.05, type=float, help='Fixed simulation time step in seconds, applied only when this client becomes the synchronous master (default: 0.05)')
+    sync_group = argparser.add_mutually_exclusive_group()
+    sync_group.add_argument('--force-sync', action='store_true', help='Always become the synchronous master and tick the world, even if another client already runs it synchronously (may double-step the simulation)')
+    sync_group.add_argument('--asynch', action='store_true', help='Do not take control of the simulation clock: never enable synchronous mode and never tick, only wait for ticks from whoever owns the world')
 
     args = argparser.parse_args()
 

--- a/PythonAPI/examples/ros2/stack.json
+++ b/PythonAPI/examples/ros2/stack.json
@@ -7,8 +7,8 @@
             "id": "rgb",
             "spawn_point": {"x": -4.5, "y": 0.0, "z": 2.5, "roll": 0.0, "pitch": 20.0, "yaw": 0.0},
             "attributes": {
-                "image_size_x": 400,
-                "image_size_y": 200,
+                "image_size_x": 600,
+                "image_size_y": 400,
                 "fov": 90.0
             }
         },

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -258,13 +258,6 @@ void UActorDispatcher::WakeActorUp(FCarlaActor::IdType Id, UCarlaEpisode* CarlaE
 void UActorDispatcher::OnActorDestroyed(AActor *Actor)
 {
   FCarlaActor* CarlaActor = Registry.FindCarlaActor(Actor);
-  if (CarlaActor)
-  {
-    if (CarlaActor->IsActive())
-    {
-      Registry.Deregister(CarlaActor->GetActorId());
-    }
-  }
 
   #ifdef WITH_ROS2
   auto ROS2 = carla::ros2::ROS2::GetInstance();
@@ -273,4 +266,9 @@ void UActorDispatcher::OnActorDestroyed(AActor *Actor)
     ROS2->RemoveActorRosName(reinterpret_cast<void *>(Actor));
   }
   #endif
+
+  if (CarlaActor && CarlaActor->IsActive())
+  {
+    Registry.Deregister(CarlaActor->GetActorId());
+  }
 }


### PR DESCRIPTION
## Description

> It is necessary to merge the open PR https://github.com/carla-simulator/carla/pull/9736 before this one to fix the camera issue present in the ROS2 camera topic.

`CarlaIMUPublisher::SetData` shipped `(float(M_PI_2) / 2.0f) - compass` for the yaw used to build the orientation quaternion. That evaluates to `pi/4 - compass`, off by 45 degrees from the intended REP-103 conversion `pi/2 - compass`. Every ROS 2 IMU consumer on `ue5-dev` has been receiving an orientation rotated by 45 degrees. The math is extracted into a small `ImuMath.h` helper so it can be unit-tested without a live FastDDS publisher.

`UActorDispatcher::OnActorDestroyed` now runs the ROS 2 `RemoveActorRosName` callback before `Registry.Deregister`. Today on `ue5-dev` this is observably a no-op (the legacy API only consumes the raw `AActor*`), but it prepares cleanly for the upcoming `UnregisterSensor` / `UnregisterVehicle` work, which reads `FCarlaActor::GetActorInfo()->Description` and therefore needs the actor still alive at unregister time. Adapted from `ue4-dev` `201d375d3`.

Closes: #9627

## Changes

- New `LibCarla/source/carla/ros2/publishers/ImuMath.h` with `OrientationFromCompass(float)` that returns the yaw-only quaternion as `std::array<float, 4>` (`w, x, y, z`).
- `CarlaIMUPublisher::SetData` calls the helper; the inline Euler-to-quaternion block is removed.
- `UActorDispatcher::OnActorDestroyed` hoists the `WITH_ROS2` block ahead of `Registry.Deregister(...)` and collapses the dead nested `if` into a single predicate.
- New GTest `LibCarla/source/test/common/test_imu_compass.cpp` covering North, East, South, West, plus a regression guard against the previous `pi/4 - compass` spelling.

## Where has this been tested?

- Platform: Ubuntu 24.04.
- Python: 3.10.
- UE: 5.5.

`libcarla_test_server` (73/73) and `libcarla_test_client` (87/87) pass with the new `ImuMath.*` cases green in both suites; `cmake --build Build --target package` completes for the Release build.

## Possible Drawbacks

- Behaviour change for any ROS 2 client compensating for the previous 45-degree IMU yaw offset: the corrected quaternion will appear rotated by 45 degrees relative to the old shipping behaviour. Such clients should drop their compensation.

## Series status

| PR | Theme | Status |
|----|-------|--------|
| 1 | IMU compass yaw + actor disposal order (this PR) | #9743 |
| 2 | Template infrastructure (publisher/subscriber) + Ackermann subscriber | #9745 |
| 3 | Camera publisher unification | #9746 |
| 4 | Point-cloud + scalar publishers, listener cleanup | #9748 |
| 5 | geom types + pitch/roll fix | #9751 |
| 6 | ROS2TopicVisibility default-startup flag | #9756 |
| 7 | V2X sensor family | #9757 |
| 8 | WalkerManager null-guard + series CHANGELOG | #9758 |

Each sub-PR's branch is cut from the previous sub-PR's tip; the GitHub PR opens against
`ue5-dev` and its diff initially includes the predecessor's commit until the predecessor
merges, at which point the diff narrows to just the sub-PR's own commit.

## Related

Part of the 8-PR port of `ue4-dev` ROS 2 enhancements to `ue5-dev` (issue #9627, discussion #9581 Category 2).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9743)
<!-- Reviewable:end -->


