### PR TITLE
fix(nav): defer retries for non-traversable walker routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed walker navigation repeatedly rebuilding failed, empty, or single-point routes on the same call stack, which could overflow the client stack when route generation remained unable to find a traversable path.
 * Added the `CARLA_MAPS_TO_COOK` CMake configure option to select which maps the `package` targets cook. Set it to a `+`-separated list of package paths (e.g. `/Game/Carla/Maps/Town10HD_Opt`) to produce a smaller package with only those maps; leave it empty (the default) to cook the full map list from `DefaultGame.ini`.
 * Fixed `from carla.command import ...` on the Python API by registering the `command` submodule under `carla.command` in `sys.modules` (the ue5 wheel ships `carla` as a bare extension module, so the previous `libcarla.command` namespace was not importable).
 * Modernized the Python navigation agents with type hints and code cleanup ported from `ue4-dev`, added typed obstacle/traffic-light detection-result tuples in `agents/tools/hints.py`, reworked `BasicAgent.set_destination` to accept an optional start location and queue-clean flag, and fixed obstacle detection treating an empty `vehicle_list` as "all vehicles".

--- a/LibCarla/source/carla/nav/WalkerManager.cpp
+++ b/LibCarla/source/carla/nav/WalkerManager.cpp
@@ -101,7 +101,10 @@ namespace nav {
                     break;
 
                 case WALKER_STOP:
-                    info.state = WALKER_IDLE;
+                    // Retry on the next update instead of recursively from
+                    // SetWalkerNextPoint. Route generation can legitimately
+                    // fail or return only the walker's current point.
+                    SetWalkerRoute(it.first);
                     break;
             }
         }
@@ -117,7 +120,8 @@ namespace nav {
 
         // set a new random target
         carla::geom::Location location;
-        _nav->GetRandomLocation(location, nullptr);
+        if (!_nav->GetRandomLocation(location, nullptr))
+            return false;
 
         // set the route
         return SetWalkerRoute(id, location);
@@ -146,10 +150,15 @@ namespace nav {
         info.state = WALKER_IDLE;
 
         // get a route from navigation
-        _nav->GetAgentRoute(id, info.from, to, path, area);
+        const bool route_found = _nav->GetAgentRoute(id, info.from, to, path, area);
 
         // create each point of the route
         info.route.clear();
+        if (!route_found) {
+            info.state = WALKER_STOP;
+            _nav->PauseAgent(id, true);
+            return false;
+        }
         info.route.reserve(path.size());
         unsigned char previous_area = CARLA_AREA_SIDEWALK;
         for (unsigned int i=0; i<path.size(); ++i) {
@@ -174,9 +183,18 @@ namespace nav {
             previous_area = area[i];
         }
 
+        // The first route point is the walker's current position, so a
+        // traversable route needs at least one more point. Keep the walker
+        // paused and let Update request another route on the next tick when
+        // the target is unreachable or already reached.
+        if (info.route.size() < 2u) {
+            info.state = WALKER_STOP;
+            _nav->PauseAgent(id, true);
+            return false;
+        }
+
         // assign the first point to go (second in the list)
-        SetWalkerNextPoint(id);
-        return true;
+        return SetWalkerNextPoint(id);
     }
 
     // set the next point in the route
@@ -207,8 +225,6 @@ namespace nav {
             // change the state
             info.state = WALKER_STOP;
             _nav->PauseAgent(id, true);
-            // we need a new route from here
-            SetWalkerRoute(id);
         }
 
         return true;

--- a/PythonAPI/test/smoke/test_walker_navigation.py
+++ b/PythonAPI/test/smoke/test_walker_navigation.py
@@ -96,8 +96,19 @@ class TestWalkerNavigation(SyncSmokeTest):
             self.world.tick()
 
             controller.start()
-            controller.go_to_location(self._destination_away_from(spawn_location))
             controller.set_max_speed(1.4)
+
+            # A destination at the current position can produce an empty or
+            # single-point path. WalkerManager previously requested its
+            # replacement recursively, so consecutive short routes could
+            # overflow the client stack.
+            controller.go_to_location(walker.get_location())
+            self.world.tick()
+            self.assertIsNotNone(
+                self.world.get_snapshot(),
+                "Server stopped responding after a zero-length walker route")
+
+            controller.go_to_location(self._destination_away_from(spawn_location))
 
             start = walker.get_location()
             for _ in range(120):


### PR DESCRIPTION
#### Description

`WalkerManager::SetWalkerNextPoint` immediately requested a new random route when a route was exhausted. `SetWalkerRoute` then called back into `SetWalkerNextPoint` even when `GetAgentRoute` failed or produced only the walker's current point. If route generation kept returning a failed, empty, or single-point path, the two methods recursively called each other until the client stack overflowed.

This change:

- checks failures from `GetRandomLocation` and `GetAgentRoute`;
- treats fewer than two filtered route points as non-traversable, since the first point is the walker's current position;
- keeps the walker paused and retries route generation from the next navigation update instead of the same call stack;
- preserves the immediate path for valid routes; and
- extends the walker navigation smoke coverage with a current-position destination before continuing to a valid destination.

Fixes #9103

#### Where has this been tested?

- **Platform(s):** Windows 11 host, WSL2 Ubuntu
- **Python version(s):** 3.x syntax validation and Ruff linting
- **Unreal Engine version(s):** Full UE5 server smoke test not run locally because the packaged server/content is not available; the regression is added to the existing packaged-server smoke suite for CI.

Validation performed:

- Compiled the actual modified `WalkerManager.cpp` with GCC 15 using `-std=c++17 -Wall -Wextra -Werror` against a controlled `Navigation` boundary.
- Reproduction guard observed 65 same-stack route-generation calls on the previous code for a single-point path.
- After the change, failed and single-point paths each make one attempt per update and remain paused; a two-point route still unpauses and dispatches its direct target immediately.
- `python -m py_compile PythonAPI/test/smoke/test_walker_navigation.py`
- `python -m ruff check PythonAPI/test/smoke/test_walker_navigation.py`
- `git diff --check`

#### Possible Drawbacks

A completed or non-traversable route now receives its random replacement on the next navigation update rather than recursively in the same call. With the smoke suite's 0.05-second fixed step this is at most one simulation tick, and it bounds both stack growth and retry work per tick.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9836)
<!-- Reviewable:end -->
