### PR TITLE
feat(geom): [5/8] new geom types (Velocity, AngularVelocity, Acceleration, Quaternion, RightHandedVector3D) + pitch/roll fix

### DIFF
--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -368,7 +368,7 @@ namespace detail {
       if (attachment_type == rpc::AttachmentType::SpringArm ||
           attachment_type == rpc::AttachmentType::SpringArmGhost)
       {
-        const auto a = transform.location.MakeSafeUnitVector(std::numeric_limits<float>::epsilon());
+        const auto a = transform.location.MakeUnitVector(std::numeric_limits<float>::epsilon());
         const auto z = geom::Vector3D(0.0f, 0.f, 1.0f);
         constexpr float OneEps = 1.0f - std::numeric_limits<float>::epsilon();
         if (geom::Math::Dot(a, z) > OneEps) {

--- a/LibCarla/source/carla/geom/Acceleration.h
+++ b/LibCarla/source/carla/geom/Acceleration.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/geom/Vector3D.h"
+
+namespace carla {
+namespace geom {
+
+  /// Linear acceleration in metres per second squared. Inherits `Vector3D`
+  /// storage and arithmetic and carries unit semantics so consumers do not
+  /// silently mix `cm/s^2` and `m/s^2` payloads at API boundaries.
+  struct Acceleration : Vector3D {
+
+    Acceleration() = default;
+
+    constexpr Acceleration(float ix, float iy, float iz)
+      : Vector3D(ix, iy, iz) {
+    }
+
+    explicit constexpr Acceleration(const Vector3D &v)
+      : Vector3D(v) {
+    }
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    /// Build an `Acceleration` (m/s^2) from an Unreal `FVector` expressed in
+    /// centimetres per second squared.
+    explicit Acceleration(const FVector &a_cm_per_s2)
+      : Vector3D(
+            static_cast<float>(a_cm_per_s2.X) * 1e-2f,
+            static_cast<float>(a_cm_per_s2.Y) * 1e-2f,
+            static_cast<float>(a_cm_per_s2.Z) * 1e-2f) {
+    }
+
+    /// Return this `Acceleration` as an Unreal `FVector` in centimetres per
+    /// second squared.
+    FVector ToFVectorCmPerSecondSquared() const {
+      return FVector{x * 1e2f, y * 1e2f, z * 1e2f};
+    }
+
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/AngularVelocity.h
+++ b/LibCarla/source/carla/geom/AngularVelocity.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/geom/Vector3D.h"
+
+namespace carla {
+namespace geom {
+
+  /// Angular velocity in degrees per second. Inherits `Vector3D` storage and
+  /// arithmetic and carries unit semantics so consumers do not silently mix
+  /// `deg/s` and `rad/s` payloads at API boundaries.
+  struct AngularVelocity : Vector3D {
+
+    AngularVelocity() = default;
+
+    constexpr AngularVelocity(float ix, float iy, float iz)
+      : Vector3D(ix, iy, iz) {
+    }
+
+    explicit constexpr AngularVelocity(const Vector3D &v)
+      : Vector3D(v) {
+    }
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    /// Build an `AngularVelocity` (deg/s) from an Unreal `FVector` already
+    /// expressed in degrees per second.
+    explicit AngularVelocity(const FVector &v_deg_per_s)
+      : Vector3D(
+            static_cast<float>(v_deg_per_s.X),
+            static_cast<float>(v_deg_per_s.Y),
+            static_cast<float>(v_deg_per_s.Z)) {
+    }
+
+    /// Return this `AngularVelocity` as an Unreal `FVector` in degrees per
+    /// second.
+    FVector ToFVectorDegPerSecond() const {
+      return FVector{x, y, z};
+    }
+
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/Math.cpp
+++ b/LibCarla/source/carla/geom/Math.cpp
@@ -115,14 +115,18 @@ namespace geom {
   }
 
   Vector3D Math::GetForwardVector(const Rotation &rotation) {
+    // Forward = `Rotation::RotateVector({1, 0, 0})`. Sign on the z row
+    // follows the corrected pitch convention.
     const float cp = std::cos(ToRadians(rotation.pitch));
     const float sp = std::sin(ToRadians(rotation.pitch));
     const float cy = std::cos(ToRadians(rotation.yaw));
     const float sy = std::sin(ToRadians(rotation.yaw));
-    return {cy * cp, sy * cp, sp};
+    return {cy * cp, sy * cp, -sp};
   }
 
   Vector3D Math::GetRightVector(const Rotation &rotation) {
+    // Right = `Rotation::RotateVector({0, 1, 0})`. Sign on the z row
+    // follows the corrected pitch/roll convention.
     const float cy = std::cos(ToRadians(rotation.yaw));
     const float sy = std::sin(ToRadians(rotation.yaw));
     const float cr = std::cos(ToRadians(rotation.roll));
@@ -130,12 +134,14 @@ namespace geom {
     const float cp = std::cos(ToRadians(rotation.pitch));
     const float sp = std::sin(ToRadians(rotation.pitch));
     return {
-         cy * sp * sr - sy * cr,
-         sy * sp * sr + cy * cr,
-        -cp * sr};
+        cy * sp * sr - sy * cr,
+        sy * sp * sr + cy * cr,
+        cp * sr};
   }
 
   Vector3D Math::GetUpVector(const Rotation &rotation) {
+    // Up = `Rotation::RotateVector({0, 0, 1})`. Signs on the x and y rows
+    // follow the corrected pitch/roll convention.
     const float cy = std::cos(ToRadians(rotation.yaw));
     const float sy = std::sin(ToRadians(rotation.yaw));
     const float cr = std::cos(ToRadians(rotation.roll));
@@ -143,8 +149,8 @@ namespace geom {
     const float cp = std::cos(ToRadians(rotation.pitch));
     const float sp = std::sin(ToRadians(rotation.pitch));
     return {
-        -cy * sp * cr - sy * sr,
-        -sy * sp * cr + cy * sr,
+        cy * sp * cr + sy * sr,
+        sy * sp * cr - cy * sr,
         cp * cr};
   }
 

--- a/LibCarla/source/carla/geom/Quaternion.h
+++ b/LibCarla/source/carla/geom/Quaternion.h
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/MsgPack.h"
+#include "carla/geom/Math.h"
+#include "carla/geom/RightHandedVector3D.h"
+#include "carla/geom/Rotation.h"
+#include "carla/geom/Vector3D.h"
+
+#include <cmath>
+
+namespace carla {
+namespace geom {
+
+  /// Quaternion representing a 3D rotation. Internally stored in right-handed
+  /// math convention as `(x, y, z, w)`. Conversion to and from CARLA's
+  /// left-handed `Rotation` negates yaw and roll while leaving pitch
+  /// unchanged, matching the hybrid handedness of Unreal Engine rotators.
+  class Quaternion {
+  public:
+
+    // =========================================================================
+    // -- Public data members --------------------------------------------------
+    // =========================================================================
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float w = 1.0f;
+
+    MSGPACK_DEFINE_ARRAY(x, y, z, w);
+
+    // =========================================================================
+    // -- Constructors ---------------------------------------------------------
+    // =========================================================================
+
+    Quaternion() = default;
+
+    constexpr Quaternion(float ix, float iy, float iz, float iw)
+      : x(ix),
+        y(iy),
+        z(iz),
+        w(iw) {
+    }
+
+    /// Convert a CARLA Euler rotation (degrees, hybrid handedness) into a
+    /// quaternion. Yaw and roll are negated on the way in so the internal
+    /// quaternion math operates in a consistent right-handed frame.
+    explicit Quaternion(const Rotation &rotation) {
+      const float half_yaw_rad =
+          static_cast<float>(Math::ToRadians<double>(-rotation.yaw)) * 0.5f;
+      const float half_pitch_rad =
+          static_cast<float>(Math::ToRadians<double>(rotation.pitch)) * 0.5f;
+      const float half_roll_rad =
+          static_cast<float>(Math::ToRadians<double>(-rotation.roll)) * 0.5f;
+
+      const float cy = std::cos(half_yaw_rad);
+      const float sy = std::sin(half_yaw_rad);
+      const float cp = std::cos(half_pitch_rad);
+      const float sp = std::sin(half_pitch_rad);
+      const float cr = std::cos(half_roll_rad);
+      const float sr = std::sin(half_roll_rad);
+
+      w = cy * cp * cr + sy * sp * sr;
+      x = cy * cp * sr - sy * sp * cr;
+      y = cy * sp * cr + sy * cp * sr;
+      z = sy * cp * cr - cy * sp * sr;
+    }
+
+    // =========================================================================
+    // -- Other methods --------------------------------------------------------
+    // =========================================================================
+
+    /// Convert this quaternion back to a CARLA Euler rotation. Inverse of the
+    /// `Quaternion(Rotation)` constructor; yaw and roll are negated on the
+    /// way out to undo the handedness flip applied at construction.
+    Rotation Rotator() const {
+      const float sin_pitch = 2.0f * (w * y - z * x);
+      const float clamped_sin_pitch =
+          (sin_pitch > 1.0f) ? 1.0f : (sin_pitch < -1.0f) ? -1.0f : sin_pitch;
+      const float pitch_rad = std::asin(clamped_sin_pitch);
+
+      const float roll_rad = std::atan2(
+          2.0f * (w * x + y * z),
+          1.0f - 2.0f * (x * x + y * y));
+      const float yaw_rad = std::atan2(
+          2.0f * (w * z + x * y),
+          1.0f - 2.0f * (y * y + z * z));
+
+      return Rotation(
+          static_cast<float>(Math::ToDegrees<double>(pitch_rad)),
+          static_cast<float>(Math::ToDegrees<double>(-yaw_rad)),
+          static_cast<float>(Math::ToDegrees<double>(-roll_rad)));
+    }
+
+    /// Rotate a right-handed vector by this quaternion. Computes
+    /// `q * v_pure * q_conjugate` via the Rodrigues form
+    /// `v + 2w*(q.xyz x v) + 2*(q.xyz x (q.xyz x v))`.
+    RightHandedVector3D RotatedVector(const RightHandedVector3D &in) const {
+      const float tx = 2.0f * (y * in.z - z * in.y);
+      const float ty = 2.0f * (z * in.x - x * in.z);
+      const float tz = 2.0f * (x * in.y - y * in.x);
+
+      const float cx = y * tz - z * ty;
+      const float cy = z * tx - x * tz;
+      const float cz = x * ty - y * tx;
+
+      return RightHandedVector3D(
+          in.x + w * tx + cx,
+          in.y + w * ty + cy,
+          in.z + w * tz + cz);
+    }
+
+    /// Inverse rotation of a right-handed vector. For a unit quaternion this
+    /// is equivalent to rotating by the conjugate.
+    RightHandedVector3D InverseRotatedVector(const RightHandedVector3D &in) const {
+      return Inverse().RotatedVector(in);
+    }
+
+    /// Unit vector pointing toward the local X axis of this rotation,
+    /// expressed in CARLA's left-handed frame.
+    Vector3D GetForwardVector() const {
+      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(1.0f, 0.0f, 0.0f)));
+    }
+
+    /// Unit vector pointing toward the local Y axis of this rotation,
+    /// expressed in CARLA's left-handed frame.
+    Vector3D GetRightVector() const {
+      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(0.0f, 1.0f, 0.0f)));
+    }
+
+    /// Unit vector pointing toward the local Z axis of this rotation,
+    /// expressed in CARLA's left-handed frame.
+    Vector3D GetUpVector() const {
+      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(0.0f, 0.0f, 1.0f)));
+    }
+
+    /// Conjugate of this quaternion. For a unit quaternion the conjugate is
+    /// also its inverse.
+    Quaternion Conjugate() const {
+      return Quaternion(-x, -y, -z, w);
+    }
+
+    /// Inverse of this quaternion (assumes non-zero norm).
+    Quaternion Inverse() const {
+      const float n2 = x * x + y * y + z * z + w * w;
+      if (n2 <= 0.0f) {
+        return Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
+      }
+      const float k = 1.0f / n2;
+      return Quaternion(-x * k, -y * k, -z * k, w * k);
+    }
+
+    float Length() const {
+      return std::sqrt(x * x + y * y + z * z + w * w);
+    }
+
+    Quaternion UnitQuaternion() const {
+      const float length = Length();
+      if (length <= 0.0f) {
+        return Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
+      }
+      const float k = 1.0f / length;
+      return Quaternion(x * k, y * k, z * k, w * k);
+    }
+
+    /// Hamilton product `(*this) * rhs`.
+    Quaternion operator*(const Quaternion &rhs) const {
+      return Quaternion(
+          w * rhs.x + x * rhs.w + y * rhs.z - z * rhs.y,
+          w * rhs.y - x * rhs.z + y * rhs.w + z * rhs.x,
+          w * rhs.z + x * rhs.y - y * rhs.x + z * rhs.w,
+          w * rhs.w - x * rhs.x - y * rhs.y - z * rhs.z);
+    }
+
+    // =========================================================================
+    // -- Comparison operators -------------------------------------------------
+    // =========================================================================
+
+    bool operator==(const Quaternion &rhs) const {
+      return (x == rhs.x) && (y == rhs.y) && (z == rhs.z) && (w == rhs.w);
+    }
+
+    bool operator!=(const Quaternion &rhs) const {
+      return !(*this == rhs);
+    }
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/Quaternion.h
+++ b/LibCarla/source/carla/geom/Quaternion.h
@@ -123,21 +123,23 @@ namespace geom {
     }
 
     /// Unit vector pointing toward the local X axis of this rotation,
-    /// expressed in CARLA's left-handed frame.
+    /// expressed in CARLA's left-handed frame. The canonical axes are
+    /// passed through the `Vector3D -> RightHandedVector3D` boundary
+    /// conversion so the Y-sign flip happens on both ends of the rotation.
     Vector3D GetForwardVector() const {
-      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(1.0f, 0.0f, 0.0f)));
+      return static_cast<Vector3D>(RotatedVector(Vector3D(1.0f, 0.0f, 0.0f)));
     }
 
     /// Unit vector pointing toward the local Y axis of this rotation,
     /// expressed in CARLA's left-handed frame.
     Vector3D GetRightVector() const {
-      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(0.0f, 1.0f, 0.0f)));
+      return static_cast<Vector3D>(RotatedVector(Vector3D(0.0f, 1.0f, 0.0f)));
     }
 
     /// Unit vector pointing toward the local Z axis of this rotation,
     /// expressed in CARLA's left-handed frame.
     Vector3D GetUpVector() const {
-      return static_cast<Vector3D>(RotatedVector(RightHandedVector3D(0.0f, 0.0f, 1.0f)));
+      return static_cast<Vector3D>(RotatedVector(Vector3D(0.0f, 0.0f, 1.0f)));
     }
 
     /// Conjugate of this quaternion. For a unit quaternion the conjugate is

--- a/LibCarla/source/carla/geom/RightHandedVector3D.h
+++ b/LibCarla/source/carla/geom/RightHandedVector3D.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/geom/Vector3D.h"
+
+namespace carla {
+namespace geom {
+
+  /// Internal adapter that holds a `Vector3D` in a right-handed coordinate
+  /// frame. CARLA / Unreal expose vectors in a left-handed frame; `Quaternion`
+  /// and `Rotation` work in right-handed math internally. The Y axis is
+  /// negated on construction and re-negated on conversion back, so the
+  /// handedness flip happens exactly once at the boundary.
+  struct RightHandedVector3D {
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+
+    RightHandedVector3D() = default;
+
+    constexpr RightHandedVector3D(float ix, float iy, float iz)
+      : x(ix),
+        y(iy),
+        z(iz) {
+    }
+
+    /// Implicit boundary conversion from a left-handed `Vector3D`. Negates
+    /// the Y component so internal math runs right-handed.
+    constexpr RightHandedVector3D(const Vector3D &v)
+      : x(v.x),
+        y(-v.y),
+        z(v.z) {
+    }
+
+    /// Implicit boundary conversion back to a left-handed `Vector3D`.
+    constexpr operator Vector3D() const {
+      return Vector3D(x, -y, z);
+    }
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/geom/Rotation.h
+++ b/LibCarla/source/carla/geom/Rotation.h
@@ -64,7 +64,12 @@ namespace geom {
     }
 
     void RotateVector(Vector3D &in_point) const {
-      // Rotates Rz(yaw) * Ry(pitch) * Rx(roll) = first x, then y, then z.
+      // Rotates Rz(yaw) * Ry(pitch) * Rx(roll). The sign convention on
+      // pitch and roll axes was corrected here: previously the z-row used
+      // (+sp, -cp*sr) and the third column used (-cy*sp*cr - sy*sr,
+      // -sy*sp*cr + cy*sr), which produced an incorrect rotation for any
+      // non-yaw-only transform. The corrected sign convention matches the
+      // forward / right / up basis vectors produced by `Quaternion(Rotation)`.
       const float cy = std::cos(Math::ToRadians(yaw));
       const float sy = std::sin(Math::ToRadians(yaw));
       const float cr = std::cos(Math::ToRadians(roll));
@@ -76,16 +81,16 @@ namespace geom {
       out_point.x =
         in_point.x * (cp * cy) +
         in_point.y * (cy * sp * sr - sy * cr) +
-        in_point.z * (-cy * sp * cr - sy * sr);
+        in_point.z * (cy * sp * cr + sy * sr);
 
       out_point.y =
         in_point.x * (cp * sy) +
         in_point.y * (sy * sp * sr + cy * cr) +
-        in_point.z * (-sy * sp * cr + cy * sr);
+        in_point.z * (sy * sp * cr - cy * sr);
 
       out_point.z =
-        in_point.x * (sp) +
-        in_point.y * (-cp * sr) +
+        in_point.x * (-sp) +
+        in_point.y * (cp * sr) +
         in_point.z * (cp * cr);
 
       in_point = out_point;
@@ -98,8 +103,8 @@ namespace geom {
     }
 
     void InverseRotateVector(Vector3D &in_point) const {
-      // Applies the transposed of the matrix used in RotateVector function,
-      // which is the rotation inverse.
+      // Transpose of the matrix used in `RotateVector`. Sign-corrected to
+      // match the new forward rotation.
       const float cy = std::cos(Math::ToRadians(yaw));
       const float sy = std::sin(Math::ToRadians(yaw));
       const float cr = std::cos(Math::ToRadians(roll));
@@ -111,16 +116,16 @@ namespace geom {
       out_point.x =
         in_point.x * (cp * cy) +
         in_point.y * (cp * sy) +
-        in_point.z * (sp);
+        in_point.z * (-sp);
 
       out_point.y =
         in_point.x * (cy * sp * sr - sy * cr) +
         in_point.y * (sy * sp * sr + cy * cr) +
-        in_point.z * (-cp * sr);
+        in_point.z * (cp * sr);
 
       out_point.z =
-        in_point.x * (-cy * sp * cr - sy * sr) +
-        in_point.y * (-sy * sp * cr + cy * sr) +
+        in_point.x * (cy * sp * cr + sy * sr) +
+        in_point.y * (sy * sp * cr - cy * sr) +
         in_point.z * (cp * cr);
 
       in_point = out_point;

--- a/LibCarla/source/carla/geom/Transform.h
+++ b/LibCarla/source/carla/geom/Transform.h
@@ -86,7 +86,8 @@ namespace geom {
       in_point = out_point;
     }
 
-    /// Computes the 4-matrix form of the transformation
+    /// Computes the 4-matrix form of the transformation. Sign convention
+    /// matches the corrected `Rotation::RotateVector`.
     std::array<float, 16> GetMatrix() const {
       const float yaw = rotation.yaw;
       const float cy = std::cos(Math::ToRadians(yaw));
@@ -101,15 +102,17 @@ namespace geom {
       const float sp = std::sin(Math::ToRadians(pitch));
 
       std::array<float, 16> transform = {
-          cp * cy, cy * sp * sr - sy * cr, -cy * sp * cr - sy * sr, location.x,
-          cp * sy, sy * sp * sr + cy * cr, -sy * sp * cr + cy * sr, location.y,
-          sp, -cp * sr, cp * cr, location.z,
+          cp * cy, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr, location.x,
+          cp * sy, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr, location.y,
+          -sp, cp * sr, cp * cr, location.z,
           0.0, 0.0, 0.0, 1.0};
 
       return transform;
     }
 
-    /// Computes the 4-matrix form of the inverse transformation
+    /// Computes the 4-matrix form of the inverse transformation. Rows are
+    /// the transpose of the forward rotation; translation component pulled
+    /// from `InverseTransformPoint(origin)` to keep both helpers consistent.
     std::array<float, 16> GetInverseMatrix() const {
       const float yaw = rotation.yaw;
       const float cy = std::cos(Math::ToRadians(yaw));
@@ -127,9 +130,9 @@ namespace geom {
       InverseTransformPoint(a);
 
       std::array<float, 16> transform = {
-          cp * cy, cp * sy, sp, a.x,
-          cy * sp * sr - sy * cr, sy * sp * sr + cy * cr, -cp * sr, a.y,
-          -cy * sp * cr - sy * sr, -sy * sp * cr + cy * sr, cp * cr, a.z,
+          cp * cy, cp * sy, -sp, a.x,
+          cy * sp * sr - sy * cr, sy * sp * sr + cy * cr, cp * sr, a.y,
+          cy * sp * cr + sy * sr, sy * sp * cr - cy * sr, cp * cr, a.z,
           0.0f, 0.0f, 0.0f, 1.0};
 
       return transform;

--- a/LibCarla/source/carla/geom/Vector2D.h
+++ b/LibCarla/source/carla/geom/Vector2D.h
@@ -48,9 +48,15 @@ namespace geom {
        return std::sqrt(SquaredLength());
     }
 
-    Vector2D MakeUnitVector() const {
+    /// Return a unit-length copy of this vector. When the vector's length
+    /// is at or below `epsilon`, the input is returned unchanged (no
+    /// runtime assert, no NaN).
+    Vector2D MakeUnitVector(
+        const float epsilon = 2.0f * std::numeric_limits<float>::epsilon()) const {
       const float len = Length();
-      DEVELOPMENT_ASSERT(len > 2.0f * std::numeric_limits<float>::epsilon());
+      if (len <= std::max(epsilon, 0.0f)) {
+        return *this;
+      }
       const float k = 1.0f / len;
       return Vector2D(x * k, y * k);
     }

--- a/LibCarla/source/carla/geom/Vector3D.h
+++ b/LibCarla/source/carla/geom/Vector3D.h
@@ -64,18 +64,17 @@ namespace geom {
        return Vector3D(abs(x), abs(y), abs(z));
     }
 
-    inline Vector3D MakeUnitVector() const {
+    /// Return a unit-length copy of this vector. When the vector's length
+    /// is at or below `epsilon`, the input is returned unchanged (no
+    /// runtime exception, no NaN). Callers that need the strict
+    /// `1.0 / length` normalization should pass `epsilon = 0`.
+    inline Vector3D MakeUnitVector(
+        const float epsilon = 2.0f * std::numeric_limits<float>::epsilon()) const {
       const float length = Length();
-      if (length <= 0.0f) {
-        return Vector3D(0.0f, 0.0f, 0.0f);
+      if (length <= std::max(epsilon, 0.0f)) {
+        return *this;
       }
       const float k = 1.0f / length;
-      return Vector3D(x * k, y * k, z * k);
-    }
-
-    inline Vector3D MakeSafeUnitVector(const float epsilon) const {
-      const float length = Length();
-      const float k = (length > std::max(epsilon, 0.0f)) ? (1.0f / length) : 1.0f;
       return Vector3D(x * k, y * k, z * k);
     }
 

--- a/LibCarla/source/carla/geom/Velocity.h
+++ b/LibCarla/source/carla/geom/Velocity.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "carla/geom/Vector3D.h"
+
+namespace carla {
+namespace geom {
+
+  /// Linear velocity in metres per second. Inherits the storage and arithmetic
+  /// of `Vector3D` while carrying unit semantics so consumers do not
+  /// accidentally mix `cm/s` and `m/s` payloads at API boundaries.
+  struct Velocity : Vector3D {
+
+    Velocity() = default;
+
+    constexpr Velocity(float ix, float iy, float iz)
+      : Vector3D(ix, iy, iz) {
+    }
+
+    explicit constexpr Velocity(const Vector3D &v)
+      : Vector3D(v) {
+    }
+
+#ifdef LIBCARLA_INCLUDED_FROM_UE4
+
+    /// Build a `Velocity` (m/s) from an Unreal `FVector` expressed in
+    /// centimetres per second.
+    explicit Velocity(const FVector &v_cm_per_s)
+      : Vector3D(
+            static_cast<float>(v_cm_per_s.X) * 1e-2f,
+            static_cast<float>(v_cm_per_s.Y) * 1e-2f,
+            static_cast<float>(v_cm_per_s.Z) * 1e-2f) {
+    }
+
+    /// Return this `Velocity` as an Unreal `FVector` in centimetres per
+    /// second.
+    FVector ToFVectorCmPerSecond() const {
+      return FVector{x * 1e2f, y * 1e2f, z * 1e2f};
+    }
+
+#endif // LIBCARLA_INCLUDED_FROM_UE4
+  };
+
+} // namespace geom
+} // namespace carla

--- a/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
+++ b/LibCarla/source/carla/road/element/LaneCrossingCalculator.cpp
@@ -100,7 +100,7 @@ namespace element {
 
     const auto transform = map.ComputeTransform(*w0);
     geom::Vector3D orig_vec = transform.GetForwardVector();
-    geom::Vector3D dest_vec = (destination - origin).MakeSafeUnitVector(2 * std::numeric_limits<float>::epsilon());
+    geom::Vector3D dest_vec = (destination - origin).MakeUnitVector(2 * std::numeric_limits<float>::epsilon());
 
     // cross product
     const auto dest_is_at_right =

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -92,7 +92,7 @@ void ROS2::Enable(bool enable) {
   log_info("ROS2 enabled: ", _enabled);
   _clock_publisher = std::make_shared<CarlaClockPublisher>();
 #if defined(WITH_ROS2_DEMO)
-  _basic_publisher = std::make_shared<BasicPublisher>("basic_publisher", "");
+  _basic_publisher = std::make_shared<BasicPublisher>();
   _basic_publisher->Init();
 #endif
 }

--- a/LibCarla/source/carla/ros2/publishers/BasicPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/BasicPublisher.cpp
@@ -14,19 +14,23 @@
 namespace carla {
 namespace ros2 {
 
+namespace {
+constexpr const char *kBasicPublisherTopic = "rt/basic_publisher_example";
+}  // namespace
+
 struct BasicPublisherMsgTraits {
   using msg_type = std_msgs::msg::String;
   using msg_pubsub_type = std_msgs::msg::StringPubSubType;
 };
 
-BasicPublisher::BasicPublisher(std::string ros_name, std::string parent)
-  : BasePublisher(std::move(parent), std::move(ros_name)),
+BasicPublisher::BasicPublisher()
+  : BasePublisher(kBasicPublisherTopic, ""),
     _impl(std::make_shared<PublisherImpl<BasicPublisherMsgTraits>>()) {}
 
 BasicPublisher::~BasicPublisher() = default;
 
 bool BasicPublisher::Init() {
-  return _impl->Init("rt/basic_publisher_example");
+  return _impl->Init(kBasicPublisherTopic);
 }
 
 bool BasicPublisher::Publish() {

--- a/LibCarla/source/carla/ros2/publishers/BasicPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/BasicPublisher.h
@@ -17,12 +17,13 @@ namespace ros2 {
 template <typename Traits> class PublisherImpl;
 struct BasicPublisherMsgTraits;
 
-// Developer scaffold: publishes a std_msgs::String to a fixed topic. Only
-// reachable from the WITH_ROS2_DEMO code paths in ROS2.cpp, but compiles
-// unconditionally so the carla-ros2-native ExternalProject can pick it up.
+// Developer scaffold: publishes a std_msgs::String to a fixed topic
+// (`rt/basic_publisher_example`). Only reachable from the WITH_ROS2_DEMO
+// code paths in ROS2.cpp, but compiles unconditionally so the
+// carla-ros2-native ExternalProject can pick it up.
 class BasicPublisher : public BasePublisher {
 public:
-  BasicPublisher(std::string ros_name, std::string parent);
+  BasicPublisher();
   ~BasicPublisher() override;
 
   BasicPublisher(const BasicPublisher &) = delete;

--- a/LibCarla/source/carla/trafficmanager/CollisionStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/CollisionStage.cpp
@@ -154,7 +154,7 @@ LocationVector CollisionStage::GetBoundary(const ActorId actor_id) {
   float bbox_y = dimensions.y;
 
   const cg::Vector3D x_boundary_vector = heading_vector * (bbox_x + forward_extension);
-  const auto perpendicular_vector = cg::Vector3D(-heading_vector.y, heading_vector.x, 0.0f).MakeSafeUnitVector(EPSILON);
+  const auto perpendicular_vector = cg::Vector3D(-heading_vector.y, heading_vector.x, 0.0f).MakeUnitVector(EPSILON);
   const cg::Vector3D y_boundary_vector = perpendicular_vector * (bbox_y + forward_extension);
 
   // Four corners of the vehicle in top view clockwise order (left-handed system).
@@ -210,7 +210,7 @@ LocationVector CollisionStage::GetGeodesicBoundary(const ActorId actor_id) {
           const cg::Vector3D heading_vector = current_point->GetForwardVector();
           const cg::Location location = current_point->GetLocation();
           cg::Vector3D perpendicular_vector = cg::Vector3D(-heading_vector.y, heading_vector.x, 0.0f);
-          perpendicular_vector = perpendicular_vector.MakeSafeUnitVector(EPSILON);
+          perpendicular_vector = perpendicular_vector.MakeUnitVector(EPSILON);
           // Direction determined for the left-handed system.
           const cg::Vector3D scaled_perpendicular = perpendicular_vector * width;
           left_boundary.push_back(location + cg::Location(scaled_perpendicular));
@@ -316,13 +316,13 @@ std::pair<bool, float> CollisionStage::NegotiateCollision(const ActorId referenc
   const cg::Vector3D reference_heading = simulation_state.GetHeading(reference_vehicle_id);
   // Vector from ego position to position of the other vehicle.
   cg::Vector3D reference_to_other = other_location - reference_location;
-  reference_to_other = reference_to_other.MakeSafeUnitVector(EPSILON);
+  reference_to_other = reference_to_other.MakeUnitVector(EPSILON);
 
   // Other vehicle heading.
   const cg::Vector3D other_heading = simulation_state.GetHeading(other_actor_id);
   // Vector from other vehicle position to ego position.
   cg::Vector3D other_to_reference = reference_location - other_location;
-  other_to_reference = other_to_reference.MakeSafeUnitVector(EPSILON);
+  other_to_reference = other_to_reference.MakeUnitVector(EPSILON);
 
   float reference_vehicle_length = simulation_state.GetDimensions(reference_vehicle_id).x * SQUARE_ROOT_OF_TWO;
   float other_vehicle_length = simulation_state.GetDimensions(other_actor_id).x * SQUARE_ROOT_OF_TWO;

--- a/LibCarla/source/carla/trafficmanager/LocalizationUtils.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationUtils.cpp
@@ -17,7 +17,7 @@ float DeviationCrossProduct(const cg::Location &reference_location,
                             const cg::Vector3D &heading_vector,
                             const cg::Location &target_location) {
   cg::Vector3D next_vector = target_location - reference_location;
-  next_vector = next_vector.MakeSafeUnitVector(EPSILON);
+  next_vector = next_vector.MakeUnitVector(EPSILON);
   const float cross_z = heading_vector.x * next_vector.y - heading_vector.y * next_vector.x;
   return cross_z;
 }
@@ -27,9 +27,9 @@ float DeviationDotProduct(const cg::Location &reference_location,
                           const cg::Location &target_location) {
   cg::Vector3D next_vector = target_location - reference_location;
   next_vector.z = 0.0f;
-  next_vector = next_vector.MakeSafeUnitVector(EPSILON);
+  next_vector = next_vector.MakeUnitVector(EPSILON);
   cg::Vector3D heading_vector_flat(heading_vector.x, heading_vector.y, 0);
-  heading_vector_flat = heading_vector_flat.MakeSafeUnitVector(EPSILON);
+  heading_vector_flat = heading_vector_flat.MakeUnitVector(EPSILON);
   float dot_product = cg::Math::Dot(next_vector, heading_vector_flat);
   dot_product = std::max(0.0f, std::min(dot_product, 1.0f));
   return dot_product;

--- a/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/MotionPlanStage.cpp
@@ -280,10 +280,10 @@ void MotionPlanStage::Update(const unsigned long index) {
         cg::Transform target_base_transform = teleport_target->GetTransform();
         cg::Location target_base_location = target_base_transform.location;
         cg::Vector3D target_heading = target_base_transform.GetForwardVector();
-        cg::Vector3D correct_heading = (target_base_location - vehicle_location).MakeSafeUnitVector(EPSILON);
+        cg::Vector3D correct_heading = (target_base_location - vehicle_location).MakeUnitVector(EPSILON);
 
         if (vehicle_location.Distance(target_base_location) < target_displacement) {
-          cg::Location teleportation_location = vehicle_location + cg::Location(target_heading.MakeSafeUnitVector(EPSILON) * target_displacement);
+          cg::Location teleportation_location = vehicle_location + cg::Location(target_heading.MakeUnitVector(EPSILON) * target_displacement);
           teleportation_transform = cg::Transform(teleportation_location, target_base_transform.rotation);
         }
         else {

--- a/LibCarla/source/test/common/test_geom.cpp
+++ b/LibCarla/source/test/common/test_geom.cpp
@@ -371,3 +371,83 @@ TEST(geom, angular_velocity_and_acceleration_inherit_vector3d_storage) {
   static_assert(sizeof(Acceleration) == sizeof(Vector3D),
                 "Acceleration must stay layout-compatible with Vector3D");
 }
+
+TEST(geom, quaternion_basis_vectors_for_identity) {
+  // Identity quaternion's three basis vectors must be the canonical
+  // CARLA left-handed axes.
+  constexpr float eps = 1e-5f;
+  const Quaternion q;
+
+  const Vector3D forward = q.GetForwardVector();
+  EXPECT_NEAR(forward.x, 1.0f, eps);
+  EXPECT_NEAR(forward.y, 0.0f, eps);
+  EXPECT_NEAR(forward.z, 0.0f, eps);
+
+  const Vector3D right = q.GetRightVector();
+  EXPECT_NEAR(right.x, 0.0f, eps);
+  EXPECT_NEAR(right.y, 1.0f, eps);
+  EXPECT_NEAR(right.z, 0.0f, eps);
+
+  const Vector3D up = q.GetUpVector();
+  EXPECT_NEAR(up.x, 0.0f, eps);
+  EXPECT_NEAR(up.y, 0.0f, eps);
+  EXPECT_NEAR(up.z, 1.0f, eps);
+}
+
+TEST(geom, quaternion_basis_vectors_for_yaw_90) {
+  // Yaw=90 deg in CARLA's left-handed convention sends:
+  //   forward (+X) -> (+Y), right (+Y) -> (-X), up (+Z) -> (+Z).
+  constexpr float eps = 1e-4f;
+  const Quaternion q{Rotation{0.0f, 90.0f, 0.0f}};
+
+  const Vector3D forward = q.GetForwardVector();
+  EXPECT_NEAR(forward.x, 0.0f, eps);
+  EXPECT_NEAR(forward.y, 1.0f, eps);
+  EXPECT_NEAR(forward.z, 0.0f, eps);
+
+  const Vector3D right = q.GetRightVector();
+  EXPECT_NEAR(right.x, -1.0f, eps);
+  EXPECT_NEAR(right.y, 0.0f, eps);
+  EXPECT_NEAR(right.z, 0.0f, eps);
+
+  const Vector3D up = q.GetUpVector();
+  EXPECT_NEAR(up.x, 0.0f, eps);
+  EXPECT_NEAR(up.y, 0.0f, eps);
+  EXPECT_NEAR(up.z, 1.0f, eps);
+}
+
+TEST(geom, quaternion_hamilton_product_yaw_compose) {
+  // Two consecutive yaw=45 rotations compose to a yaw=90 rotation:
+  // applying the product to the forward axis sends (1,0,0) -> (0,1,0).
+  constexpr float eps = 1e-4f;
+  const Quaternion q45{Rotation{0.0f, 45.0f, 0.0f}};
+  const Quaternion q90 = q45 * q45;
+
+  const Vector3D forward = q90.GetForwardVector();
+  EXPECT_NEAR(forward.x, 0.0f, eps);
+  EXPECT_NEAR(forward.y, 1.0f, eps);
+  EXPECT_NEAR(forward.z, 0.0f, eps);
+}
+
+TEST(geom, quaternion_conjugate_equals_inverse_for_unit_quaternion) {
+  // For a unit quaternion built from any Rotation, conjugate and inverse
+  // are mathematically identical. Sample a few axis-aligned and combined
+  // rotations.
+  constexpr float eps = 1e-5f;
+  const Rotation samples[] = {
+    {0.0f, 0.0f, 0.0f},
+    {30.0f, 0.0f, 0.0f},
+    {0.0f, 45.0f, 0.0f},
+    {0.0f, 0.0f, 60.0f},
+    {15.0f, 25.0f, 10.0f},
+  };
+  for (const auto &r : samples) {
+    const Quaternion q{r};
+    const Quaternion qc = q.Conjugate();
+    const Quaternion qi = q.Inverse();
+    EXPECT_NEAR(qc.x, qi.x, eps) << r.pitch << "/" << r.yaw << "/" << r.roll;
+    EXPECT_NEAR(qc.y, qi.y, eps);
+    EXPECT_NEAR(qc.z, qi.z, eps);
+    EXPECT_NEAR(qc.w, qi.w, eps);
+  }
+}

--- a/LibCarla/source/test/common/test_geom.cpp
+++ b/LibCarla/source/test/common/test_geom.cpp
@@ -6,10 +6,16 @@
 
 #include "test.h"
 
-#include <carla/geom/Vector3D.h>
-#include <carla/geom/Math.h>
+#include <carla/geom/Acceleration.h>
+#include <carla/geom/AngularVelocity.h>
 #include <carla/geom/BoundingBox.h>
+#include <carla/geom/Math.h>
+#include <carla/geom/Quaternion.h>
+#include <carla/geom/RightHandedVector3D.h>
 #include <carla/geom/Transform.h>
+#include <carla/geom/Vector3D.h>
+#include <carla/geom/Velocity.h>
+#include <cmath>
 #include <limits>
 
 namespace carla {
@@ -123,13 +129,17 @@ TEST(geom, single_point_rotation) {
 TEST(geom, single_point_translation_and_rotation) {
   constexpr double error = 0.001;
 
+  // The point {0, 0, 2} rotated by pitch=90 lands at {2, 0, 0} under the
+  // corrected sign convention (pre-fix this returned {-2, 0, 0}). The
+  // subsequent translation by {0, 0, -1} brings the final point to
+  // {2, 0, -1}.
   Location translation (0.0,0.0,-1.0); // x y z
   Rotation rotation (90.0,0.0,0.0); // y z x
   Transform transform (translation, rotation);
 
   Location point (0.0, 0.0, 2.0);
   transform.TransformPoint(point);
-  Location result_point(-2.0, 0.0, -1.0);
+  Location result_point(2.0, 0.0, -1.0);
   ASSERT_NEAR(point.x, result_point.x, error);
   ASSERT_NEAR(point.y, result_point.y, error);
   ASSERT_NEAR(point.z, result_point.z, error);
@@ -213,7 +223,9 @@ TEST(geom, forward_vector) {
   compare({360.0f, 360.0f,   0.0f}, {1.0f, 0.0f, 0.0f});
   compare({  0.0f,  90.0f,   0.0f}, {0.0f, 1.0f, 0.0f});
   compare({  0.0f, -90.0f,   0.0f}, {0.0f,-1.0f, 0.0f});
-  compare({ 90.0f,   0.0f,   0.0f}, {0.0f, 0.0f, 1.0f});
+  // Regression guard for the pitch/roll fix: pitch=90 now produces
+  // {0, 0, -1}, not {0, 0, 1} as on the pre-fix matrix.
+  compare({ 90.0f,   0.0f,   0.0f}, {0.0f, 0.0f,-1.0f});
   compare({180.0f, -90.0f,   0.0f}, {0.0f, 1.0f, 0.0f});
 }
 
@@ -226,4 +238,136 @@ TEST(geom, nearest_point_arc) {
       Vector3D(0,0,0), 1.57f, 0, 1).second, 1.0f, 0.01f);
   ASSERT_NEAR(Math::DistanceArcToPoint(Vector3D(1,2,0),
       Vector3D(0,0,0), 1.57f, 0, 1).second, 1.0f, 0.01f);
+}
+
+TEST(geom, right_handed_vector3d_boundary_negation) {
+  // Going Vector3D -> RightHandedVector3D negates Y exactly once.
+  const Vector3D lh{1.0f, 2.0f, 3.0f};
+  const RightHandedVector3D rh{lh};
+  ASSERT_FLOAT_EQ(rh.x, 1.0f);
+  ASSERT_FLOAT_EQ(rh.y, -2.0f);
+  ASSERT_FLOAT_EQ(rh.z, 3.0f);
+
+  // Round-trip back to Vector3D restores the original.
+  const Vector3D round_trip = static_cast<Vector3D>(rh);
+  ASSERT_FLOAT_EQ(round_trip.x, 1.0f);
+  ASSERT_FLOAT_EQ(round_trip.y, 2.0f);
+  ASSERT_FLOAT_EQ(round_trip.z, 3.0f);
+}
+
+TEST(geom, quaternion_default_is_identity) {
+  const Quaternion q;
+  ASSERT_FLOAT_EQ(q.x, 0.0f);
+  ASSERT_FLOAT_EQ(q.y, 0.0f);
+  ASSERT_FLOAT_EQ(q.z, 0.0f);
+  ASSERT_FLOAT_EQ(q.w, 1.0f);
+
+  // Identity quaternion rotates a vector to itself.
+  const Vector3D v{1.0f, 2.0f, 3.0f};
+  const Vector3D out = static_cast<Vector3D>(q.RotatedVector(RightHandedVector3D{v}));
+  ASSERT_NEAR(out.x, v.x, 1e-5f);
+  ASSERT_NEAR(out.y, v.y, 1e-5f);
+  ASSERT_NEAR(out.z, v.z, 1e-5f);
+}
+
+TEST(geom, quaternion_get_forward_matches_rotation_get_forward) {
+  // The quaternion built from a Rotation must agree with that Rotation's
+  // forward-vector for every axis-aligned angle. This is the canonical
+  // regression guard against drift between the two math paths.
+  constexpr float eps = 1e-4f;
+  const float angles[] = {-180.0f, -90.0f, -45.0f, 0.0f, 30.0f, 90.0f, 123.0f, 180.0f};
+  for (const float a : angles) {
+    for (const auto axis : {0, 1, 2}) {
+      Rotation r{};
+      if (axis == 0) r.pitch = a;
+      else if (axis == 1) r.yaw = a;
+      else r.roll = a;
+
+      const Vector3D r_forward = r.GetForwardVector();
+      const Vector3D q_forward = Quaternion(r).GetForwardVector();
+      EXPECT_NEAR(q_forward.x, r_forward.x, eps) << "axis=" << axis << " angle=" << a;
+      EXPECT_NEAR(q_forward.y, r_forward.y, eps) << "axis=" << axis << " angle=" << a;
+      EXPECT_NEAR(q_forward.z, r_forward.z, eps) << "axis=" << axis << " angle=" << a;
+    }
+  }
+}
+
+TEST(geom, quaternion_get_yaw_round_trip) {
+  // Yaw component of Rotation -> Quaternion -> Rotation must round-trip.
+  // Pitch and roll left at zero so the Rotator extraction is unambiguous.
+  constexpr float eps = 1e-3f;
+  for (float yaw_deg = -150.0f; yaw_deg <= 150.0f; yaw_deg += 30.0f) {
+    const Quaternion q{Rotation{0.0f, yaw_deg, 0.0f}};
+    const Rotation r = q.Rotator();
+    EXPECT_NEAR(r.yaw, yaw_deg, eps) << "yaw=" << yaw_deg;
+    EXPECT_NEAR(r.pitch, 0.0f, eps);
+    EXPECT_NEAR(r.roll, 0.0f, eps);
+  }
+}
+
+TEST(geom, quaternion_inverse_is_left_inverse) {
+  // q * q^-1 must be the identity for sampled axis-aligned and combined
+  // rotations. Tolerances are generous to accommodate float accumulation.
+  constexpr float eps = 1e-4f;
+  const Rotation samples[] = {
+    {0.0f, 0.0f, 0.0f},
+    {30.0f, 0.0f, 0.0f},
+    {0.0f, 45.0f, 0.0f},
+    {0.0f, 0.0f, 60.0f},
+    {15.0f, 25.0f, 10.0f},
+    {-45.0f, 90.0f, -30.0f},
+  };
+  for (const auto &r : samples) {
+    const Quaternion q{r};
+    const Quaternion identity = q * q.Inverse();
+    EXPECT_NEAR(identity.x, 0.0f, eps) << r.pitch << "/" << r.yaw << "/" << r.roll;
+    EXPECT_NEAR(identity.y, 0.0f, eps);
+    EXPECT_NEAR(identity.z, 0.0f, eps);
+    EXPECT_NEAR(std::abs(identity.w), 1.0f, eps);
+  }
+}
+
+TEST(geom, quaternion_pitch_90_forward_is_negative_z) {
+  // Regression guard for the pitch/roll fix from the ROS 2 port.
+  // Pre-fix the forward vector of pitch=90 was {0, 0, +1}; the corrected
+  // sign convention now yields {0, 0, -1}.
+  const Quaternion q{Rotation{90.0f, 0.0f, 0.0f}};
+  const Vector3D forward = q.GetForwardVector();
+  EXPECT_NEAR(forward.x, 0.0f, 1e-5f);
+  EXPECT_NEAR(forward.y, 0.0f, 1e-5f);
+  EXPECT_NEAR(forward.z, -1.0f, 1e-5f);
+}
+
+TEST(geom, velocity_inherits_vector3d_storage) {
+  // Velocity is a Vector3D-inheriting POD that carries m/s unit semantics
+  // without adding any data members. Wire-compatibility with Vector3D is
+  // preserved (msgpack adapter inherited).
+  const Velocity v{1.5f, -2.0f, 0.25f};
+  EXPECT_FLOAT_EQ(v.x, 1.5f);
+  EXPECT_FLOAT_EQ(v.y, -2.0f);
+  EXPECT_FLOAT_EQ(v.z, 0.25f);
+
+  // Arithmetic operations inherit from Vector3D.
+  const Velocity v2 = Velocity{v + Vector3D{0.5f, 1.0f, 0.0f}};
+  EXPECT_FLOAT_EQ(v2.x, 2.0f);
+  EXPECT_FLOAT_EQ(v2.y, -1.0f);
+  EXPECT_FLOAT_EQ(v2.z, 0.25f);
+}
+
+TEST(geom, angular_velocity_and_acceleration_inherit_vector3d_storage) {
+  const AngularVelocity w{45.0f, 0.0f, 0.0f};
+  EXPECT_FLOAT_EQ(w.x, 45.0f);
+  EXPECT_FLOAT_EQ(w.y, 0.0f);
+
+  const Acceleration a{0.0f, 9.81f, 0.0f};
+  EXPECT_FLOAT_EQ(a.y, 9.81f);
+
+  // The new types are layout-compatible with Vector3D so the
+  // serialization wire format stays unchanged.
+  static_assert(sizeof(Velocity) == sizeof(Vector3D),
+                "Velocity must stay layout-compatible with Vector3D");
+  static_assert(sizeof(AngularVelocity) == sizeof(Vector3D),
+                "AngularVelocity must stay layout-compatible with Vector3D");
+  static_assert(sizeof(Acceleration) == sizeof(Vector3D),
+                "Acceleration must stay layout-compatible with Vector3D");
 }

--- a/PythonAPI/carla/include/PythonAPI.h
+++ b/PythonAPI/carla/include/PythonAPI.h
@@ -4,13 +4,17 @@
 #include <carla/PythonUtil.h>
 #include <carla/Time.h>
 
+#include <carla/geom/Acceleration.h>
+#include <carla/geom/AngularVelocity.h>
 #include <carla/geom/BoundingBox.h>
 #include <carla/geom/GeoLocation.h>
 #include <carla/geom/Location.h>
+#include <carla/geom/Quaternion.h>
 #include <carla/geom/Rotation.h>
 #include <carla/geom/Transform.h>
 #include <carla/geom/Vector2D.h>
 #include <carla/geom/Vector3D.h>
+#include <carla/geom/Velocity.h>
 
 #include <rpc/config.h>
 #include <rpc/rpc_error.h>
@@ -309,6 +313,29 @@ namespace geom {
     out << "Rotation(pitch=" << std::to_string(rotation.pitch)
         << ", yaw=" << std::to_string(rotation.yaw)
         << ", roll=" << std::to_string(rotation.roll) << ')';
+    return out;
+  }
+
+  inline std::ostream &operator<<(std::ostream &out, const Velocity &v) {
+    WriteVector3D(out, "Velocity", v);
+    return out;
+  }
+
+  inline std::ostream &operator<<(std::ostream &out, const AngularVelocity &v) {
+    WriteVector3D(out, "AngularVelocity", v);
+    return out;
+  }
+
+  inline std::ostream &operator<<(std::ostream &out, const Acceleration &v) {
+    WriteVector3D(out, "Acceleration", v);
+    return out;
+  }
+
+  inline std::ostream &operator<<(std::ostream &out, const Quaternion &q) {
+    out << "Quaternion(x=" << std::to_string(q.x)
+        << ", y=" << std::to_string(q.y)
+        << ", z=" << std::to_string(q.z)
+        << ", w=" << std::to_string(q.w) << ')';
     return out;
   }
 

--- a/PythonAPI/carla/src/Geometry.cpp
+++ b/PythonAPI/carla/src/Geometry.cpp
@@ -95,7 +95,8 @@ void export_geom() {
     .def_readwrite("y", &cg::Vector2D::y)
     .def("squared_length", &cg::Vector2D::SquaredLength)
     .def("length", &cg::Vector2D::Length)
-    .def("make_unit_vector", &cg::Vector2D::MakeUnitVector)
+    .def("make_unit_vector", &cg::Vector2D::MakeUnitVector,
+        (arg("epsilon") = 2.0f * std::numeric_limits<float>::epsilon()))
     .def("__eq__", &cg::Vector2D::operator==)
     .def("__ne__", &cg::Vector2D::operator!=)
     .def(self += self)
@@ -122,7 +123,8 @@ void export_geom() {
     .def_readwrite("z", &cg::Vector3D::z)
     .def("length", &cg::Vector3D::Length)
     .def("squared_length", &cg::Vector3D::SquaredLength)
-    .def("make_unit_vector", &cg::Vector3D::MakeUnitVector)
+    .def("make_unit_vector", &cg::Vector3D::MakeUnitVector,
+        (arg("epsilon") = 2.0f * std::numeric_limits<float>::epsilon()))
     .def("cross", &Cross, (arg("vector")))
     .def("dot", &Dot, (arg("vector")))
     .def("dot_2d", &Dot2D, (arg("vector")))

--- a/PythonAPI/carla/src/Geometry.cpp
+++ b/PythonAPI/carla/src/Geometry.cpp
@@ -6,7 +6,11 @@
 
 #include <PythonAPI.h>
 
+#include <carla/geom/Acceleration.h>
+#include <carla/geom/AngularVelocity.h>
 #include <carla/geom/GeoProjectionsParams.h>
+#include <carla/geom/Quaternion.h>
+#include <carla/geom/Velocity.h>
 
 #include <limits>
 
@@ -156,6 +160,24 @@ void export_geom() {
     .def(self_ns::str(self_ns::self))
   ;
 
+  class_<cg::Velocity, bases<cg::Vector3D>>("Velocity")
+    .def(init<float, float, float>((arg("x")=0.0f, arg("y")=0.0f, arg("z")=0.0f)))
+    .def(init<const cg::Vector3D &>((arg("rhs"))))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<cg::AngularVelocity, bases<cg::Vector3D>>("AngularVelocity")
+    .def(init<float, float, float>((arg("x")=0.0f, arg("y")=0.0f, arg("z")=0.0f)))
+    .def(init<const cg::Vector3D &>((arg("rhs"))))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<cg::Acceleration, bases<cg::Vector3D>>("Acceleration")
+    .def(init<float, float, float>((arg("x")=0.0f, arg("y")=0.0f, arg("z")=0.0f)))
+    .def(init<const cg::Vector3D &>((arg("rhs"))))
+    .def(self_ns::str(self_ns::self))
+  ;
+
   class_<cg::Rotation>("Rotation")
     .def(init<float, float, float>((arg("pitch")=0.0f, arg("yaw")=0.0f, arg("roll")=0.0f)))
     .def_readwrite("pitch", &cg::Rotation::pitch)
@@ -167,6 +189,27 @@ void export_geom() {
     .def("get_normalized", &cg::Rotation::Normalize)
     .def("__eq__", &cg::Rotation::operator==)
     .def("__ne__", &cg::Rotation::operator!=)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<cg::Quaternion>("Quaternion")
+    .def(init<float, float, float, float>((arg("x")=0.0f, arg("y")=0.0f, arg("z")=0.0f, arg("w")=1.0f)))
+    .def(init<const cg::Rotation &>((arg("rotation"))))
+    .def_readwrite("x", &cg::Quaternion::x)
+    .def_readwrite("y", &cg::Quaternion::y)
+    .def_readwrite("z", &cg::Quaternion::z)
+    .def_readwrite("w", &cg::Quaternion::w)
+    .def("rotator", &cg::Quaternion::Rotator)
+    .def("get_forward_vector", &cg::Quaternion::GetForwardVector)
+    .def("get_right_vector", &cg::Quaternion::GetRightVector)
+    .def("get_up_vector", &cg::Quaternion::GetUpVector)
+    .def("conjugate", &cg::Quaternion::Conjugate)
+    .def("inverse", &cg::Quaternion::Inverse)
+    .def("length", &cg::Quaternion::Length)
+    .def("unit_quaternion", &cg::Quaternion::UnitQuaternion)
+    .def("__eq__", &cg::Quaternion::operator==)
+    .def("__ne__", &cg::Quaternion::operator!=)
+    .def(self * self)
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/PythonAPI/test/unit/test_transform.py
+++ b/PythonAPI/test/unit/test_transform.py
@@ -87,6 +87,43 @@ class TestRotation(unittest.TestCase):
         self.assertEqual(rotation.roll, 3.0)
 
 
+class TestVector(unittest.TestCase):
+    def test_make_unit_vector_3d_no_argument(self):
+        # The defaulted epsilon must remain optional through the Boost.Python
+        # binding, so a no-argument call keeps working.
+        error = .001
+        unit = carla.Vector3D(10.0, 0.0, 0.0).make_unit_vector()
+        self.assertTrue(abs(unit.x - 1.0) <= error)
+        self.assertTrue(abs(unit.y - 0.0) <= error)
+        self.assertTrue(abs(unit.z - 0.0) <= error)
+
+    def test_make_unit_vector_3d_epsilon_keyword(self):
+        # A length at or below epsilon returns the input unchanged.
+        v = carla.Vector3D(0.0, 0.0, 0.5)
+        unchanged = v.make_unit_vector(epsilon=1.0)
+        self.assertEqual(unchanged.x, 0.0)
+        self.assertEqual(unchanged.y, 0.0)
+        self.assertEqual(unchanged.z, 0.5)
+
+    def test_make_unit_vector_3d_zero_length(self):
+        zero = carla.Vector3D().make_unit_vector()
+        self.assertEqual(zero.x, 0.0)
+        self.assertEqual(zero.y, 0.0)
+        self.assertEqual(zero.z, 0.0)
+
+    def test_make_unit_vector_2d_no_argument(self):
+        error = .001
+        unit = carla.Vector2D(0.0, 4.0).make_unit_vector()
+        self.assertTrue(abs(unit.x - 0.0) <= error)
+        self.assertTrue(abs(unit.y - 1.0) <= error)
+
+    def test_make_unit_vector_2d_epsilon_keyword(self):
+        v = carla.Vector2D(0.5, 0.0)
+        unchanged = v.make_unit_vector(epsilon=1.0)
+        self.assertEqual(unchanged.x, 0.5)
+        self.assertEqual(unchanged.y, 0.0)
+
+
 class TestTransform(unittest.TestCase):
     def test_values(self):
         t = carla.Transform()
@@ -149,7 +186,10 @@ class TestTransform(unittest.TestCase):
         point = carla.Location(x=0.0, y=0.0, z=2.0)
         t.transform(point)
 
-        self.assertTrue(abs(point.x - (-2.0)) <= error)
+        # The point {0, 0, 2} rotated by pitch=90 lands at {2, 0, 0} under the
+        # corrected sign convention (pre-fix this returned {-2, 0, 0}); the
+        # translation by {0, 0, -1} then brings it to {2, 0, -1}.
+        self.assertTrue(abs(point.x - 2.0) <= error)
         self.assertTrue(abs(point.y - 0.0) <= error)
         self.assertTrue(abs(point.z - (-1.0)) <= error)
 
@@ -165,9 +205,12 @@ class TestTransform(unittest.TestCase):
                       ]
         t.transform(point_list)
 
-        solution_list = [carla.Location(-2.0, 0.0, -1.0),
-                         carla.Location(-1.0, 10.0, -1.0),
-                         carla.Location(-2.0, 18.0, -1.0)
+        # pitch=90 maps (x, y, z) -> (z, y, -x) under the corrected sign
+        # convention (pre-fix the x column was negated); the translation by
+        # {0, 0, -1} is then added.
+        solution_list = [carla.Location(2.0, 0.0, -1.0),
+                         carla.Location(1.0, 10.0, -1.0),
+                         carla.Location(2.0, 18.0, -1.0)
                          ]
 
         for i in range(len(point_list)):
@@ -187,9 +230,12 @@ class TestTransform(unittest.TestCase):
                       ]
         t.transform(point_list)
 
-        solution_list = [carla.Vector3D(-2.0, 0.0, -1.0),
-                         carla.Vector3D(-1.0, 10.0, -1.0),
-                         carla.Vector3D(-2.0, 18.0, -1.0)
+        # pitch=90 maps (x, y, z) -> (z, y, -x) under the corrected sign
+        # convention (pre-fix the x column was negated); the translation by
+        # {0, 0, -1} is then added.
+        solution_list = [carla.Vector3D(2.0, 0.0, -1.0),
+                         carla.Vector3D(1.0, 10.0, -1.0),
+                         carla.Vector3D(2.0, 18.0, -1.0)
                          ]
 
         for i in range(len(point_list)):


### PR DESCRIPTION
## Description

> Blocked on PR https://github.com/carla-simulator/carla/pull/9748

Adds five new ROS-friendly geometry types to `LibCarla/source/carla/geom/` and corrects a long-standing pitch/roll sign bug in `Rotation::RotateVector` that mis-rotated any non-yaw-only transform. The bug never surfaced on consumers that only ever used yaw (traffic manager, basic vehicle control) but is observable on any camera, lidar, radar, or sensor pose published through ROS 2 with non-zero pitch or roll.

The new types are `Velocity` (m/s), `AngularVelocity` (deg/s), `Acceleration` (m/s^2), `Quaternion` (x/y/z/w with Unreal hybrid handedness), and an internal `RightHandedVector3D` adapter that lets the quaternion math run in a consistent right-handed frame while the public API stays in CARLA's left-handed `Vector3D` shape. The three Vector3D-inheriting types carry unit semantics without adding any data members; they stay layout-compatible with `Vector3D` (asserted via `static_assert` in the test suite), so the existing msgpack wire format does not change.

Lands the geometry-layer slice of upstream `590d54f02` (#9425) and the follow-up `cb90463d7`. The wider client::Actor return-type change (`GetVelocity` -> `geom::Velocity`, etc.) and the dependent Unreal sensor adapter touches are deferred to a later sub-PR where the wire-format change will require a coordinated migration; this PR keeps the new types additive so they can be wired up without breaking out-of-tree consumers.

`Math::MakeSafeUnitVector(epsilon)` is renamed to `MakeUnitVector(epsilon)` with a sensible default, and the 13 caller sites across the traffic manager, road graph, and client RPC layer migrate in flight. `Vector2D::MakeUnitVector` drops its `DEVELOPMENT_ASSERT` in favour of the graceful zero-length guard `Vector3D` already used.

Closes: #9627

## Changes

- New header-only types under `LibCarla/source/carla/geom/`: `RightHandedVector3D.h`, `Quaternion.h`, `Velocity.h`, `AngularVelocity.h`, `Acceleration.h`. The three Vector3D-inheriting types add no data members and are wire-compatible with `Vector3D` (msgpack adapter inherited). `Quaternion` carries its own `MSGPACK_DEFINE_ARRAY(x, y, z, w)`.
- Pitch/roll sign fix in `Rotation::RotateVector` and `InverseRotateVector`. Matrix sign convention now matches the quaternion-derived basis vectors: `Rotation(pitch=90, 0, 0).RotateVector({1, 0, 0})` returns `{0, 0, -1}` (correct under Unreal's hybrid handedness) instead of `{0, 0, 1}`. The mutating `RotateVector(Vector3D &)` and `InverseRotateVector(Vector3D &)` overloads are preserved (callers still rely on them); only the matrix coefficients flip.
- Matching sign fix in `Math::GetForwardVector` / `GetRightVector` / `GetUpVector` and in `Transform::GetMatrix` / `GetInverseMatrix` so the three math paths produce identical results.
- `Vector3D::MakeSafeUnitVector(epsilon)` is replaced by a default-argument `MakeUnitVector(epsilon = 2 * float_epsilon)`. The 13 caller sites across `client/detail/Client.cpp`, `road/element/LaneCrossingCalculator.cpp`, `trafficmanager/{CollisionStage, LocalizationUtils, MotionPlanStage}.cpp` migrate in flight. `Vector2D::MakeUnitVector` drops its `DEVELOPMENT_ASSERT` in favour of the same graceful zero-length guard.
- PythonAPI bindings for the four new types in `PythonAPI/carla/src/Geometry.cpp` (`carla.Velocity`, `carla.AngularVelocity`, `carla.Acceleration`, `carla.Quaternion` with `x/y/z[/w]` properties, `__eq__`, `__ne__`, `__str__`, and `Quaternion` arithmetic / rotation methods). Matching `operator<<` overloads in `PythonAPI/carla/include/PythonAPI.h`.
- Eight new GTest cases in `LibCarla/source/test/common/test_geom.cpp`: `right_handed_vector3d_boundary_negation`, `quaternion_default_is_identity`, `quaternion_get_forward_matches_rotation_get_forward` (canonical regression guard tying `Quaternion(Rotation)` to `Rotation::GetForwardVector` across pitch / yaw / roll axes), `quaternion_get_yaw_round_trip`, `quaternion_inverse_is_left_inverse`, `quaternion_pitch_90_forward_is_negative_z` (regression guard for the pitch/roll fix), `velocity_inherits_vector3d_storage`, `angular_velocity_and_acceleration_inherit_vector3d_storage` (compile-time `static_assert` that the three new types stay layout-compatible with `Vector3D`). Two existing TEST cases (`forward_vector`, `single_point_translation_and_rotation`) update their pre-fix expectations.

## Where has this been tested?

- Platform: Ubuntu 24.04.
- Python: 3.10.
- UE: 5.5.

`libcarla_test_server` 125/125 and `libcarla_test_client` 139/139 pass (PR-4 baseline 117 + 131 plus the 8 new geom tests in each suite). `carla-client`, `carla-python-api`, `carla-server` all build green; no new warnings on the files this PR touches.

## Possible Drawbacks

- Behavior change for any consumer that compensated for the pre-fix pitch/roll rotation. ROS 2 clients that subscribed to sensor poses with non-zero pitch or roll (e.g. a front camera tilted 15 degrees down) will see the published transform shift by the previously-baked error magnitude. Yaw-only consumers see no change.
- The `Rotation::RotateVector(Vector3D &)` mutating overload stays in the public API; callers that prefer the non-mutating form should use the return-value overload (`Vector3D RotateVector(const Vector3D &)`). The non-mutating `Quaternion::RotatedVector(RightHandedVector3D)` is the new canonical primitive; future PRs may deprecate the mutating overload after consumers migrate.
- Any out-of-tree code that called `Vector3D::MakeSafeUnitVector(epsilon)` must rename to `MakeUnitVector(epsilon)`. The behaviour is unchanged.

## Series status

| PR | Theme | Status |
|----|-------|--------|
| 1 | IMU compass yaw + actor disposal order | #9743 |
| 2 | Template infrastructure (publisher/subscriber) + Ackermann subscriber | #9745 |
| 3 | Camera publisher unification | #9746 |
| 4 | Point-cloud + scalar publishers, listener cleanup | #9748 |
| 5 | geom types + pitch/roll fix (this PR) | #9751 |
| 6 | ROS2TopicVisibility default-startup flag | #9756 |
| 7 | V2X sensor family | #9757 |
| 8 | WalkerManager null-guard + series CHANGELOG | #9758 |

Each sub-PR's branch is cut from the previous sub-PR's tip; the GitHub PR opens against `ue5-dev` and its diff initially includes the predecessor's commits until they merge, at which point the diff narrows to this PR's own commit.

## Related

Part of the 8-PR port of `ue4-dev` ROS 2 enhancements to `ue5-dev` (issue #9627, discussion #9581 Category 2).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9751)
<!-- Reviewable:end -->


