### PR TITLE
fix(cmake): link libm in the UE libc++ toolchain standard libraries

### DIFF
--- a/CMake/Toolchain.cmake
+++ b/CMake/Toolchain.cmake
@@ -197,6 +197,9 @@ set (
 	CACHE FILEPATH ""
 )
 
+# UE's static libc++/libc++abi reference math symbols (e.g. fmod, sqrt) but
+# do not pull in libm themselves, so the final link must request it explicitly.
+# Without -lm the link fails with undefined references to those symbols.
 set (
 	CMAKE_CXX_STANDARD_LIBRARIES
 	"${UE_LIBS}/libc++.a ${UE_LIBS}/libc++abi.a -lm"

--- a/CMake/Toolchain.cmake
+++ b/CMake/Toolchain.cmake
@@ -199,7 +199,7 @@ set (
 
 set (
 	CMAKE_CXX_STANDARD_LIBRARIES
-	"${UE_LIBS}/libc++.a ${UE_LIBS}/libc++abi.a"
+	"${UE_LIBS}/libc++.a ${UE_LIBS}/libc++abi.a -lm"
 )
 
 set (


### PR DESCRIPTION
#### Description

UE ships `libc++`/`libc++abi` as **static** archives, and `CMake/Toolchain.cmake` lists them in `CMAKE_CXX_STANDARD_LIBRARIES`. Unlike the shared `libc++.so`, a static `libc++.a` carries no `DT_NEEDED` entry on the math library, so any C++ executable that does not otherwise pull `libm` transitively from its dependency graph fails to link with undefined references to `ceilf` / `floorf` / `sincosf` / `roundf` / `cosf`.

CARLA's own targets escape this because their dependency graph pulls `m` (e.g. `Dependencies.cmake` does `find_library(STD_MATH_LIB m)` for sqlite3). But two host-tool executables built by bundled upstream CMakeLists — the FetchContent `RecastBuilder` (recastnavigation) and the `foonathan_memory` `node_size_debugger` (pulled in with `ENABLE_ROS2=ON`) — assume `libm` is auto-linked, so they break under this static-`libc++` toolchain. The failure is masked by incremental builds (the host tools are already present) but bites a **clean / CI build**:

```
.../math.h:852: undefined reference to `ceilf'
.../DetourMath.h:16: undefined reference to `sincosf'
clang++: error: linker command failed with exit code 1
ninja: build stopped: subcommand failed.
```

This appends `-lm` to `CMAKE_CXX_STANDARD_LIBRARIES`. The toolchain file (unlike `add_link_options`) is forwarded to both FetchContent subdirectories and the `foonathan_memory` `ExternalProject`, so this single line fixes every target without patching each bundled dependency.

Fixes #  <!-- none filed; build-infra fix -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu, UE5 bundled clang 18 / static libc++ toolchain
  * **Python version(s):** n/a (build-system change)
  * **Unreal Engine version(s):** CARLA UE5.5 fork

Verified by clean-rebuilding both previously-failing host tools with the patched toolchain and **no** manual `build.ninja` edits:

- `foonathan_memory` `ExternalProject` prefix deleted and rebuilt from scratch (`cmake --build … --target carla-server`, `ENABLE_ROS2=ON`) → links cleanly; the regenerated link line now carries `-lm` straight from the toolchain.
- `RecastBuilder` executable and object dir removed and rebuilt → recompiles + links cleanly.
- In both cases the previously-observed `ceilf`/`floorf`/`sincosf`/`roundf`/`cosf` undefined references no longer occur.

The change only **adds** a library that is always present on Linux and is appended at the end of the link line, so existing targets are unaffected (CARLA's own binaries already linked `libm` via their dependency graph).

#### Possible Drawbacks

None expected. `-lm` is appended to every C++ link; on Linux `libm` is a standard system library and the linker ignores it where unused. This does not change Windows builds (the block is inside the UE Linux libc++ toolchain path).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9776)
<!-- Reviewable:end -->
