### PR TITLE
feat(ros2): [6/8] add ROS2TopicVisibility default-startup flag

### DIFF
--- a/LibCarla/source/carla/streaming/Server.h
+++ b/LibCarla/source/carla/streaming/Server.h
@@ -75,6 +75,10 @@ namespace streaming {
       return _server.GetToken(sensor_id);
     }
 
+    void SetROS2TopicVisibilityDefaultEnabled(bool enabled) {
+      _server.SetROS2TopicVisibilityDefaultEnabled(enabled);
+    }
+
     void EnableForROS(stream_id sensor_id) {
       _server.EnableForROS(sensor_id);
     }

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.cpp
@@ -47,6 +47,9 @@ namespace detail {
       if (!result.second) {
         throw_exception(std::runtime_error("failed to create stream!"));
       }
+      if (_topic_visibility_default_enabled) {
+        ptr->EnableForROS();
+      }
       log_debug("Stream created");
       return carla::streaming::Stream(ptr);
     } else {
@@ -120,9 +123,14 @@ namespace detail {
       auto ptr = std::make_shared<MultiStreamState>(temp_token);
       auto result = _stream_map.emplace(std::make_pair(temp_token.get_stream_id(), ptr));
       ptr->ForceActive();
+
+      if (_topic_visibility_default_enabled) {
+        ptr->EnableForROS();
+      }
       if (!result.second) {
         log_debug("Failed to create multistream for stream ", sensor_id, " on port ", temp_token.get_port());
       }
+
       log_debug("Created token from stream ", sensor_id, " on port ", temp_token.get_port());
       return temp_token;
     }

--- a/LibCarla/source/carla/streaming/detail/Dispatcher.h
+++ b/LibCarla/source/carla/streaming/detail/Dispatcher.h
@@ -43,6 +43,10 @@ namespace detail {
 
     token_type GetToken(stream_id_type sensor_id);
 
+    void SetROS2TopicVisibilityDefaultEnabled(bool enabled) {
+      _topic_visibility_default_enabled = enabled;
+    }
+
     void EnableForROS(stream_id_type sensor_id) {
       auto search = _stream_map.find(sensor_id);
       if (search != _stream_map.end()) {
@@ -74,6 +78,10 @@ namespace detail {
     token_type _cached_token;
 
     StreamMap _stream_map;
+
+    // When true, every newly created stream starts visible to ROS 2 without an
+    // explicit EnableForROS call. Driven by the ROS2TopicVisibility setting.
+    bool _topic_visibility_default_enabled{false};
   };
 
 } // namespace detail

--- a/LibCarla/source/carla/streaming/low_level/Server.h
+++ b/LibCarla/source/carla/streaming/low_level/Server.h
@@ -81,6 +81,10 @@ namespace low_level {
       return _dispatcher.GetToken(sensor_id);
     }
 
+    void SetROS2TopicVisibilityDefaultEnabled(bool enabled) {
+      _dispatcher.SetROS2TopicVisibilityDefaultEnabled(enabled);
+    }
+
     void EnableForROS(stream_id sensor_id) {
       _dispatcher.EnableForROS(sensor_id);
     }

--- a/LibCarla/source/test/common/test_streaming.cpp
+++ b/LibCarla/source/test/common/test_streaming.cpp
@@ -284,3 +284,58 @@ TEST(streaming, multi_stream) {
     }
   }
 }
+
+// When the ROS2 topic-visibility default is left off (the out-of-the-box
+// behavior), a freshly created stream is not visible to ROS 2 until something
+// explicitly enables it.
+TEST(streaming, ros_topic_visibility_default_off) {
+  using namespace carla::streaming;
+  using namespace carla::streaming::detail;
+
+  Server srv(TESTING_PORT);
+  constexpr stream_id_type sensor_id{1u};
+  srv.GetToken(sensor_id); // Materializes the stream in the dispatcher.
+  EXPECT_FALSE(srv.IsEnabledForROS(sensor_id));
+}
+
+// With the default flag on, every stream created afterwards is ROS-visible from
+// the moment it is born (this is what ROS2TopicVisibility=true delivers).
+TEST(streaming, ros_topic_visibility_default_on) {
+  using namespace carla::streaming;
+  using namespace carla::streaming::detail;
+
+  Server srv(TESTING_PORT);
+  srv.SetROS2TopicVisibilityDefaultEnabled(true);
+  constexpr stream_id_type sensor_id{1u};
+  srv.GetToken(sensor_id);
+  EXPECT_TRUE(srv.IsEnabledForROS(sensor_id));
+}
+
+// The default flag must also apply to streams born through MakeStream(), not
+// only through the GetToken() create-on-miss path.
+TEST(streaming, ros_topic_visibility_make_stream_path) {
+  using namespace carla::streaming;
+  using namespace carla::streaming::detail;
+
+  Server srv(TESTING_PORT);
+  srv.SetROS2TopicVisibilityDefaultEnabled(true);
+  auto stream = srv.MakeStream();
+  const auto sensor_id = token_type(stream.token()).get_stream_id();
+  EXPECT_TRUE(srv.IsEnabledForROS(sensor_id));
+}
+
+// Independently of the startup default, the per-stream EnableForROS /
+// DisableForROS surface this feature relies on must round-trip.
+TEST(streaming, ros_topic_visibility_manual_toggle) {
+  using namespace carla::streaming;
+  using namespace carla::streaming::detail;
+
+  Server srv(TESTING_PORT);
+  constexpr stream_id_type sensor_id{1u};
+  srv.GetToken(sensor_id);
+  EXPECT_FALSE(srv.IsEnabledForROS(sensor_id));
+  srv.EnableForROS(sensor_id);
+  EXPECT_TRUE(srv.IsEnabledForROS(sensor_id));
+  srv.DisableForROS(sensor_id);
+  EXPECT_FALSE(srv.IsEnabledForROS(sensor_id));
+}

--- a/PythonAPI/examples/ros2/rviz/ros2_native.rviz
+++ b/PythonAPI/examples/ros2/rviz/ros2_native.rviz
@@ -48,7 +48,11 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
+        gnss:
+          Value: true
         hero:
+          Value: true
+        imu:
           Value: true
         lidar:
           Value: true
@@ -61,6 +65,10 @@ Visualization Manager:
       Show Names: true
       Tree:
         hero:
+          gnss:
+            {}
+          imu:
+            {}
           lidar:
             {}
           rgb:

--- a/PythonAPI/examples/ros2/stack.json
+++ b/PythonAPI/examples/ros2/stack.json
@@ -28,6 +28,35 @@
                 "dropoff_intensity_limit": 0.8,
                 "dropoff_zero_intensity": 0.4
             }
+        },
+        {
+            "type": "sensor.other.gnss",
+            "id": "gnss",
+            "spawn_point": {"x": 1.0, "y": 0.0, "z": 2.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+            "attributes": {
+                "noise_alt_stddev": 0.0,
+                "noise_lat_stddev": 0.0,
+                "noise_lon_stddev": 0.0,
+                "noise_alt_bias": 0.0,
+                "noise_lat_bias": 0.0,
+                "noise_lon_bias": 0.0
+            }
+        },
+        {
+            "type": "sensor.other.imu",
+            "id": "imu",
+            "spawn_point": {"x": 2.0, "y": 0.0, "z": 2.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+            "attributes": {
+                "noise_accel_stddev_x": 0.0,
+                "noise_accel_stddev_y": 0.0,
+                "noise_accel_stddev_z": 0.0,
+                "noise_gyro_stddev_x": 0.0,
+                "noise_gyro_stddev_y": 0.0,
+                "noise_gyro_stddev_z": 0.0,
+                "noise_gyro_bias_x": 0.0,
+                "noise_gyro_bias_y": 0.0,
+                "noise_gyro_bias_z": 0.0
+            }
         }
     ]
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
@@ -226,6 +226,10 @@ void FCarlaEngine::NotifyInitGame(const UCarlaSettings &Settings)
     UE_LOG(LogCarla, Log, TEXT("ROS2: Enabling ROS2..."));
     ROS2->Enable(true);
     UE_LOG(LogCarla, Log, TEXT("ROS2: ROS2 enabled..."));
+    // Apply the configured default topic visibility before any sensor stream is
+    // created. Gated on Settings.ROS2 so non-ROS2 runs never force every stream
+    // active (which would make every sensor produce data each tick).
+    Server.GetStreamingServer().SetROS2TopicVisibilityDefaultEnabled(Settings.ROS2TopicVisibility);
   } else {
     UE_LOG(LogCarla, Log, TEXT("ROS2: ROS2 enabled..."));
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Settings/CarlaSettings.h
@@ -161,5 +161,15 @@ public:
       DisplayName = "Enable ROS2")
   bool ROS2 = false;
 
+  /// Default ROS2 topic visibility on startup. When true, every topic offered by
+  /// the implementation is visible from the beginning; when false, only the
+  /// sensors/actors explicitly enabled via EnableForROS calls are visible.
+  UPROPERTY(Category = "Quality Settings/ROS2",
+      BlueprintReadOnly,
+      EditAnywhere,
+      config,
+      DisplayName = "ROS2 Topics Visible On Startup")
+  bool ROS2TopicVisibility = true;
+
   /// @}
 };


### PR DESCRIPTION
## Description

> Blocked on PR https://github.com/carla-simulator/carla/pull/9751

Adds a `ROS2TopicVisibility` startup setting that controls whether sensor topics are visible to ROS 2
from the moment their stream is created. When `true` (the default), every topic offered by the
implementation publishes from startup without an explicit `enable_for_ros` call; when `false`, only the
sensors explicitly enabled through `Sensor.enable_for_ros()` are visible (useful for disabling interfaces,
for example on the leaderboard).

On ue5-dev a sensor only produces and publishes data while `AreClientsListening()` is true, which holds
when a TCP client is subscribed, the stream is force-active, or the stream is marked enabled-for-ros.
That ROS flag defaults to off per stream and today flips on only through the per-sensor
`enable_sensor_for_ros` RPC, so a freshly spawned sensor stays silent on ROS 2 until a client enables it.
This setting lets the server flip the default for every newly created stream at startup.

Lands the topic-visibility-default slice of upstream `3b938d718` (#9431), adapted to ue5-dev's existing
stream-level visibility model. The multistream and per-actor scaffolding from that commit
(`RpcServerInterface`, the `Message.h` relocation, the `Session` abstraction, the Dispatcher shared
pointer migration, per-actor visibility) is **not included**: it is groundwork for the out-of-scope DDS
middleware series and the ROS-2-as-RPC-client work, and has no consumer on ue5-dev.

Closes: #9627

## Changes

- `Settings/CarlaSettings.h`: new `config` UPROPERTY `ROS2TopicVisibility` (default `true`), bound to
  `DefaultGame.ini` like the existing `ROS2` flag.
- `streaming/detail/Dispatcher.{h,cpp}`: a `_topic_visibility_default_enabled` flag with a
  `SetROS2TopicVisibilityDefaultEnabled(bool)` setter; when set, every stream created through
  `MakeStream()` and through the `GetToken()` create-on-miss path starts enabled for ROS 2.
- `streaming/Server.h` and `streaming/low_level/Server.h`: thin pass-throughs for the new setter. The
  existing stream-id based `EnableForROS` / `DisableForROS` / `IsEnabledForROS` surface is unchanged.
- `Game/CarlaEngine.cpp`: inside the existing `if (Settings.ROS2)` block of `NotifyInitGame`, apply the
  configured default to the streaming server before any sensor stream is created. Gating on
  `Settings.ROS2` keeps non-ROS-2 runs from forcing every sensor active each tick.
- `test/common/test_streaming.cpp`: four new GTest cases covering the default-off behavior, the
  default-on behavior through both the `GetToken` and `MakeStream` stream-birth paths, and the manual
  enable/disable round-trip.

## Where has this been tested?

- Platform: Ubuntu.
- Python: 3.10.
- UE: 5.5.

`libcarla_test_server` and `libcarla_test_client` both pass the full `streaming.*` group (9/9: the 5
pre-existing cases plus the 4 new `ros_topic_visibility_*` cases). The Release `package` target builds
green with no new warnings on the files this PR touches.

## Possible Drawbacks

- With `ROS2TopicVisibility = true` (the default) and ROS 2 enabled, every sensor stream is active from
  creation, so sensors produce and publish data even when no client has subscribed and no explicit
  `enable_for_ros` was called. Set it to `false` to restore the opt-in behavior. Non-ROS-2 runs are
  unaffected, since the default is applied only when ROS 2 is enabled.
- Propagation of the startup default to multigpu secondary servers is not included; the flag applies to
  the primary streaming server. Per-sensor `enable_for_ros` continues to work across the multigpu path
  as before.

## Series status

| PR | Theme | Status |
|----|-------|--------|
| 1 | IMU compass yaw + actor disposal order | #9743 |
| 2 | Template infrastructure (publisher/subscriber) + Ackermann subscriber | #9745 |
| 3 | Camera publisher unification | #9746 |
| 4 | Point-cloud + scalar publishers, listener cleanup | #9748 |
| 5 | geom types + pitch/roll fix | #9751 |
| 6 | ROS2TopicVisibility default-startup flag (this PR) | #9756 |
| 7 | V2X sensor family | #9757 |
| 8 | WalkerManager null-guard + series CHANGELOG | #9758 |

Each sub-PR's branch is cut from the previous sub-PR's tip; the GitHub PR opens against the predecessor's
branch and is auto-retargeted to `ue5-dev` once the predecessor merges, at which point the diff narrows to
this PR's own commit.

## Related

Part of the 8-PR port of `ue4-dev` ROS 2 enhancements to `ue5-dev` (issue #9627, discussion #9581
Category 2).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9756)
<!-- Reviewable:end -->

