### PR TITLE
feat(LibCarla/ros2): [1/3] add publisher durability QoS and latched OpenDRIVE map topic

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -27,6 +27,7 @@
 #include "publishers/CarlaIMUPublisher.h"
 #include "publishers/CarlaISCameraPublisher.h"
 #include "publishers/CarlaLidarPublisher.h"
+#include "publishers/CarlaMapPublisher.h"
 #include "publishers/CarlaNormalsCameraPublisher.h"
 #include "publishers/CarlaOpticalFlowCameraPublisher.h"
 #include "publishers/CarlaRadarPublisher.h"
@@ -478,6 +479,24 @@ void ROS2::ProcessDataFromCollisionSensor(
   }
 }
 
+void ROS2::ProcessDataFromMap(const std::string &open_drive) {
+  std::lock_guard<std::recursive_mutex> lock(_mutex);
+  if (!_enabled) {
+    return;
+  }
+  if (open_drive.empty()) {
+    // Reached once per episode start, never per frame, so logging
+    // unconditionally cannot flood the output.
+    log_warning("ROS2: empty OpenDRIVE description, skipping map publish");
+    return;
+  }
+  if (!_map_publisher) {
+    _map_publisher = std::make_shared<CarlaMapPublisher>();
+  }
+  _map_publisher->Write(open_drive);
+  _map_publisher->Publish();
+}
+
 void ROS2::Shutdown() {
   std::lock_guard<std::recursive_mutex> lock(_mutex);
   // Destroy publishers first so DataWriter unregister-dispose messages are
@@ -488,6 +507,7 @@ void ROS2::Shutdown() {
   _publishers.clear();
   _tf_publishers.clear();
   _clock_publisher.reset();
+  _map_publisher.reset();
 
   _subscribers.clear();
 

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -44,6 +44,7 @@ namespace ros2 {
 
   class CarlaTransformPublisher;
   class CarlaClockPublisher;
+  class CarlaMapPublisher;
 
 class ROS2
 {
@@ -140,6 +141,10 @@ class ROS2
       uint32_t other_actor,
       carla::geom::Vector3D impulse,
       void* actor);
+    // Publishes the OpenDRIVE description of the current map as a latched
+    // topic. Called once per episode; re-publishing refreshes the latched
+    // sample after a map change.
+    void ProcessDataFromMap(const std::string &open_drive);
 
   private:
     std::shared_ptr<CarlaTransformPublisher> GetOrCreateTransformPublisher(void *actor);
@@ -162,6 +167,7 @@ class ROS2
   uint32_t _nanoseconds { 0 };
 
   std::shared_ptr<CarlaClockPublisher> _clock_publisher;
+  std::shared_ptr<CarlaMapPublisher> _map_publisher;
 
   // actor->parent relationship
   std::unordered_map<void *, void *> _actor_parent_map;

--- a/LibCarla/source/carla/ros2/middleware/IPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/IPublisherMiddleware.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "carla/ros2/middleware/PublisherQos.h"
+
 #include <string>
 
 namespace carla {
@@ -23,9 +25,13 @@ class IPublisherMiddleware {
   virtual ~IPublisherMiddleware() = default;
 
   /// Initialize the underlying middleware entities.
-  /// @param topic_name  Full topic name including "rt/" prefix.
+  /// @param topic_name     Full topic name including "rt/" prefix.
+  /// @param publisher_qos  QoS applied to the underlying writer; the default
+  ///                       PublisherQos reproduces the historical behavior.
   /// @return true on success.
-  virtual bool Init(const std::string& topic_name) = 0;
+  virtual bool Init(
+      const std::string& topic_name,
+      const PublisherQos& publisher_qos) = 0;
 
   /// Serialize and write a message to the network.
   /// @param message_data  Pointer to the message object (type-erased, cast internally).

--- a/LibCarla/source/carla/ros2/middleware/PublisherQos.h
+++ b/LibCarla/source/carla/ros2/middleware/PublisherQos.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <cstdint>
+
+namespace carla {
+namespace ros2 {
+
+/// Durability of a publisher endpoint, mirroring the DDS durability QoS.
+enum class DurabilityKind : uint8_t {
+  /// Late-joining subscribers only receive samples written after they match.
+  Volatile,
+  /// The writer keeps a sample cache so late-joining subscribers receive the
+  /// last history_depth samples (the ROS 2 "latched topic" behavior).
+  TransientLocal
+};
+
+/// QoS settings applied to a publisher middleware at Init time.
+/// The defaults reproduce the exact behavior every publisher had before QoS
+/// support was added: volatile durability with a keep-last history of 1.
+struct PublisherQos {
+  DurabilityKind durability{DurabilityKind::Volatile};
+  uint32_t history_depth{1u};
+};
+
+} // namespace ros2
+} // namespace carla

--- a/LibCarla/source/carla/ros2/middleware/PublisherQos.h
+++ b/LibCarla/source/carla/ros2/middleware/PublisherQos.h
@@ -18,12 +18,33 @@ enum class DurabilityKind : uint8_t {
   TransientLocal
 };
 
+/// Reliability of a publisher endpoint, mirroring the DDS reliability QoS.
+enum class ReliabilityKind : uint8_t {
+  /// The writer retransmits until every matched reliable subscriber acks the
+  /// sample, blocking the publish call while the writer history is full.
+  Reliable,
+  /// Samples are sent once and may be dropped; the publish call never blocks
+  /// on slow subscribers (the ROS 2 sensor-data idiom for high-rate streams).
+  BestEffort
+};
+
 /// QoS settings applied to a publisher middleware at Init time.
 /// The defaults reproduce the exact behavior every publisher had before QoS
-/// support was added: volatile durability with a keep-last history of 1.
+/// support was added: reliable delivery, volatile durability, and a
+/// keep-last history of 1.
 struct PublisherQos {
   DurabilityKind durability{DurabilityKind::Volatile};
+  ReliabilityKind reliability{ReliabilityKind::Reliable};
   uint32_t history_depth{1u};
+
+  /// Profile for high-rate sensor streams (camera images, point clouds):
+  /// best-effort delivery so a slow or vanished subscriber can never stall
+  /// the publishing thread, matching the ROS 2 sensor-data QoS reliability.
+  static PublisherQos SensorData() {
+    PublisherQos qos;
+    qos.reliability = ReliabilityKind::BestEffort;
+    return qos;
+  }
 
   /// History depth to hand to the middleware: a keep-last history needs a
   /// positive depth, so the invalid value 0 is clamped to 1.

--- a/LibCarla/source/carla/ros2/middleware/PublisherQos.h
+++ b/LibCarla/source/carla/ros2/middleware/PublisherQos.h
@@ -24,6 +24,12 @@ enum class DurabilityKind : uint8_t {
 struct PublisherQos {
   DurabilityKind durability{DurabilityKind::Volatile};
   uint32_t history_depth{1u};
+
+  /// History depth to hand to the middleware: a keep-last history needs a
+  /// positive depth, so the invalid value 0 is clamped to 1.
+  uint32_t effective_history_depth() const {
+    return history_depth == 0u ? 1u : history_depth;
+  }
 };
 
 } // namespace ros2

--- a/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
@@ -75,8 +75,15 @@ class CycloneDDSPublisherMiddleware : public IPublisherMiddleware {
     }
 
     dds_qos_t* qos = dds_create_qos();
-    dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
-                         DDS_SECS(1));
+    if (publisher_qos.reliability == ReliabilityKind::BestEffort) {
+      // High-rate sensor stream: drop samples instead of blocking the publish
+      // call on retransmissions to slow subscribers. max_blocking_time is
+      // meaningless for best-effort writers, so pass 0.
+      dds_qset_reliability(qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    } else {
+      dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
+                           DDS_SECS(1));
+    }
     // Keep-last writer history with the requested depth. The default depth 1
     // matches the previous hardcoded value, so volatile publishers are
     // unchanged.

--- a/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
@@ -55,7 +55,9 @@ class CycloneDDSPublisherMiddleware : public IPublisherMiddleware {
     if (_topic  > 0) { dds_delete(_topic);  }
   }
 
-  bool Init(const std::string& topic_name) override {
+  bool Init(
+      const std::string& topic_name,
+      const PublisherQos& publisher_qos) override {
     dds_entity_t participant = carla_cdr_get_participant();
     if (participant < 0) {
       log_error("CycloneDDSPublisherMiddleware: Shared participant unavailable "
@@ -76,6 +78,22 @@ class CycloneDDSPublisherMiddleware : public IPublisherMiddleware {
     dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
                          DDS_SECS(1));
     dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, 1);
+    if (publisher_qos.durability == DurabilityKind::TransientLocal) {
+      // Latched topic: keep the last history_depth samples for late joiners.
+      // durability_service governs what the writer's transient-local cache
+      // delivers to a late-joining reader.
+      const int32_t depth = static_cast<int32_t>(publisher_qos.history_depth);
+      dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+      dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, depth);
+      dds_qset_durability_service(
+          qos,
+          0,
+          DDS_HISTORY_KEEP_LAST,
+          depth,
+          DDS_LENGTH_UNLIMITED,
+          DDS_LENGTH_UNLIMITED,
+          DDS_LENGTH_UNLIMITED);
+    }
     // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
     // to the REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
     auto ud = build_user_data_for<msg_type>();

--- a/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/cyclonedds/CycloneDDSPublisherMiddleware.h
@@ -77,14 +77,17 @@ class CycloneDDSPublisherMiddleware : public IPublisherMiddleware {
     dds_qos_t* qos = dds_create_qos();
     dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE,
                          DDS_SECS(1));
-    dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, 1);
+    // Keep-last writer history with the requested depth. The default depth 1
+    // matches the previous hardcoded value, so volatile publishers are
+    // unchanged.
+    const int32_t depth =
+        static_cast<int32_t>(publisher_qos.effective_history_depth());
+    dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, depth);
     if (publisher_qos.durability == DurabilityKind::TransientLocal) {
       // Latched topic: keep the last history_depth samples for late joiners.
       // durability_service governs what the writer's transient-local cache
       // delivers to a late-joining reader.
-      const int32_t depth = static_cast<int32_t>(publisher_qos.history_depth);
       dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
-      dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, depth);
       dds_qset_durability_service(
           qos,
           0,

--- a/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
@@ -127,12 +127,16 @@ class FastDDSPublisherMiddleware
     wqos.endpoint().history_memory_policy =
         eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+    // Keep-last writer history with the requested depth. The default depth 1
+    // matches DATAWRITER_QOS_DEFAULT, so volatile publishers are unchanged.
+    wqos.history().kind = efd::KEEP_LAST_HISTORY_QOS;
+    wqos.history().depth =
+        static_cast<int32_t>(publisher_qos.effective_history_depth());
+
     if (publisher_qos.durability == DurabilityKind::TransientLocal) {
       // Latched topic: the writer keeps the last history_depth samples and
       // hands them to late-joining subscribers that request transient_local.
       wqos.durability().kind = efd::TRANSIENT_LOCAL_DURABILITY_QOS;
-      wqos.history().kind = efd::KEEP_LAST_HISTORY_QOS;
-      wqos.history().depth = static_cast<int32_t>(publisher_qos.history_depth);
     }
 
     // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)

--- a/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
@@ -139,6 +139,13 @@ class FastDDSPublisherMiddleware
       wqos.durability().kind = efd::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
 
+    if (publisher_qos.reliability == ReliabilityKind::BestEffort) {
+      // High-rate sensor stream: drop samples instead of blocking the publish
+      // call on retransmissions to slow subscribers. The default stays
+      // RELIABLE (DATAWRITER_QOS_DEFAULT), unchanged for existing publishers.
+      wqos.reliability().kind = efd::BEST_EFFORT_RELIABILITY_QOS;
+    }
+
     // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
     // to the REP-2011/REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".
     // Jazzy rmw_cyclonedds_cpp / rmw_fastrtps_cpp parse this during SEDP

--- a/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/fastdds/FastDDSPublisherMiddleware.h
@@ -83,7 +83,9 @@ class FastDDSPublisherMiddleware
     }
   }
 
-  bool Init(const std::string& topic_name) override {
+  bool Init(
+      const std::string& topic_name,
+      const PublisherQos& publisher_qos) override {
     if (_type == nullptr) {
       log_error("FastDDSPublisherMiddleware: Invalid TypeSupport");
       return false;
@@ -124,6 +126,14 @@ class FastDDSPublisherMiddleware
     efd::DataWriterQos wqos = efd::DATAWRITER_QOS_DEFAULT;
     wqos.endpoint().history_memory_policy =
         eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    if (publisher_qos.durability == DurabilityKind::TransientLocal) {
+      // Latched topic: the writer keeps the last history_depth samples and
+      // hands them to late-joining subscribers that request transient_local.
+      wqos.durability().kind = efd::TRANSIENT_LOCAL_DURABILITY_QOS;
+      wqos.history().kind = efd::KEEP_LAST_HISTORY_QOS;
+      wqos.history().depth = static_cast<int32_t>(publisher_qos.history_depth);
+    }
 
     // Set USER_DATA (PID_USER_DATA = 0x002c per OMG DDSI-RTPS v2.5 §9.6.2.2.2)
     // to the REP-2011/REP-2016 type-hash KV payload "typehash=RIHS01_<hex>;".

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohPublisherMiddleware.h
@@ -31,6 +31,12 @@ namespace ros2 {
 /// "<domain>/<topic>/<type>/<hash>".  A liveliness token is declared so the
 /// endpoint shows up in rmw_zenoh's graph cache.
 ///
+/// With PublisherQos durability TransientLocal the endpoint is declared as a
+/// zenoh-ext advanced publisher whose cache keeps the last history_depth
+/// samples, so late-joining rmw_zenoh transient_local subscribers recover
+/// them (the ROS 2 latched-topic behavior). The liveliness QoS segment
+/// advertises the durability so matching subscribers query the cache.
+///
 /// Parameterized on a traits type T that provides:
 ///   T::msg_type — the message type (a carla::ros2::msg::* POD struct)
 template<typename T>
@@ -41,6 +47,7 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
   ZenohPublisherMiddleware() {
     // Gravestone owned handles so destructor's z_drop is safe if Init never ran.
     z_internal_null(&_publisher);
+    z_internal_null(&_advanced_publisher);
     z_internal_null(&_liveliness_token);
     z_internal_null(&_matching_listener);
   }
@@ -55,10 +62,13 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
     std::lock_guard<std::mutex> lock(_publish_mutex);
     z_drop(z_move(_matching_listener));
     z_drop(z_move(_liveliness_token));
+    z_drop(z_move(_advanced_publisher));
     z_drop(z_move(_publisher));
   }
 
-  bool Init(const std::string& topic_name) override {
+  bool Init(
+      const std::string& topic_name,
+      const PublisherQos& publisher_qos) override {
     const z_loaned_session_t* session = zenoh_get_shared_session();
 
     const std::string topic_no_rt = zenoh_strip_rt_prefix(topic_name);
@@ -79,19 +89,51 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
       return false;
     }
 
-    z_publisher_options_t pub_opts;
-    z_publisher_options_default(&pub_opts);
-    if (z_declare_publisher(session, &_publisher, z_loan(ke), &pub_opts)
-        != Z_OK) {
-      log_error("ZenohPublisherMiddleware (", topic_name,
-                "): z_declare_publisher failed");
-      return false;
+    _use_advanced =
+        publisher_qos.durability == DurabilityKind::TransientLocal;
+    if (_use_advanced) {
+      ze_advanced_publisher_options_t adv_opts;
+      ze_advanced_publisher_options_default(&adv_opts);
+      adv_opts.cache.is_enabled = true;
+      adv_opts.cache.max_samples =
+          static_cast<size_t>(publisher_qos.history_depth);
+      if (ze_declare_advanced_publisher(
+              session, &_advanced_publisher, z_loan(ke), &adv_opts)
+          != Z_OK) {
+        // The advanced-publisher cache needs a session with timestamping
+        // enabled; the zenoh default config (used when the bundled session
+        // config cannot be loaded) does not have it. Degrade to a volatile
+        // publisher so the topic stays alive: subscribers still get live
+        // samples, only the latched history for late joiners is lost.
+        log_warning("ZenohPublisherMiddleware (", topic_name,
+                    "): ze_declare_advanced_publisher failed; "
+                    "falling back to a volatile publisher "
+                    "(transient_local latching unavailable)");
+        _use_advanced = false;
+      }
+    }
+    if (!_use_advanced) {
+      z_publisher_options_t pub_opts;
+      z_publisher_options_default(&pub_opts);
+      if (z_declare_publisher(session, &_publisher, z_loan(ke), &pub_opts)
+          != Z_OK) {
+        log_error("ZenohPublisherMiddleware (", topic_name,
+                  "): z_declare_publisher failed");
+        return false;
+      }
     }
 
+    // Advertise the durability actually provided: after a fallback the
+    // liveliness token must not promise transient_local history.
+    PublisherQos effective_qos = publisher_qos;
+    if (!_use_advanced) {
+      effective_qos.durability = DurabilityKind::Volatile;
+    }
+    const std::string qos_str = zenoh_make_qos_string(effective_qos);
     const std::string lv_ke_str = zenoh_make_topic_liveliness_keyexpr(
         zenoh_ros_domain_id(), zenoh_session_zid(), zenoh_next_entity_id(),
         kZenohEntityKindPub, topic_no_rt, type_name, type_hash,
-        kZenohDefaultQos);
+        qos_str.c_str());
     z_view_keyexpr_t lv_ke;
     if (z_view_keyexpr_from_str(&lv_ke, lv_ke_str.c_str()) != Z_OK) {
       log_error("ZenohPublisherMiddleware (", topic_name,
@@ -107,11 +149,14 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
 
     z_owned_closure_matching_status_t closure;
     z_closure_matching_status(&closure, &on_matching_status, nullptr, this);
-    if (z_publisher_declare_matching_listener(
-            z_loan(_publisher), &_matching_listener, z_move(closure))
-        != Z_OK) {
+    const z_result_t listener_result = _use_advanced
+        ? ze_advanced_publisher_declare_matching_listener(
+              z_loan(_advanced_publisher), &_matching_listener, z_move(closure))
+        : z_publisher_declare_matching_listener(
+              z_loan(_publisher), &_matching_listener, z_move(closure));
+    if (listener_result != Z_OK) {
       log_error("ZenohPublisherMiddleware (", topic_name,
-                "): z_publisher_declare_matching_listener failed");
+                "): declare_matching_listener failed");
       return false;
     }
 
@@ -121,7 +166,9 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
 
   bool Publish(void* message_data) override {
     std::lock_guard<std::mutex> lock(_publish_mutex);
-    if (!z_internal_check(_publisher)) {
+    if (_use_advanced
+            ? !z_internal_check(_advanced_publisher)
+            : !z_internal_check(_publisher)) {
       return false;
     }
 
@@ -135,13 +182,23 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
     z_owned_bytes_t attachment;
     z_bytes_copy_from_buf(&attachment, attach.data(), attach.size());
 
-    z_publisher_put_options_t opts;
-    z_publisher_put_options_default(&opts);
-    opts.attachment = z_move(attachment);
+    z_result_t put_result;
+    if (_use_advanced) {
+      ze_advanced_publisher_put_options_t opts;
+      ze_advanced_publisher_put_options_default(&opts);
+      opts.put_options.attachment = z_move(attachment);
+      put_result = ze_advanced_publisher_put(
+          z_loan(_advanced_publisher), z_move(payload), &opts);
+    } else {
+      z_publisher_put_options_t opts;
+      z_publisher_put_options_default(&opts);
+      opts.attachment = z_move(attachment);
+      put_result = z_publisher_put(z_loan(_publisher), z_move(payload), &opts);
+    }
 
-    if (z_publisher_put(z_loan(_publisher), z_move(payload), &opts) != Z_OK) {
+    if (put_result != Z_OK) {
       log_error("ZenohPublisherMiddleware::Publish (", _topic_name,
-                "): z_publisher_put failed");
+                "): put failed");
       return false;
     }
     return true;
@@ -162,13 +219,15 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
     self->_alive.store(status->matching, std::memory_order_relaxed);
   }
 
-  z_owned_publisher_t         _publisher;
-  z_owned_liveliness_token_t  _liveliness_token;
-  z_owned_matching_listener_t _matching_listener;
+  z_owned_publisher_t           _publisher;
+  ze_owned_advanced_publisher_t _advanced_publisher;
+  z_owned_liveliness_token_t    _liveliness_token;
+  z_owned_matching_listener_t   _matching_listener;
 
   mutable std::mutex _publish_mutex;
   std::atomic<bool>  _alive { false };
   std::string        _topic_name;
+  bool               _use_advanced { false };
 };
 
 } // namespace ros2

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohPublisherMiddleware.h
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohPublisherMiddleware.h
@@ -96,7 +96,7 @@ class ZenohPublisherMiddleware : public IPublisherMiddleware {
       ze_advanced_publisher_options_default(&adv_opts);
       adv_opts.cache.is_enabled = true;
       adv_opts.cache.max_samples =
-          static_cast<size_t>(publisher_qos.history_depth);
+          static_cast<size_t>(publisher_qos.effective_history_depth());
       if (ze_declare_advanced_publisher(
               session, &_advanced_publisher, z_loan(ke), &adv_opts)
           != Z_OK) {

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohSharedSession.cpp
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohSharedSession.cpp
@@ -71,6 +71,17 @@ const z_loaned_session_t* zenoh_get_shared_session() {
       log_error("ZenohSharedSession: failed to read config at '", path,
                 "'; falling back to zenoh defaults");
       z_config_default(&cfg);
+      // The advanced-publisher cache backing transient_local latching only
+      // works on a session with timestamping enabled. The bundled config
+      // turns it on, but the zenoh default config does not, which would
+      // silently degrade latched topics (rt/carla/map) to volatile. Patch
+      // the fallback so latching stays on by default.
+      if (zc_config_insert_json5(z_loan_mut(cfg), "timestamping/enabled",
+                                 "true") != Z_OK) {
+        log_warning("ZenohSharedSession: failed to enable timestamping on "
+                    "the fallback config; transient_local latching may be "
+                    "unavailable");
+      }
     }
     apply_config_overrides(z_loan_mut(cfg));
 

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
@@ -56,7 +56,7 @@ inline std::string zenoh_make_qos_string(const PublisherQos& publisher_qos) {
   const char* durability =
       publisher_qos.durability == DurabilityKind::TransientLocal ? "1" : "";
   return std::string(":") + durability + ":," +
-         std::to_string(publisher_qos.history_depth) + ":,:,:,,";
+         std::to_string(publisher_qos.effective_history_depth()) + ":,:,:,,";
 }
 
 /// Strip the "rt/" prefix that ROS2-to-DDS mapping adds to message topics.

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
@@ -49,13 +49,18 @@ inline std::string zenoh_ros_domain_id() {
 /// QoS segment of an endpoint liveliness keyexpr, rmw_zenoh format: six
 /// ':'-separated fields (reliability : durability : history_kind,history_depth
 /// : deadline : lifespan : liveliness) holding numeric rmw_qos enum values,
-/// where an empty field means "default". Durability TRANSIENT_LOCAL is rmw
-/// enum value 1. The default PublisherQos (volatile, depth 1) produces a
-/// string byte-identical to kZenohDefaultQos.
+/// where an empty field means "default". Reliability BEST_EFFORT is rmw enum
+/// value 2; durability TRANSIENT_LOCAL is rmw enum value 1. The default
+/// PublisherQos (reliable, volatile, depth 1) produces a string
+/// byte-identical to kZenohDefaultQos. Reliability only needs advertising
+/// here: zenoh itself has no per-publisher reliability knob, rmw_zenoh
+/// matches endpoints on this liveliness QoS segment.
 inline std::string zenoh_make_qos_string(const PublisherQos& publisher_qos) {
+  const char* reliability =
+      publisher_qos.reliability == ReliabilityKind::BestEffort ? "2" : "";
   const char* durability =
       publisher_qos.durability == DurabilityKind::TransientLocal ? "1" : "";
-  return std::string(":") + durability + ":," +
+  return std::string(reliability) + ":" + durability + ":," +
          std::to_string(publisher_qos.effective_history_depth()) + ":,:,:,,";
 }
 

--- a/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
+++ b/LibCarla/source/carla/ros2/middleware/zenoh/ZenohWireFormat.h
@@ -9,6 +9,8 @@
 #if defined(CARLA_ROS2_MIDDLEWARE_ZENOH) || defined(CARLA_ROS2_MIDDLEWARE_TESTING)
 
 #include "carla/ros2/middleware/MiddlewareConfig.h"
+#include "carla/ros2/middleware/PublisherQos.h"
+#include "carla/Logging.h"
 
 #include <atomic>
 #include <cstdint>
@@ -42,6 +44,19 @@ inline uint64_t zenoh_next_entity_id() {
 /// FastDDS/CycloneDDS middlewares pass to their DomainParticipant.
 inline std::string zenoh_ros_domain_id() {
   return std::to_string(MiddlewareConfig::GetEffectiveDomainId());
+}
+
+/// QoS segment of an endpoint liveliness keyexpr, rmw_zenoh format: six
+/// ':'-separated fields (reliability : durability : history_kind,history_depth
+/// : deadline : lifespan : liveliness) holding numeric rmw_qos enum values,
+/// where an empty field means "default". Durability TRANSIENT_LOCAL is rmw
+/// enum value 1. The default PublisherQos (volatile, depth 1) produces a
+/// string byte-identical to kZenohDefaultQos.
+inline std::string zenoh_make_qos_string(const PublisherQos& publisher_qos) {
+  const char* durability =
+      publisher_qos.durability == DurabilityKind::TransientLocal ? "1" : "";
+  return std::string(":") + durability + ":," +
+         std::to_string(publisher_qos.history_depth) + ":,:,:,,";
 }
 
 /// Strip the "rt/" prefix that ROS2-to-DDS mapping adds to message topics.

--- a/LibCarla/source/carla/ros2/publishers/CarlaCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaCameraPublisher.h
@@ -30,10 +30,13 @@ namespace ros2 {
         BasePublisher(base_topic_name, frame_id),
         _impl_image(std::make_shared<PublisherImpl<ImageMsgTraits>>()),
         _impl_camera_info(std::make_shared<PublisherImpl<CameraInfoMsgTraits>>()) {
-          if (!_impl_image->Init(GetBaseTopicName() + "/image")) {
+          // Best-effort sensor-data QoS: image frames are large and per-tick,
+          // so a slow subscriber must never block the publishing thread.
+          // camera_info shares the image QoS, the image_transport convention.
+          if (!_impl_image->Init(GetBaseTopicName() + "/image", PublisherQos::SensorData())) {
             log_warning("CarlaCameraPublisher: Init failed for topic: ", GetBaseTopicName(), "/image");
           }
-          if (!_impl_camera_info->Init(GetBaseTopicName() + "/camera_info")) {
+          if (!_impl_camera_info->Init(GetBaseTopicName() + "/camera_info", PublisherQos::SensorData())) {
             log_warning("CarlaCameraPublisher: Init failed for topic: ", GetBaseTopicName(), "/camera_info");
           }
         }

--- a/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "CarlaMapPublisher.h"
+
+namespace carla {
+namespace ros2 {
+
+bool CarlaMapPublisher::Write(const std::string& open_drive) {
+  _impl->GetMessage()->data = open_drive;
+
+  return true;
+}
+
+}  // namespace ros2
+}  // namespace carla

--- a/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "carla/ros2/publishers/BasePublisher.h"
+#include "carla/ros2/publishers/PublisherImpl.h"
+
+#include "carla/ros2/types/msg/String.h"
+
+namespace carla {
+namespace ros2 {
+
+  /// Publishes the OpenDRIVE description of the current map as a latched
+  /// std_msgs/String on rt/carla/map. The transient_local durability lets
+  /// late-joining subscribers receive the map without CARLA re-publishing it.
+  class CarlaMapPublisher : public BasePublisher {
+    public:
+      struct MapMsgTraits {
+        using msg_type = msg::String;
+      };
+
+      CarlaMapPublisher() :
+        BasePublisher("rt/carla/map"),
+        _impl(std::make_shared<PublisherImpl<MapMsgTraits>>()) {
+          PublisherQos qos;
+          qos.durability = DurabilityKind::TransientLocal;
+          if (!_impl->Init(GetBaseTopicName(), qos)) {
+            log_warning("CarlaMapPublisher: Init failed for topic: ", GetBaseTopicName());
+          }
+      }
+
+      bool Publish() {
+        return _impl->Publish();
+      }
+
+      bool Write(const std::string& open_drive);
+
+    private:
+      std::shared_ptr<PublisherImpl<MapMsgTraits>> _impl;
+  };
+
+}  // namespace ros2
+}  // namespace carla

--- a/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaMapPublisher.h
@@ -18,6 +18,18 @@ namespace ros2 {
   /// Publishes the OpenDRIVE description of the current map as a latched
   /// std_msgs/String on rt/carla/map. The transient_local durability lets
   /// late-joining subscribers receive the map without CARLA re-publishing it.
+  ///
+  /// std_msgs/String carries no Header, and that is deliberate: it keeps the
+  /// topic wire-compatible with carla-ros-bridge's /carla/map, which existing
+  /// tooling already consumes. The message therefore has no stamp or episode
+  /// id of its own; its identity contract is positional instead. The writer
+  /// cache holds exactly one sample (keep-last depth 1) and the map is
+  /// re-published on every episode start / map load, overwriting that sample,
+  /// so the latched payload a late joiner receives always describes the map
+  /// of the current episode. Consumers that need to detect a map change
+  /// should watch for a new sample arriving on this topic (the OpenDRIVE
+  /// header's own revision/name attributes identify the map) rather than
+  /// expect a ROS stamp.
   class CarlaMapPublisher : public BasePublisher {
     public:
       struct MapMsgTraits {

--- a/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.h
@@ -24,7 +24,9 @@ namespace ros2 {
       CarlaPointCloudPublisher(std::string base_topic_name, std::string frame_id) :
         BasePublisher(base_topic_name, frame_id),
         _impl(std::make_shared<PublisherImpl<PointCloudMsgTraits>>()) {
-          if (!_impl->Init(GetBaseTopicName() + "/point_cloud")) {
+          // Best-effort sensor-data QoS: point clouds are large and per-tick,
+          // so a slow subscriber must never block the publishing thread.
+          if (!_impl->Init(GetBaseTopicName() + "/point_cloud", PublisherQos::SensorData())) {
             log_warning("CarlaPointCloudPublisher: Init failed for topic: ", GetBaseTopicName(), "/point_cloud");
           }
         }

--- a/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
+++ b/LibCarla/source/carla/ros2/publishers/PublisherImpl.h
@@ -18,7 +18,7 @@ namespace ros2 {
   public:
     using msg_type = typename T::msg_type;
 
-    bool Init(std::string topic_name) {
+    bool Init(std::string topic_name, const PublisherQos& publisher_qos = PublisherQos()) {
 #ifdef LIBCARLA_WITH_GTEST
       if (!_middleware) {
 #endif
@@ -30,7 +30,7 @@ namespace ros2 {
 #ifdef LIBCARLA_WITH_GTEST
       }
 #endif
-      return _middleware->Init(topic_name);
+      return _middleware->Init(topic_name, publisher_qos);
     }
 
     std::string GetTopicName() {

--- a/LibCarla/source/test/server/test_ros2_middleware.cpp
+++ b/LibCarla/source/test/server/test_ros2_middleware.cpp
@@ -58,10 +58,14 @@ class MockPublisherMiddleware : public IPublisherMiddleware {
   bool publish_called{false};
   std::string last_topic_name;
   void* last_published_data{nullptr};
+  PublisherQos last_publisher_qos;
 
-  bool Init(const std::string& topic_name) override {
+  bool Init(
+      const std::string& topic_name,
+      const PublisherQos& publisher_qos) override {
     init_called = true;
     last_topic_name = topic_name;
+    last_publisher_qos = publisher_qos;
     return init_return_value;
   }
 
@@ -344,7 +348,7 @@ TEST_F(MiddlewareFactoryFixture, create_subscriber_zenoh_unavailable) {
 }
 
 // ==========================================================================
-// Group 7: publisher_impl (7 tests)
+// Group 7: publisher_impl (10 tests)
 // ==========================================================================
 
 TEST(publisher_impl, get_message_returns_pointer) {
@@ -417,6 +421,37 @@ TEST(publisher_impl, data_flows_through_publish) {
   ASSERT_NE(mock->last_published_data, nullptr);
   auto* published = static_cast<TestMsg*>(mock->last_published_data);
   EXPECT_EQ(published->value, 42);
+}
+
+TEST(publisher_impl, default_qos_is_volatile_depth_one) {
+  // The default PublisherQos must reproduce the historical behavior of every
+  // publisher created before QoS support existed.
+  PublisherQos qos;
+  EXPECT_EQ(qos.durability, DurabilityKind::Volatile);
+  EXPECT_EQ(qos.history_depth, 1u);
+}
+
+TEST(publisher_impl, init_without_qos_passes_default_qos) {
+  PublisherImpl<TestPubTraits> pub;
+  auto* mock = new MockPublisherMiddleware();
+  pub.SetMiddlewareForTesting(
+      std::unique_ptr<IPublisherMiddleware>(mock));
+  EXPECT_TRUE(pub.Init("rt/test_topic"));
+  EXPECT_EQ(mock->last_publisher_qos.durability, DurabilityKind::Volatile);
+  EXPECT_EQ(mock->last_publisher_qos.history_depth, 1u);
+}
+
+TEST(publisher_impl, init_passes_transient_local_qos) {
+  PublisherImpl<TestPubTraits> pub;
+  auto* mock = new MockPublisherMiddleware();
+  pub.SetMiddlewareForTesting(
+      std::unique_ptr<IPublisherMiddleware>(mock));
+  PublisherQos qos;
+  qos.durability = DurabilityKind::TransientLocal;
+  qos.history_depth = 5u;
+  EXPECT_TRUE(pub.Init("rt/carla/map", qos));
+  EXPECT_EQ(mock->last_publisher_qos.durability, DurabilityKind::TransientLocal);
+  EXPECT_EQ(mock->last_publisher_qos.history_depth, 5u);
 }
 
 // ==========================================================================

--- a/LibCarla/source/test/server/test_ros2_middleware.cpp
+++ b/LibCarla/source/test/server/test_ros2_middleware.cpp
@@ -431,6 +431,17 @@ TEST(publisher_impl, default_qos_is_volatile_depth_one) {
   EXPECT_EQ(qos.history_depth, 1u);
 }
 
+TEST(publisher_impl, effective_history_depth_clamps_zero_to_one) {
+  // A keep-last history needs a positive depth, so the middlewares apply the
+  // clamped value instead of the raw field.
+  PublisherQos qos;
+  EXPECT_EQ(qos.effective_history_depth(), 1u);
+  qos.history_depth = 0u;
+  EXPECT_EQ(qos.effective_history_depth(), 1u);
+  qos.history_depth = 10u;
+  EXPECT_EQ(qos.effective_history_depth(), 10u);
+}
+
 TEST(publisher_impl, init_without_qos_passes_default_qos) {
   PublisherImpl<TestPubTraits> pub;
   auto* mock = new MockPublisherMiddleware();

--- a/LibCarla/source/test/server/test_ros2_middleware.cpp
+++ b/LibCarla/source/test/server/test_ros2_middleware.cpp
@@ -348,7 +348,7 @@ TEST_F(MiddlewareFactoryFixture, create_subscriber_zenoh_unavailable) {
 }
 
 // ==========================================================================
-// Group 7: publisher_impl (10 tests)
+// Group 7: publisher_impl (12 tests)
 // ==========================================================================
 
 TEST(publisher_impl, get_message_returns_pointer) {
@@ -423,10 +423,20 @@ TEST(publisher_impl, data_flows_through_publish) {
   EXPECT_EQ(published->value, 42);
 }
 
-TEST(publisher_impl, default_qos_is_volatile_depth_one) {
+TEST(publisher_impl, default_qos_is_reliable_volatile_depth_one) {
   // The default PublisherQos must reproduce the historical behavior of every
   // publisher created before QoS support existed.
   PublisherQos qos;
+  EXPECT_EQ(qos.durability, DurabilityKind::Volatile);
+  EXPECT_EQ(qos.reliability, ReliabilityKind::Reliable);
+  EXPECT_EQ(qos.history_depth, 1u);
+}
+
+TEST(publisher_impl, sensor_data_qos_is_best_effort) {
+  // The sensor-data profile only relaxes reliability; durability and history
+  // stay at the defaults so high-rate streams keep the same memory footprint.
+  const PublisherQos qos = PublisherQos::SensorData();
+  EXPECT_EQ(qos.reliability, ReliabilityKind::BestEffort);
   EXPECT_EQ(qos.durability, DurabilityKind::Volatile);
   EXPECT_EQ(qos.history_depth, 1u);
 }
@@ -449,7 +459,18 @@ TEST(publisher_impl, init_without_qos_passes_default_qos) {
       std::unique_ptr<IPublisherMiddleware>(mock));
   EXPECT_TRUE(pub.Init("rt/test_topic"));
   EXPECT_EQ(mock->last_publisher_qos.durability, DurabilityKind::Volatile);
+  EXPECT_EQ(mock->last_publisher_qos.reliability, ReliabilityKind::Reliable);
   EXPECT_EQ(mock->last_publisher_qos.history_depth, 1u);
+}
+
+TEST(publisher_impl, init_passes_sensor_data_qos) {
+  PublisherImpl<TestPubTraits> pub;
+  auto* mock = new MockPublisherMiddleware();
+  pub.SetMiddlewareForTesting(
+      std::unique_ptr<IPublisherMiddleware>(mock));
+  EXPECT_TRUE(pub.Init("rt/carla/hero/lidar/point_cloud", PublisherQos::SensorData()));
+  EXPECT_EQ(mock->last_publisher_qos.reliability, ReliabilityKind::BestEffort);
+  EXPECT_EQ(mock->last_publisher_qos.durability, DurabilityKind::Volatile);
 }
 
 TEST(publisher_impl, init_passes_transient_local_qos) {
@@ -1457,7 +1478,7 @@ TEST(domain_id_resolution, invalid_command_line_falls_through_to_environment) {
 }
 
 // ==========================================================================
-// Group 14: zenoh_wire_format (3 tests)
+// Group 14: zenoh_wire_format (5 tests)
 // Pure string tests for the rmw_zenoh keyexpr builders: the domain id must be
 // the leading segment of every keyexpr so we only match rmw_zenoh peers on
 // the same domain.
@@ -1481,6 +1502,21 @@ TEST(zenoh_wire_format, topic_liveliness_keyexpr_has_domain_and_mangled_topic) {
       "sensor_msgs::msg::dds_::Imu_", "RIHS01_abc", kZenohDefaultQos);
   EXPECT_EQ(ke.compare(0, 12, "@ros2_lv/42/"), 0) << "keyexpr: " << ke;
   EXPECT_NE(ke.find("%vehicle%imu"), std::string::npos);
+}
+
+TEST(zenoh_wire_format, default_qos_string_matches_rmw_zenoh_default) {
+  // The default PublisherQos must advertise the exact QoS segment rmw_zenoh
+  // peers used before QoS support existed.
+  EXPECT_EQ(zenoh_make_qos_string(PublisherQos()), kZenohDefaultQos);
+}
+
+TEST(zenoh_wire_format, qos_string_advertises_reliability_and_durability) {
+  // rmw enum values: reliability BEST_EFFORT = 2, durability TRANSIENT_LOCAL = 1.
+  EXPECT_EQ(zenoh_make_qos_string(PublisherQos::SensorData()), "2::,1:,:,:,,");
+  PublisherQos latched;
+  latched.durability = DurabilityKind::TransientLocal;
+  latched.history_depth = 5u;
+  EXPECT_EQ(zenoh_make_qos_string(latched), ":1:,5:,:,:,,");
 }
 
 #ifndef _WIN32

--- a/PythonAPI/examples/ros2/README.md
+++ b/PythonAPI/examples/ros2/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to utilize the ROS 2 native interface in CARLA. It
 
 ## What the demo shows
 
-The native ROS 2 interface publishes a latched `std_msgs/String` with the full OpenDRIVE description of the current map on `/carla/map` (transient local durability, re-published on every map load). Any node can join late, read the map once, and combine it with the live sensor streams. The demo uses that topic to draw the real lane geometry of the town in RViz:
+The native ROS 2 interface publishes a latched `std_msgs/String` with the full OpenDRIVE description of the current map on `/carla/map` (transient local durability, re-published on every map load). `std_msgs/String` carries no `Header`, matching the carla-ros-bridge `/carla/map` topic: the latched sample has no stamp or episode id, but it always describes the currently loaded map because the single cached sample is overwritten on every map load. Any node can join late, read the map once, and combine it with the live sensor streams. The demo uses that topic to draw the real lane geometry of the town in RViz:
 
 * **Lane markers**: the OpenDRIVE string is parsed client-side and converted into a latched `visualization_msgs/MarkerArray` on `/carla/map_markers`. Lane boundaries are computed from the true lane width given by the OpenDRIVE (centerline plus and minus half the lane width), and each lane edge is published as one continuous polyline.
 * **Hero vehicle and sensors**: a vehicle with camera, lidar, GNSS and IMU drives on autopilot, with every sensor publishing natively (no bridge).

--- a/PythonAPI/examples/ros2/README.md
+++ b/PythonAPI/examples/ros2/README.md
@@ -1,17 +1,46 @@
 # ROS2 Native Example
 
-This example demonstrates how to utilize the ROS 2 native interface in CARLA.
+This example demonstrates how to utilize the ROS 2 native interface in CARLA. It includes a one-command demo, the map and lidar demo, that spawns a sensorized hero vehicle on autopilot and renders it in RViz together with the lane network of the map and the live lidar point cloud, all in a single world-fixed frame.
+
+## What the demo shows
+
+The native ROS 2 interface publishes a latched `std_msgs/String` with the full OpenDRIVE description of the current map on `/carla/map` (transient local durability, re-published on every map load). Any node can join late, read the map once, and combine it with the live sensor streams. The demo uses that topic to draw the real lane geometry of the town in RViz:
+
+* **Lane markers**: the OpenDRIVE string is parsed client-side and converted into a latched `visualization_msgs/MarkerArray` on `/carla/map_markers`. Lane boundaries are computed from the true lane width given by the OpenDRIVE (centerline plus and minus half the lane width), and each lane edge is published as one continuous polyline.
+* **Hero vehicle and sensors**: a vehicle with camera, lidar, GNSS and IMU drives on autopilot, with every sensor publishing natively (no bridge).
+* **Combined view**: a `map->hero` transform is broadcast every simulation tick, completing the TF chain `map->hero-><sensor>`, so the lidar point cloud and the vehicle TF tree render at their world position on top of the lane network.
+
+## Files
+
+| File | Role |
+|------|------|
+| `ros2_native.py` | Spawns the hero vehicle defined in `stack.json` (camera, lidar, GNSS, IMU) and drives it on autopilot. Destroys the actors and restores the world settings on shutdown. |
+| `stack.json` | Sensor setup of the hero vehicle. Edit it to adjust the sensors. |
+| `run_map_and_lidar_demo.sh` | Demo entry point. Builds the demo image if missing and runs the demo stack in Docker. |
+| `run_rviz.sh` | Runs RViz in Docker with the bundled preset. |
+| `rviz/ros2_native.rviz` | RViz preset: camera panel, lidar point cloud, TF tree and the map markers display (transient local, fixed frame `map`). |
+| `Dockerfile`, `config/` | Base RViz image and the RMW configuration files mounted into the containers. |
+
+The `map_and_lidar_demo/` folder holds the internals of the demo image:
+
+| File | Role |
+|------|------|
+| `map_and_lidar_demo/Dockerfile` | Demo image: the RViz image extended with the carla Python wheel and the helpers below. |
+| `map_and_lidar_demo/build.sh` | Builds the `carla-map-and-lidar-demo-<distro>-<rmw>` image. Run automatically by `run_map_and_lidar_demo.sh`. |
+| `map_and_lidar_demo/launcher.sh` | In-image entry point. Launches the helpers and stops them all together when the first one exits or the container is stopped. |
+| `map_and_lidar_demo/map_to_markers.py` | Subscribes to the latched `/carla/map`, parses the OpenDRIVE with the carla Python package (no simulator connection needed) and publishes the lane markers on `/carla/map_markers`. |
+| `map_and_lidar_demo/ego_tf_broadcaster.py` | Broadcasts the `map->hero` transform every simulation tick through the Python API, stamped with simulation time. |
+| `map_and_lidar_demo/cleanup.py` | Destroys leftover hero vehicles and their sensors and restores asynchronous mode. Run automatically at stack startup and shutdown so an unclean exit never leaks a second vehicle publishing on the same topics. |
 
 ## Prerequisites
 
-To run this example, ensure `docker` is installed in your system, which is used to launch an instance of `rviz` for
-visualizing sensor data.
+To run this example, ensure `docker` is installed in your system, which is used to launch the demo stack and an instance of `rviz` for visualizing the data.
+
+The demo image needs the carla Python wheel from `PythonAPI/carla/dist`, built with `make PythonAPI` (cp310 for humble, cp312 for jazzy; pass `--wheel=<path>` to `map_and_lidar_demo/build.sh` to use another one).
 
 ## Usage
 
 ### Step 1: Start the CARLA Simulator with ROS2 enabled
-
-Launch the CARLA simulator with the ROS 2 integration enabled:
 
 ```bash
 # If running a package:
@@ -22,33 +51,57 @@ make launch ARGS="--ros2 --editor-flags='--ros2'"
 ```
 
 > [!NOTE]
-> To use the Zenoh middleware, add `--rmw=zenoh` to the launch command above and to `run_rviz.sh`, and start a Zenoh router first:
+> To use the Zenoh middleware, add `--rmw=zenoh` to the launch command above and to the scripts below, and start a Zenoh router first:
 > ```bash
 > docker run --rm --net=host carla-rviz-<distro>-zenoh ros2 run rmw_zenoh_cpp rmw_zenohd
 > ```
 > The `carla-rviz-<distro>-zenoh` image is built the first time you run `run_rviz.sh` (`<distro>` is `humble` or `jazzy`).
 
-### Step 2: Run the ROS2 Example
-
-Execute the ROS 2 example script:
+### Step 2: Run the map and lidar demo
 
 ```bash
-python3 ros2_native.py --file stack.json
+./run_map_and_lidar_demo.sh
 ```
 
-* The `stack.json` file defines the sensor configuration.
-* You can edit this file to adjust the sensor setup according to your requirements.
+Options:
 
-### Step 3: Run RViz to Visualize Sensor Data
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--distro=<distro>` | `humble` | ROS 2 distribution: `humble` or `jazzy`. |
+| `--rmw=<middleware>` | `fastdds` | RMW implementation: `fastdds`, `cyclonedds` or `zenoh`. Must match the `--rmw=` the simulator was started with. |
+| `--host=<host>` | `localhost` | IP of the host CARLA Simulator. |
+| `--port=<port>` | `2000` | TCP port of the CARLA Simulator. Must match `-carla-rpc-port` if the server uses a non-default port. |
+| `--waypoint-distance=<meters>` | `2.0` | Distance between sampled lane points. Lower values give smoother curves at the cost of more markers. |
+| `--map-only` | off | Only publish the map markers, do not spawn the vehicle stack. |
 
-Start `rviz` to visualize the sensor output from CARLA:
+The first run builds the `carla-map-and-lidar-demo-<distro>-<rmw>` image automatically. Stop the demo with a single Ctrl+C (or `docker stop carla-map-and-lidar-demo-<distro>-<rmw>`); the stack destroys the vehicle and its sensors, restores the world settings and removes any leftovers before exiting. A second concurrent run fails fast instead of spawning a duplicate vehicle on the same topics.
 
-> [!NOTE]
-> Docker must be installed on your system to complete this step.
+### Step 3: Run RViz to visualize the result
 
 ```bash
 ./run_rviz.sh
 ```
+
+With the bundled preset (`Fixed Frame: map`) you get the combined view: the town lane network, the hero TF tree driving along it, the lidar point cloud rendered at the vehicle's world position and the camera image panel.
+
+Tips:
+
+* The lane centerlines are published in their own marker namespace (`lane_centerlines`) and hidden by default. Enable them under the Map display Namespaces in RViz.
+* To follow the vehicle automatically, set `Views -> Target Frame` to `hero` (the `Orbit` view keeps a fixed compass orientation, `ThirdPersonFollower` rotates with the vehicle heading).
+* If RViz started before the transforms were available it may have dropped the latched map markers. Toggle the Map display checkbox to force a resubscription.
+
+### Running the helpers standalone
+
+Each helper can also run directly from any ROS 2 environment that has the `carla` Python package installed:
+
+```bash
+python3 ros2_native.py --file stack.json
+python3 map_and_lidar_demo/map_to_markers.py
+python3 map_and_lidar_demo/ego_tf_broadcaster.py
+python3 map_and_lidar_demo/cleanup.py
+```
+
+`ros2_native.py` and `map_and_lidar_demo/cleanup.py` only need the `carla` package (no ROS environment).
 
 ### Optional: Custom ROS 2 domain id
 

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/Dockerfile
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE=carla-rviz-humble-fastdds
+FROM ${BASE_IMAGE}
+
+# PEP 668: allow installing into the system python on newer bases (jazzy)
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY carla-*.whl /tmp/
+RUN python3 -m pip install --no-cache-dir /tmp/carla-*.whl && \
+    rm -f /tmp/carla-*.whl
+
+COPY ros2_native.py stack.json map_to_markers.py ego_tf_broadcaster.py cleanup.py launcher.sh /opt/carla/
+RUN chmod +x /opt/carla/launcher.sh
+
+CMD ["/opt/carla/launcher.sh"]

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/build.sh
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/build.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLES_DIR="$(dirname "${SCRIPT_DIR}")"
+
+# --- Defaults ---
+DISTRO="humble"
+RMW="fastdds"
+WHEEL=""
+
+# --- Argument parsing ---
+usage() {
+    cat <<EOF
+Usage: $0 [--distro=<distro>] [--rmw=<middleware>] [--wheel=<path>]
+
+Builds the carla-map-and-lidar-demo-<distro>-<rmw> Docker image: the RViz image
+extended with the carla Python wheel and the demo helpers (ros2_native.py,
+map_to_markers.py, ego_tf_broadcaster.py) installed.
+
+Options:
+  --distro    ROS 2 distribution to use. Supported: humble, jazzy  (default: humble)
+  --rmw       RMW implementation to use. Supported: fastdds, cyclonedds, zenoh  (default: fastdds)
+  --wheel     Path to the carla wheel to install (default: autodetect in PythonAPI/carla/dist)
+
+Examples:
+  $0 --distro=humble --rmw=fastdds
+  $0 --distro=jazzy  --rmw=cyclonedds --wheel=/path/to/carla-0.9.16-cp312-cp312-manylinux_2_31_x86_64.whl
+EOF
+    exit 1
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --distro=*) DISTRO="${arg#*=}" ;;
+        --rmw=*)    RMW="${arg#*=}" ;;
+        --wheel=*)  WHEEL="${arg#*=}" ;;
+        --help|-h)  usage ;;
+        *) echo "Unknown argument: $arg"; usage ;;
+    esac
+done
+
+# --- Validate ---
+case "$DISTRO" in
+    humble) PYTHON_TAG="cp310" ;;
+    jazzy)  PYTHON_TAG="cp312" ;;
+    *) echo "Unsupported distro '${DISTRO}'. Supported values: humble, jazzy"; exit 1 ;;
+esac
+
+case "$RMW" in
+    fastdds|cyclonedds|zenoh) ;;
+    *) echo "Unsupported RMW '${RMW}'. Supported values: fastdds, cyclonedds, zenoh"; exit 1 ;;
+esac
+
+# Map short names to ROS RMW implementation identifiers
+if [ "$RMW" = "cyclonedds" ]; then
+    RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
+elif [ "$RMW" = "zenoh" ]; then
+    RMW_IMPLEMENTATION="rmw_zenoh_cpp"
+else
+    RMW_IMPLEMENTATION="rmw_fastrtps_cpp"
+fi
+
+BASE_IMAGE="carla-rviz-${DISTRO}-${RMW}"
+IMAGE_NAME="carla-map-and-lidar-demo-${DISTRO}-${RMW}"
+
+# --- Locate the carla wheel ---
+if [ -z "$WHEEL" ]; then
+    WHEEL="$(ls "${EXAMPLES_DIR}"/../../carla/dist/carla-*-${PYTHON_TAG}-*.whl 2>/dev/null | head -n 1 || true)"
+fi
+if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then
+    echo "No carla ${PYTHON_TAG} wheel found in '${EXAMPLES_DIR}/../../carla/dist'."
+    echo "Build it with 'make PythonAPI' or pass one explicitly with --wheel=<path>."
+    exit 1
+fi
+
+# --- Build the base RViz image if missing ---
+if ! docker image inspect "${BASE_IMAGE}" &>/dev/null; then
+    echo "[demo] Building base Docker image '${BASE_IMAGE}' (distro=${DISTRO}, rmw=${RMW})..."
+    docker build \
+        --build-arg ROS_DISTRO="${DISTRO}" \
+        --build-arg RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION}" \
+        --file "${EXAMPLES_DIR}/Dockerfile" \
+        --tag "${BASE_IMAGE}" \
+        "${EXAMPLES_DIR}"
+fi
+
+# --- Build the demo image from a staged context ---
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+cp "${SCRIPT_DIR}/Dockerfile" "${BUILD_DIR}/Dockerfile"
+cp "${EXAMPLES_DIR}/ros2_native.py" \
+   "${EXAMPLES_DIR}/stack.json" \
+   "${SCRIPT_DIR}/map_to_markers.py" \
+   "${SCRIPT_DIR}/ego_tf_broadcaster.py" \
+   "${SCRIPT_DIR}/cleanup.py" \
+   "${SCRIPT_DIR}/launcher.sh" \
+   "${BUILD_DIR}/"
+cp "$WHEEL" "${BUILD_DIR}/"
+
+echo "[demo] Building Docker image '${IMAGE_NAME}' (wheel=$(basename "$WHEEL"))..."
+docker build \
+    --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+    --tag "${IMAGE_NAME}" \
+    "${BUILD_DIR}"

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/cleanup.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/cleanup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+# Destroys leftover demo actors: every vehicle with the given role_name and the
+# sensors attached to it. Also restores asynchronous mode, which a killed stack
+# can leave enabled with nobody ticking. Run by launcher.sh before
+# spawning so that a previous demo stack that died without cleaning up (killed
+# container, double Ctrl+C, docker stop grace timeout) does not leave a second
+# vehicle publishing on the same topics.
+
+import argparse
+
+import carla
+
+
+def main(args):
+    client = carla.Client(args.host, args.port)
+    client.set_timeout(10.0)
+    world = client.get_world()
+    actors = world.get_actors()
+
+    leftovers = [vehicle for vehicle in actors.filter('vehicle.*')
+                 if vehicle.attributes.get('role_name') == args.role_name]
+    for vehicle in leftovers:
+        for sensor in actors.filter('sensor.*'):
+            if sensor.parent is not None and sensor.parent.id == vehicle.id:
+                sensor.destroy()
+        vehicle.destroy()
+        print("Destroyed leftover vehicle {} (role_name '{}')".format(vehicle.id, args.role_name))
+
+    if not leftovers:
+        print("No leftover vehicles with role_name '{}'".format(args.role_name))
+
+    settings = world.get_settings()
+    if settings.synchronous_mode:
+        settings.synchronous_mode = False
+        settings.fixed_delta_seconds = None
+        world.apply_settings(settings)
+        print('Restored asynchronous mode')
+
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser(description='CARLA demo leftover actor cleanup')
+    argparser.add_argument('--host', metavar='H', default='localhost', help='IP of the host CARLA Simulator (default: localhost)')
+    argparser.add_argument('--port', metavar='P', default=2000, type=int, help='TCP port of CARLA Simulator (default: 2000)')
+    argparser.add_argument('--role-name', metavar='NAME', default='hero', help='role_name of the vehicles to destroy (default: hero)')
+
+    main(argparser.parse_args())

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/cleanup.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/cleanup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
 # Barcelona (UAB).

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/ego_tf_broadcaster.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/ego_tf_broadcaster.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+# Broadcasts the map-><vehicle> TF for a CARLA vehicle.
+#
+# The native ROS2 interface publishes the sensor TFs (<vehicle>-><sensor>) but
+# no transform for the vehicle itself. This helper reads the vehicle transform
+# through the CARLA Python API every simulation tick and broadcasts it as a
+# ROS 2 TF map-><frame>, completing the chain so RViz can combine the latched
+# map markers with live sensor data under the 'map' fixed frame. Stamps use
+# simulation time to line up with the native sensor headers.
+
+import argparse
+import math
+import time
+
+import carla
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import TransformStamped
+from tf2_ros import TransformBroadcaster
+
+
+def _quaternion_from_rpy(roll, pitch, yaw):
+    cr, sr = math.cos(roll * 0.5), math.sin(roll * 0.5)
+    cp, sp = math.cos(pitch * 0.5), math.sin(pitch * 0.5)
+    cy, sy = math.cos(yaw * 0.5), math.sin(yaw * 0.5)
+    return (
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+        cr * cp * cy + sr * sp * sy)
+
+
+def _find_vehicle(world, role_name, node):
+    while rclpy.ok():
+        for actor in world.get_actors().filter('vehicle.*'):
+            if actor.attributes.get('role_name') == role_name:
+                return actor
+        node.get_logger().info("Waiting for a vehicle with role_name '{}'...".format(role_name))
+        time.sleep(1.0)
+    return None
+
+
+def main(args):
+    rclpy.init()
+    node = Node('carla_ego_tf_broadcaster')
+    broadcaster = TransformBroadcaster(node)
+
+    client = carla.Client(args.host, args.port)
+    client.set_timeout(10.0)
+    world = client.get_world()
+
+    vehicle = _find_vehicle(world, args.role_name, node)
+    if vehicle is None:
+        return
+    node.get_logger().info('Broadcasting TF map->{} for actor {}'.format(args.frame, vehicle.id))
+
+    try:
+        while rclpy.ok():
+            # Short timeout: signals cannot be delivered while blocked inside
+            # the call, so a long wait would hang shutdown when the ticking
+            # client stops before this helper.
+            try:
+                snapshot = world.wait_for_tick(seconds=1.0)
+            except RuntimeError:
+                continue
+            # A signal received while blocked in wait_for_tick may have shut
+            # down the ROS context; publishing on it would raise.
+            if not rclpy.ok():
+                break
+            transform = vehicle.get_transform()
+
+            tf_msg = TransformStamped()
+            elapsed = snapshot.timestamp.elapsed_seconds
+            tf_msg.header.stamp.sec = int(elapsed)
+            tf_msg.header.stamp.nanosec = int((elapsed - int(elapsed)) * 1e9)
+            tf_msg.header.frame_id = 'map'
+            tf_msg.child_frame_id = args.frame
+            # CARLA left-handed (x, y, z) to ROS right-handed: negate y;
+            # rotation as roll, -pitch, -yaw in radians.
+            tf_msg.transform.translation.x = transform.location.x
+            tf_msg.transform.translation.y = -transform.location.y
+            tf_msg.transform.translation.z = transform.location.z
+            qx, qy, qz, qw = _quaternion_from_rpy(
+                math.radians(transform.rotation.roll),
+                -math.radians(transform.rotation.pitch),
+                -math.radians(transform.rotation.yaw))
+            tf_msg.transform.rotation.x = qx
+            tf_msg.transform.rotation.y = qy
+            tf_msg.transform.rotation.z = qz
+            tf_msg.transform.rotation.w = qw
+            broadcaster.sendTransform(tf_msg)
+    except KeyboardInterrupt:
+        print('\nCancelled by user. Bye!')
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser(description='CARLA map->vehicle TF broadcaster')
+    argparser.add_argument('--host', metavar='H', default='localhost', help='IP of the host CARLA Simulator (default: localhost)')
+    argparser.add_argument('--port', metavar='P', default=2000, type=int, help='TCP port of CARLA Simulator (default: 2000)')
+    argparser.add_argument('--role-name', metavar='NAME', default='hero', help='role_name of the vehicle to track (default: hero)')
+    argparser.add_argument('--frame', metavar='FRAME', default='hero', help='TF child frame, must match the vehicle ros_name (default: hero)')
+
+    main(argparser.parse_args())

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/ego_tf_broadcaster.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/ego_tf_broadcaster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
 # Barcelona (UAB).

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/launcher.sh
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/launcher.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Entry point of the carla-map-and-lidar-demo-<distro>-<rmw> Docker image (see
+# run_map_and_lidar_demo.sh). Launches the demo helpers and stops them all together when
+# the first one exits or the container receives INT/TERM.
+
+set -uo pipefail
+
+CARLA_HOST="${CARLA_HOST:-localhost}"
+CARLA_PORT="${CARLA_PORT:-2000}"
+WAYPOINT_DISTANCE="${WAYPOINT_DISTANCE:-2.0}"
+MAP_ONLY="${MAP_ONLY:-0}"
+
+pids=()
+
+python3 /opt/carla/map_to_markers.py --waypoint-distance "${WAYPOINT_DISTANCE}" &
+pids+=($!)
+
+if [ "${MAP_ONLY}" != "1" ]; then
+    # A previous stack that died without cleanup (killed container, double
+    # Ctrl+C) leaves its vehicle behind, publishing on the same topics as the
+    # one about to spawn. Remove it first.
+    python3 /opt/carla/cleanup.py --host "${CARLA_HOST}" --port "${CARLA_PORT}"
+
+    python3 /opt/carla/ego_tf_broadcaster.py --host "${CARLA_HOST}" --port "${CARLA_PORT}" &
+    pids+=($!)
+    python3 /opt/carla/ros2_native.py --file /opt/carla/stack.json --host "${CARLA_HOST}" --port "${CARLA_PORT}" &
+    pids+=($!)
+fi
+
+# Stop the helpers with SIGTERM: background jobs of a non-interactive shell
+# start with SIGINT ignored, so python never installs its KeyboardInterrupt
+# handler and a SIGINT would be dropped. SIGTERM reaches all of them and lets
+# ros2_native.py run its cleanup (destroy sensors and vehicle, restore world
+# settings). Send it only once: a second signal would land inside that
+# cleanup and abort it, leaking the actors.
+stopped=0
+stop() {
+    if [ "${stopped}" = "0" ]; then
+        stopped=1
+        kill -TERM "${pids[@]}" 2>/dev/null || true
+    fi
+}
+trap stop INT TERM
+
+wait -n || true
+echo "[demo] A helper exited, stopping the stack..."
+stop
+wait || true
+
+# Belt and braces: if the spawning helper was killed mid-cleanup, remove what
+# it left behind so the next run starts from a clean world anyway.
+if [ "${MAP_ONLY}" != "1" ]; then
+    python3 /opt/carla/cleanup.py --host "${CARLA_HOST}" --port "${CARLA_PORT}" || true
+fi

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/map_to_markers.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/map_to_markers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
 # Barcelona (UAB).
@@ -36,6 +36,11 @@ LATCHED_QOS = QoSProfile(
     reliability=QoSReliabilityPolicy.RELIABLE,
     durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
 
+# Safety cap on the waypoints walked per lane, in case a malformed map makes
+# next() loop forever. No real town comes close: at the default 2.0 m sampling
+# this allows lanes up to 200 km.
+MAX_CHAIN_WAYPOINTS = 100000
+
 
 def _make_line_marker(ns, red, green, blue):
     marker = Marker()
@@ -62,7 +67,7 @@ def _lane_edge(waypoint, side):
             location.z + right.z * offset)
 
 
-def _lane_chains(carla_map, distance):
+def _lane_chains(carla_map, distance, logger):
     """Yields each lane of the map as one list of consecutive waypoints.
 
     Walks every lane returned by get_topology() in driving direction at the
@@ -74,9 +79,13 @@ def _lane_chains(carla_map, distance):
     for start, _ in carla_map.get_topology():
         chain = [start]
         following = start.next(distance)
-        while following and following[0].road_id == start.road_id and len(chain) < 100000:
+        while following and following[0].road_id == start.road_id and len(chain) < MAX_CHAIN_WAYPOINTS:
             chain.append(following[0])
             following = chain[-1].next(distance)
+        if len(chain) >= MAX_CHAIN_WAYPOINTS:
+            logger.warning(
+                'Lane chain on road {} truncated at {} waypoints, '
+                'its polyline may be incomplete'.format(start.road_id, MAX_CHAIN_WAYPOINTS))
         if following:
             chain.append(following[0])
         yield chain
@@ -110,7 +119,7 @@ class MapToMarkers(Node):
                 marker.points.append(Point(x=x, y=-y, z=z + 0.1))
             markers.append(marker)
 
-        for chain in _lane_chains(carla_map, self._waypoint_distance):
+        for chain in _lane_chains(carla_map, self._waypoint_distance, self.get_logger()):
             add_strip('lane_centerlines', (0.2, 0.8, 1.0),
                       [(w.transform.location.x, w.transform.location.y, w.transform.location.z)
                        for w in chain])

--- a/PythonAPI/examples/ros2/map_and_lidar_demo/map_to_markers.py
+++ b/PythonAPI/examples/ros2/map_and_lidar_demo/map_to_markers.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+# Converts the latched /carla/map OpenDRIVE string into lane markers for RViz.
+#
+# Subscribes to /carla/map (std_msgs/String, transient_local), parses the
+# OpenDRIVE with the carla Python package (no simulator connection needed) and
+# publishes a latched visualization_msgs/MarkerArray on /carla/map_markers:
+#   * lane_boundaries   the lane edges (centerline +/- half the lane width
+#                       given by the OpenDRIVE), one continuous polyline per
+#                       lane edge
+#   * lane_centerlines  the waypoint guide lines (hidden by default in the
+#                       bundled RViz preset; enable it under the Map display
+#                       Namespaces)
+# Markers are re-published whenever a new map sample arrives (e.g. after
+# load_world), replacing the previous ones.
+
+import argparse
+
+import carla
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy, QoSReliabilityPolicy
+from std_msgs.msg import String
+from visualization_msgs.msg import Marker, MarkerArray
+from geometry_msgs.msg import Point
+
+LATCHED_QOS = QoSProfile(
+    depth=1,
+    reliability=QoSReliabilityPolicy.RELIABLE,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+
+
+def _make_line_marker(ns, red, green, blue):
+    marker = Marker()
+    marker.header.frame_id = 'map'
+    marker.ns = ns
+    marker.type = Marker.LINE_STRIP
+    marker.action = Marker.ADD
+    marker.scale.x = 0.2
+    marker.color.r = red
+    marker.color.g = green
+    marker.color.b = blue
+    marker.color.a = 1.0
+    marker.frame_locked = True
+    return marker
+
+
+def _lane_edge(waypoint, side):
+    """Returns the (x, y, z) of the lane edge on the given side (-1 left, +1 right)."""
+    location = waypoint.transform.location
+    right = waypoint.transform.get_right_vector()
+    offset = side * 0.5 * waypoint.lane_width
+    return (location.x + right.x * offset,
+            location.y + right.y * offset,
+            location.z + right.z * offset)
+
+
+def _lane_chains(carla_map, distance):
+    """Yields each lane of the map as one list of consecutive waypoints.
+
+    Walks every lane returned by get_topology() in driving direction at the
+    given sampling distance, then appends the first waypoint of the successor
+    road so consecutive roads connect without a gap. Walking each lane as a
+    single chain (instead of pairing independently sampled waypoints with
+    next()) keeps the polyline continuous across lane sections and road seams.
+    """
+    for start, _ in carla_map.get_topology():
+        chain = [start]
+        following = start.next(distance)
+        while following and following[0].road_id == start.road_id and len(chain) < 100000:
+            chain.append(following[0])
+            following = chain[-1].next(distance)
+        if following:
+            chain.append(following[0])
+        yield chain
+
+
+class MapToMarkers(Node):
+
+    def __init__(self, waypoint_distance):
+        super().__init__('carla_map_markers')
+        self._waypoint_distance = waypoint_distance
+        self._marker_publisher = self.create_publisher(MarkerArray, '/carla/map_markers', LATCHED_QOS)
+        self._map_subscription = self.create_subscription(String, '/carla/map', self._on_map, LATCHED_QOS)
+        self.get_logger().info('Waiting for latched /carla/map...')
+
+    def _on_map(self, map_msg):
+        self.get_logger().info('Received OpenDRIVE ({} bytes), parsing...'.format(len(map_msg.data)))
+        carla_map = carla.Map('map_to_markers', map_msg.data)
+
+        # Drop the markers of a previously received map before adding the new ones.
+        clear_previous = Marker()
+        clear_previous.action = Marker.DELETEALL
+        markers = [clear_previous]
+
+        def add_strip(ns, color, points):
+            if len(points) < 2:
+                return
+            marker = _make_line_marker(ns, *color)
+            marker.id = len(markers)
+            for x, y, z in points:
+                # CARLA left-handed (x, y, z) to ROS right-handed: negate y.
+                marker.points.append(Point(x=x, y=-y, z=z + 0.1))
+            markers.append(marker)
+
+        for chain in _lane_chains(carla_map, self._waypoint_distance):
+            add_strip('lane_centerlines', (0.2, 0.8, 1.0),
+                      [(w.transform.location.x, w.transform.location.y, w.transform.location.z)
+                       for w in chain])
+            for side in (-1.0, 1.0):
+                add_strip('lane_boundaries', (0.9, 0.9, 0.9),
+                          [_lane_edge(w, side) for w in chain])
+
+        self._marker_publisher.publish(MarkerArray(markers=markers))
+        boundary_count = sum(1 for m in markers if m.ns == 'lane_boundaries')
+        centerline_count = sum(1 for m in markers if m.ns == 'lane_centerlines')
+        self.get_logger().info(
+            'Published {} lane boundary and {} centerline polylines on /carla/map_markers'.format(
+                boundary_count, centerline_count))
+
+
+def main(args):
+    rclpy.init()
+    node = MapToMarkers(args.waypoint_distance)
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        print('\nCancelled by user. Bye!')
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser(description='CARLA latched OpenDRIVE map to RViz lane markers')
+    argparser.add_argument('--waypoint-distance', metavar='D', default=2.0, type=float, help='distance in meters between sampled lane points (default: 2.0)')
+
+    main(argparser.parse_args())

--- a/PythonAPI/examples/ros2/ros2_native.py
+++ b/PythonAPI/examples/ros2/ros2_native.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2025 Computer Vision Center (CVC) at the Universitat Autonoma de
 # Barcelona (UAB).

--- a/PythonAPI/examples/ros2/ros2_native.py
+++ b/PythonAPI/examples/ros2/ros2_native.py
@@ -12,6 +12,7 @@
 import argparse
 import json
 import logging
+import signal
 
 import carla
 
@@ -127,5 +128,11 @@ if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s: %(message)s', level=log_level)
 
     logging.info('Listening to server %s:%s', args.host, args.port)
+
+    # Containers stop with SIGTERM; translate it into KeyboardInterrupt so the
+    # cleanup in main() runs (destroy actors, restore world settings).
+    def _on_sigterm(signum, frame):
+        raise KeyboardInterrupt
+    signal.signal(signal.SIGTERM, _on_sigterm)
 
     main(args)

--- a/PythonAPI/examples/ros2/run_map_and_lidar_demo.sh
+++ b/PythonAPI/examples/ros2/run_map_and_lidar_demo.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Defaults ---
+DISTRO="humble"
+RMW="fastdds"
+HOST="localhost"
+PORT="2000"
+WAYPOINT_DISTANCE="2.0"
+MAP_ONLY="0"
+
+# --- Argument parsing ---
+usage() {
+    cat <<EOF
+Usage: $0 [--distro=<distro>] [--rmw=<middleware>] [--host=<host>] [--port=<port>]
+          [--waypoint-distance=<meters>] [--map-only]
+
+Runs the ROS2 demo stack in Docker against a CARLA server started with --ros2:
+  * ros2_native.py        spawns the hero vehicle with camera/lidar/gnss/imu on autopilot
+  * map_to_markers.py     converts the latched /carla/map OpenDRIVE into lane markers
+  * ego_tf_broadcaster.py broadcasts the map->hero TF so map and sensors compose in RViz
+
+Options:
+  --distro              ROS 2 distribution to use. Supported: humble, jazzy  (default: humble)
+  --rmw                 RMW implementation to use. Supported: fastdds, cyclonedds, zenoh  (default: fastdds)
+  --host                IP of the host CARLA Simulator  (default: localhost)
+  --port                TCP port of CARLA Simulator  (default: 2000)
+  --waypoint-distance   Distance in meters between sampled lane points  (default: 2.0)
+  --map-only            Only publish the map markers, do not spawn the vehicle stack
+
+Examples:
+  $0
+  $0 --port=3654
+  $0 --distro=jazzy --rmw=cyclonedds --map-only
+EOF
+    exit 1
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --distro=*)            DISTRO="${arg#*=}" ;;
+        --rmw=*)               RMW="${arg#*=}" ;;
+        --host=*)              HOST="${arg#*=}" ;;
+        --port=*)              PORT="${arg#*=}" ;;
+        --waypoint-distance=*) WAYPOINT_DISTANCE="${arg#*=}" ;;
+        --map-only)            MAP_ONLY="1" ;;
+        --help|-h)             usage ;;
+        *) echo "Unknown argument: $arg"; usage ;;
+    esac
+done
+
+# --- Validate ---
+case "$DISTRO" in
+    humble|jazzy) ;;
+    *) echo "Unsupported distro '${DISTRO}'. Supported values: humble, jazzy"; exit 1 ;;
+esac
+
+case "$RMW" in
+    fastdds|cyclonedds|zenoh) ;;
+    *) echo "Unsupported RMW '${RMW}'. Supported values: fastdds, cyclonedds, zenoh"; exit 1 ;;
+esac
+
+# Map short names to ROS RMW implementation identifiers
+if [ "$RMW" = "cyclonedds" ]; then
+    RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
+elif [ "$RMW" = "zenoh" ]; then
+    RMW_IMPLEMENTATION="rmw_zenoh_cpp"
+else
+    RMW_IMPLEMENTATION="rmw_fastrtps_cpp"
+fi
+
+IMAGE_NAME="carla-map-and-lidar-demo-${DISTRO}-${RMW}"
+
+# --- Build ---
+if ! docker image inspect "${IMAGE_NAME}" &>/dev/null; then
+    "${SCRIPT_DIR}/map_and_lidar_demo/build.sh" --distro="${DISTRO}" --rmw="${RMW}"
+fi
+
+# --- RMW-specific environment variables ---
+EXTRA_ENV=()
+if [ "$RMW" = "cyclonedds" ]; then
+    EXTRA_ENV+=(--env="CYCLONEDDS_URI=/config/cyclonedds.xml")
+elif [ "$RMW" = "fastdds" ]; then
+    EXTRA_ENV+=(--env="FASTRTPS_DEFAULT_PROFILES_FILE=/config/fastrtps-profile.xml")
+fi
+
+# --- Run ---
+echo "[demo] Launching (distro=${DISTRO}, rmw=${RMW}, server=${HOST}:${PORT}, map-only=${MAP_ONLY})..."
+# The fixed container name makes a second concurrent run fail fast instead of
+# spawning a duplicate vehicle publishing on the same topics.
+docker run \
+    --rm \
+    --init \
+    --net=host \
+    --name="${IMAGE_NAME}" \
+    --stop-timeout=30 \
+    --env="RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}" \
+    --env="CARLA_HOST=${HOST}" \
+    --env="CARLA_PORT=${PORT}" \
+    --env="WAYPOINT_DISTANCE=${WAYPOINT_DISTANCE}" \
+    --env="MAP_ONLY=${MAP_ONLY}" \
+    "${EXTRA_ENV[@]}" \
+    --volume="${SCRIPT_DIR}/config:/config:ro" \
+    "${IMAGE_NAME}"

--- a/PythonAPI/examples/ros2/rviz/ros2_native.rviz
+++ b/PythonAPI/examples/ros2/rviz/ros2_native.rviz
@@ -131,10 +131,23 @@ Visualization Manager:
           Value: true
       Enabled: true
       Name: Lidar
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Map
+      Namespaces:
+        lane_boundaries: true
+        lane_centerlines: false
+      Topic:
+        Depth: 1
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /carla/map_markers
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: hero
+    Fixed Frame: map
     Frame Rate: 30
   Name: root
   Tools:

--- a/PythonAPI/examples/ros2/rviz/ros2_native.rviz
+++ b/PythonAPI/examples/ros2/rviz/ros2_native.rviz
@@ -88,7 +88,7 @@ Visualization Manager:
             Depth: 5
             Durability Policy: Volatile
             History Policy: Keep Last
-            Reliability Policy: Reliable
+            Reliability Policy: Best Effort
             Value: /carla/hero/rgb/image
           Value: true
       Enabled: true
@@ -124,7 +124,7 @@ Visualization Manager:
             Durability Policy: Volatile
             Filter size: 10
             History Policy: Keep Last
-            Reliability Policy: Reliable
+            Reliability Policy: Best Effort
             Value: /carla/hero/lidar/point_cloud
           Use Fixed Frame: true
           Use rainbow: true

--- a/PythonAPI/test/smoke/test_ros2.py
+++ b/PythonAPI/test/smoke/test_ros2.py
@@ -170,6 +170,23 @@ class TestROS2(SyncSmokeTest):
             dvs.destroy()
             sem_lidar.destroy()
 
+    def test_ros2_map_publish_on_reload(self):
+        """World reload re-publishes the latched OpenDRIVE map without crashing.
+
+        Every episode start publishes the map as a latched std_msgs/String on
+        rt/carla/map (NotifyBeginEpisode -> ROS2::ProcessDataFromMap). A crash
+        in the transient_local publisher or in the OpenDRIVE retrieval would
+        abort the reload or stop the world from ticking afterwards.
+        """
+        self.world = self.client.reload_world()
+        settings = carla.WorldSettings(
+            no_rendering_mode=False,
+            synchronous_mode=True,
+            fixed_delta_seconds=0.05)
+        self.world.apply_settings(settings)
+        for _ in range(5):
+            self.world.tick()
+
     def test_ros2_enable_disable_cycle(self):
         """Enable → tick → disable → tick → re-enable → tick: no crash or state leak.
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEngine.cpp
@@ -18,6 +18,7 @@
 #include "Runtime/Core/Public/Misc/App.h"
 #include "PhysicsEngine/PhysicsSettings.h"
 #include "Carla/MapGen/LargeMapManager.h"
+#include "Carla/OpenDrive/OpenDrive.h"
 
 #include <compiler/disable-ue4-macros.h>
 #include <carla/Logging.h>
@@ -296,6 +297,19 @@ void FCarlaEngine::NotifyBeginEpisode(UCarlaEpisode &Episode)
   Server.NotifyBeginEpisode(Episode);
 
   Episode.bIsPrimaryServer = bIsPrimaryServer;
+
+  #if defined(WITH_ROS2)
+  {
+    auto ROS2 = carla::ros2::ROS2::GetInstance();
+    if (ROS2->IsEnabled())
+    {
+      // Latched rt/carla/map sample; re-published on every map load so late
+      // joiners always receive the OpenDRIVE description of the current map.
+      const FString XODR = UOpenDrive::GetXODR(World);
+      ROS2->ProcessDataFromMap(std::string(TCHAR_TO_UTF8(*XODR)));
+    }
+  }
+  #endif
 }
 
 void FCarlaEngine::NotifyEndEpisode()


### PR DESCRIPTION
> Is recommended merge this PR after https://github.com/carla-simulator/carla/pull/9778

#### Description

The native ROS 2 interface streams sensor data well, but everything it publishes is volatile: a node that joins after the simulation has started has no way to learn anything about the world it is observing. The most basic piece of that picture is the map itself.

This PR teaches the publisher layer about durability. A publisher can now request transient local delivery, and each middleware (FastDDS, CycloneDDS and Zenoh) translates that into its own QoS, so the last sample is retained and delivered to late-joining subscribers. The default behavior of every existing topic is unchanged.

The first topic built on top of it is `/carla/map`, which carries the full OpenDRIVE description of the current map and is refreshed on every map load. Any ROS 2 node can read it at any time, with no connection to the simulator:

```bash
ros2 topic echo --qos-durability transient_local --once /carla/map
```

To show what that enables, the PR also adds a small example. A single command runs a demo stack in Docker against a server started with `--ros2`: it spawns the hero vehicle on autopilot, converts the latched map into lane markers and broadcasts the map to hero transform, so RViz displays the camera, the lidar point cloud and the town lane network together in one world-fixed view.

```bash
./run_map_and_lidar_demo.sh
./run_rviz.sh
```

The demo stack cleans up after itself: stopping the container destroys the vehicle and its sensors, and a new run removes anything left behind by a previous unclean exit.

Related to #9784 (first part of the series; ego vehicle topics and traffic lights follow in separate PRs, the last of which updates the CHANGELOG).

#### Preview

<img width="1921" height="1106" alt="carla-ros2-path" src="https://github.com/user-attachments/assets/4514a5da-f859-4489-a386-e9f5a98d97f1" />

#### Where has this been tested?

  * **Platform(s):** Linux (Ubuntu)
  * **Python version(s):** 3.10, 3.12
  * **Unreal Engine version(s):** 4.26

Validation: `make check.LibCarla ARGS="--ros2"` passes (140 server + 66 client tests, debug and release), `make CarlaUE4Editor` builds, full package build with `--ros2` passes the ROS 2 smoke tests, and a late-joining `ros2 topic echo` receives the latched map on all three `--rmw=` middlewares. The demo was run end-to-end against the packaged server and verified in RViz on ROS 2 Humble.

#### Possible Drawbacks

The latched map sample is kept in the middleware history, which holds the OpenDRIVE string (around 2 MB for the stock towns) in memory for the lifetime of the episode. On Zenoh, if the advanced publisher cache cannot be created, the publisher falls back to volatile delivery and logs a warning, so late joiners would not receive the map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9786)
<!-- Reviewable:end -->
