### PR TITLE
fix(sensor): repair latent bugs in GPU pixel readback path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 =======
 ## LATEST Changes
 
+* Fixed three latent bugs in the `FPixelReader` GPU pixel-readback path: an inverted validity guard in `SendPixelsInRenderThread` that discarded every valid sensor's frame, the readback-wait task being scheduled onto a render-pipeline thread (deadlocking game/render/RHI threads), and `FRHIGPUTextureReadback::Lock` truncating the payload to a single row by aliasing its row-pitch out-parameter.
 * Fixed ServerSession::CloseNow double-invocation on ue5-dev by guarding with std::atomic_bool _is_closed so the close path runs exactly once, preventing a dropped client from evicting a still-alive subscriber (port of ue4-dev fix #9740)
 * Added NumPy 2 compatibility to the PythonAPI by upgrading Boost to 1.90.0, which ships the upstream NumPy 2 C ABI fix. LibCarla networking migrated from `boost::asio::deadline_timer` to `boost::asio::steady_timer`, and the deprecated `io_service`, `address::from_string`, `resolver::query`, `buffer_cast`, and `io_context::work` APIs replaced across LibCarla and the CarlaTools plugin.
 * Added `Vehicle.get_telemetry_data()` returning `VehicleTelemetryData` with last-applied control, forward speed, engine RPM, current gear, and per-wheel lateral slip, longitudinal slip, and angular velocity sourced from the Chaos vehicle physics state.

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -88,7 +88,11 @@ void FPixelReader::WritePixelsToBuffer(
     RHIGetRenderQueryResult(Query, OldAbsTime, true);
   }
 
-  AsyncTask(ENamedThreads::HighTaskPriority,
+  // Must run on a generic background worker, never a render-pipeline named
+  // thread. The task busy-waits on FRHIGPUTextureReadback::IsReady(), whose
+  // completion the RHI thread itself has to drive; scheduling it on the RHI
+  // (or render) thread deadlocks the whole pipeline.
+  AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
     [=, Pool = std::move(Pool),
         Fallback = std::move(FallbackReadback)]() mutable {
     {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -93,7 +93,7 @@ void FPixelReader::WritePixelsToBuffer(
   // completion the RHI thread itself has to drive; scheduling it on the RHI
   // (or render) thread deadlocks the whole pipeline.
   AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
-    [=, Pool = std::move(Pool),
+    [=, FuncForSending = std::move(FuncForSending), Pool = std::move(Pool),
         Fallback = std::move(FallbackReadback)]() mutable {
     {
       TRACE_CPUPROFILER_EVENT_SCOPE_STR("Wait GPU transfer");

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -108,7 +108,11 @@ void FPixelReader::WritePixelsToBuffer(
       FPixelFormatInfo PixelFormat = GPixelFormats[BackBufferPixelFormat];
       uint32 ExpectedRowBytes = BackBufferSize.X * PixelFormat.BlockBytes;
       int32 Size = (BackBufferSize.Y * (PixelFormat.BlockBytes * BackBufferSize.X));
-      void* LockedData = Readback->Lock(Size);
+      // FRHIGPUTextureReadback::Lock takes its argument by reference and writes
+      // the row stride (in pixels) back into it. It must not alias `Size`, or
+      // the payload length collapses to a single row's pixel count.
+      int32 RowPitchInPixels = 0;
+      void* LockedData = Readback->Lock(RowPitchInPixels);
       if (LockedData)
       {
         FuncForSending(LockedData, Size, Offset, ExpectedRowBytes);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.cpp
@@ -88,11 +88,11 @@ void FPixelReader::WritePixelsToBuffer(
     RHIGetRenderQueryResult(Query, OldAbsTime, true);
   }
 
-  // Must run on a generic background worker, never a render-pipeline named
-  // thread. The task busy-waits on FRHIGPUTextureReadback::IsReady(), whose
-  // completion the RHI thread itself has to drive; scheduling it on the RHI
-  // (or render) thread deadlocks the whole pipeline.
-  AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
+  // Must stay off the render-pipeline named threads: the task busy-waits
+  // on FRHIGPUTextureReadback::IsReady(), which the RHI thread itself has
+  // to drive — dispatching there deadlocks. AnyBackgroundHiPriTask keeps
+  // the original high-priority intent.
+  AsyncTask(ENamedThreads::AnyBackgroundHiPriTask,
     [=, FuncForSending = std::move(FuncForSending), Pool = std::move(Pool),
         Fallback = std::move(FallbackReadback)]() mutable {
     {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/PixelReader.h
@@ -106,7 +106,7 @@ void FPixelReader::SendPixelsInRenderThread(TSensor &Sensor, bool use16BitFormat
   TRACE_CPUPROFILER_EVENT_SCOPE(FPixelReader::SendPixelsInRenderThread);
   check(Sensor.CaptureRenderTarget != nullptr);
 
-  if (!Sensor.HasActorBegunPlay() || IsValidChecked(&Sensor))
+  if (!Sensor.HasActorBegunPlay() || !IsValidChecked(&Sensor))
   {
     return;
   }


### PR DESCRIPTION
#### Description

`FPixelReader::SendPixelsInRenderThread` / `WritePixelsToBuffer` carried three latent bugs. The path had **no callers on `ue5-dev`** (dead code since the `CarlaUE4` → `CarlaUnreal` rename), so the bugs were dormant.
The wide-angle fisheye sensors (separate PR) are the first code to exercise it, which surfaced all three. Fixing them here keeps the fisheye PR scoped to fisheye work.

1. **Inverted validity guard** (`PixelReader.h`) — the early-out used `IsValidChecked(&Sensor)` without negation, so every *valid* sensor returned before capturing. The sensor produced only black frames.

2. **Render-pipeline deadlock** (`PixelReader.cpp`) — the readback-wait task was posted with `AsyncTask(ENamedThreads::HighTaskPriority, ...)`, which can land on the RHI thread. There it busy-waits on `FRHIGPUTextureReadback::IsReady()`, whose completion the RHI thread must itself drive — deadlocking game + render + RHI threads. Moved to `AnyBackgroundThreadNormalTask`.

3. **Truncated payload** (`PixelReader.cpp`) — `Readback->Lock(Size)` binds the current `Lock(int32& OutRowPitchInPixels)` overload, which overwrites `Size` with the row stride in pixels. Only one row was streamed. Now uses a dedicated `RowPitchInPixels` out-parameter.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04, Linux x86_64 + Vulkan
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 5.5 (CARLA fork)

Verified by building the packaged Shipping server and running the wide-angle camera sensors end-to-end: capture, GPU readback, and client-side image delivery all succeed.

Before:
<img width="1308" height="786" alt="Screenshot from 2026-05-21 18-58-17" src="https://github.com/user-attachments/assets/03d75d2a-fcb2-46d7-bd69-38e494ac9045" />

After:
<img width="1308" height="786" alt="Screenshot from 2026-05-21 19-08-01" src="https://github.com/user-attachments/assets/360234d7-1a15-4f4b-98c8-0467905595ba" />

#### Possible Drawbacks

None expected. The code path is currently unreachable on `ue5-dev`, so
these changes only correct behaviour for future callers; no existing
sensor path changes.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9744)
<!-- Reviewable:end -->
