### PR TITLE
Deploy UE5 nightly to Cloudflare R2 (ue58-dev)

### DIFF
--- a/Docs/download.md
+++ b/Docs/download.md
@@ -10,7 +10,7 @@ This is an automated build with the latest changes pushed to our `ue5-dev`
 branch. It contains the very latest fixes and features that will be part of the
 next release, but also some experimental changes. Use at your own risk!
 
-- [CARLA Nightly Build (Linux)](https://s3.us-east-005.backblazeb2.com/carla-releases/Linux/Dev/CARLA_UE5_Latest.tar.gz)
+- [CARLA Nightly Build (Linux)](https://downloads.carlasim.com/Linux/Dev/CARLA_UE5_Latest.tar.gz)
 
 <p><a id="last-run-link" href='https://github.com/carla-simulator/carla/actions'>Last successful build</a>: <span id="last-run-time" class="loading">Loading...</span></p>
 

--- a/Util/Tools/Deploy.sh
+++ b/Util/Tools/Deploy.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REPLACE_LATEST=false
 AWS_COPY="aws s3 cp"
-ENDPOINT="https://s3.us-east-005.backblazeb2.com"
+ENDPOINT="https://1b808339cbe94fecce530dfada93713b.r2.cloudflarestorage.com"
 SUMMARY_OUTPUT_PATH=
 
 # ==============================================================================
@@ -68,9 +68,9 @@ fi
 NIGHTLY_DEPLOY_NAME=$(git log --pretty=format:'%cd_%h' --date=format:'%Y%m%d' -n 1).tar.gz
 LATEST_DEPLOY_NAME="CARLA_UE5_Latest.tar.gz"
 
-# Backblaze bucket paths
+# Cloudflare R2 bucket paths
 S3_PREFIX=s3://carla-releases/Linux
-URL_PREFIX=${ENDPOINT}/carla-releases/Linux
+URL_PREFIX=https://downloads.carlasim.com/Linux
 
 NIGHTLY_DEPLOY_URI=${S3_PREFIX}/Dev/${NIGHTLY_DEPLOY_NAME}
 LATEST_DEPLOY_URI=${S3_PREFIX}/Dev/${LATEST_DEPLOY_NAME}


### PR DESCRIPTION
UE5 counterpart of #9858 for `ue58-dev`.

- `Util/Tools/Deploy.sh`: S3 endpoint → Cloudflare R2 (`carla-releases` bucket behind `downloads.carlasim.com`); CI summary `package_uri` now uses the public download domain instead of the raw endpoint (the R2 S3 endpoint is not publicly readable)
- `Docs/download.md`: nightly link → `https://downloads.carlasim.com/Linux/Dev/CARLA_UE5_Latest.tar.gz`

The `AWS_ACCESS_KEY_ID`/`AWS_ACCESS_KEY` secrets already hold R2 credentials, so UE5 nightly uploads are broken against B2 until this merges. `CARLA_UE5_Latest.tar.gz` (15.7 GB) is being mirrored to R2 so the docs link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9860)
<!-- Reviewable:end -->
