### PR TITLE
Fix MSVC build for DVS event encoding test

### DIFF
--- a/LibCarla/source/test/common/test_dvs_event_encoding.cpp
+++ b/LibCarla/source/test/common/test_dvs_event_encoding.cpp
@@ -90,12 +90,22 @@ TEST(DvsEventEncoding, out_of_bounds_events_are_dropped) {
 TEST(DvsEventEncoding, raw_byte_overload_matches_struct_overload) {
   // Packed wire layout for sensor::data::DVSEvent: 13 bytes (2 + 2 + 8 + 1).
   // Build a stride-13 byte stream and confirm both overloads agree.
+  // MSVC does not support GCC's `__attribute__((packed))`; use `#pragma pack`
+  // there (including clang-cl, which defines `_MSC_VER`).
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
   struct PackedEvent {
     std::uint16_t x;
     std::uint16_t y;
     std::int64_t t;
     bool pol;
+#ifdef _MSC_VER
+  };
+#pragma pack(pop)
+#else
   } __attribute__((packed));
+#endif
 
   PackedEvent raw_events[2] = {
       {2u, 1u, 100, true},


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [x] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes MSVC build bug:
Replace GCC-only `__attribute__((packed)`) on PackedEvent with `#pragma pack` under `_MSC_VER`, keeping the attribute on other compilers so the 13-byte wire layout test compiles with MSVC.

#### Where has this been tested?

  * **Platform(s):** Windows MSVC
  * **Python version(s):** N/A (C++ only).
  * **Unreal Engine version(s):** N/A (test + LibCarla, not UE editor/runtime).

#### Possible Drawbacks
None expected. Change is applied only to test code with `#ifedf` protector.
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9793)
<!-- Reviewable:end -->
