### PR TITLE
Fix lidar smoke helper signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Modernized the Python navigation agents with type hints and code cleanup ported from `ue4-dev`, added typed obstacle/traffic-light detection-result tuples in `agents/tools/hints.py`, reworked `BasicAgent.set_destination` to accept an optional start location and queue-clean flag, and fixed obstacle detection treating an empty `vehicle_list` as "all vehicles".
 * Updated the `invertedai_traffic.py` example with InvertedAI quality-of-life improvements for ego-vehicle integration and video generation.
+* Fixed `Sensor.get_current_detection_points` in the LiDAR smoke tests so it remains a valid instance method.
 * Added fisheye camera sensors (`sensor.camera.rgb_fisheye`, `sensor.camera.depth_fisheye`, `sensor.camera.semantic_segmentation_fisheye`, `sensor.camera.instance_segmentation_fisheye`) using the Kannala-Brandt projection model. Each variant captures up to 6 cubemap face render targets (the back face is skipped unless the FOV or equirectangular mode requires it) and composites them through a custom HLSL shader (`Plugins/Carla/Shaders/WideAngleLens.usf`) using configurable distortion coefficients. See `PythonAPI/examples/manual_control_fisheye.py` for an interactive demo. Ported from ue4-dev.
 * Fixed the Windows build: the setup now installs the MSVC 14.38 toolset required by the Unreal Engine 5.5.4 fork, MSVC builds use `/W4` instead of `/Wall`, and two Windows compile/link errors in LibCarla were fixed.
 * Added a Hybrid Solid-State LiDAR sensor (`sensor.lidar.hss_lidar`) modelled on the Hesai AT128, with configurable channels, horizontal/vertical FOV, and horizontal resolution. Reuses the rotating LiDAR's intensity, drop-off, and noise model.
@@ -97,5 +98,3 @@
 * RSS functionality removed from docs
 * Removed Light Manager from API and docs
 * Added Mine01 off-road mining map from Synkrotron
-
-

--- a/PythonAPI/test/smoke/test_lidar.py
+++ b/PythonAPI/test/smoke/test_lidar.py
@@ -88,7 +88,7 @@ class Sensor():
     def is_correct(self):
         return self.error is None
 
-    def get_current_detection_points():
+    def get_current_detection_points(self):
         return self.curr_det_pts
 
 class TestSyncLidar(SyncSmokeTest):

--- a/PythonAPI/test/unit/test_lidar_smoke_helpers.py
+++ b/PythonAPI/test/unit/test_lidar_smoke_helpers.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma de
+# Barcelona (UAB).
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+import ast
+import os
+import unittest
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+LIDAR_SMOKE_TEST = os.path.join(
+    REPO_ROOT, "PythonAPI", "test", "smoke", "test_lidar.py")
+
+
+class TestLidarSmokeHelpers(unittest.TestCase):
+    def test_get_current_detection_points_is_instance_method(self):
+        with open(LIDAR_SMOKE_TEST) as f:
+            module = ast.parse(f.read(), filename=LIDAR_SMOKE_TEST)
+
+        sensor_class = next(
+            node for node in module.body
+            if isinstance(node, ast.ClassDef) and node.name == "Sensor")
+        helper = next(
+            node for node in sensor_class.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "get_current_detection_points")
+
+        self.assertEqual(
+            [arg.arg for arg in helper.args.args],
+            ["self"],
+            "Sensor.get_current_detection_points must accept self")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Description

Fix `Sensor.get_current_detection_points` in `PythonAPI/test/smoke/test_lidar.py` by restoring the missing `self` parameter. Without it, calling the helper as an instance method raises a `TypeError` before it can return the latest detection points.

Add a focused AST-based regression test that verifies the helper remains an instance method, and document the fix in `CHANGELOG.md`.

Fixes #

#### Where has this been tested?

  * **Platform(s):** macOS
  * **Python version(s):** Python 3.11
  * **Unreal Engine version(s):** Not required; this is a Python smoke-test helper fix

Validation:

  * `python3.11 -m unittest PythonAPI.test.unit.test_lidar_smoke_helpers`
  * `python3.11 -m py_compile PythonAPI/test/smoke/test_lidar.py PythonAPI/test/unit/test_lidar_smoke_helpers.py`
  * `git diff --check`

#### Possible Drawbacks

None expected. The change only restores normal bound-method behavior for a smoke-test helper and adds a source-level regression test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9791)
<!-- Reviewable:end -->
