### PR TITLE
Fix self-occlusion for body/corner-mounted ray_cast lidar sensors

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -126,6 +126,13 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
   ResetRecordedHits(ChannelCount, PointsToScanWithOneLaser);
   PreprocessRays(ChannelCount, PointsToScanWithOneLaser);
 
+  // Body/corner-mounted lidars (as opposed to roof-mounted) can have a large
+  // fraction of their rays immediately blocked by the parent vehicle's own
+  // mesh, since the trace only ignores the sensor actor itself (see #1797,
+  // #1498). Ignoring the attach parent too removes this self-occlusion,
+  // mirroring the same pattern already used in ObstacleDetectionSensor.cpp.
+  AActor* ParentActor = GetAttachParentActor();
+
   GetWorld()->GetPhysicsScene()->GetPxScene()->lockRead();
   {
     TRACE_CPUPROFILER_EVENT_SCOPE(ParallelFor);
@@ -135,6 +142,10 @@ void ARayCastSemanticLidar::SimulateLidar(const float DeltaTime)
       FCollisionQueryParams TraceParams = FCollisionQueryParams(FName(TEXT("Laser_Trace")), true, this);
       TraceParams.bTraceComplex = true;
       TraceParams.bReturnPhysicalMaterial = false;
+      if (ParentActor)
+      {
+        TraceParams.AddIgnoredActor(ParentActor);
+      }
 
       for (auto idxPtsOneLaser = 0u; idxPtsOneLaser < PointsToScanWithOneLaser; idxPtsOneLaser++) {
         FHitResult HitResult;


### PR DESCRIPTION
## Problem

`sensor.lidar.ray_cast`'s trace (`RayCastSemanticLidar::SimulateLidar` -> `ShootLaser`) builds its `FCollisionQueryParams` with `InIgnoreActor = this` (the sensor itself), but never ignores the vehicle it's attached to:

```cpp
FCollisionQueryParams TraceParams = FCollisionQueryParams(FName(TEXT("Laser_Trace")), true, this);
```

For roof-mounted sensors this mostly clips a few rings against the roof — the only workaround anyone has found is "mount it higher" (#1797, #1498, both open since 2019, never fixed). For **corner/side/body-mounted sensors**, a large fraction of the horizontal FOV can be permanently blocked by the vehicle's own mesh, with no blueprint attribute or Python API to configure around it (confirmed via `world.get_blueprint_library().find('sensor.lidar.ray_cast')`'s full attribute list — no self-collision toggle exists).

## Fix

Ignore the sensor's attach-parent actor in the trace, in addition to the sensor itself. This mirrors the existing pattern already used in `ObstacleDetectionSensor.cpp` for exactly the same reason:

```cpp
FCollisionQueryParams TraceParams(FName(TEXT("ObstacleDetection Trace")), true, this);
...
TraceParams.AddIgnoredActor(this);
if (Super::GetOwner() != nullptr)
  TraceParams.AddIgnoredActor(Super::GetOwner());
```

`GetAttachParentActor()` is already used elsewhere in this same file (`PostPhysTick`, for the ROS2 relative-transform computation), so the parent handle is cheap to obtain. `RayCastLidar` inherits `SimulateLidar`/`ShootLaser` unchanged from `RayCastSemanticLidar`, so this fixes both `sensor.lidar.ray_cast` and `sensor.lidar.ray_cast_semantic`.

## Context / motivation

We hit this while modeling a 4-LiDAR sensor suite (front/rear long-range + two corner-mounted side units) for an autonomous-shuttle research project on CARLA 0.9.16. The two corner units measured only ~90-130° of real angular coverage out of a configured 220° FOV, independent of mount height/yaw/FOV tuning -- traced it down to this exact self-occlusion mechanism at the source level.

## Testing

I have **not** built/tested this against a running CARLA instance (no local UE4.26 build environment set up for this). The change is a minimal, direct application of an existing, already-shipped pattern in the same file/codebase (`ObstacleDetectionSensor.cpp`), so I'm submitting it for maintainer review/CI rather than claiming local verification. Happy to iterate based on review feedback (e.g. gating this behind an opt-in `LidarDescription` flag if changing the default self-occlusion behavior for all existing users is a concern).

Fixes #1797, Fixes #1498

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9804)
<!-- Reviewable:end -->
