### PR TITLE
Fix NumPy alias usage in PythonAPI examples

### DIFF
--- a/PythonAPI/examples/lidar_to_camera.py
+++ b/PythonAPI/examples/lidar_to_camera.py
@@ -231,8 +231,8 @@ def tutorial(args):
             intensity = intensity[points_in_canvas_mask]
 
             # Extract the screen coords (uv) as integers.
-            u_coord = points_2d[:, 0].astype(np.int)
-            v_coord = points_2d[:, 1].astype(np.int)
+            u_coord = points_2d[:, 0].astype(int)
+            v_coord = points_2d[:, 1].astype(int)
 
             # Since at the time of the creation of this script, the intensity function
             # is returning high values, these are adjusted to be nicely visualized.
@@ -240,7 +240,7 @@ def tutorial(args):
             color_map = np.array([
                 np.interp(intensity, VID_RANGE, VIRIDIS[:, 0]) * 255.0,
                 np.interp(intensity, VID_RANGE, VIRIDIS[:, 1]) * 255.0,
-                np.interp(intensity, VID_RANGE, VIRIDIS[:, 2]) * 255.0]).astype(np.int).T
+                np.interp(intensity, VID_RANGE, VIRIDIS[:, 2]) * 255.0]).astype(int).T
 
             if args.dot_extent <= 0:
                 # Draw the 2d points on the image as a single pixel using numpy.

--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -1208,7 +1208,7 @@ class CameraManager(object):
             # Example of converting the raw_data from a carla.DVSEventArray
             # sensor into a NumPy array and using it as an image
             dvs_events = np.frombuffer(image.raw_data, dtype=np.dtype([
-                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool)]))
+                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool_)]))
             dvs_img = np.zeros((image.height, image.width, 3), dtype=np.uint8)
             # Blue is positive, red is negative
             dvs_img[dvs_events[:]['y'], dvs_events[:]['x'], dvs_events[:]['pol'] * 2] = 255

--- a/PythonAPI/examples/manual_control_carsim.py
+++ b/PythonAPI/examples/manual_control_carsim.py
@@ -1063,7 +1063,7 @@ class CameraManager(object):
             # Example of converting the raw_data from a carla.DVSEventArray
             # sensor into a NumPy array and using it as an image
             dvs_events = np.frombuffer(image.raw_data, dtype=np.dtype([
-                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool)]))
+                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool_)]))
             dvs_img = np.zeros((image.height, image.width, 3), dtype=np.uint8)
             # Blue is positive, red is negative
             dvs_img[dvs_events[:]['y'], dvs_events[:]['x'], dvs_events[:]['pol'] * 2] = 255

--- a/PythonAPI/examples/manual_control_chrono.py
+++ b/PythonAPI/examples/manual_control_chrono.py
@@ -1071,7 +1071,7 @@ class CameraManager(object):
             # Example of converting the raw_data from a carla.DVSEventArray
             # sensor into a NumPy array and using it as an image
             dvs_events = np.frombuffer(image.raw_data, dtype=np.dtype([
-                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool)]))
+                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool_)]))
             dvs_img = np.zeros((image.height, image.width, 3), dtype=np.uint8)
             # Blue is positive, red is negative
             dvs_img[dvs_events[:]['y'], dvs_events[:]['x'], dvs_events[:]['pol'] * 2] = 255


### PR DESCRIPTION
## Summary
- replace removed `np.bool` aliases with `np.bool_` in DVS event dtypes
- replace removed `np.int` aliases with `int` in lidar-to-camera coordinate/color conversions

These aliases raise `AttributeError` with NumPy 2.x, which breaks the affected PythonAPI examples before they can run.

## Tests
- `rg -n "np\.(bool|int)\b" PythonAPI -S` (no matches)
- `python3 -m py_compile PythonAPI/examples/manual_control.py PythonAPI/examples/manual_control_carsim.py PythonAPI/examples/manual_control_chrono.py PythonAPI/examples/lidar_to_camera.py`
- `python3` NumPy dtype/conversion smoke check for `np.bool_` and `astype(int)`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9790)
<!-- Reviewable:end -->
