### PR TITLE
build(LibCarla, BuildTools): upgrade Fast-DDS to 2.14.6 LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Latest Changes
+ * Upgraded the bundled eProsima Fast-DDS used by the native ROS 2 integration from v2.11.2 to the v2.14.6 LTS line, moving serialization onto Fast-CDR 2.x while keeping the classic XCDRv1 wire format so published topics stay compatible with every ROS 2 distribution.
  * Added Zenoh as a third ROS 2 middleware backend, selectable at runtime via `--rmw=zenoh` alongside `--rmw=fastdds` and `--rmw=cyclonedds`.
  * Renamed the ROS2 abstraction layer from dds/DDS* to generic middleware/Middleware* naming to support future non-DDS backends like Zenoh. FastDDS and CycloneDDS vendor classes are unchanged.
  * Added NumPy 2 compatibility to the PythonAPI: replaced removed aliases (`np.bool`, `np.matrix`) in example scripts and upgraded Boost to 1.90.0, which ships the upstream NumPy 2 C ABI fix (boostorg/python#432) so the C extension builds against both NumPy 1.x (>=1.18.4) and NumPy 2.x

--- a/LibCarla/source/carla/ros2/middleware/fastdds/GenericCdrPubSubType.h
+++ b/LibCarla/source/carla/ros2/middleware/fastdds/GenericCdrPubSubType.h
@@ -67,7 +67,7 @@ class GenericCdrPubSubType : public eprosima::fastdds::dds::TopicDataType {
     eprosima::fastcdr::Cdr ser(
         fb,
         eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
-        eprosima::fastcdr::Cdr::DDS_CDR);
+        eprosima::fastcdr::CdrVersion::XCDRv1);
     payload->encapsulation = CDR_LE;
 
     try {
@@ -77,13 +77,26 @@ class GenericCdrPubSubType : public eprosima::fastdds::dds::TopicDataType {
       return false;
     }
 
-    const uint32_t len = static_cast<uint32_t>(ser.getSerializedDataLength());
+    const uint32_t len = static_cast<uint32_t>(ser.get_serialized_data_length());
     if (len > payload->max_size) {
       return false;
     }
     std::memcpy(payload->data, fb.getBuffer(), len);
     payload->length = len;
     return true;
+  }
+
+  /// FastDDS 2.13+ data-representation-aware serialize overload. CARLA always
+  /// emits classic CDR (XCDRv1, little-endian) regardless of the requested
+  /// representation, so this simply delegates to the 2-argument override. It
+  /// guarantees the writer path reaches our CDR serializer whichever overload
+  /// FastDDS calls internally.
+  bool serialize(
+      void* data,
+      SerializedPayload_t* payload,
+      eprosima::fastdds::dds::DataRepresentationId_t /*data_representation*/)
+      override {
+    return serialize(data, payload);
   }
 
   /// Deserialize a FastDDS payload buffer into a MsgType instance.
@@ -103,7 +116,7 @@ class GenericCdrPubSubType : public eprosima::fastdds::dds::TopicDataType {
     eprosima::fastcdr::Cdr deser(
         fastbuffer,
         eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
-        eprosima::fastcdr::Cdr::DDS_CDR);
+        eprosima::fastcdr::CdrVersion::XCDRv1);
 
     try {
       deser.read_encapsulation();
@@ -126,6 +139,16 @@ class GenericCdrPubSubType : public eprosima::fastdds::dds::TopicDataType {
     return [msg]() -> uint32_t {
       return cdr_serialized_size(*msg);
     };
+  }
+
+  /// FastDDS 2.13+ data-representation-aware size-provider overload. CARLA
+  /// serializes the same classic-CDR bytes regardless of the requested
+  /// representation, so this delegates to the 1-argument override.
+  std::function<uint32_t()> getSerializedSizeProvider(
+      void* data,
+      eprosima::fastdds::dds::DataRepresentationId_t /*data_representation*/)
+      override {
+    return getSerializedSizeProvider(data);
   }
 
   /// Allocate a new default-initialized MsgType on the heap.

--- a/LibCarla/source/carla/ros2/types/CdrSerialization.h
+++ b/LibCarla/source/carla/ros2/types/CdrSerialization.h
@@ -655,7 +655,7 @@ std::vector<uint8_t> serialize_to_cdr(const T& msg) {
   eprosima::fastcdr::Cdr cdr{
       fb,
       eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
-      eprosima::fastcdr::Cdr::DDS_CDR};
+      eprosima::fastcdr::CdrVersion::XCDRv1};
   try {
     cdr.serialize_encapsulation();
     serialize_cdr(cdr, msg);
@@ -663,7 +663,7 @@ std::vector<uint8_t> serialize_to_cdr(const T& msg) {
     return std::vector<uint8_t>{};
   }
   const char* buf{fb.getBuffer()};
-  const size_t len{cdr.getSerializedDataLength()};
+  const size_t len{cdr.get_serialized_data_length()};
   return std::vector<uint8_t>{
       reinterpret_cast<const uint8_t*>(buf),
       reinterpret_cast<const uint8_t*>(buf) + len};
@@ -680,10 +680,10 @@ uint32_t cdr_serialized_size(const T& msg) {
   eprosima::fastcdr::Cdr cdr{
       fb,
       eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
-      eprosima::fastcdr::Cdr::DDS_CDR};
+      eprosima::fastcdr::CdrVersion::XCDRv1};
   cdr.serialize_encapsulation();
   serialize_cdr(cdr, msg);
-  return static_cast<uint32_t>(cdr.getSerializedDataLength());
+  return static_cast<uint32_t>(cdr.get_serialized_data_length());
 }
 
 /// Deserialize a msg::X from a CDR byte buffer that was produced by
@@ -701,7 +701,7 @@ bool deserialize_from_cdr(
   eprosima::fastcdr::Cdr cdr{
       fb,
       eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
-      eprosima::fastcdr::Cdr::DDS_CDR};
+      eprosima::fastcdr::CdrVersion::XCDRv1};
   try {
     cdr.read_encapsulation();
     deserialize_cdr(cdr, msg);

--- a/LibCarla/source/test/server/test_ros2_middleware.cpp
+++ b/LibCarla/source/test/server/test_ros2_middleware.cpp
@@ -527,10 +527,12 @@ TEST(cdr_serialization, time_golden_xcdrv1_bytes) {
       0x00u, 0x01u, 0x00u, 0x00u,
       0x2Au, 0x00u, 0x00u, 0x00u,
       0x15u, 0xCDu, 0x5Bu, 0x07u};
+  // Assert the size first: a failed or short serialization then yields a
+  // targeted size mismatch instead of a noisy full-vector diff.
+  ASSERT_EQ(buf.size(), expected.size());
   EXPECT_EQ(buf, expected);
   // Discriminator byte: classic CDR_LE is 0x01; any XCDRv2 representation
   // (PLAIN_CDR2 / DELIMIT_CDR2 / PL_CDR2) would change byte 1.
-  ASSERT_GE(buf.size(), 2u);
   EXPECT_EQ(buf[0], 0x00u);
   EXPECT_EQ(buf[1], 0x01u);
 }

--- a/LibCarla/source/test/server/test_ros2_middleware.cpp
+++ b/LibCarla/source/test/server/test_ros2_middleware.cpp
@@ -505,6 +505,36 @@ TEST(cdr_serialization, time_round_trip) {
   EXPECT_EQ(recovered.nanosec, 123456789u);
 }
 
+// Byte-exact wire-format guard. The symmetric round-trip tests above cannot
+// detect an encoding drift (e.g. Fast-CDR defaulting to XCDRv2, which inserts
+// DHEADERs) because deserialize_from_cdr would consume whatever encoding
+// serialize_to_cdr emitted. This test pins the literal bytes so a regression
+// to XCDRv2 or big-endian is caught deterministically. These exact bytes are
+// what every backend puts on the wire: FastDDS via write_serialized_payload,
+// CycloneDDS via dds_writecdr (raw passthrough of serialize_to_cdr), and Zenoh.
+// Layout (classic CDR, encoding version 1, little-endian):
+//   00 01 00 00  encapsulation header (PLAIN_CDR little-endian + 2 option bytes)
+//   2A 00 00 00  sec    = int32  42        (0x0000002A, LE)
+//   15 CD 5B 07  nanosec= uint32 123456789 (0x075BCD15, LE)
+TEST(cdr_serialization, time_golden_xcdrv1_bytes) {
+  carla::ros2::msg::Time original{};
+  original.sec = 42;
+  original.nanosec = 123456789u;
+
+  const auto buf = carla::ros2::serialize_to_cdr(original);
+
+  const std::vector<uint8_t> expected{
+      0x00u, 0x01u, 0x00u, 0x00u,
+      0x2Au, 0x00u, 0x00u, 0x00u,
+      0x15u, 0xCDu, 0x5Bu, 0x07u};
+  EXPECT_EQ(buf, expected);
+  // Discriminator byte: classic CDR_LE is 0x01; any XCDRv2 representation
+  // (PLAIN_CDR2 / DELIMIT_CDR2 / PL_CDR2) would change byte 1.
+  ASSERT_GE(buf.size(), 2u);
+  EXPECT_EQ(buf[0], 0x00u);
+  EXPECT_EQ(buf[1], 0x01u);
+}
+
 TEST(cdr_serialization, header_round_trip) {
   carla::ros2::msg::Header original{};
   original.stamp.sec = 10;

--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -972,7 +972,7 @@ if ${USE_ROS2} ; then
     FAST_DDS_LIB_BASENAME=fast-dds-lib
     FAST_DDS_LIB_SOURCE_DIR=${PWD}/${FAST_DDS_LIB_BASENAME}-source
     FAST_DDS_LIB_REPO="https://github.com/eProsima/Fast-DDS.git"
-    FAST_DDS_LIB_BRANCH=v2.11.2
+    FAST_DDS_LIB_BRANCH=v2.14.6
 
     git clone --recurse-submodules --depth 1 --branch ${FAST_DDS_LIB_BRANCH} ${FAST_DDS_LIB_REPO} ${FAST_DDS_LIB_SOURCE_DIR}
 


### PR DESCRIPTION
#### Description

CARLA's native ROS 2 integration bundled eProsima Fast-DDS v2.11.2. This pull request moves it to the v2.14.6 LTS release, the Jazzy-era long-term support line, so the simulator builds against a maintained Fast-DDS that incorporates several years of fixes over the previous pin.

One consequence of the jump that reaches the code is that Fast-DDS 2.14 ships Fast-CDR 2.x instead of 1.x, which is a breaking change to the serialization API. Because CARLA serializes its ROS 2 message structs to CDR by hand rather than through generated type code, the migration stays small and contained. The serializer now explicitly requests the classic XCDRv1 encoding, since Fast-CDR 2.x otherwise defaults to XCDRv2, which inserts member headers and would break compatibility with current ROS 2 distributions, and it uses the renamed serialized-length accessor. The generic FastDDS type support also gains data-representation-aware serialize and size overloads that FastDDS 2.13 and later may call, each delegating to the existing path so that the writer always reaches the same serializer.

The wire format stays classic CDR, little-endian, so every published topic remains byte-compatible with all ROS 2 distributions. To make that guarantee explicit and durable, a new unit test pins the exact serialized bytes of a known message, which catches any future drift back to XCDRv2 or to a different endianness.

This change applies only to the `ue4-dev` branch. The `ue5-dev` pin is left at its current version and can be upgraded separately.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04 (Linux, x86_64)
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 4.26

Validation performed:

  * `make check.LibCarla ARGS="--ros2"`: all server and client unit tests pass, including the new byte-exact XCDRv1 wire-format test and the existing CDR round-trip tests.
  * `make package ARGS="--python-version=3.12 --ros2 ..."`: the full ROS 2 package builds successfully against Fast-DDS 2.14.6 and Fast-CDR 2.2.7.
  * On-wire check: with the packaged server running with `--ros2`, an external ROS 2 Humble node discovered every native topic with the correct type and decoded live data for Clock, Imu, NavSatFix, CameraInfo and TFMessage, confirming the classic XCDRv1 format is preserved end to end.

#### Possible Drawbacks

The CycloneDDS and Zenoh backends share the same hand-written CDR serializer, so they inherit the same encoding and wire-format guarantees. Windows continues to build only the FastDDS backend, as before. No behavior change is expected for existing users: this is a dependency upgrade with the wire format intentionally held constant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9789)
<!-- Reviewable:end -->
