### PR TITLE
Unify Weather and PostProcess control into BP_Carla_Sky

### DIFF
--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -230,6 +230,7 @@ class World(object):
         self._actor_filter = args.filter
         self._actor_generation = args.generation
         self._gamma = args.gamma
+        self._post_process_profile = args.post_process_profile
         self.restart()
         self.world.on_tick(hud.on_world_tick)
         self.recording_enabled = False
@@ -304,7 +305,7 @@ class World(object):
         self.lane_invasion_sensor = LaneInvasionSensor(self.player, self.hud)
         self.gnss_sensor = GnssSensor(self.player)
         self.imu_sensor = IMUSensor(self.player)
-        self.camera_manager = CameraManager(self.player, self.hud, self._gamma)
+        self.camera_manager = CameraManager(self.player, self.hud, self._gamma, self._post_process_profile)
         self.camera_manager.transform_index = cam_pos_index
         self.camera_manager.set_sensor(cam_index, notify=False)
         actor_type = get_actor_display_name(self.player)
@@ -1116,7 +1117,7 @@ class RadarSensor(object):
 
 
 class CameraManager(object):
-    def __init__(self, parent_actor, hud, gamma_correction):
+    def __init__(self, parent_actor, hud, gamma_correction, post_process_profile='Default'):
         self.sensor = None
         self.surface = None
         self._parent = parent_actor
@@ -1142,8 +1143,6 @@ class CameraManager(object):
                 (carla.Transform(carla.Location(x=-4.0, z=2.0), carla.Rotation(pitch=6.0)), Attachment.SpringArmGhost),
                 (carla.Transform(carla.Location(x=0, y=-2.5, z=-0.0), carla.Rotation(yaw=90.0)), Attachment.Rigid)]
         world = self._parent.get_world()
-        map_name = world.get_map().name
-        post_process_profile = self.get_post_process_profile(map_name)
         self.transform_index = 1
         self.sensors = [
             ['sensor.camera.rgb', cc.Raw, 'Camera RGB', {'post_process_profile' : post_process_profile }],
@@ -1241,13 +1240,6 @@ class CameraManager(object):
         if self.surface is not None:
             display.blit(self.surface, (0, 0))
     
-    def get_post_process_profile(self, map_name: str) -> str:
-        if "Town10HD_Opt" in map_name:
-            return "Town10HD_Opt"
-        if "Town_C" in map_name:
-            return "Town_C"
-        return "Default"
-
     @staticmethod
     def _parse_image(weak_self, image):
         self = weak_self()
@@ -1413,6 +1405,11 @@ def main():
     argparser.add_argument(
         '--gamma', default=1.0, type=float,
         help='Gamma correction of the camera (default: 1.0)')
+    argparser.add_argument(
+        '--post-process-profile', metavar='NAME', default='Default',
+        help='camera post-process profile to load, i.e. a file name (without '
+             '.json) under Unreal/CarlaUnreal/Content/Carla/Config/PostProcess/ '
+             '-- e.g. "Default" or "GoPro" (default: "Default")')
     argparser.add_argument(
         '--sync', action='store_true',
         help='Activate synchronous mode execution')

--- a/PythonAPI/examples/manual_control_rtlens.py
+++ b/PythonAPI/examples/manual_control_rtlens.py
@@ -226,6 +226,7 @@ class World(object):
         self._actor_filter = args.filter
         self._actor_generation = args.generation
         self._gamma = args.gamma
+        self._post_process_profile = args.post_process_profile
         self.restart()
         self.world.on_tick(hud.on_world_tick)
         self.recording_enabled = False
@@ -300,7 +301,7 @@ class World(object):
         self.lane_invasion_sensor = LaneInvasionSensor(self.player, self.hud)
         self.gnss_sensor = GnssSensor(self.player)
         self.imu_sensor = IMUSensor(self.player)
-        self.camera_manager = CameraManager(self.player, self.hud, self._gamma)
+        self.camera_manager = CameraManager(self.player, self.hud, self._gamma, self._post_process_profile)
         self.camera_manager.transform_index = cam_pos_index
         self.camera_manager.set_sensor(cam_index, notify=False)
         actor_type = get_actor_display_name(self.player)
@@ -1095,7 +1096,7 @@ class RadarSensor(object):
 
 
 class CameraManager(object):
-    def __init__(self, parent_actor, hud, gamma_correction):
+    def __init__(self, parent_actor, hud, gamma_correction, post_process_profile='Default'):
         self.sensor = None
         self.surface = None
         self._parent = parent_actor
@@ -1121,8 +1122,6 @@ class CameraManager(object):
                 (carla.Transform(carla.Location(x=-4.0, z=2.0), carla.Rotation(pitch=6.0)), Attachment.SpringArmGhost),
                 (carla.Transform(carla.Location(x=0, y=-2.5, z=-0.0), carla.Rotation(yaw=90.0)), Attachment.Rigid)]
         world = self._parent.get_world()
-        map_name = world.get_map().name
-        post_process_profile = self.get_post_process_profile(map_name)
         self.transform_index = 1
         self.sensors = [
             ['sensor.camera.rgb', cc.Raw, 'Camera RGB', {'post_process_profile' : post_process_profile }],
@@ -1219,13 +1218,6 @@ class CameraManager(object):
         if self.surface is not None:
             display.blit(self.surface, (0, 0))
     
-    def get_post_process_profile(self, map_name: str) -> str:
-        if "Town10HD_Opt" in map_name:
-            return "Town10HD_Opt"
-        if "Town_C" in map_name:
-            return "Town_C"
-        return "Default"
-
     @staticmethod
     def _parse_image(weak_self, image):
         self = weak_self()
@@ -1382,6 +1374,11 @@ def main():
     argparser.add_argument(
         '--gamma', default=1.0, type=float,
         help='Gamma correction of the camera (default: 1.0)')
+    argparser.add_argument(
+        '--post-process-profile', metavar='NAME', default='Default',
+        help='camera post-process profile to load, i.e. a file name (without '
+             '.json) under Unreal/CarlaUnreal/Content/Carla/Config/PostProcess/ '
+             '-- e.g. "Default" or "GoPro" (default: "Default")')
     argparser.add_argument(
         '--sync', action='store_true',
         help='Activate synchronous mode execution')

--- a/Unreal/CarlaUnreal/Config/DefaultEngine.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultEngine.ini
@@ -119,6 +119,7 @@ r.Lumen.TraceDistanceScale=1.0
 
 r.Shadow.Virtual.TranslucentQuality=1
 # r.Lumen.ScreenProbeGather.DownsampleFactor=8
+r.MegaLights.EnableForProject=True
 
 [SystemSettings]
 ; Applied via ApplyCVarSettingsFromIni at init, which CAN set ECVF_ReadOnly
@@ -251,6 +252,14 @@ g.TimeoutForBlockOnRenderFence=30000
 ; "LogNavigation: Warning: Null rawdata" (2000+ per session). Disabling the
 ; reuse path is the engine's own suggested workaround in that warning text.
 LevelStreaming.ShouldReuseUnloadedButStillAroundLevels=0
+
+; The hard swap to the Billowy volumetric cloud material at Cloudiness>=90
+; reads as a visible break (two completely different rendering techniques,
+; not just a density change) -- shadows disappear and the sky flattens to
+; white right at the threshold. Disabled until there's a real crossfade
+; between the two materials; this keeps the plain MI_Clouds master (with its
+; BaseNoiseExp formula extended through 100) for the whole 0-100 range.
+carla.Weather.EnableOvercastClouds=0
 
 [/Script/AIModule.AISense_Sight]
 bAutoRegisterAllPawnsAsSources=False

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -2167,25 +2167,15 @@ void UActorBlueprintFunctionLibrary::SetCamera(
         Description.Variations,
         TEXT(""));
 
-    // Empty or the legacy lowercase "default" sentinel means "no preference":
-    // load the profile named after the active map. Case-sensitive so an
-    // explicit "Default" still force-loads Default.json.
+    // Post-process profiles are camera-lens presets (Default, GoPro, ...),
+    // not per-map looks: the same BP_Carla_Sky + PostProcessVolume already
+    // gives every map the same base grading. Empty or the legacy lowercase
+    // "default" sentinel means "no preference", so just load Default.json.
+    // Callers that want a specific look (e.g. GoPro.json) set
+    // post_process_profile explicitly via the API/scripts.
     if (PostProcessProfileName.IsEmpty() || PostProcessProfileName == TEXT("default"))
     {
-      const UWorld *World = Camera->GetWorld();
-      FString MapName{};
-      if (World != nullptr)
-      {
-        MapName = World->GetMapName();
-        MapName.RemoveFromStart(World->StreamingLevelsPrefix);
-      }
-      else
-      {
-        UE_LOG(LogCarla, Warning,
-            TEXT("SetCamera: camera has no UWorld; falling back to Default post-process profile."));
-      }
-      const FString MapJsonPath = UPostProcessJsonUtils::GetPostProcessConfigPath(MapName);
-      PostProcessProfileName = FPaths::FileExists(MapJsonPath) ? MapName : TEXT("Default");
+      PostProcessProfileName = TEXT("Default");
     }
 
     UPostProcessJsonUtils::LoadAllPostProcessFromJsonToSceneCapture(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.cpp
@@ -95,9 +95,22 @@ bool UPostProcessJsonUtils::LoadAllPostProcessFromJsonToSceneCapture(USceneCaptu
         FPostProcessSettingsWrapper Wrapper;
         if (FJsonObjectConverter::JsonObjectStringToUStruct(InputString, &Wrapper, 0, 0))
         {
-            SensorCamera->PostProcessSettings = Wrapper.Settings; 
+            SensorCamera->PostProcessSettings = Wrapper.Settings;
             return true;
         }
     }
     return false;
+}
+
+TArray<FString> UPostProcessJsonUtils::GetAvailablePostProcessProfileNames()
+{
+    TArray<FString> ProfileNames;
+    const FString ConfigDir = FPaths::ProjectContentDir() / TEXT("Carla/Config/PostProcess/");
+    IFileManager::Get().FindFiles(ProfileNames, *(ConfigDir / TEXT("*.json")), true, false);
+    for (FString& Name : ProfileNames)
+    {
+        Name = FPaths::GetBaseFilename(Name);
+    }
+    ProfileNames.Sort();
+    return ProfileNames;
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/PostProcessJsonUtils.h
@@ -47,6 +47,13 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PostProcess|JSON")
     static bool LoadAllPostProcessFromJsonToSceneCapture(USceneCaptureComponent2D* SensorCamera, const FString& FileName);
 
+    // Names (without ".json") of every profile currently saved under
+    // Content/Carla/Config/PostProcess/. Backs the "Get Options" dropdown on
+    // APostProcessProfileVolume::ProfileName so artists can pick an existing
+    // profile or type a new one to create it on the next SaveProfile.
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PostProcess|JSON")
+    static TArray<FString> GetAvailablePostProcessProfileNames();
+
     static FString GetPostProcessConfigPath(const FString& FileName)
     {
         return FPaths::ProjectContentDir() / TEXT("Carla/Config/PostProcess/") + FileName + TEXT(".json");

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/WeatherJsonUtils.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/WeatherJsonUtils.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "BlueprintLibary/WeatherJsonUtils.h"
+
+#include "Dom/JsonObject.h"
+#include "HAL/FileManager.h"
+#include "JsonObjectConverter.h"
+#include "Misc/FileHelper.h"
+#include "Serialization/JsonSerializer.h"
+
+namespace
+{
+    TSharedRef<FJsonObject> LoadJsonRoot(const FString& Path)
+    {
+        FString InputString;
+        TSharedPtr<FJsonObject> Root;
+        if (FFileHelper::LoadFileToString(InputString, *Path))
+        {
+            TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(InputString);
+            FJsonSerializer::Deserialize(Reader, Root);
+        }
+        return Root.IsValid() ? Root.ToSharedRef() : MakeShared<FJsonObject>();
+    }
+
+    bool SaveJsonRoot(const TSharedRef<FJsonObject>& Root, const FString& Path)
+    {
+        FString OutputString;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+        if (!FJsonSerializer::Serialize(Root, Writer))
+            return false;
+        IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+        return FFileHelper::SaveStringToFile(OutputString, *Path);
+    }
+
+    // "time" or "conditions" sub-object of the shared Presets.json, creating
+    // it if this is the first preset saved in that catalog.
+    TSharedRef<FJsonObject> GetOrCreateCatalog(const TSharedRef<FJsonObject>& Root, const TCHAR* CatalogKey)
+    {
+        const TSharedPtr<FJsonObject>* Existing = nullptr;
+        if (Root->TryGetObjectField(CatalogKey, Existing) && Existing->IsValid())
+            return Existing->ToSharedRef();
+        TSharedRef<FJsonObject> Catalog = MakeShared<FJsonObject>();
+        Root->SetObjectField(CatalogKey, Catalog);
+        return Catalog;
+    }
+
+    template <typename TPresetStruct>
+    bool SavePreset(const TPresetStruct& Preset, const FString& Name, const TCHAR* CatalogKey)
+    {
+        TSharedRef<FJsonObject> Root = LoadJsonRoot(UWeatherJsonUtils::GetPresetsPath());
+        TSharedRef<FJsonObject> Catalog = GetOrCreateCatalog(Root, CatalogKey);
+
+        TSharedPtr<FJsonObject> PresetObject = FJsonObjectConverter::UStructToJsonObject(Preset);
+        if (!PresetObject.IsValid())
+            return false;
+        Catalog->SetObjectField(Name, PresetObject);
+
+        return SaveJsonRoot(Root, UWeatherJsonUtils::GetPresetsPath());
+    }
+
+    template <typename TPresetStruct>
+    bool LoadPreset(TPresetStruct& OutPreset, const FString& Name, const TCHAR* CatalogKey)
+    {
+        TSharedRef<FJsonObject> Root = LoadJsonRoot(UWeatherJsonUtils::GetPresetsPath());
+        const TSharedPtr<FJsonObject>* Catalog = nullptr;
+        if (!Root->TryGetObjectField(CatalogKey, Catalog) || !Catalog->IsValid())
+            return false;
+
+        const TSharedPtr<FJsonObject>* PresetObject = nullptr;
+        if (!(*Catalog)->TryGetObjectField(Name, PresetObject) || !PresetObject->IsValid())
+            return false;
+
+        return FJsonObjectConverter::JsonObjectToUStruct(PresetObject->ToSharedRef(), &OutPreset);
+    }
+
+    TArray<FString> GetCatalogNames(const TCHAR* CatalogKey)
+    {
+        TArray<FString> Names;
+        TSharedRef<FJsonObject> Root = LoadJsonRoot(UWeatherJsonUtils::GetPresetsPath());
+        const TSharedPtr<FJsonObject>* Catalog = nullptr;
+        if (Root->TryGetObjectField(CatalogKey, Catalog) && Catalog->IsValid())
+        {
+            for (const auto& Pair : (*Catalog)->Values)
+                Names.Add(FString(Pair.Key));
+        }
+        Names.Sort();
+        return Names;
+    }
+}
+
+bool UWeatherJsonUtils::SaveTimePreset(const FWeatherTimePreset& Preset, const FString& Name)
+{
+    return SavePreset(Preset, Name, TEXT("time"));
+}
+
+bool UWeatherJsonUtils::LoadTimePreset(FWeatherTimePreset& OutPreset, const FString& Name)
+{
+    return LoadPreset(OutPreset, Name, TEXT("time"));
+}
+
+bool UWeatherJsonUtils::SaveConditionPreset(const FWeatherConditionPreset& Preset, const FString& Name)
+{
+    return SavePreset(Preset, Name, TEXT("conditions"));
+}
+
+bool UWeatherJsonUtils::LoadConditionPreset(FWeatherConditionPreset& OutPreset, const FString& Name)
+{
+    return LoadPreset(OutPreset, Name, TEXT("conditions"));
+}
+
+TArray<FString> UWeatherJsonUtils::GetAvailableTimePresetNames()
+{
+    return GetCatalogNames(TEXT("time"));
+}
+
+TArray<FString> UWeatherJsonUtils::GetAvailableConditionPresetNames()
+{
+    return GetCatalogNames(TEXT("conditions"));
+}
+
+FWeatherParameters UWeatherJsonUtils::MergeWeatherPresets(
+    const FWeatherParameters& Base,
+    const FWeatherTimePreset& TimePreset,
+    const FWeatherConditionPreset& ConditionPreset)
+{
+    FWeatherParameters Result = Base;
+
+    Result.SunAzimuthAngle = TimePreset.SunAzimuthAngle;
+    Result.SunAltitudeAngle = TimePreset.SunAltitudeAngle;
+
+    Result.Cloudiness = ConditionPreset.Cloudiness;
+    Result.Precipitation = ConditionPreset.Precipitation;
+    Result.PrecipitationDeposits = ConditionPreset.PrecipitationDeposits;
+    Result.WindIntensity = ConditionPreset.WindIntensity;
+    Result.FogDensity = ConditionPreset.FogDensity;
+    Result.FogDistance = ConditionPreset.FogDistance;
+    Result.FogFalloff = ConditionPreset.FogFalloff;
+    Result.Wetness = ConditionPreset.Wetness;
+    Result.ScatteringIntensity = ConditionPreset.ScatteringIntensity;
+    Result.MieScatteringScale = ConditionPreset.MieScatteringScale;
+    Result.RayleighScatteringScale = ConditionPreset.RayleighScatteringScale;
+
+    return Result;
+}
+
+bool UWeatherJsonUtils::GetMapDefaultPresetNames(const FString& MapName, FString& OutTimeName, FString& OutConditionName)
+{
+    TSharedRef<FJsonObject> Root = LoadJsonRoot(GetMapDefaultsPath());
+    const TSharedPtr<FJsonObject>* MapEntry = nullptr;
+    if (!Root->TryGetObjectField(MapName, MapEntry) || !MapEntry->IsValid())
+        return false;
+
+    return (*MapEntry)->TryGetStringField(TEXT("time"), OutTimeName)
+        && (*MapEntry)->TryGetStringField(TEXT("condition"), OutConditionName);
+}
+
+bool UWeatherJsonUtils::SetMapDefaultPresetNames(const FString& MapName, const FString& TimeName, const FString& ConditionName)
+{
+    TSharedRef<FJsonObject> Root = LoadJsonRoot(GetMapDefaultsPath());
+
+    TSharedRef<FJsonObject> MapEntry = MakeShared<FJsonObject>();
+    MapEntry->SetStringField(TEXT("time"), TimeName);
+    MapEntry->SetStringField(TEXT("condition"), ConditionName);
+    Root->SetObjectField(MapName, MapEntry);
+
+    return SaveJsonRoot(Root, GetMapDefaultsPath());
+}
+
+bool UWeatherJsonUtils::GetMapDefaultWeather(const FString& MapName, const FWeatherParameters& Base, FWeatherParameters& OutWeather)
+{
+    TSharedRef<FJsonObject> Root = LoadJsonRoot(GetMapDefaultsPath());
+    const TSharedPtr<FJsonObject>* MapEntry = nullptr;
+    if (!Root->TryGetObjectField(MapName, MapEntry) || !MapEntry->IsValid())
+        return false;
+
+    FString TimeName, ConditionName;
+    const bool bIsPresetPair = (*MapEntry)->TryGetStringField(TEXT("time"), TimeName)
+        && (*MapEntry)->TryGetStringField(TEXT("condition"), ConditionName);
+    if (bIsPresetPair)
+    {
+        FWeatherTimePreset TimePreset;
+        FWeatherConditionPreset ConditionPreset;
+        if (!LoadTimePreset(TimePreset, TimeName) || !LoadConditionPreset(ConditionPreset, ConditionName))
+            return false;
+        OutWeather = MergeWeatherPresets(Base, TimePreset, ConditionPreset);
+        return true;
+    }
+
+    // Not a {time, condition} pair -- the entry itself is a full inline
+    // FWeatherParameters snapshot (see SetMapDefaultWeather). Start from Base
+    // so a future field this snapshot predates keeps Base's value instead of
+    // silently zeroing.
+    OutWeather = Base;
+    return FJsonObjectConverter::JsonObjectToUStruct((*MapEntry).ToSharedRef(), &OutWeather);
+}
+
+bool UWeatherJsonUtils::SetMapDefaultWeather(const FString& MapName, const FWeatherParameters& Weather)
+{
+    TSharedRef<FJsonObject> Root = LoadJsonRoot(GetMapDefaultsPath());
+
+    TSharedPtr<FJsonObject> WeatherObject = FJsonObjectConverter::UStructToJsonObject(Weather);
+    if (!WeatherObject.IsValid())
+        return false;
+    Root->SetObjectField(MapName, WeatherObject);
+
+    return SaveJsonRoot(Root, GetMapDefaultsPath());
+}

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/WeatherJsonUtils.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/BlueprintLibary/WeatherJsonUtils.h
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Carla/Weather/WeatherParameters.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Misc/Paths.h"
+#include "WeatherJsonUtils.generated.h"
+
+// Sun position only -- everything a "time of day" preset (Sunrise, Noon,
+// Sunset, Night...) needs to say.
+USTRUCT(BlueprintType)
+struct FWeatherTimePreset
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "360.0"))
+    float SunAzimuthAngle = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "-90.0", ClampMax = "90.0"))
+    float SunAltitudeAngle = 75.0f;
+};
+
+// Everything else in FWeatherParameters -- what a "weather condition" preset
+// (Clear, Cloudy, Rain...) means to set, independent of time of day.
+USTRUCT(BlueprintType)
+struct FWeatherConditionPreset
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float Cloudiness = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float Precipitation = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float PrecipitationDeposits = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float WindIntensity = 0.35f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+    float FogDensity = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+    float FogDistance = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0"))
+    float FogFalloff = 0.2f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float Wetness = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "100.0"))
+    float ScatteringIntensity = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "5.0"))
+    float MieScatteringScale = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0.0", ClampMax = "2.0"))
+    float RayleighScatteringScale = 0.0331f;
+};
+
+UCLASS()
+class CARLA_API UWeatherJsonUtils : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+
+    // Both catalogs -- every named time preset and every named condition
+    // preset -- live together in one file, Config/Weather/Presets.json:
+    //   { "time": { "Noon": {...}, "Town10_dusk": {...} },
+    //     "conditions": { "Clear": {...}, "Rain": {...} } }
+    // A custom preset invented while tuning one map (e.g. "Town10_dusk")
+    // lands in the same shared catalog, so it can be picked for any other
+    // map's default too -- nothing is namespaced per-map.
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool SaveTimePreset(const FWeatherTimePreset& Preset, const FString& Name);
+
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool LoadTimePreset(UPARAM(ref) FWeatherTimePreset& OutPreset, const FString& Name);
+
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool SaveConditionPreset(const FWeatherConditionPreset& Preset, const FString& Name);
+
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool LoadConditionPreset(UPARAM(ref) FWeatherConditionPreset& OutPreset, const FString& Name);
+
+    // Names of every saved preset in each catalog. Back the "Get Options"
+    // dropdowns on ASkyBase::TimePresetName / ConditionPresetName.
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Weather|JSON")
+    static TArray<FString> GetAvailableTimePresetNames();
+
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Weather|JSON")
+    static TArray<FString> GetAvailableConditionPresetNames();
+
+    // Applies TimePreset's sun position and ConditionPreset's everything-else
+    // on top of Base (so fields neither preset touches -- there aren't any
+    // today, but future ones -- keep whatever Base already had).
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Weather|JSON")
+    static FWeatherParameters MergeWeatherPresets(
+        const FWeatherParameters& Base,
+        const FWeatherTimePreset& TimePreset,
+        const FWeatherConditionPreset& ConditionPreset);
+
+    // Per-map default preset names, read from MapDefaults.json:
+    //   { "Town10HD_Opt": { "time": "Noon", "condition": "Clear" } }
+    // Returns false if the map has no entry.
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool GetMapDefaultPresetNames(const FString& MapName, FString& OutTimeName, FString& OutConditionName);
+
+    // Writes/overwrites MapName's entry in MapDefaults.json as a reference to
+    // two named catalog presets.
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool SetMapDefaultPresetNames(const FString& MapName, const FString& TimeName, const FString& ConditionName);
+
+    // MapName's entry, resolved regardless of which of the two shapes
+    // MapDefaults.json holds it in:
+    //   { "Town10HD_Opt": { "time": "Noon", "condition": "Clear" } }         -- named presets, merged onto Base
+    //   { "Town10HD_Opt": { "sunAzimuthAngle": 180, "cloudiness": 5, ... } } -- a full inline snapshot
+    // A map's hand-tuned one-off setup doesn't need a named preset invented
+    // just to be reachable as its default -- and doesn't pollute the shared
+    // Presets.json catalog other maps pick from. Returns false if the map has
+    // no entry, or a named-preset entry names a preset that no longer exists.
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool GetMapDefaultWeather(const FString& MapName, const FWeatherParameters& Base, UPARAM(ref) FWeatherParameters& OutWeather);
+
+    // Writes/overwrites MapName's entry in MapDefaults.json as a full inline
+    // snapshot of Weather -- no named preset involved on either side.
+    UFUNCTION(BlueprintCallable, Category = "Weather|JSON")
+    static bool SetMapDefaultWeather(const FString& MapName, const FWeatherParameters& Weather);
+
+    static FString GetPresetsPath()
+    {
+        return FPaths::ProjectContentDir() / TEXT("Carla/Config/Weather/Presets.json");
+    }
+
+    static FString GetMapDefaultsPath()
+    {
+        return FPaths::ProjectContentDir() / TEXT("Carla/Config/Weather/MapDefaults.json");
+    }
+};

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Game/CarlaGameModeBase.cpp
@@ -14,6 +14,7 @@
 #include "Carla/Vehicle/VehicleSpawnPoint.h"
 #include "Carla/Util/BoundingBoxCalculator.h"
 #include "Carla/Weather/Sky.h"
+#include "BlueprintLibary/WeatherJsonUtils.h"
 
 #include <util/disable-ue4-macros.h>
 #include "carla/opendrive/OpenDriveParser.h"
@@ -182,18 +183,10 @@ void ACarlaGameModeBase::InitGame(
       UE_LOG(LogCarla, Log, TEXT(
           "World Partition map without a sky rig: spawned BP_Carla_Sky"));
     }
-    // Town10 also places BP_GeneralSceneSettings alongside the sky; give
-    // converted maps the same baseline actors.
-    UClass* SceneSettingsClass = LoadClass<AActor>(
-        nullptr,
-        TEXT("/Game/Carla/Blueprints/BP_GeneralSceneSettings.BP_GeneralSceneSettings_C"));
-    if (SceneSettingsClass != nullptr &&
-        UGameplayStatics::GetActorOfClass(World, SceneSettingsClass) == nullptr)
-    {
-      World->SpawnActor<AActor>(SceneSettingsClass);
-      UE_LOG(LogCarla, Log, TEXT(
-          "World Partition map without scene settings: spawned BP_GeneralSceneSettings"));
-    }
+    // BP_GeneralSceneSettings used to be spawned alongside the sky here too,
+    // but everything it did (post-process delta-baseline, cloud density) is
+    // now handled natively in AWeather::ApplyWeatherToSkyActor -- no actor
+    // needed.
   }
 
   AActor* WeatherActor =
@@ -299,7 +292,25 @@ void ACarlaGameModeBase::BeginPlay()
 
   if (Episode->Weather != nullptr)
   {
-    Episode->Weather->ApplyWeather(carla::rpc::WeatherParameters::Default);
+    // Per-map defaults now come from MapDefaults.json (either a named
+    // {time, condition} preset pair via ASkyBase::SetAsMapDefault, or a full
+    // inline snapshot via ASkyBase::SaveCurrentWeatherAsMapDefault --
+    // GetMapDefaultWeather resolves whichever shape the entry is), not the
+    // flat carla::rpc::WeatherParameters::Default sentinel (which forces e.g.
+    // SunAltitudeAngle to -1 regardless of what the map's sky rig was
+    // authored with). Fall back to the old sentinel only for maps with no
+    // MapDefaults.json entry yet.
+    FString MapName = World->GetMapName();
+    MapName.RemoveFromStart(World->StreamingLevelsPrefix);
+    FWeatherParameters DefaultWeather;
+    if (UWeatherJsonUtils::GetMapDefaultWeather(MapName, Episode->Weather->GetCurrentWeather(), DefaultWeather))
+    {
+      Episode->Weather->ApplyWeather(DefaultWeather);
+    }
+    else
+    {
+      Episode->Weather->ApplyWeather(carla::rpc::WeatherParameters::Default);
+    }
   }
 
   /// @todo Recorder should not tick here, FCarlaEngine should do it.

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
@@ -79,6 +79,12 @@ UCarlaLight::UCarlaLight()
   PrimaryComponentTick.bCanEverTick = false;
 }
 
+void UCarlaLight::OnRegister()
+{
+  Super::OnRegister();
+  RegisterLight();
+}
+
 void UCarlaLight::BeginPlay()
 {
   Super::BeginPlay();
@@ -118,6 +124,21 @@ void UCarlaLight::RegisterLight()
 
 void UCarlaLight::OnComponentDestroyed(bool bDestroyingHierarchy)
 {
+  // OnRegister above now registers in the editor too, not just BeginPlay --
+  // so a component actually destroyed (level edit, not just a construction-
+  // script re-register, which doesn't hit this at all) needs to unregister
+  // here too, or deleting a light in the editor leaves a dangling pointer in
+  // the subsystem until the next EndPlay/Deinitialize. Safe to call
+  // alongside EndPlay's own unregister: both go through UnregisterLight,
+  // which no-ops if already absent.
+  UWorld* World = GetWorld();
+  if (World != nullptr)
+  {
+    if (UCarlaLightSubsystem* CarlaLightSubsystem = World->GetSubsystem<UCarlaLightSubsystem>())
+      CarlaLightSubsystem->UnregisterLight(this);
+  }
+  flags &= ~ECarlaLightFlags::Registered;
+
   Super::OnComponentDestroyed(bDestroyingHierarchy);
 }
 
@@ -252,7 +273,12 @@ void UCarlaLight::SetLightOn(bool bOn)
 void UCarlaLight::HandleDayTimeChanged(bool bIsDay)
 {
   DayTimeChanged(bIsDay);
-  if (LightType == ELightType::Street)
+  // Street already auto-toggled; Building and Vehicle (parked-car decoration,
+  // not the ego vehicle's driver-controlled lights) should too -- "Other" is
+  // left alone, its members are too varied to assume night-on is always right.
+  if (LightType == ELightType::Street
+      || LightType == ELightType::Building
+      || LightType == ELightType::Vehicle)
   {
     SetLightOn(!bIsDay);
   }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.cpp
@@ -116,8 +116,14 @@ void UCarlaLight::RegisterLight()
   UWorld *World = GetWorld();
   if (World != nullptr)
   {
-    UCarlaLightSubsystem* CarlaLightSubsystem = World->GetSubsystem<UCarlaLightSubsystem>();
-    CarlaLightSubsystem->RegisterLight(this);
+    // OnRegister now runs for every world, including inactive worlds
+    // (e.g. double-clicking a map asset in the Content Browser opens an
+    // EWorldType::Inactive preview world). UCarlaLightSubsystem doesn't
+    // support that world type, so GetSubsystem returns nullptr there.
+    if (UCarlaLightSubsystem* CarlaLightSubsystem = World->GetSubsystem<UCarlaLightSubsystem>())
+    {
+      CarlaLightSubsystem->RegisterLight(this);
+    }
   }
   flags |= ECarlaLightFlags::Registered;
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Lights/CarlaLight.h
@@ -114,6 +114,14 @@ public:
 
   UCarlaLight();
 
+  // Registers with UCarlaLightSubsystem so it can preview day/night toggling
+  // in the editor too, not just once actually playing -- BeginPlay (the only
+  // other place that calls RegisterLight) never fires outside Play/PIE, so
+  // in a pure editor world nothing was ever registered and the day/night
+  // broadcast had zero listeners. RegisterLight() is idempotent (checks its
+  // own Registered flag), so this is harmless alongside BeginPlay's call.
+  void OnRegister() override;
+
   void BeginPlay() override;
 
   void EndPlay(const EEndPlayReason::Type EndPlayReason) override;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -625,8 +625,16 @@ protected:
   UPROPERTY(VisibleAnywhere)
   TObjectPtr<USceneCaptureComponent2D_CARLA> CaptureComponent2D = nullptr;
 
+  // Standard RGB/depth/segmentation cameras (MakeCameraDefinition) never
+  // register a "gamma" blueprint attribute -- only Wide Angle Lens and
+  // RayTraced Lens cameras do, defaulting it to 2.2 (sRGB). Client code that
+  // guards on bp.has_attribute('gamma') before setting it (e.g.
+  // manual_control.py's --gamma) silently no-ops for the standard camera, so
+  // this default is the only gamma that ever actually applies to it. 2.4
+  // reads visibly brighter/blown-out next to the editor/server's own ~2.2
+  // display gamma; match it instead.
   UPROPERTY(EditAnywhere)
-  float TargetGamma = 2.4f;
+  float TargetGamma = 2.2f;
 
   /// Image width in pixels.
   UPROPERTY(EditAnywhere)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Sky.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Sky.cpp
@@ -10,6 +10,61 @@
 #include "Components/SkyAtmosphereComponent.h"
 #include <util/ue-header-guard-end.h>
 
+#include "BlueprintLibary/PostProcessJsonUtils.h"
+#include "BlueprintLibary/WeatherJsonUtils.h"
+#include "Carla/Weather/Weather.h"
+
+#include <util/ue-header-guard-begin.h>
+#include "Kismet/GameplayStatics.h"
+#include <util/ue-header-guard-end.h>
+
+namespace
+{
+    AWeather* FindWeatherActor(const UWorld* World)
+    {
+        return World != nullptr
+            ? Cast<AWeather>(UGameplayStatics::GetActorOfClass(World, AWeather::StaticClass()))
+            : nullptr;
+    }
+
+    // "Current weather" for this sky rig: if a BP_CarlaWeather happens to be
+    // placed in the level, its Weather member is authoritative (same value
+    // the API/recorder see). Otherwise fall back to this actor's own "Sky
+    // Parameters" -- kept in sync by ApplyWeatherTo below -- so none of this
+    // requires an AWeather actor to be placed at all.
+    FWeatherParameters GetEffectiveCurrentWeather(AActor* SkyActor)
+    {
+        if (AWeather* Weather = FindWeatherActor(SkyActor->GetWorld()))
+            return Weather->GetCurrentWeather();
+        if (FWeatherParameters* Params = ASkyBase::FindWeatherParameters(SkyActor))
+            return *Params;
+        return FWeatherParameters();
+    }
+
+    // Applies NewWeather to this sky rig. Prefers routing through a placed
+    // AWeather (full pipeline: post-process camera blendables, day/night
+    // light broadcast, recorder) when one exists; otherwise pushes directly
+    // to the rig via the same per-actor logic AWeather itself uses.
+    void ApplyWeatherTo(AActor* SkyActor, const FWeatherParameters& NewWeather)
+    {
+        if (AWeather* Weather = FindWeatherActor(SkyActor->GetWorld()))
+            Weather->ApplyWeather(NewWeather);
+        else
+            AWeather::ApplyWeatherToSkyActor(SkyActor, NewWeather);
+    }
+}
+
+
+FWeatherParameters* ASkyBase::FindWeatherParameters(AActor* SkyActor)
+{
+	for (TFieldIterator<FProperty> It(SkyActor->GetClass()); It; ++It)
+	{
+		FStructProperty* StructProperty = CastField<FStructProperty>(*It);
+		if (StructProperty != nullptr && StructProperty->Struct == FWeatherParameters::StaticStruct())
+			return StructProperty->ContainerPtrToValuePtr<FWeatherParameters>(SkyActor);
+	}
+	return nullptr;
+}
 
 ASkyBase::ASkyBase(
 	const FObjectInitializer& ObjectInitializer) :
@@ -23,6 +78,13 @@ ASkyBase::ASkyBase(
 
   DirectionalLightComponentSun = CreateDefaultSubobject<UDirectionalLightComponent>("DirectionalLightComponentSun");
   DirectionalLightComponentSun->SetupAttachment(RootComponent);
+  // Both lights default to ForwardShadingPriority 0, so forward shading/
+  // translucency/volumetric fog fall back to picking whichever is brighter
+  // right now -- flip-flopping as day turns to night -- and the engine logs
+  // "Multiple directional lights are competing..." every time. The Sun
+  // should always win outright; it's the one everything (fog, water,
+  // volumetrics) is actually meant to be lit by.
+  DirectionalLightComponentSun->ForwardShadingPriority = 1;
 
   DirectionalLightComponentMoon = CreateDefaultSubobject<UDirectionalLightComponent>("DirectionalLightComponentMoon");
   DirectionalLightComponentMoon->SetupAttachment(RootComponent);
@@ -36,4 +98,318 @@ ASkyBase::ASkyBase(
   SkyAtmosphereComponent = CreateDefaultSubobject<USkyAtmosphereComponent>("SkyAtmosphereComponent");
   SkyAtmosphereComponent->SetupAttachment(RootComponent);
 
+}
+
+void ASkyBase::SaveProfile()
+{
+  UPostProcessJsonUtils::SaveAllPostProcessComponentToJson(PostProcessComponent, ProfileName);
+}
+
+void ASkyBase::LoadProfile()
+{
+  UPostProcessJsonUtils::LoadAllPostProcessFromJsonToPostProcessComponent(PostProcessComponent, ProfileName);
+
+  // Profiles that don't claim AutoExposureMinBrightness/MaxBrightness (i.e.
+  // rely on Weather's fallback clamp, see ApplyWeatherToSkyActor) store those
+  // overrides as false -- loading them resets the component straight back to
+  // the engine's own AutoExposure defaults until something else happens to
+  // re-trigger the fallback. Re-run it immediately so a profile switch alone
+  // (no other property edit in between) doesn't leave exposure unclamped.
+  RefreshWeather();
+
+  // CameraParameters is a curated view onto the same Settings this profile
+  // just overwrote wholesale -- resync it so the shortcuts reflect the
+  // loaded profile instead of whatever was left over from before.
+  SyncCameraParametersFromPostProcess();
+}
+
+void ASkyBase::CreateProfile()
+{
+  if (NewProfileName.IsEmpty())
+    return;
+  ProfileName = NewProfileName;
+  SaveProfile();
+}
+
+TArray<FString> ASkyBase::GetAvailablePostProcessProfileNamesForPicker()
+{
+  return UPostProcessJsonUtils::GetAvailablePostProcessProfileNames();
+}
+
+void ASkyBase::ApplyTimeAndConditionPresets()
+{
+  FWeatherTimePreset TimePreset;
+  FWeatherConditionPreset ConditionPreset;
+  const bool bTimeOk = UWeatherJsonUtils::LoadTimePreset(TimePreset, TimePresetName);
+  const bool bConditionOk = UWeatherJsonUtils::LoadConditionPreset(ConditionPreset, ConditionPresetName);
+  if (!bTimeOk && !bConditionOk)
+    return;
+
+  // Only overwrite the half that actually loaded, so a missing condition
+  // preset (say) doesn't reset the sun position to defaults.
+  FWeatherParameters Base = GetEffectiveCurrentWeather(this);
+  if (!bTimeOk)
+  {
+    TimePreset.SunAzimuthAngle = Base.SunAzimuthAngle;
+    TimePreset.SunAltitudeAngle = Base.SunAltitudeAngle;
+  }
+  if (!bConditionOk)
+  {
+    ConditionPreset.Cloudiness = Base.Cloudiness;
+    ConditionPreset.Precipitation = Base.Precipitation;
+    ConditionPreset.PrecipitationDeposits = Base.PrecipitationDeposits;
+    ConditionPreset.WindIntensity = Base.WindIntensity;
+    ConditionPreset.FogDensity = Base.FogDensity;
+    ConditionPreset.FogDistance = Base.FogDistance;
+    ConditionPreset.FogFalloff = Base.FogFalloff;
+    ConditionPreset.Wetness = Base.Wetness;
+    ConditionPreset.ScatteringIntensity = Base.ScatteringIntensity;
+    ConditionPreset.MieScatteringScale = Base.MieScatteringScale;
+    ConditionPreset.RayleighScatteringScale = Base.RayleighScatteringScale;
+  }
+
+  ApplyWeatherTo(this, UWeatherJsonUtils::MergeWeatherPresets(Base, TimePreset, ConditionPreset));
+
+  // A hand-edit of a WeatherParameters field always gets a FULL editor
+  // reconstruction cycle for free (property edit -> OnConstruction -> the
+  // Blueprint's own construction graph runs, THEN this class's C++ override
+  // re-pushes). This function updates the struct and pushes natively, same
+  // as OnConstruction's own push, but skips the Blueprint graph's own pass
+  // entirely -- if that pass does any one-time setup the raw push doesn't
+  // replicate (respawning/re-registering the sky sphere, stars material,
+  // etc.), the result can look wrong until some later, unrelated edit
+  // finally triggers a real reconstruction. Force that same full cycle here
+  // instead of leaving it to chance. Editor-only API -- irrelevant at
+  // runtime anyway, OnConstruction only ever runs once there, at spawn.
+#if WITH_EDITOR
+  RerunConstructionScripts();
+#endif
+}
+
+void ASkyBase::B_SaveTimePreset()
+{
+  const FWeatherParameters Current = GetEffectiveCurrentWeather(this);
+  FWeatherTimePreset Preset;
+  Preset.SunAzimuthAngle = Current.SunAzimuthAngle;
+  Preset.SunAltitudeAngle = Current.SunAltitudeAngle;
+  UWeatherJsonUtils::SaveTimePreset(Preset, TimePresetName);
+}
+
+void ASkyBase::C_SaveConditionPreset()
+{
+  const FWeatherParameters Current = GetEffectiveCurrentWeather(this);
+  FWeatherConditionPreset Preset;
+  Preset.Cloudiness = Current.Cloudiness;
+  Preset.Precipitation = Current.Precipitation;
+  Preset.PrecipitationDeposits = Current.PrecipitationDeposits;
+  Preset.WindIntensity = Current.WindIntensity;
+  Preset.FogDensity = Current.FogDensity;
+  Preset.FogDistance = Current.FogDistance;
+  Preset.FogFalloff = Current.FogFalloff;
+  Preset.Wetness = Current.Wetness;
+  Preset.ScatteringIntensity = Current.ScatteringIntensity;
+  Preset.MieScatteringScale = Current.MieScatteringScale;
+  Preset.RayleighScatteringScale = Current.RayleighScatteringScale;
+  UWeatherJsonUtils::SaveConditionPreset(Preset, ConditionPresetName);
+}
+
+void ASkyBase::F_CreateTimePreset()
+{
+  if (NewTimePresetName.IsEmpty())
+    return;
+  TimePresetName = NewTimePresetName;
+  B_SaveTimePreset();
+}
+
+void ASkyBase::G_CreateConditionPreset()
+{
+  if (NewConditionPresetName.IsEmpty())
+    return;
+  ConditionPresetName = NewConditionPresetName;
+  C_SaveConditionPreset();
+}
+
+void ASkyBase::RefreshWeather()
+{
+  if (FWeatherParameters* SkyParameters = ASkyBase::FindWeatherParameters(this))
+    ApplyWeatherTo(this, *SkyParameters);
+}
+
+void ASkyBase::H_LoadMapDefault()
+{
+  const UWorld* World = GetWorld();
+  if (World == nullptr)
+    return;
+  FString MapName = World->GetMapName();
+  MapName.RemoveFromStart(World->StreamingLevelsPrefix);
+
+  const FWeatherParameters Base = GetEffectiveCurrentWeather(this);
+  FWeatherParameters MapDefault;
+  if (UWeatherJsonUtils::GetMapDefaultWeather(MapName, Base, MapDefault))
+  {
+    ApplyWeatherTo(this, MapDefault);
+#if WITH_EDITOR
+    RerunConstructionScripts();  // see the comment in ApplyTimeAndConditionPresets
+#endif
+  }
+}
+
+void ASkyBase::PushCameraParameters()
+{
+  FPostProcessSettings& Settings = PostProcessComponent->Settings;
+
+  // NOTE: ShutterSpeed/ISO/Aperture only actually affect the image when
+  // ExposureMode is AEM_Manual -- under AEM_Histogram (the default, what
+  // Default/Test.json use) UE's auto exposure ignores them entirely, they're
+  // visually inert. Flip ExposureMode below to Manual to make them matter
+  // (that's what GoPro.json does). A separate attempt at making them work
+  // under Histogram too, by forcing AutoExposureApplyPhysicalCameraExposure
+  // on, was reverted: it broke night-time exposure (fights the auto-exposure
+  // system's own day/night adaptation).
+
+  // ExposureMinEV/MaxEV are intentionally NOT pushed here (read-only,
+  // display-only in FCameraParameters -- see SyncCameraParametersFromPost
+  // Process below). Default/Test.json deliberately leave these two fields
+  // unclaimed (bOverride_AutoExposureMinBrightness/MaxBrightness = false) so
+  // AWeather::ApplyWeatherToSkyActor's own fallback can fill them in per
+  // push; forcing them here on every edit claimed them permanently, and once
+  // that got captured by a SaveProfile click it corrupted Default.json into
+  // a fixed EV range that badly over-exposed night scenes (the moon at night
+  // rendering as a blown-out blue sky). Fixed by reverting that override in
+  // Default.json; don't reintroduce the same push here.
+  Settings.bOverride_LocalExposureHighlightContrastScale = true;
+  Settings.LocalExposureHighlightContrastScale = CameraParameters.HighlightContrast;
+  Settings.bOverride_LocalExposureShadowContrastScale = true;
+  Settings.LocalExposureShadowContrastScale = CameraParameters.ShadowContrast;
+
+  Settings.bOverride_CameraShutterSpeed = true;
+  Settings.CameraShutterSpeed = CameraParameters.ShutterSpeed;
+  Settings.bOverride_AutoExposureMethod = true;
+  Settings.AutoExposureMethod = CameraParameters.ExposureMode;
+  Settings.bOverride_CameraISO = true;
+  Settings.CameraISO = CameraParameters.ISO;
+  Settings.bOverride_DepthOfFieldFstop = true;
+  Settings.DepthOfFieldFstop = CameraParameters.Aperture;
+
+  Settings.bOverride_DepthOfFieldSensorWidth = true;
+  Settings.DepthOfFieldSensorWidth = CameraParameters.SensorWidth;
+  Settings.bOverride_DepthOfFieldFocalDistance = true;
+  Settings.DepthOfFieldFocalDistance = CameraParameters.FocalDistance;
+
+  Settings.bOverride_WhiteTemp = true;
+  Settings.WhiteTemp = CameraParameters.Temperature;
+  Settings.bOverride_WhiteTint = true;
+  Settings.WhiteTint = CameraParameters.Tint;
+  Settings.bOverride_SceneColorTint = true;
+  Settings.SceneColorTint = CameraParameters.SceneColorTint;
+  Settings.bOverride_ColorSaturation = true;
+  Settings.ColorSaturation = FVector4(CameraParameters.GlobalSaturation, CameraParameters.GlobalSaturation,
+      CameraParameters.GlobalSaturation, Settings.ColorSaturation.W);
+  Settings.bOverride_ColorContrast = true;
+  Settings.ColorContrast = FVector4(CameraParameters.GlobalContrast, CameraParameters.GlobalContrast,
+      CameraParameters.GlobalContrast, Settings.ColorContrast.W);
+  Settings.bOverride_ColorGamma = true;
+  Settings.ColorGamma = FVector4(CameraParameters.GlobalGamma, CameraParameters.GlobalGamma,
+      CameraParameters.GlobalGamma, Settings.ColorGamma.W);
+  Settings.bOverride_VignetteIntensity = true;
+  Settings.VignetteIntensity = CameraParameters.VignetteIntensity;
+}
+
+void ASkyBase::SyncCameraParametersFromPostProcess()
+{
+  const FPostProcessSettings& Settings = PostProcessComponent->Settings;
+
+  CameraParameters.ExposureMinEV = Settings.AutoExposureMinBrightness;
+  CameraParameters.ExposureMaxEV = Settings.AutoExposureMaxBrightness;
+  CameraParameters.HighlightContrast = Settings.LocalExposureHighlightContrastScale;
+  CameraParameters.ShadowContrast = Settings.LocalExposureShadowContrastScale;
+
+  CameraParameters.ShutterSpeed = Settings.CameraShutterSpeed;
+  CameraParameters.ExposureMode = Settings.AutoExposureMethod;
+  CameraParameters.ISO = Settings.CameraISO;
+  CameraParameters.Aperture = Settings.DepthOfFieldFstop;
+
+  CameraParameters.SensorWidth = Settings.DepthOfFieldSensorWidth;
+  CameraParameters.FocalDistance = Settings.DepthOfFieldFocalDistance;
+
+  CameraParameters.Temperature = Settings.WhiteTemp;
+  CameraParameters.Tint = Settings.WhiteTint;
+  CameraParameters.SceneColorTint = Settings.SceneColorTint;
+  CameraParameters.GlobalSaturation = Settings.ColorSaturation.X;
+  CameraParameters.GlobalContrast = Settings.ColorContrast.X;
+  CameraParameters.GlobalGamma = Settings.ColorGamma.X;
+  CameraParameters.VignetteIntensity = Settings.VignetteIntensity;
+}
+
+#if WITH_EDITOR
+void ASkyBase::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+  Super::PostEditChangeProperty(PropertyChangedEvent);
+
+  const FName PropertyName = PropertyChangedEvent.GetPropertyName();
+  if (PropertyName == GET_MEMBER_NAME_CHECKED(ASkyBase, TimePresetName)
+      || PropertyName == GET_MEMBER_NAME_CHECKED(ASkyBase, ConditionPresetName))
+  {
+    ApplyTimeAndConditionPresets();
+  }
+}
+#endif
+
+void ASkyBase::OnConstruction(const FTransform& Transform)
+{
+  Super::OnConstruction(Transform);
+
+  // OnConstruction also fires once at actor spawn in a game world (PIE or
+  // packaged), not just on editor property edits. Pushing here unconditionally
+  // meant BOTH this AND ACarlaGameModeBase::BeginPlay's own weather push ran
+  // at Play start, and SetSkySphere's respawn (destroy-old, spawn-new) isn't
+  // safe against two independent, near-simultaneous callers -- it produced
+  // duplicate BP_Sky_Sphere/DirectionalLight actors and the "multiple
+  // directional lights competing" warning. Editor-only: let BeginPlay's push
+  // be the sole driver once actually playing.
+  if (GetWorld() != nullptr && GetWorld()->IsGameWorld())
+    return;
+
+  // Direct push, not ApplyWeatherTo: this must never depend on finding an
+  // AWeather actor (irrelevant here) or go through its full pipeline (camera
+  // blendables, recorder) -- just put this rig's own components back in sync
+  // with whatever "Sky Parameters" already holds.
+  if (FWeatherParameters* SkyParameters = ASkyBase::FindWeatherParameters(this))
+    AWeather::ApplyWeatherToSkyActor(this, *SkyParameters);
+
+  // Same self-healing story as Sky Parameters above: any edit reruns
+  // Construction and would otherwise leave CameraParameters' last pushed
+  // values sitting unapplied against a Settings struct that just got reset.
+  PushCameraParameters();
+}
+
+void ASkyBase::E_SetAsMapDefault()
+{
+  const UWorld* World = GetWorld();
+  if (World == nullptr)
+    return;
+  FString MapName = World->GetMapName();
+  MapName.RemoveFromStart(World->StreamingLevelsPrefix);
+  UWeatherJsonUtils::SetMapDefaultPresetNames(MapName, TimePresetName, ConditionPresetName);
+}
+
+void ASkyBase::D_SaveCurrentWeatherAsMapDefault()
+{
+  const UWorld* World = GetWorld();
+  if (World == nullptr)
+    return;
+  FString MapName = World->GetMapName();
+  MapName.RemoveFromStart(World->StreamingLevelsPrefix);
+  if (FWeatherParameters* SkyParameters = ASkyBase::FindWeatherParameters(this))
+    UWeatherJsonUtils::SetMapDefaultWeather(MapName, *SkyParameters);
+}
+
+TArray<FString> ASkyBase::GetAvailableTimePresetNamesForPicker()
+{
+  return UWeatherJsonUtils::GetAvailableTimePresetNames();
+}
+
+TArray<FString> ASkyBase::GetAvailableConditionPresetNamesForPicker()
+{
+  return UWeatherJsonUtils::GetAvailableConditionPresetNames();
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Sky.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Sky.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/ue-header-guard-begin.h>
+#include "Engine/Scene.h"
 #include "GameFramework/Actor.h"
 #include <util/ue-header-guard-end.h>
 
@@ -13,7 +14,87 @@ class USkyLightComponent;
 class UVolumetricCloudComponent;
 class USkyAtmosphereComponent;
 
-UCLASS(Abstract)
+// Curated shortcuts into PostProcessComponent's Settings -- the handful of
+// camera/exposure/color-grading fields an artist actually reaches for per
+// shot, without hunting through the full "Post Process Volume" category
+// (hundreds of fields). This is NOT a second, parallel post process: editing
+// these pushes straight into the same Settings that category also edits, and
+// they're kept in sync with whatever PostProcess profile is loaded (see
+// ASkyBase::SyncCameraParametersFromPostProcess). For anything not listed
+// here, go edit "Post Process Volume" directly -- it's still the same volume.
+USTRUCT(BlueprintType)
+struct FCameraParameters
+{
+	GENERATED_BODY()
+
+	// Exposure (FPostProcessSettings::AutoExposureMinBrightness/MaxBrightness,
+	// in EV100 -- what Weather's own exposure fallback also fills in for any
+	// PostProcess profile that doesn't claim them itself).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Exposure")
+	float ExposureMinEV = 10.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Exposure")
+	float ExposureMaxEV = 12.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Exposure")
+	float HighlightContrast = 1.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Exposure")
+	float ShadowContrast = 1.0f;
+
+	// Camera (Lens|Camera in the full Post Process Volume category).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Camera")
+	float ShutterSpeed = 60.0f;
+
+	// AKA metering/exposure method: AEM_Histogram (auto, scene-average --
+	// what every profile here uses) vs AEM_Manual (fixed, actually reads
+	// ShutterSpeed/ISO/Aperture below for real camera-triangle exposure).
+	// ISO/Aperture do nothing visible under Histogram -- flip this to Manual
+	// to make them matter.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Camera")
+	TEnumAsByte<EAutoExposureMethod> ExposureMode = AEM_Histogram;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Camera")
+	float ISO = 100.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Camera")
+	float Aperture = 4.0f;
+
+	// Depth of Field (Lens|Depth of Field).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Depth Of Field")
+	float SensorWidth = 24.576f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Depth Of Field")
+	float FocalDistance = 1000.0f;
+
+	// Color Grading. GlobalSaturation/Contrast/Gamma are single-knob
+	// shortcuts onto the full RGB+luma FVector4 fields (ColorSaturation/
+	// ColorContrast/ColorGamma) -- they set all three color channels equally
+	// and leave the luma (w) channel untouched. Use "Post Process Volume" ->
+	// Color Grading|Global directly for per-channel control.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float Temperature = 6500.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float Tint = 0.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	FLinearColor SceneColorTint = FLinearColor::White;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float GlobalSaturation = 1.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float GlobalContrast = 1.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float GlobalGamma = 1.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Color Grading")
+	float VignetteIntensity = 0.4f;
+};
+
+UCLASS(Abstract, PrioritizeCategories = "CustomParameters PostProcessProfile WeatherPreset")
 class CARLA_API ASkyBase :
 	public AActor
 {
@@ -23,7 +104,186 @@ public:
 
 	ASkyBase(const FObjectInitializer& ObjectInitializer);
 
+	// The actor's FWeatherParameters variable (a Blueprint-added variable on
+	// BP_Carla_Sky, currently named "WeatherParameters" -- but matched by
+	// TYPE, not name, so it survives being renamed again in the Blueprint
+	// editor). The single source of truth every lookup here and in
+	// AWeather::ApplyWeatherToSkyActor must go through -- don't re-implement
+	// a name-based search elsewhere, that's exactly what broke last time.
+	static FWeatherParameters* FindWeatherParameters(AActor* SkyActor);
+
+	// Profile to load/save on PostProcessComponent, i.e. the JSON file name
+	// (without extension) under Content/Carla/Config/PostProcess/. Pick an
+	// existing one from the dropdown or type a new name to create it on the
+	// next SaveProfile.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PostProcessProfile",
+		meta = (GetOptions = "GetAvailablePostProcessProfileNamesForPicker"))
+	FString ProfileName = TEXT("Default");
+
+	// Writes PostProcessComponent's current Settings -- edited live, in the
+	// normal "Settings" category of the component, absolute values, no
+	// delta/remap -- to Config/PostProcess/<ProfileName>.json. This is
+	// exactly what a spawned camera loads at runtime for that profile.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "PostProcessProfile")
+	void SaveProfile();
+
+	// Loads Config/PostProcess/<ProfileName>.json into PostProcessComponent's
+	// Settings, replacing whatever is currently set. Also refreshes
+	// CameraParameters (below) from the newly loaded Settings so those
+	// shortcuts never show a stale value, and re-applies Weather's exposure
+	// fallback immediately (see RefreshWeather) instead of waiting for some
+	// unrelated later property edit to do it.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "PostProcessProfile")
+	void LoadProfile();
+
+	// Name for a brand new profile -- free text, not restricted to the
+	// dropdown above. CreateProfile sets ProfileName to this and saves.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PostProcessProfile")
+	FString NewProfileName;
+
+	// Sets ProfileName = NewProfileName and saves the current Settings under
+	// it, creating Config/PostProcess/<NewProfileName>.json. Use this to
+	// start a new profile from the current PostProcessComponent state; the
+	// dropdown above picks it up on the next click.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "PostProcessProfile")
+	void CreateProfile();
+
+	// Curated shortcuts onto PostProcessComponent's Settings -- see
+	// FCameraParameters. Kept in sync with whatever profile LoadProfile last
+	// loaded; edit here for the common cases, or go to "Post Process Volume"
+	// directly for anything not exposed here.
+	//
+	// Category is "CustomParameters", same as the Blueprint's own "Sky
+	// Parameters"/"Weather Parameters" variable -- sharing one category name
+	// (set on that BP variable too, from the Blueprint editor) groups both
+	// under a single header instead of two.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "CustomParameters")
+	FCameraParameters CameraParameters;
+
+	// Time-of-day preset (sun position only) and weather-condition preset
+	// (everything else -- cloudiness/rain/wind/fog/wetness/...), both named
+	// entries in the shared catalog Config/Weather/Presets.json. Independent
+	// axes: pick any time with any condition. Selecting either one applies it
+	// immediately (see PostEditChangeProperty) -- no separate Load button.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WeatherPreset",
+		meta = (GetOptions = "GetAvailableTimePresetNamesForPicker", DisplayName = "Time Preset"))
+	FString TimePresetName = TEXT("Noon");
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WeatherPreset",
+		meta = (GetOptions = "GetAvailableConditionPresetNamesForPicker", DisplayName = "Condition Preset"))
+	FString ConditionPresetName = TEXT("Clear");
+
+	// CallInEditor buttons in one category are always shown together, above
+	// the category's properties, sorted alphabetically by function name --
+	// not declaration order, and Unreal doesn't offer a way to interleave
+	// them with the dropdowns/textboxes below. These are named B_/C_/D_...
+	// (no A_: that was LoadPreset, removed -- see PostEditChangeProperty) so
+	// that alphabetical order matches the intended reading order (the two
+	// Saves, then the two MapDefault buttons, then the two Creates, then
+	// LoadMapDefault); DisplayName keeps each button's own label clean.
+
+	// Saves the map's current sun position (AWeather::GetCurrentWeather) to
+	// the "time" catalog under TimePresetName.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "SaveTimePreset"))
+	void B_SaveTimePreset();
+
+	// Saves everything else in the map's current weather to the "conditions"
+	// catalog under ConditionPresetName.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "SaveConditionPreset"))
+	void C_SaveConditionPreset();
+
+	// Saves this actor's current "Sky Parameters" as this map's default
+	// directly -- a full inline snapshot in MapDefaults.json, not a reference
+	// to two named Presets.json entries. Use this for a one-off hand-tuned
+	// setup that doesn't need to exist as a reusable Time/Condition preset
+	// other maps could also pick.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "SaveCurrentWeatherAsMapDefault"))
+	void D_SaveCurrentWeatherAsMapDefault();
+
+	// Saves TimePresetName/ConditionPresetName as this map's default pair in
+	// MapDefaults.json -- what ACarlaGameModeBase::BeginPlay loads for this
+	// map from now on instead of the flat carla::rpc::WeatherParameters::Default.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "SetAsMapDefault"))
+	void E_SetAsMapDefault();
+
+	// Free-text name for a brand new time preset. CreateTimePreset sets
+	// TimePresetName to this and saves -- e.g. a bespoke "Town10_dusk" you
+	// can later pick as another map's default too, same shared catalog.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WeatherPreset")
+	FString NewTimePresetName;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WeatherPreset")
+	FString NewConditionPresetName;
+
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "CreateTimePreset"))
+	void F_CreateTimePreset();
+
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "CreateConditionPreset"))
+	void G_CreateConditionPreset();
+
+	// Loads and applies this map's current default weather from
+	// MapDefaults.json -- whichever shape it's in, a named Time/Condition
+	// preset pair or a hand-tuned inline snapshot (see
+	// UWeatherJsonUtils::GetMapDefaultWeather). There was no way to get back
+	// to a map's custom default once you'd hand-edited Sky Parameters away
+	// from it, short of re-entering the values by hand; this just re-applies
+	// whatever SetAsMapDefault/SaveCurrentWeatherAsMapDefault last saved.
+	UFUNCTION(BlueprintCallable, CallInEditor, Category = "WeatherPreset", meta = (DisplayName = "LoadMapDefault"))
+	void H_LoadMapDefault();
+
 protected:
+
+	// Editing ANY property on a placed Blueprint actor in the editor Details
+	// panel reruns its Construction Script, and BP_Carla_Sky's own
+	// construction resets components like VolumetricCloudComponent's material
+	// back to their authored/instance default -- undoing whatever
+	// RefreshWeather/LoadPreset just pushed the moment you touch an unrelated
+	// field. OnConstruction runs right after every such rerun (and once at
+	// spawn/Play), so re-push "Sky Parameters" here to make that self-healing:
+	// any edit still ends with the rig showing the current weather.
+	virtual void OnConstruction(const FTransform& Transform) override;
+
+#if WITH_EDITOR
+	// Applies TimePresetName/ConditionPresetName as soon as either dropdown
+	// is changed -- OnConstruction can't do this itself (it fires on every
+	// property edit with no way to tell which one changed; re-applying the
+	// selected presets on every WeatherParameters/CameraParameters edit too
+	// would stomp hand-tuning right back to the preset every keystroke).
+	// Replaces the old separate LoadPreset button.
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+
+	// Loads TimePresetName + ConditionPresetName and applies the merged
+	// result through the map's AWeather actor (same pipeline the API/client
+	// uses), so the sky rig actually refreshes -- not just this actor's own
+	// WeatherParameters variable, which the rig only reads from when told to.
+	void ApplyTimeAndConditionPresets();
+
+	// Writes CameraParameters into PostProcessComponent->Settings (claiming
+	// each field's bOverride_*), and the reverse -- reads Settings back into
+	// CameraParameters. See FCameraParameters and LoadProfile.
+	void PushCameraParameters();
+	void SyncCameraParametersFromPostProcess();
+
+	// Re-applies this actor's own "Sky Parameters" as they currently stand,
+	// through AWeather. Internal helper -- LoadProfile calls this to
+	// re-clamp exposure right after loading; OnConstruction does the
+	// equivalent push directly. Not exposed as a button: it was redundant
+	// there (OnConstruction already runs it on every edit), replaced by the
+	// more useful LoadMapDefault.
+	void RefreshWeather();
+
+	// GetOptions callbacks need a UFUNCTION taking no world-context args;
+	// thin wrappers around the shared JSON utils lookups.
+	UFUNCTION()
+	static TArray<FString> GetAvailablePostProcessProfileNamesForPicker();
+
+	UFUNCTION()
+	static TArray<FString> GetAvailableTimePresetNamesForPicker();
+
+	UFUNCTION()
+	static TArray<FString> GetAvailableConditionPresetNamesForPicker();
+
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Components")
 	UPostProcessComponent* PostProcessComponent;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.cpp
@@ -19,9 +19,13 @@
 #include "Components/PostProcessComponent.h"
 #include "Components/SceneCaptureComponent2D.h"
 #include "Components/SkyLightComponent.h"
+#include "Components/VolumetricCloudComponent.h"
 #include "Curves/CurveFloat.h"
 #include "HAL/IConsoleManager.h"
 #include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetMaterialLibrary.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "Materials/MaterialParameterCollection.h"
 #include "UObject/ConstructorHelpers.h"
 #include "UObject/UnrealType.h"
 #include <util/ue-header-guard-end.h>
@@ -100,11 +104,41 @@ static TAutoConsoleVariable<float> CVarCarlaWeatherNightSkylightIntensity(
 // halos or day-side effect (the whole block is gated to SunAltitudeAngle<0).
 static TAutoConsoleVariable<float> CVarCarlaWeatherStarsBrightness(
     TEXT("carla.Weather.StarsBrightness"),
-    5000.0f,
+    0.0f,
     TEXT("Value forced into the night sky sphere's \"Stars Brightness\" variable ")
     TEXT("(BP_Sky_Sphere, engine content) whenever SunAltitudeAngle < 0, floored the same ")
-    TEXT("way as the moon/skylight intensities above. Set 0 to leave the rig's authored ")
-    TEXT("value untouched."),
+    TEXT("way as the moon/skylight intensities above. Set 0 (the default) to leave the rig's ")
+    TEXT("authored/artist-edited value untouched -- this used to default to 5000, which stomped ")
+    TEXT("any hand-tuned \"Stars brightness\" value on the sky sphere BP back up to 5000 on ")
+    TEXT("every push, making it look uneditable."),
+    ECVF_Default);
+
+// Reverse-engineered from BP_GeneralSceneSettings.UpdateClouds (before it was
+// ported here natively): below this Cloudiness value the rig's
+// VolumetricCloudComponent gets a fresh MID off the plain MI_Clouds master
+// (no density override -- the sphere's 2D texture is doing the actual cloud
+// look at low cloudiness); at or above it, a fresh MID off the "Billowy"
+// overcast master (M_VolumetricCloud_03_Profiles_Billowy_Inst) with its
+// "Cloud Density" scalar driven by C_BillowyDensity.GetFloatValue(Cloudiness)
+// -- confirmed by probing the live material param through the same threshold
+// BP_GeneralSceneSettings used (90): 90->10, 95->38, 100->247.
+static TAutoConsoleVariable<float> CVarCarlaWeatherOvercastThreshold(
+    TEXT("carla.Weather.OvercastThreshold"),
+    90.0f,
+    TEXT("Cloudiness value at/above which the sky rig's VolumetricCloudComponent switches ")
+    TEXT("from the plain cloud master material to the Billowy overcast one."),
+    ECVF_Default);
+
+// Under evaluation: the hard swap to the Billowy material right at the
+// threshold reads as a visible break (two completely different rendering
+// techniques). Set to 0 to always use the plain MI_Clouds master and extend
+// the BaseNoiseExp formula up through Cloudiness=100, to compare against the
+// swapped look.
+static TAutoConsoleVariable<bool> CVarCarlaWeatherEnableOvercastClouds(
+    TEXT("carla.Weather.EnableOvercastClouds"),
+    true,
+    TEXT("Whether Cloudiness at/above OvercastThreshold switches the cloud material to the ")
+    TEXT("Billowy overcast one. Set false to always use the plain master instead."),
     ECVF_Default);
 
 AWeather::AWeather(const FObjectInitializer& ObjectInitializer)
@@ -147,17 +181,48 @@ void AWeather::PushWeatherToSky()
     TArray<AActor*> SkyActors;
     UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASkyBase::StaticClass(), SkyActors);
     for (AActor* SkyActor : SkyActors)
+        ApplyWeatherToSkyActor(SkyActor, Weather);
+}
+
+void AWeather::ApplyWeatherToSkyActor(AActor* SkyActor, const FWeatherParameters& Weather)
+{
+    if (SkyActor == nullptr)
+        return;
+
     {
+        // Blueprint member variables get decorated FNames in their generated
+        // class (exact FindPropertyByName misses them), so match on the
+        // authored name instead -- same lesson as the vehicle "Beam Lights"
+        // variable in CarlaWheeledVehicle.cpp. Shared by every reflection
+        // lookup in this function.
+        const auto FindPropertyByAuthoredName =
+            [](const UClass* Class, const TCHAR* AuthoredName) -> FProperty*
+        {
+            for (TFieldIterator<FProperty> It(Class); It; ++It)
+            {
+                if ((*It)->GetAuthoredName() == AuthoredName || (*It)->GetName() == AuthoredName)
+                    return *It;
+            }
+            return nullptr;
+        };
+
         // The rig stores the parameters it renders from in a blueprint variable
         // and refreshes every component from its blueprint Update function.
-        FProperty* Property = SkyActor->GetClass()->FindPropertyByName(TEXT("Sky Parameters"));
-        if (Property == nullptr)
-            Property = SkyActor->GetClass()->FindPropertyByName(TEXT("SkyParameters"));
-        FStructProperty* StructProperty = CastField<FStructProperty>(Property);
-        if (StructProperty != nullptr && StructProperty->Struct == FWeatherParameters::StaticStruct())
-            StructProperty->SetValue_InContainer(SkyActor, &Weather);
+        // Matched by type via ASkyBase::FindWeatherParameters, not by name --
+        // a name-based lookup here silently broke (no warning triggered,
+        // because "SkyParameters"/"Sky Parameters" both still resolved to
+        // *something* is wrong; it just returned null and this whole write
+        // no-opped) the moment that Blueprint variable got renamed to
+        // "WeatherParameters". Precipitation/Wetness visuals -- driven by the
+        // legacy UpdateAtmosphereAndPrecipitation Blueprint call below, which
+        // reads this struct rather than taking Weather as a parameter -- are
+        // what silently went stale; native pushes further down (sun, clouds,
+        // fog, exposure) read straight from the Weather parameter and were
+        // never affected.
+        if (FWeatherParameters* SkyParameters = ASkyBase::FindWeatherParameters(SkyActor))
+            *SkyParameters = Weather;
         else
-            UE_LOG(LogCarla, Warning, TEXT("AWeather: no WeatherParameters 'Sky Parameters' property on %s"),
+            UE_LOG(LogCarla, Warning, TEXT("AWeather: no WeatherParameters property on %s"),
                 *SkyActor->GetName());
 
         // The rig's blueprint 'Update' only reaches UpdateClouds (the rest of
@@ -192,6 +257,78 @@ void AWeather::PushWeatherToSky()
                     FunctionName, *SkyActor->GetName());
         }
 
+        // SetSkySphere (just called above) spawns a fresh stock-engine
+        // BP_Sky_Sphere and tries to attach it to this rig's root
+        // (PostProcessComponent), but that root's Mobility is Movable while
+        // the stock sphere's root is Static -- UE refuses to attach a Static
+        // child to a non-Static parent ("AttachTo: ... is not static ...
+        // Aborting", logged every push). The spawn itself still succeeds and
+        // "SkySphere" still gets assigned, so this is silent rather than
+        // fatal: the sphere just renders unattached at wherever it spawned
+        // instead of following the rig. Finish the attach here natively,
+        // forcing the spawned instance's root to Movable first (a fresh
+        // stock actor with no other purpose -- safe to change).
+        {
+            FObjectProperty* SphereProperty = CastField<FObjectProperty>(
+                FindPropertyByAuthoredName(SkyActor->GetClass(), TEXT("SkySphere")));
+            if (SphereProperty == nullptr)
+                SphereProperty = CastField<FObjectProperty>(
+                    FindPropertyByAuthoredName(SkyActor->GetClass(), TEXT("Sky Sphere")));
+            AActor* SphereActor = SphereProperty != nullptr
+                ? Cast<AActor>(SphereProperty->GetObjectPropertyValue_InContainer(SkyActor))
+                : nullptr;
+            USceneComponent* SphereRoot = SphereActor != nullptr ? SphereActor->GetRootComponent() : nullptr;
+            if (SphereRoot != nullptr && SphereRoot->GetAttachParent() == nullptr)
+            {
+                if (SphereRoot->Mobility == EComponentMobility::Static)
+                    SphereRoot->SetMobility(EComponentMobility::Movable);
+                SphereActor->AttachToActor(SkyActor, FAttachmentTransformRules::KeepWorldTransform);
+            }
+
+            // PIE start reliably left duplicate attached actors -- not just
+            // the sphere (SetSkySphere's respawn: destroy-old, spawn-new,
+            // doesn't reliably find/destroy the previous one across
+            // PIE's construction timing), but independently a duplicate
+            // DirectionalLight too (SetSunActorReference, called earlier in
+            // the UpdateFunctionNames loop above, manages its own actor
+            // reference the same lossy way) -- tripping the "multiple
+            // directional lights competing" render warning. Rather than
+            // chase the exact PIE timing for each function separately, make
+            // this self-healing and general: whatever ends up attached to
+            // this rig, keep at most one instance per class.
+            {
+                TMap<UClass*, TArray<AActor*>> AttachedByClass;
+                TArray<AActor*> AttachedToSky;
+                SkyActor->GetAttachedActors(AttachedToSky);
+                for (AActor* AttachedActor : AttachedToSky)
+                    if (AttachedActor != nullptr)
+                        AttachedByClass.FindOrAdd(AttachedActor->GetClass()).Add(AttachedActor);
+
+                for (const TPair<UClass*, TArray<AActor*>>& Pair : AttachedByClass)
+                {
+                    const TArray<AActor*>& Instances = Pair.Value;
+                    if (Instances.Num() <= 1)
+                        continue;
+                    // Keep the one "SkySphere" actually points to when this
+                    // is its class; otherwise keep whichever is last (order
+                    // is not meaningful here, just needs to be consistent).
+                    AActor* ToKeep = (SphereActor != nullptr && Instances.Contains(SphereActor))
+                        ? SphereActor : Instances.Last();
+                    for (AActor* Instance : Instances)
+                    {
+                        if (Instance == ToKeep)
+                            continue;
+                        TArray<AActor*> OrphanChildren;
+                        Instance->GetAttachedActors(OrphanChildren);
+                        for (AActor* OrphanChild : OrphanChildren)
+                            if (OrphanChild != nullptr)
+                                OrphanChild->Destroy();
+                        Instance->Destroy();
+                    }
+                }
+            }
+        }
+
         // The blueprint's UpdateFog runs, but the values it leaves on the
         // height fog component were saved for the old small towns and break
         // on large maps: a 1 km FogCutoffDistance erases fog on everything
@@ -216,16 +353,23 @@ void AWeather::PushWeatherToSky()
 
         // The blueprint's ControlSunIntensity has a severed exec chain (its
         // entry sets SunTrayectory and dead-ends), so the curve-driven light
-        // intensities never apply. Evaluate the curves bound on this weather
-        // blueprint and drive the rig components directly; the curve assets
-        // remain the content-side tuning source.
-        auto FindCurve = [this](const TCHAR* PropertyName) -> UCurveFloat*
+        // intensities never apply. Evaluate the curves directly and drive the
+        // rig components; the curve assets remain the content-side tuning
+        // source. Loaded by fixed path (BP_CarlaWeather's own default values
+        // for these two variables) rather than read off an AWeather instance,
+        // so this function works with no AWeather actor placed in the level
+        // at all -- see ASkyBase::RefreshWeather/LoadPreset.
+        auto FindCurve = [](const TCHAR* PropertyName) -> UCurveFloat*
         {
-            FObjectProperty* CurveProperty =
-                CastField<FObjectProperty>(GetClass()->FindPropertyByName(PropertyName));
-            return CurveProperty != nullptr
-                ? Cast<UCurveFloat>(CurveProperty->GetObjectPropertyValue_InContainer(this))
-                : nullptr;
+            static UCurveFloat* const SunIntensityCurve = LoadObject<UCurveFloat>(nullptr,
+                TEXT("/Game/Carla/Blueprints/Weather/Weather2_Curves/SunIntensity_2.SunIntensity_2"));
+            static UCurveFloat* const SkyIntensityCurve = LoadObject<UCurveFloat>(nullptr,
+                TEXT("/Game/Carla/Blueprints/Weather/Weather2_Curves/SkylightIntensity_2.SkylightIntensity_2"));
+            if (FCString::Strcmp(PropertyName, TEXT("SunIntensity_Curve")) == 0)
+                return SunIntensityCurve;
+            if (FCString::Strcmp(PropertyName, TEXT("SkyIntensity_Curve")) == 0)
+                return SkyIntensityCurve;
+            return nullptr;
         };
         auto FindComponent = [SkyActor](const TCHAR* PropertyName) -> ULightComponent*
         {
@@ -258,6 +402,21 @@ void AWeather::PushWeatherToSky()
                 // Rigs saved with a black light color render no sunlight at any
                 // intensity; the physical tint comes from the color temperature.
                 SunLightComponent->SetLightColor(FLinearColor::White);
+            }
+        }
+        // The rig's Moon light ships with AffectsWorld off -- a disabled
+        // light contributes nothing to the scene no matter what its
+        // Intensity is set to below, which is why night always rendered
+        // pitch black regardless of the moon/skylight floor cvars. Always
+        // on, not just at night: harmless during the day (Intensity there is
+        // whatever the curve/floor logic below leaves it at), and this way
+        // there's nothing left to toggle when the sun crosses the horizon.
+        if (ULightComponent* MoonLightComponentAffects = FindComponent(TEXT("DirectionalLightComponentMoon")))
+        {
+            if (!MoonLightComponentAffects->bAffectsWorld)
+            {
+                MoonLightComponentAffects->bAffectsWorld = true;
+                MoonLightComponentAffects->MarkRenderStateDirty();
             }
         }
         // The rig ships EVERY component with bAutoActivate false on the
@@ -359,22 +518,8 @@ void AWeather::PushWeatherToSky()
             // already respawned this push's sphere actor by the time we get
             // here, so "SkySphere" always resolves to the fresh instance. See
             // the cvar comment above for the full reflection path and why
-            // this stays gated to night.
-            // Blueprint member variables get decorated FNames in their
-            // generated class (exact FindPropertyByName misses them), so
-            // match on the authored name instead -- same lesson as the
-            // vehicle "Beam Lights" variable in CarlaWheeledVehicle.cpp.
-            const auto FindPropertyByAuthoredName =
-                [](const UClass* Class, const TCHAR* AuthoredName) -> FProperty*
-            {
-                for (TFieldIterator<FProperty> It(Class); It; ++It)
-                {
-                    if ((*It)->GetAuthoredName() == AuthoredName || (*It)->GetName() == AuthoredName)
-                        return *It;
-                }
-                return nullptr;
-            };
-
+            // this stays gated to night. FindPropertyByAuthoredName is
+            // shared, defined at the top of this function's SkyActor loop.
             FObjectProperty* SphereProperty = CastField<FObjectProperty>(
                 FindPropertyByAuthoredName(SkyActor->GetClass(), TEXT("SkySphere")));
             if (SphereProperty == nullptr)
@@ -424,32 +569,147 @@ void AWeather::PushWeatherToSky()
         }
     }
 
-    // BP_GeneralSceneSettings owns the post-process volume that keeps the
-    // exposure in step with the sun (its Update was another dead call site in
-    // BP_CarlaWeather). Only invoke it when a sky rig exists: its blueprint
-    // retries itself endlessly when it cannot find an ASkyBase.
-    if (SkyActors.Num() > 0)
+    // Cloud density. Ported from BP_GeneralSceneSettings.UpdateClouds (that
+    // actor is gone -- this used to depend on it being placed in the level,
+    // which routinely wasn't the case in the editor, silently leaving clouds
+    // disconnected from Weather.Cloudiness). See CVarCarlaWeatherOvercastThreshold
+    // above for how this was reverse-engineered.
     {
-        UClass* SceneSettingsClass = LoadClass<AActor>(nullptr,
-            TEXT("/Game/Carla/Blueprints/BP_GeneralSceneSettings.BP_GeneralSceneSettings_C"));
-        AActor* SceneSettingsActor = SceneSettingsClass != nullptr
-            ? UGameplayStatics::GetActorOfClass(GetWorld(), SceneSettingsClass)
+        FObjectProperty* CloudComponentProperty = CastField<FObjectProperty>(
+            SkyActor->GetClass()->FindPropertyByName(TEXT("VolumetricCloudComponent")));
+        UVolumetricCloudComponent* CloudComponent = CloudComponentProperty != nullptr
+            ? Cast<UVolumetricCloudComponent>(CloudComponentProperty->GetObjectPropertyValue_InContainer(SkyActor))
             : nullptr;
-        UFunction* SettingsUpdateFunction = SceneSettingsActor != nullptr
-            ? SceneSettingsActor->FindFunction(TEXT("Update"))
-            : nullptr;
-        if (SettingsUpdateFunction != nullptr && SettingsUpdateFunction->ParmsSize == 0)
-            SceneSettingsActor->ProcessEvent(SettingsUpdateFunction, nullptr);
+        if (CloudComponent != nullptr)
+        {
+            static UCurveFloat* const DensityCurve = LoadObject<UCurveFloat>(nullptr,
+                TEXT("/Game/Carla/Blueprints/Weather/CloudsBillowy/C_BillowyDensity.C_BillowyDensity"));
+            static UMaterialInterface* const NormalCloudMaterial = LoadObject<UMaterialInterface>(nullptr,
+                TEXT("/Game/Carla/Static/FX/VolumetricClouds/MI_Clouds.MI_Clouds"));
+            static UMaterialInterface* const BillowyCloudMaterial = LoadObject<UMaterialInterface>(nullptr,
+                TEXT("/Game/Carla/Static/GenericMaterials/VolumetricClouds/Masters/M_VolumetricCloud_03_Profiles_Billowy_Inst.M_VolumetricCloud_03_Profiles_Billowy_Inst"));
+
+            const float OvercastThreshold = CVarCarlaWeatherOvercastThreshold.GetValueOnGameThread();
+            const bool bOvercast = CVarCarlaWeatherEnableOvercastClouds.GetValueOnGameThread()
+                && Weather.Cloudiness >= OvercastThreshold;
+            UMaterialInterface* BaseMaterial = bOvercast ? BillowyCloudMaterial : NormalCloudMaterial;
+            if (BaseMaterial != nullptr)
+            {
+                // A brand new MID every push (this runs on every weather
+                // update, not just when Cloudiness crosses the threshold)
+                // resets VolumetricCloudComponent's temporal accumulation
+                // each time -- a visible pop/flash even when the parameters
+                // end up identical. Reuse the existing MID when the base
+                // material (Normal vs Billowy) hasn't actually changed; only
+                // create a fresh one on the first push or an actual
+                // threshold cross. Cached by component here rather than read
+                // back via CloudComponent->GetMaterial(): that getter didn't
+                // reliably report the MID just assigned by SetMaterial below
+                // (still returned the previous push's, so the read-back
+                // approach always saw a "different" parent and recreated
+                // every time -- this side-steps whatever that mismatch was).
+                static TMap<TWeakObjectPtr<UVolumetricCloudComponent>, TWeakObjectPtr<UMaterialInstanceDynamic>> CloudMIDCache;
+                TWeakObjectPtr<UMaterialInstanceDynamic>* CachedMID = CloudMIDCache.Find(CloudComponent);
+                UMaterialInstanceDynamic* CloudMID = (CachedMID != nullptr && CachedMID->IsValid()
+                        && CachedMID->Get()->Parent == BaseMaterial)
+                    ? CachedMID->Get()
+                    : nullptr;
+                if (CloudMID == nullptr)
+                {
+                    CloudMID = UMaterialInstanceDynamic::Create(BaseMaterial, CloudComponent);
+                    CloudMIDCache.Add(CloudComponent, CloudMID);
+                }
+                if (bOvercast)
+                {
+                    // Below MI_Clouds's own "BaseNoiseExp" scalar is what
+                    // actually thins/thickens the cloud layer under the
+                    // overcast threshold (probed live against
+                    // BP_GeneralSceneSettings.UpdateClouds before removing
+                    // it: exactly linear -- 100 - 0.8*Cloudiness -- for
+                    // Cloudiness in [1, 89], collapsing to a huge exponent
+                    // (~invisible clouds) only right at 0. Leaving this
+                    // param at the material's own unrelated default is what
+                    // produced the single ugly cloud mass instead of a
+                    // normal layer.
+                    if (DensityCurve != nullptr)
+                        CloudMID->SetScalarParameterValue(TEXT("Cloud Density"), DensityCurve->GetFloatValue(Weather.Cloudiness));
+                }
+                else
+                {
+                    const float BaseNoiseExp = Weather.Cloudiness <= 0.0f
+                        ? 6000.0f
+                        : FMath::Clamp(100.0f - 0.8f * Weather.Cloudiness, 0.0f, 6000.0f);
+                    CloudMID->SetScalarParameterValue(TEXT("BaseNoiseExp"), BaseNoiseExp);
+                }
+                CloudComponent->SetMaterial(CloudMID);
+            }
+            else
+            {
+                UE_LOG(LogCarla, Warning, TEXT("AWeather: cloud master material missing for %s"), *SkyActor->GetName());
+            }
+        }
     }
 
-    // Viewport exposure. The project ships with auto exposure disabled by
-    // default (r.DefaultFeature.AutoExposure=False) and the rigs were saved
-    // for the old frozen ~15 lux suns, so a physical 100k lux sun white-outs
-    // the main view. Apply the same histogram exposure the RGB sensor uses by
-    // default (bias 0, EV100 range [10,12], speeds 3/1) to the sky rig's
-    // post-process volume. This must run AFTER BP_GeneralSceneSettings.Update,
-    // which rewrites the whole post-process struct with its own values.
-    for (AActor* SkyActor : SkyActors)
+    // Day/night light broadcast. AWeather::ApplyWeather already does this
+    // (respecting the artist-facing DayNightCycle toggle) when an AWeather
+    // actor exists, but street lamps otherwise only ever turned on when
+    // actually playing: ASkyBase::RefreshWeather/LoadPreset fall back to
+    // calling this function directly with no AWeather placed, and that path
+    // never reached UpdateStreetLightsForDayNight. Broadcasting again here is
+    // harmless when an AWeather is present too -- registered lights just
+    // re-receive the same state.
+    if (UWorld* World = SkyActor->GetWorld())
+    {
+        if (UCarlaLightSubsystem* CarlaLightSubsystem = World->GetSubsystem<UCarlaLightSubsystem>())
+            CarlaLightSubsystem->NotifyDayTimeChange(Weather.SunAltitudeAngle > 0.0f);
+    }
+
+    // Wind + Wetness, both on the same global collection. WindIntensity: no
+    // one was pushing it at all (UpdateAtmosphereAndPrecipitation's exec
+    // chain for it is severed, same pattern as everything else natively
+    // re-driven in this function) -- M_VegetationMaster divides it by 10
+    // before feeding its wind shader function, so this pushes the raw 0-100
+    // CARLA value, not normalized.
+    //
+    // Wetness: UpdateAtmosphereAndPrecipitation DOES push it (and Puddles/
+    // Ripples/Precipitation alongside it) -- but normalized to 0-1 first
+    // (confirmed live: Weather.Wetness=90 -> collection value 0.9). Puddles
+    // reads fine at that scale. Wetness does not: MF_WetSurfaceFx's own
+    // "Wetness" section divides the collection value by 100 *again* before
+    // using it (confirmed in the material graph, and by hardcoding 100
+    // straight into that Divide node -- wets correctly; the collection read
+    // is the only broken link). A pre-normalized 0-1 input run through
+    // another /100 lands at ~0.009 -- functionally zero, which is exactly
+    // "wetness does nothing". Puddles/Ripples/Precipitation are left alone
+    // (already correct at 0-1); only Wetness gets overridden here, raw, right
+    // after the BP call above wrote the wrong value.
+    {
+        static UMaterialParameterCollection* const WeatherMPC = LoadObject<UMaterialParameterCollection>(nullptr,
+            TEXT("/Game/Carla/Blueprints/Weather/Materials/WeatherMaterialParameters.WeatherMaterialParameters"));
+        if (WeatherMPC != nullptr && SkyActor->GetWorld() != nullptr)
+        {
+            UKismetMaterialLibrary::SetScalarParameterValue(
+                SkyActor->GetWorld(), WeatherMPC, TEXT("WindIntensity"), Weather.WindIntensity);
+            UKismetMaterialLibrary::SetScalarParameterValue(
+                SkyActor->GetWorld(), WeatherMPC, TEXT("Wetness"), Weather.Wetness);
+        }
+    }
+
+    // Viewport exposure fallback. The project ships with auto exposure
+    // disabled by default (r.DefaultFeature.AutoExposure=False) and the rigs
+    // were saved for the old frozen ~15 lux suns, so a physical 100k lux sun
+    // white-outs the main view with no exposure settings at all. This fills
+    // in the same histogram exposure the RGB sensor uses by default (bias 0,
+    // EV100 range [10,12], speeds 3/1) -- but ONLY for fields the currently
+    // loaded PostProcess profile (Content/Carla/Config/PostProcess/*.json)
+    // doesn't already claim via bOverride_*. Profiles set their own Method
+    // and Bias (e.g. GoPro.json: AEM_Manual/0) and rely on this to supply
+    // Min/Max/SpeedUp/SpeedDown, which they intentionally leave unset. This
+    // runs on every editor property edit (via OnConstruction), so forcing
+    // these unconditionally used to stomp the profile's Method/Bias back to
+    // Histogram/0 the instant you touched anything on the Sky actor,
+    // including just switching ProfileName -- e.g. GoPro's Manual exposure
+    // never stuck, and switching profiles never visibly changed exposure.
     {
         FObjectProperty* PostProcessProperty = CastField<FObjectProperty>(
             SkyActor->GetClass()->FindPropertyByName(TEXT("PostProcessComponent")));
@@ -459,18 +719,36 @@ void AWeather::PushWeatherToSky()
         if (PostProcessComponent != nullptr)
         {
             FPostProcessSettings& Settings = PostProcessComponent->Settings;
-            Settings.bOverride_AutoExposureMethod = true;
-            Settings.AutoExposureMethod = AEM_Histogram;
-            Settings.bOverride_AutoExposureBias = true;
-            Settings.AutoExposureBias = 0.0f;
-            Settings.bOverride_AutoExposureMinBrightness = true;
-            Settings.AutoExposureMinBrightness = 10.0f;
-            Settings.bOverride_AutoExposureMaxBrightness = true;
-            Settings.AutoExposureMaxBrightness = 12.0f;
-            Settings.bOverride_AutoExposureSpeedUp = true;
-            Settings.AutoExposureSpeedUp = 3.0f;
-            Settings.bOverride_AutoExposureSpeedDown = true;
-            Settings.AutoExposureSpeedDown = 1.0f;
+            if (!Settings.bOverride_AutoExposureMethod)
+            {
+                Settings.bOverride_AutoExposureMethod = true;
+                Settings.AutoExposureMethod = AEM_Histogram;
+            }
+            if (!Settings.bOverride_AutoExposureBias)
+            {
+                Settings.bOverride_AutoExposureBias = true;
+                Settings.AutoExposureBias = 0.0f;
+            }
+            if (!Settings.bOverride_AutoExposureMinBrightness)
+            {
+                Settings.bOverride_AutoExposureMinBrightness = true;
+                Settings.AutoExposureMinBrightness = 10.0f;
+            }
+            if (!Settings.bOverride_AutoExposureMaxBrightness)
+            {
+                Settings.bOverride_AutoExposureMaxBrightness = true;
+                Settings.AutoExposureMaxBrightness = 12.0f;
+            }
+            if (!Settings.bOverride_AutoExposureSpeedUp)
+            {
+                Settings.bOverride_AutoExposureSpeedUp = true;
+                Settings.AutoExposureSpeedUp = 3.0f;
+            }
+            if (!Settings.bOverride_AutoExposureSpeedDown)
+            {
+                Settings.bOverride_AutoExposureSpeedDown = true;
+                Settings.AutoExposureSpeedDown = 1.0f;
+            }
             PostProcessComponent->bUnbound = true;
         }
     }
@@ -547,12 +825,13 @@ void AWeather::ApplyWeather(const FWeatherParameters& InWeather)
 
 void AWeather::NotifyWeather(ASensor* Sensor)
 {
+    // Only re-sync this new sensor's own postprocess blendables (rain/dust)
+    // with the already-active weather. A full PushWeatherToSky() here
+    // respawns BP_Sky_Sphere and reapplies the exposure clamp on every
+    // camera sensor spawn, which is redundant (global weather state hasn't
+    // changed) and visibly jitters clouds/postprocess each time a client
+    // spawns a camera.
     CheckWeatherPostProcessEffects();
-
-    // Call the blueprint that actually changes the weather.
-    RefreshWeather(Weather);
-    PushWeatherToSky();
-    UpdateStreetLightsForDayNight();
 }
 
 void AWeather::SetWeather(const FWeatherParameters& InWeather)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/Weather.h
@@ -54,6 +54,16 @@ public:
   /// Update the day night cycle
   void SetDayNightCycle(const bool &active);
 
+  /// Pushes Weather into a single ASkyBase rig (sun/fog/clouds/atmosphere/
+  /// exposure) and runs its blueprint refresh functions -- everything
+  /// PushWeatherToSky does per-actor, factored out so it works on any sky
+  /// actor directly, without requiring an AWeather instance to exist in the
+  /// world. Used by ASkyBase::RefreshWeather/LoadPreset for editor-time
+  /// preview when no BP_CarlaWeather is placed in the level, and by
+  /// PushWeatherToSky itself for the full runtime path.
+  UFUNCTION(BlueprintCallable, Category = "Weather")
+  static void ApplyWeatherToSkyActor(AActor* SkyActor, const FWeatherParameters& Weather);
+
 protected:
 
 #if WITH_EDITOR

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/WeatherParameters.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Weather/WeatherParameters.h
@@ -52,6 +52,9 @@ struct CARLA_API FWeatherParameters
   UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(ClampMin = "0.0", ClampMax = "2.0", UIMin = "0.0", UIMax = "2.0"))
   float RayleighScatteringScale = 0.0331f;
 
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(ClampMin = "0.0", ClampMax = "100.0", UIMin = "0.0", UIMax = "100.0"))
+  // Deprecated -- kept for API/recorder compatibility, hidden from the
+  // Details panel (no EditAnywhere) since it no longer does anything
+  // meaningful in this rig. Still settable from C++/Blueprint graphs.
+  UPROPERTY(BlueprintReadWrite, meta=(ClampMin = "0.0", ClampMax = "100.0", UIMin = "0.0", UIMax = "100.0"))
   float DustStorm = 0.0f;
 };


### PR DESCRIPTION
**Summary**

Weather (sun/clouds/rain/fog) and camera PostProcess (e.g. GoPro-style profiles) were split across two blueprints (BP_CarlaWeather, BP_GeneralSceneSettings) that had to be placed per-map, drifted between editor/Play/client, and had no save/load workflow. This PR consolidates both into ASkyBase (BP_Carla_Sky, already present on every map), so an artist can author weather and camera looks directly in the Details panel and save/load them as JSON presets that apply identically in editor, Play, and the pygame client (manual_control.py).

This is a two-repo PR: code changes in CarlaUE5 (ue58-dev) and companion blueprint/config/asset changes in Content/Carla (ue58-dev-carla). Land together.

**Design**

- PostProcess: ProfileName dropdown + SaveProfile/LoadProfile/NewProfileName+CreateProfile on BP_Carla_Sky. One JSON per profile under Config/PostProcess/. SetCamera always loads Default.json unless a sensor explicitly requests another profile via its post_process_profile attribute (new --post-process-profile flag in the example clients).
- Weather: TimePresetName / ConditionPresetName dropdowns + LoadPreset (merges and applies both) + save/create/SetAsMapDefault on BP_Carla_Sky. One shared catalog, Config/Weather/Presets.json ({"time": {...}, "conditions": {...}}), reusable across towns; per-map defaults in Config/Weather/MapDefaults.json, read by CarlaGameModeBase::BeginPlay in place of the old WeatherParameters::Default sentinel.
- New AWeather::ApplyWeatherToSkyActor factors the per-actor apply logic (sun/fog/clouds/atmosphere/exposure) out of PushWeatherToSky, so ASkyBase can self-apply weather without an AWeather instance in the scene.

**Bug fixes bundled in (root-caused and fixed on the way to the unified design)**

- **BeginPlay forced `WeatherParameters::Default`** (broken `SunAltitudeAngle=-1` sentinel), ignoring map-authored weather → read from `MapDefaults.json`
- **Cloud material swap created a new `UMaterialInstanceDynamic` on every push**, resetting the volumetric cloud's temporal history (visible pop on every update) → cache MIDs per component, reuse when base material unchanged
- **Wetness had no visible effect** → `MF_WetSurfaceFX` divides by 100 on top of an existing 0-1 normalization upstream; push the raw 0-100 value natively
- **`WindIntensity` never reached `M_VegetationMaster`** → nothing wrote it to the MPC; push natively (raw 0-100)
- **Black clouds at night** → moon's `DirectionalLightComponent` had `AffectsWorld=false`; forced to `true`
- **Duplicate sky sphere / directional light actors on Play** → de-duplicate actors attached to `BP_Carla_Sky`, grouped by class, after each push
- **Stars invisible** → `CVarCarlaWeatherStarsBrightness` floor of 5000 lowered to 0
- **Street/building/vehicle lights didn't self-activate at night** → `CarlaLight::HandleDayTimeChanged` extended from Street-only to Building + Vehicle
- **Lights didn't turn on in-editor (only in Play)** → register from `OnRegister()` too, with matching de-registration

**Not fixed / follow-up (tracked, not blocking)**

- Cloud material swap at the OvercastThreshold (90) is still a visible cut (Normal → Billowy material change is an asset swap, not just an MID reset) — needs a crossfade or a decision to keep the hard swap.
- "Multiple directional lights" editor warning persists (actors are no longer actually duplicated — likely a Sun/Moon shadow-priority conflict, not yet investigated).
- Loading the Test PostProcess profile over-exposes the image and doesn't reset on switching back to Default/GoPro (suspect stuck auto-exposure state or LoadProfile not resetting to baseline before applying).

**Content changes**

- Removed BP_CarlaWeather / BP_GeneralSceneSettings from Town10HD_Opt (logic ported to native code).
- Added Config/Weather/{Presets,MapDefaults}.json; replaced per-map PostProcess JSONs with a single Default.json (Town10HD_Opt.json, autoware_demo.json removed).
- Vegetation/surface material instance defaults (pine, oak, boxwood, grass, palm, concrete, sidewalk) touched by the wind/wetness native-push fix.

**Testing**

Verified in-engine, headless (nullrhi + Python editor scripts against live actor/MPC/material state, not just config diffs): wetness, wind, star brightness, directional-light de-duplication across repeated Play/Stop cycles. Not yet verified with a renderable session (visual confirmation of cloud crossfade, lighting look) — flagged above as follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9850)
<!-- Reviewable:end -->
