### PR TITLE
fix(plugin): add missing includes that only resolve via unity blobs

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/MeshToLandscape.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/MeshToLandscape.cpp
@@ -8,6 +8,7 @@
 #include "Engine/StaticMeshActor.h"
 #include "Components/StaticMeshComponent.h"
 #include "StaticMeshLODResourcesAdapter.h"
+#include "Physics/Experimental/PhysScene_Chaos.h"
 #include "PhysicsEngine/PhysicsObjectExternalInterface.h"
 #include "Async/ParallelFor.h"
 #include "Kismet/KismetMathLibrary.h"

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.cpp
@@ -4,11 +4,14 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#pragma once
-
-
 #include "BlueprintLibary/PostProcessJsonUtils.h"
+
 #include "Components/PostProcessComponent.h"
+#include "Components/SceneCaptureComponent2D.h"
+#include "HAL/FileManager.h"
+#include "JsonObjectConverter.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 
 bool UPostProcessJsonUtils::SaveAllPostProcessToJson(APostProcessVolume* Volume, const FString& FileName)
 {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.h
@@ -7,8 +7,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Kismet/BlueprintFunctionLibrary.h"
 #include "Engine/PostProcessVolume.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Misc/Paths.h"
 #include "PostProcessJsonUtils.generated.h"
 
 USTRUCT(BlueprintType)
@@ -22,6 +23,7 @@ struct FPostProcessSettingsWrapper
 
 
 class UPostProcessComponent;
+class USceneCaptureComponent2D;
 
 UCLASS()
 class CARLA_API UPostProcessJsonUtils : public UBlueprintFunctionLibrary

--- a/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/BlueprintLibrary/MeshToSplineActor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaTools/Source/CarlaTools/Private/BlueprintLibrary/MeshToSplineActor.cpp
@@ -2,6 +2,7 @@
 #include "Components/SplineComponent.h"
 #include "Components/StaticMeshComponent.h"
 #include "KismetProceduralMeshLibrary.h"
+#include "ProceduralMeshComponent.h"
 
 
 // ========================= Actor boilerplate =========================


### PR DESCRIPTION
#### Description

Four files in the Carla and CarlaTools plugins relied on transitive includes pulled in by neighboring `.cpp` files in their unity blob. With `bUseUnityBuild=false` they fail to compile, and even with unity on the implicit dependency makes `ccache` invalidate sibling translation units on minor edits.

- `Plugins/Carla/.../PostProcessJsonUtils.cpp`: drop a stray `#pragma once` from the `.cpp` and add `JsonObjectConverter.h`, `Components/SceneCaptureComponent2D.h`, `Misc/FileHelper.h`, `Misc/Paths.h`, `HAL/FileManager.h`.
- `Plugins/Carla/.../PostProcessJsonUtils.h`: forward-declare `USceneCaptureComponent2D` for the `LoadAllPostProcessFromJsonToSceneCapture` parameter, and include `Misc/Paths.h` so the inline `GetPostProcessConfigPath` helper resolves `FPaths::ProjectContentDir()` in consumers.
- `Plugins/Carla/.../MeshToLandscape.cpp`: include `Physics/Experimental/PhysScene_Chaos.h` so the `FPhysScene*` → `FChaosScene*` upcast in `FPhysicsObjectExternalInterface::LockRead(World->GetPhysicsScene())` sees the full `FPhysScene_Chaos` definition.
- `Plugins/CarlaTools/.../MeshToSplineActor.cpp`: include `ProceduralMeshComponent.h` so the `TArray<FProcMeshTangent>` destructor instantiation sees a complete type and `DestructItems`' constraint is satisfied.

The bundled StreetMap plugin (carla-simulator/StreetMap, branch `ue5-dev-carla`) has the same class of bug in two more files and is handled by a companion PR: carla-simulator/StreetMap#11.

Fixes #9763

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04, x86_64
  * **Python version(s):** 3.12 (unchanged by this PR)
  * **Unreal Engine version(s):** 5.5 (CARLA fork)

Verified by setting `bUseUnityBuild=false` in `~/.config/Unreal Engine/UnrealBuildTool/BuildConfiguration.xml` and rebuilding both the `carla-unreal` and `carla-unreal-editor` cmake targets to green (`[3022/3022]` for the editor, no errors). Unity-on builds remain green as before.

#### Possible Drawbacks

None expected. The change only adds explicit includes (and removes one nonsensical `#pragma once` from a `.cpp`); no public APIs or runtime behavior change.

#### Impact on CI / default settings

None. CI uses the default `bUseUnityBuild=true` and PCH ON, under which the new include directives are no-ops — the same headers are already supplied by unity-blob siblings and the Shared PCHs. No change to `*.Build.cs`, public APIs, or runtime behavior.

#### Motivation

These bugs surfaced while enabling a local `ccache` setup (`CARLA_CCACHE=1`) and switching to `bUseUnityBuild=false` for iterative single-file rebuilds. With this PR + companion StreetMap PR applied (and ccache `sloppiness = pch_defines,time_macros,include_file_mtime,include_file_ctime,locale`), a measured editor rebuild touching all 197 Carla / CarlaTools / StreetMap `.cpp` files went from ~9.5% effective ccache hit rate to ~94%.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9764)
<!-- Reviewable:end -->
