### PR TITLE
docs: mention Ubuntu 24.04 support in UE5 build/quickstart guides

### DIFF
--- a/Docs/build_carla.md
+++ b/Docs/build_carla.md
@@ -7,7 +7,7 @@ Users can build CARLA from source code for development purposes. This is recomme
 
 Build instructions are available for both Linux and Windows. You can also build CARLA in a Docker container for deployment in AWS, Azure or Google cloud services. Visit the [__CARLA GitHub__](https://github.com/carla-simulator/carla) and clone the repository. 
 
-The Unreal Engine 5 version of CARLA requires a minimum of Windows 10 or Ubuntu 22.04, and also supports Ubuntu 24.04. 
+The Unreal Engine 5 version of CARLA requires a minimum of Windows 11 or Ubuntu 22.04, and also supports Ubuntu 24.04. 
 
 * [__Linux build__](build_linux_ue5.md)  
 * [__Windows build__](build_windows_ue5.md)

--- a/Docs/build_carla.md
+++ b/Docs/build_carla.md
@@ -7,7 +7,7 @@ Users can build CARLA from source code for development purposes. This is recomme
 
 Build instructions are available for both Linux and Windows. You can also build CARLA in a Docker container for deployment in AWS, Azure or Google cloud services. Visit the [__CARLA GitHub__](https://github.com/carla-simulator/carla) and clone the repository. 
 
-The Unreal Engine 5 version of CARLA requires a minimum of Windows 10 or Ubuntu 22.04. 
+The Unreal Engine 5 version of CARLA requires a minimum of Windows 10 or Ubuntu 22.04, and also supports Ubuntu 24.04. 
 
 * [__Linux build__](build_linux_ue5.md)  
 * [__Windows build__](build_windows_ue5.md)

--- a/Docs/build_linux_ue5.md
+++ b/Docs/build_linux_ue5.md
@@ -1,10 +1,10 @@
 # Building CARLA in Linux with Unreal Engine 5.5
 
 !!! note
-    The Unreal Engine 5 version of CARLA requires Ubuntu version 22.04 at minimum. It has not been configured to build on older Ubuntu versions.
+    The Unreal Engine 5 version of CARLA supports Ubuntu 22.04 and 24.04. It has not been configured to build on older Ubuntu versions.
 
 !!! note
-    If you are using a different Ubuntu version (e.g., 24.04) and experiencing compilation issues, you can use the Docker-based development environment to build CARLA inside an Ubuntu 22.04 container. See [CARLA Docker Dev Environment (UE5)](build_devcontainer.md) for instructions.
+    If you are using a different Ubuntu version and experiencing compilation issues, you can use the Docker-based development environment to build CARLA inside an Ubuntu 22.04 container. See [CARLA Docker Dev Environment (UE5)](build_devcontainer.md) for instructions.
 
 * __[Set up the environment](#set-up-the-environment)__  
 * __[Build and run CARLA UE5](#build-and-run-carla-ue5)__  

--- a/Docs/build_linux_ue5.md
+++ b/Docs/build_linux_ue5.md
@@ -4,7 +4,7 @@
     The Unreal Engine 5 version of CARLA supports Ubuntu 22.04 and 24.04. It has not been configured to build on older Ubuntu versions.
 
 !!! note
-    If you are using a different Ubuntu version and experiencing compilation issues, you can use the Docker-based development environment to build CARLA inside an Ubuntu 22.04 container. See [CARLA Docker Dev Environment (UE5)](build_devcontainer.md) for instructions.
+    If you are using an Ubuntu version other than 22.04 or 24.04, or experiencing compilation issues, you can use the Docker-based development environment to build CARLA inside an Ubuntu 22.04 container. See [CARLA Docker Dev Environment (UE5)](build_devcontainer.md) for instructions.
 
 * __[Set up the environment](#set-up-the-environment)__  
 * __[Build and run CARLA UE5](#build-and-run-carla-ue5)__  

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -14,7 +14,7 @@ This guide shows how to download and install the packaged version of CARLA. The 
 The following requirements should be fulfilled before installing CARLA:
 
 * __System requirements__: CARLA is built for Windows and Linux systems.
-* __Operating system__: CARLA Unreal Engine 5 version requires **Ubuntu 22.04** or **Ubuntu 24.04**, or **Windows 11**.
+* __Operating system__: CARLA Unreal Engine 5 version requires **Ubuntu 22.04/24.04** or **Windows 11**.
 * __An adequate GPU__: CARLA aims for realistic simulations that require a lot of compute power. We recommend at minimum an NVIDIA RTX 3000 series or better with at least **16 Gb of VRAM**. NVIDIA RTX 40 and 50 series GPUs are also supported. A dedicated GPU, separate from the GPU used for CARLA, is highly recommended to handle large machine learning workloads.
 * __GPU drivers__: CARLA Unreal Engine 5 version requires NVIDIA RTX driver release **550 or later for Ubuntu** and NVIDIA RTX driver release **560 or later for Windows**. For NVIDIA RTX 50 series (Blackwell) GPUs, driver release **570 or later** is required.
 * __Disk space__: CARLA requires **130 GB** of hard disk (or SSD) space.

--- a/Docs/start_quickstart.md
+++ b/Docs/start_quickstart.md
@@ -14,7 +14,7 @@ This guide shows how to download and install the packaged version of CARLA. The 
 The following requirements should be fulfilled before installing CARLA:
 
 * __System requirements__: CARLA is built for Windows and Linux systems.
-* __Operating system__: CARLA Unreal Engine 5 version requires a minimum of **Ubuntu 22.04** or **Windows 11**.
+* __Operating system__: CARLA Unreal Engine 5 version requires **Ubuntu 22.04** or **Ubuntu 24.04**, or **Windows 11**.
 * __An adequate GPU__: CARLA aims for realistic simulations that require a lot of compute power. We recommend at minimum an NVIDIA RTX 3000 series or better with at least **16 Gb of VRAM**. NVIDIA RTX 40 and 50 series GPUs are also supported. A dedicated GPU, separate from the GPU used for CARLA, is highly recommended to handle large machine learning workloads.
 * __GPU drivers__: CARLA Unreal Engine 5 version requires NVIDIA RTX driver release **550 or later for Ubuntu** and NVIDIA RTX driver release **560 or later for Windows**. For NVIDIA RTX 50 series (Blackwell) GPUs, driver release **570 or later** is required.
 * __Disk space__: CARLA requires **130 GB** of hard disk (or SSD) space.


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

PR #9596 added Ubuntu 24.04 support alongside 22.04 but only updated the top-level `README.md`. The UE5 documentation still listed 22.04 as the only supported Ubuntu version. This PR brings the docs in line by listing 24.04 as a supported OS, matching the README wording.

Changes (docs only):

- **`Docs/build_linux_ue5.md`**: "requires Ubuntu version 22.04 at minimum" -> "supports Ubuntu 22.04 and 24.04". Removed the now-misleading `(e.g., 24.04)` example from the Docker-fallback note.
- **`Docs/start_quickstart.md`**: Operating system requirement now reads **Ubuntu 22.04** or **Ubuntu 24.04**, or **Windows 11**.
- **`Docs/build_carla.md`**: notes that Ubuntu 24.04 is also supported.

This completes the `Docs/` checklist item in #9597.

Refs #9597

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04 (documentation change only)
  * **Python version(s):** N/A
  * **Unreal Engine version(s):** 5.5

#### Possible Drawbacks

None. Documentation-only change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9772)
<!-- Reviewable:end -->
