### PR TITLE
Deploy nightly and release packages to Cloudflare R2

### DIFF
--- a/Util/BuildTools/Deploy.bat
+++ b/Util/BuildTools/Deploy.bat
@@ -62,7 +62,7 @@ set PACKAGE_PATH=%CARLA_DIST_FOLDER%\%PACKAGE%
 set PACKAGE2=AdditionalMaps_%REPOSITORY_TAG%.zip
 set PACKAGE_PATH2=%CARLA_DIST_FOLDER%\%PACKAGE2%
 
-set ENDPOINT=https://s3.us-east-005.backblazeb2.com
+set ENDPOINT=https://1b808339cbe94fecce530dfada93713b.r2.cloudflarestorage.com
 
 set S3_PREFIX=s3://carla-releases/Windows
 set URL_PREFIX=%ENDPOINT%/carla-releases/Windows

--- a/Util/BuildTools/Deploy.sh
+++ b/Util/BuildTools/Deploy.sh
@@ -10,7 +10,7 @@ AWS_COPY="aws s3 cp"
 DOCKER="docker"
 UNTAR="tar -xvzf"
 UPLOAD_MAPS=true
-ENDPOINT="https://s3.us-east-005.backblazeb2.com"
+ENDPOINT="https://1b808339cbe94fecce530dfada93713b.r2.cloudflarestorage.com"
 SUMMARY_OUTPUT_PATH=
 
 # ==============================================================================


### PR DESCRIPTION
Follow-up to #9854. The deploy scripts still uploaded packages to the Backblaze B2 bucket, so the R2 mirror behind `downloads.carlasim.com` would go stale on the next nightly.

Changes:
- `Util/BuildTools/Deploy.sh` / `Deploy.bat`: S3 endpoint → Cloudflare R2 (`carla-releases` bucket serving downloads.carlasim.com)

The existing `AWS_ACCESS_KEY_ID` / `AWS_ACCESS_KEY` repository secrets have been updated in place to hold the R2 credentials, so no workflow changes are needed.

⚠️ Since those secrets no longer hold Backblaze credentials, other jobs that still point at the B2 endpoint will fail to upload until they are migrated too:
- `ue5-dev` branch deploy scripts (UE5 nightly)
- `ue4_content.yml` → `carla-content`'s `make upload-dist` (endpoint lives in that repo)

Also: if the self-hosted runners' aws CLI v2 is recent and R2 rejects uploads with checksum errors, set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` in the upload steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9858)
<!-- Reviewable:end -->
