### PR TITLE
fix(Sensor): use point sampling for fisheye depth cubemap

### DIFF
--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/DepthCamera_WideAngleLens.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/DepthCamera_WideAngleLens.cpp
@@ -22,7 +22,7 @@ ADepthCamera_WideAngleLens::ADepthCamera_WideAngleLens(const FObjectInitializer 
 {
   // Depth is a measurement, not a colour: blending two cube faces across a
   // silhouette averages the near and far hit and emits a surface that exists
-  // nowhere, so the cubemap has to be point sampled like the label cameras.
+  // nowhere, so the cubemap has to be point sampled like the label cameras. 
   Super::SetCubemapSampler(CameraModelUtil::GetSampler(ESamplerFilter::SF_Point));
 
   AddPostProcessingMaterial(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/DepthCamera_WideAngleLens.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/DepthCamera_WideAngleLens.cpp
@@ -20,6 +20,11 @@ FActorDefinition ADepthCamera_WideAngleLens::GetSensorDefinition()
 ADepthCamera_WideAngleLens::ADepthCamera_WideAngleLens(const FObjectInitializer &ObjectInitializer)
   : Super(ObjectInitializer)
 {
+  // Depth is a measurement, not a colour: blending two cube faces across a
+  // silhouette averages the near and far hit and emits a surface that exists
+  // nowhere, so the cubemap has to be point sampled like the label cameras.
+  Super::SetCubemapSampler(CameraModelUtil::GetSampler(ESamplerFilter::SF_Point));
+
   AddPostProcessingMaterial(
 #if PLATFORM_LINUX
       TEXT("Material'/Carla/PostProcessingMaterials/WideAngleLens/DepthEffectMaterial_GLSL_WAL.DepthEffectMaterial_GLSL_WAL'")


### PR DESCRIPTION
## Summary
- Use point sampling for the fisheye depth camera cubemap instead of linear filtering.
- Prevents blended near/far depth values at cubemap face boundaries (phantom surfaces at silhouettes).
- Aligns depth wide-angle lens behavior with semantic/instance segmentation cameras, which already use point sampling.

# Test
I didn't do much tests. I ran 4 fisheye depth camera on car in Town01 for several meters, and convert the depth image to point cloud. After this fix, the noisy flying points gone, and the point cloud looks much better.

Just post the PR to let some one know this problem and provide a possible solution (without much test :(

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9840)
<!-- Reviewable:end -->
