### PR TITLE
perf(sensor): process GPU readbacks off the render thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Added Docker-based development environment for CARLA UE5
 * Fixed potential segfault in LaneCrossingCalculator by adding a nullptr guard for missing lane marking records
 * Fixed traffic sign bounding box returned through the Python API to use the first valid trigger volume and preserve its rotation, with a guard against null trigger volumes
+* Improved sensor GPU readback performance by moving asynchronous readback completion off the render thread, removing the blocking GPU query and RHI-thread flush, and adding a bounded in-flight readback limit to prevent unbounded staging-buffer accumulation.
 
 ## CARLA 0.10.0
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/ImageUtil.cpp
@@ -15,6 +15,7 @@
 #include <RHIGPUReadback.h>
 #include <util/ue-header-guard-end.h>
 
+#include <atomic>
 #include <chrono>
 #include <thread>
 
@@ -198,6 +199,17 @@ namespace ImageUtil
 
 
 
+  // Backpressure for async GPU readbacks. With the per-frame RHI flush removed,
+  // the game/render threads can enqueue readbacks faster than they complete,
+  // growing memory without bound (this previously OOM-killed the editor at
+  // ~57 GB RSS). Cap the number of concurrent in-flight readbacks; when the
+  // consumer falls behind we skip a frame's capture instead of accumulating
+  // staging buffers. This is a soft cap (check-then-increment is not atomic as a
+  // pair, so it may transiently exceed by the number of concurrent producers);
+  // that is fine for bounding memory. Tunable / could be promoted to a CVar.
+  static std::atomic<int32> GReadbackInFlight{ 0 };
+  static constexpr int32 GMaxReadbackInFlight = 8;
+
   struct ReadImageDataContext
   {
     EPixelFormat Format;
@@ -217,9 +229,6 @@ namespace ImageUtil
     FRHIGPUReadbackPoolPtr Pool,
     ReadImageDataAsyncCallback&& Callback)
   {
-    static thread_local auto RenderQueryPool =
-        RHICreateRenderQueryPool(RQT_AbsoluteTime);
-
     auto& CmdList = FRHICommandListImmediate::Get();
     auto Resource = static_cast<FTextureRenderTarget2DResource*>(
       RenderTarget.GetResource());
@@ -241,14 +250,11 @@ namespace ImageUtil
     Self.Size = Texture->GetSizeXY();
     Self.Format = Texture->GetFormat();
     auto ResolveRect = FResolveRect();
+    // Just enqueue the async copy. The readback completion is polled off-thread
+    // in ReadImageDataEndAsync via IsReady(); we intentionally do NOT flush the
+    // RHI thread or block on a GPU query here (doing so serialized the whole
+    // pipeline and caused the per-frame render-thread stall).
     Self.Readback->EnqueueCopy(CmdList, Texture, ResolveRect);
-
-    auto Query = RenderQueryPool->AllocateQuery();
-    CmdList.EndRenderQuery(Query.GetQuery());
-    CmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThread);
-    uint64 DeltaTime;
-    RHIGetRenderQueryResult(Query.GetQuery(), DeltaTime, true);
-    Query.ReleaseQuery();
   }
 
   static void ReadImageDataEnd(
@@ -271,13 +277,22 @@ namespace ImageUtil
   static void ReadImageDataEndAsync(
     ReadImageDataContext&& Self)
   {
+    // ReadImageDataBegin bailed (e.g. null render target) without enqueuing a
+    // copy: release the reserved backpressure slot so the counter stays balanced.
+    if (Self.Readback == nullptr)
+    {
+      GReadbackInFlight.fetch_sub(1, std::memory_order_relaxed);
+      return;
+    }
     AsyncTask(
-      ENamedThreads::HighTaskPriority, [
+      ENamedThreads::AnyHiPriThreadHiPriTask, [
       Self = std::move(Self)]() mutable
     {
       while (!Self.Readback->IsReady())
         std::this_thread::sleep_for(std::chrono::microseconds(100));
       ReadImageDataEnd(Self);
+      // Release the in-flight slot once the readback is fully consumed.
+      GReadbackInFlight.fetch_sub(1, std::memory_order_relaxed);
     });
   }
 
@@ -298,6 +313,14 @@ namespace ImageUtil
     FRHIGPUReadbackPoolPtr Pool,
     ReadImageDataAsyncCallback&& Callback)
   {
+    // Backpressure: reserve an in-flight slot before enqueuing any GPU work. If
+    // the consumer is behind (at the cap), drop this frame's capture rather than
+    // let readback buffers accumulate without bound. The matching release is in
+    // ReadImageDataEndAsync (both the null-bail and the completion paths).
+    if (GReadbackInFlight.load(std::memory_order_relaxed) >= GMaxReadbackInFlight)
+      return false;
+    GReadbackInFlight.fetch_add(1, std::memory_order_relaxed);
+
     if (IsInRenderingThread())
     {
       ReadImageDataAsyncCommand(
@@ -313,7 +336,7 @@ namespace ImageUtil
       {
         ReadImageDataContext Context = { };
         ReadImageDataBegin(Context, RenderTarget, std::move(Pool), std::move(Callback));
-        ReadImageDataEnd(Context);
+        ReadImageDataEndAsync(std::move(Context));
       });
 
     }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch.
If it is for UE5 version of CARLA you merge against ue5-dev branch.

Checklist:

  - [x] Your branch is up-to-date with the ue5-dev branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with make check (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

#### Description

This pull request improves the asynchronous GPU readback path used by CARLA
sensors.

Previously, the readback path performed a GPU query and immediate RHI-thread
flush for each capture. This could block the render pipeline and prevent other
render work from progressing while waiting for GPU completion.

This change:

- Removes the blocking GPU query and immediate RHI-thread flush.
- Keeps GPU readback submission asynchronous.
- Moves readback completion polling to a high-priority worker task.
- Allows the render thread to continue submitting work without waiting for
  the GPU readback to complete.
- Adds a bounded in-flight readback counter as supporting backpressure.
- Drops a capture when the maximum number of in-flight readbacks is reached,
  preventing unbounded staging-buffer accumulation if the consumer falls behind.
- Releases the in-flight counter after readback completion or failed readback
  initialization.

The primary purpose of this change is to process asynchronous GPU readback
completion off the render thread. The in-flight limit is a secondary safeguard
to bound memory usage under load.

Fixes: N/A

#### Related issue

This PR also includes the `AnyHiPriThreadHiPriTask` change previously
reported in [#9825](https://github.com/carla-simulator/carla/issues/9825),
which addresses the UE5 Linux/Vulkan ImageUtil thread-deadlock path.

#### Performance

Under the same test conditions, the observed performance improved from
approximately **18–21 FPS** to **25–30 FPS**.

This corresponds to an absolute improvement of approximately **4–9 FPS**.
Using the midpoint of each range, performance increased from about **19.5 FPS**
to **27.5 FPS**, which is approximately a **40% improvement**.

The exact result depends on scene complexity, camera resolution, GPU, and the
number of active sensors.

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** Not applicable to the C++ readback implementation
  * **Unreal Engine version(s):** Unreal Engine 5 / CARLA UE5 branch
  * **Performance:** Approximately 18–21 FPS before and 25–30 FPS after under
    the same test conditions

#### Possible Drawbacks

- When the readback worker cannot keep up, captures are intentionally dropped
  after the in-flight limit is reached.
- The completion path uses a worker task that polls GPU-readiness with a short
  sleep interval, which consumes worker-thread time while waiting.
- Removing the immediate RHI flush changes the timing and ordering behavior of
  readback completion, so additional testing across GPUs and driver versions
  may be needed.
- The in-flight limit is currently a fixed value of 8 and may need tuning for
  different resolutions, frame rates, and hardware configurations.

#### Unreal Insights comparison

**Before:** the render thread is affected by the synchronous GPU query/RHI flush.

<img width="1470" height="896" alt="traffic_f1b" src="https://github.com/user-attachments/assets/656703e0-5e8d-4355-9f18-87290a8bcef2" />

**After:** GPU readback completion is handled asynchronously by a worker task,
allowing the render thread to continue processing.

<img width="1286" height="760" alt="threadasync_f5b" src="https://github.com/user-attachments/assets/57b8cd7b-7143-484e-89ae-c3544b345a3a" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9839)
<!-- Reviewable:end -->
