### PR TITLE
Update nightly download links to downloads.carlasim.com

### DIFF
--- a/Docs/download.md
+++ b/Docs/download.md
@@ -12,10 +12,10 @@ This is an automated build with the latest changes pushed to our `ue4-dev`
 branch. It contains the very latest fixes and features that will be part of the
 next release, but also some experimental changes. Use at your own risk!
 
-- [CARLA Nightly Build (Linux)](https://carla-releases.s3.us-east-005.backblazeb2.com/Linux/Dev/CARLA_Latest.tar.gz)
-- [AdditionalMaps Nightly Build (Linux)](https://carla-releases.s3.us-east-005.backblazeb2.com/Linux/Dev/AdditionalMaps_Latest.tar.gz)
-- [CARLA Nightly Build (Windows)](https://carla-releases.s3.us-east-005.backblazeb2.com/Windows/Dev/CARLA_Latest.zip)
-- [AdditionalMaps Nightly Build (Windows)](https://carla-releases.s3.us-east-005.backblazeb2.com/Windows/Dev/AdditionalMaps_Latest.zip)
+- [CARLA Nightly Build (Linux)](https://downloads.carlasim.com/Linux/Dev/CARLA_Latest.tar.gz)
+- [AdditionalMaps Nightly Build (Linux)](https://downloads.carlasim.com/Linux/Dev/AdditionalMaps_Latest.tar.gz)
+- [CARLA Nightly Build (Windows)](https://downloads.carlasim.com/Windows/Dev/CARLA_Latest.zip)
+- [AdditionalMaps Nightly Build (Windows)](https://downloads.carlasim.com/Windows/Dev/AdditionalMaps_Latest.zip)
 
 <p><a id="last-run-link" href='https://github.com/carla-simulator/carla/actions'>Last successful build</a>: <span id="last-run-time" class="loading">Loading...</span></p>
 


### PR DESCRIPTION
The nightly build links on [the downloads page](https://carla.readthedocs.io/en/latest/download/) pointed at Backblaze via a Bunny CDN pull zone that is no longer configured, so they were broken (HTTP 403).

This PR points the four UE4 nightly links at the new Cloudflare R2 mirror (`downloads.carlasim.com`).

Note: the nightly artifacts are being mirrored to R2 now; merge once the copy completes (tracked internally). The CI deploy scripts (e.g. `Util/Tools/Deploy.bat`) still upload nightlies to the Backblaze bucket and need a follow-up change so new nightlies land on R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9854)
<!-- Reviewable:end -->
