### PR TITLE
fix(streaming): make ServerSession::CloseNow idempotent on ue5-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 =======
 ## LATEST Changes
 
+* Fixed ServerSession::CloseNow double-invocation on ue5-dev by guarding with std::atomic_bool _is_closed so the close path runs exactly once, preventing a dropped client from evicting a still-alive subscriber (port of ue4-dev fix #9740)
 * Added NumPy 2 compatibility to the PythonAPI by upgrading Boost to 1.90.0, which ships the upstream NumPy 2 C ABI fix. LibCarla networking migrated from `boost::asio::deadline_timer` to `boost::asio::steady_timer`, and the deprecated `io_service`, `address::from_string`, `resolver::query`, `buffer_cast`, and `io_context::work` APIs replaced across LibCarla and the CarlaTools plugin.
 * Added `Vehicle.get_telemetry_data()` returning `VehicleTelemetryData` with last-applied control, forward speed, engine RPM, current gear, and per-wheel lateral slip, longitudinal slip, and angular velocity sourced from the Chaos vehicle physics state.
 * Added a GeoProjection engine that parses the OpenDRIVE `geoReference` PROJ string into a typed cartographic projection (Transverse Mercator, UTM, Web Mercator, or Lambert Conformal Conic) and exposes it via `Map.get_geoprojection`. `Map.transform_to_geolocation` and `Map.geolocation_to_transform` now accept an optional projection argument together with the new `carla.GeoProjectionTM`/`GeoProjectionUTM`/`GeoProjectionWebMerc`/`GeoProjectionLCC2SP` and `carla.GeoEllipsoid` types, replacing the previous fixed Mercator conversion.

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.cpp
@@ -135,6 +135,7 @@ namespace tcp {
   }
 
   void ServerSession::CloseNow(boost::system::error_code ec) {
+    if (_is_closed.exchange(true)) return;
     _deadline.cancel();
     if (!ec)
     {

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
@@ -25,6 +25,7 @@
 #  pragma clang diagnostic pop
 #endif
 
+#include<atomic>
 #include <functional>
 #include <memory>
 
@@ -109,6 +110,7 @@ namespace tcp {
     callback_function_type _on_closed;
 
     bool _is_writing = false;
+    std::atomic_bool _is_closed{false};
   };
 
 } // namespace tcp

--- a/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
+++ b/LibCarla/source/carla/streaming/detail/tcp/ServerSession.h
@@ -25,7 +25,7 @@
 #  pragma clang diagnostic pop
 #endif
 
-#include<atomic>
+#include <atomic>
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
#### Description
Port of #9740 (ue4-dev) to ue5-dev.

Adds `std::atomic_bool _is_closed{false}` to `ServerSession` and guards
`CloseNow()` with `_is_closed.exchange(true)` so the close path runs exactly
once, preventing a double-disconnect from evicting a still-alive subscriber
from the world-snapshot stream.

Fixes #9759

#### Where has this been tested?
  * **Platform(s):** Not compiled/tested locally — this is a straight port of the reviewed and approved fix from #9740
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** UE5 (ue5-dev)

#### Possible Drawbacks
None expected. The change is minimal (~3 lines), platform-independent LibCarla C++, and matches the fix already approved for ue4-dev.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9761)
<!-- Reviewable:end -->
