### PR TITLE
fix(autoware): make the in-tree Autoware layer match its documentation

### DIFF
--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -695,6 +695,13 @@ def parse_hz_rate(value):
         raise argparse.ArgumentTypeError("hz_rate must be an integer or 'None'.")
 
 
+def parse_timeout(value):
+    seconds = float(value)
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("--timeout must be a positive number of seconds.")
+    return seconds
+
+
 def main():
     argparser = argparse.ArgumentParser(
         description='CARLA Autoware sensor-kit demo')
@@ -748,6 +755,11 @@ def main():
     argparser.add_argument(
         '--spawn_index', type=int, default=None,
         help='Index into the ego spawn point list; random choice if omitted.')
+    argparser.add_argument(
+        '--timeout', type=parse_timeout, default=60.0,
+        help='RPC timeout in seconds (default: 60). A cold simulator start on UE 5.8 can '
+             'take longer than a minute to answer get_world(); raise this when the map is '
+             'still loading.')
     args = argparser.parse_args()
 
     # Deploy PostProcess profiles before connecting to the server
@@ -755,7 +767,7 @@ def main():
 
     # Get Client info
     client = carla.Client(args.host, args.port)
-    client.set_timeout(60.0)
+    client.set_timeout(args.timeout)
 
     if args.list_maps:
         print("Available maps")

--- a/PythonAPI/examples/av_stacks/autoware/README.md
+++ b/PythonAPI/examples/av_stacks/autoware/README.md
@@ -191,11 +191,25 @@ pinned deps from `map_tools/requirements.txt` in a venv — see
 ### 3. Run
 
 ```bash
-# Full classical stack, drive to a goal (CARLA coordinates: x,y,yaw°):
-./run/run_carla_autoware.sh --mode classical --goal "80.0,-16.5,90"
+# Full classical stack, drive to a goal (CARLA coordinates: x,y,yaw°).
+# Pin the spawn so the run is reproducible; this pair is a 7-lanelet,
+# ~200 m route with two junction turns that reaches ARRIVED:
+./run/run_carla_autoware.sh --mode classical --spawn-index 24 --goal "-1.16,28.37,0.16"
 
 # End-to-end VAD:
 ./run/run_carla_autoware.sh --mode e2e
+```
+
+A goal must sit on a driving lane, centred and heading-aligned, or
+`mission_planner` rejects it (`Goal's footprint exceeds lane!`) and the stack
+comes up healthy but never drives. To derive your own goal from a running
+simulator, take a waypoint's transform rather than typing coordinates:
+
+```python
+import carla
+m = carla.Client("127.0.0.1", 2000).get_world().get_map()
+wp = m.get_waypoint(carla.Location(x=-1.0, y=28.0), project_to_road=True, lane_type=carla.LaneType.Driving)
+t = wp.transform; print(f'--goal "{t.location.x:.2f},{t.location.y:.2f},{t.rotation.yaw:.2f}"')
 ```
 
 The default town is `Town10HD_Opt` (the UE5 packaged name; its map dir is
@@ -465,6 +479,12 @@ Read this before filing bugs — most of it is inherited and known.
   (`converged_param_nearest_voxel_transformation_likelihood` 2.3 → 1.0).
   Regenerating `pointcloud_map.pcd` with `map_tools` against the UE5.8 server
   removes the need for that override.
+- **A goal must land on a driving lane.** `mission_planner` only accepts a
+  goal that's centred on a lane and roughly heading-aligned; an off-lane goal
+  passes both pre-engage gates and is rejected only afterward, with `Goal's
+  footprint exceeds lane!`, so it looks like a hang rather than a bad
+  argument. See [Run](#3-run) for a spawn/goal pair that reaches ARRIVED and
+  a snippet to derive your own goal from a waypoint transform.
 - **Cleanup discipline.** Never `pkill -f <pattern>` when the pattern also
   appears in a wrapping `docker exec bash -c` command line — it kills its own
   wrapper shell (exit 143) and leaves the container processes running. Use

--- a/PythonAPI/examples/av_stacks/autoware/README.md
+++ b/PythonAPI/examples/av_stacks/autoware/README.md
@@ -442,15 +442,18 @@ Two hard-won warnings:
   **must** be overridden via `CYCLONEDDS_URI`; the run script does this. (Its
   10 MB buffer demand, on the other hand, was right all along — see the kernel
   UDP buffer prerequisite.)
-- **Do not run the simulator with `-rmw=cyclonedds` for now**: the CARLA
-  CycloneDDS receive path has a known fragmented-receive bug (large samples
-  can be dropped; a fix is in progress separately). The script defaults to
-  `fastdds` on the sim side and warns if you override it.
+- **The simulator may run either Fast DDS or CycloneDDS.** The CycloneDDS
+  fragmented-receive bug that earlier versions of this note warned about was
+  fixed in `b9c33737a` (fragment reassembly in `from_ser`, with unit tests);
+  a full classical run with `--rmw cyclonedds` on the simulator reaches
+  `ARRIVED`; rates measured once in that Phase 1 run were comparable to Fast
+  DDS. Fast DDS stays the default because its generated bridge-whitelist
+  profile has the longer validation history.
 
 | Simulator RMW | Status |
 |---|---|
 | **Fast DDS** (`-rmw=fastdds`, default) | **Validated.** UDPv4-only with the generated bridge-whitelist profile; containerized Autoware (CycloneDDS) discovers the simulator out of the box. |
-| CycloneDDS (`-rmw=cyclonedds`) | **Not recommended (sim side)** until the fragmented-receive fix lands. |
+| CycloneDDS (`-rmw=cyclonedds`) | **Validated** (Town10HD classical to ARRIVED in one measured Phase 1 run; control_cmd ~20 Hz, LiDAR ~10 Hz — not yet repeated). Uses the generated `dds/cyclonedds.xml`. |
 | Zenoh (`-rmw=zenoh`) | Works with `--stack source`; the script starts the required router first (`ros2 run rmw_zenoh_cpp rmw_zenohd`) and runs zenoh end-to-end. |
 
 Both Humble/22.04 and Jazzy/24.04 hosts work; Jazzy is the Autoware Docker

--- a/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
@@ -401,10 +401,13 @@ install_acados() {
 # (e.g. tiny/) but lidar_centerpoint's launch expects the four files FLAT in
 # ml_models/lidar_centerpoint/. Without them classical-mode perception dies at
 # startup. Create flat symlinks from whatever subdir carries a matching file.
-# Idempotent; no-op if the model dir does not exist yet.
+# Idempotent; warns and no-ops if the model dir does not exist yet.
 # ---------------------------------------------------------------------------
 fixup_centerpoint_layout() {
-    [ -d "${CENTERPOINT_DATA_DIR}" ] || return 0
+    if [ ! -d "${CENTERPOINT_DATA_DIR}" ]; then
+        warn "lidar_centerpoint model dir ${CENTERPOINT_DATA_DIR} not present -- classical perception_mode:=lidar will fail at ONNX load. Hosts with the older layout: ln -s ../lidar_centerpoint ~/autoware_data/ml_models/lidar_centerpoint (see README)."
+        return 0
+    fi
     log "Checking lidar_centerpoint flat layout in ${CENTERPOINT_DATA_DIR}"
     local f src missing=0
     for f in "${CENTERPOINT_FLAT_FILES[@]}"; do

--- a/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
@@ -275,6 +275,24 @@ do_check() {
     have colcon || echo "  -> colcon: apt install python3-colcon-common-extensions"
 
     echo
+    echo "--- Kernel / container runtime (README prerequisites) ---"
+    local rmem wmem
+    rmem="$(sysctl -n net.core.rmem_max 2>/dev/null || echo 0)"
+    wmem="$(sysctl -n net.core.wmem_max 2>/dev/null || echo 0)"
+    if [ "${rmem}" -ge 67108864 ] && [ "${wmem}" -ge 67108864 ]; then
+        echo "UDP buffers    : OK (rmem_max=${rmem} wmem_max=${wmem})"
+    else
+        echo "UDP buffers    : TOO SMALL (rmem_max=${rmem} wmem_max=${wmem}; need 67108864). Fix: sudo sysctl -w net.core.rmem_max=67108864 net.core.wmem_max=67108864 and persist in /etc/sysctl.d/"
+    fi
+    if have docker && docker info 2>/dev/null | grep -qiE 'nvidia|cdi'; then
+        echo "NVIDIA runtime : OK (docker reports an nvidia runtime or CDI spec)"
+    elif have nvidia-ctk || [ -f /etc/cdi/nvidia.yaml ]; then
+        echo "NVIDIA runtime : nvidia-ctk/CDI present but docker does not report it -- run 'sudo nvidia-ctk runtime configure --runtime=docker' and restart docker"
+    else
+        echo "NVIDIA runtime : MISSING (nvidia-container-toolkit not found; GPU perception in --docker mode will fail)"
+    fi
+
+    echo
     echo "--- Existing installs ---"
     if [ -d "${WORKSPACE}" ]; then
         echo "Workspace      : ${WORKSPACE} EXISTS"

--- a/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/install/install_autoware.sh
@@ -79,14 +79,21 @@ VAD_FILES=(
 VAD_DATA_DIR="${HOME}/autoware_data/ml_models/vad/v0.1"
 
 # lidar_centerpoint perception models. The HuggingFace bundle lands under
-# ~/autoware_data/ml_models/lidar_centerpoint/ in SUBDIRS (e.g. tiny/), but the
-# launch files expect these FLAT files directly in the lidar_centerpoint dir:
+# ~/autoware_data/ml_models/lidar_centerpoint/ in SUBDIRS (e.g. tiny/), FLAT
+# in the lidar_centerpoint dir. The ONNX and ml_package names are NOT bare:
+# lidar_centerpoint.launch.xml interpolates them as
+# pts_voxel_encoder_$(var model_name).onnx, pts_backbone_neck_head_$(var
+# model_name).onnx and $(var model_name)_ml_package.param.yaml, and
+# defaults model_name to "centerpoint_tiny" (verified against the shipped
+# Autoware image). detection_class_remapper.param.yaml is the one file the
+# launch hardcodes, not model-name-dependent.
 CENTERPOINT_DATA_DIR="${HOME}/autoware_data/ml_models/lidar_centerpoint"
+CENTERPOINT_MODEL_NAME="${CENTERPOINT_MODEL_NAME:-centerpoint_tiny}"
 CENTERPOINT_FLAT_FILES=(
-    "centerpoint_tiny_ml_package.param.yaml"
+    "${CENTERPOINT_MODEL_NAME}_ml_package.param.yaml"
     "detection_class_remapper.param.yaml"
-    "pts_voxel_encoder.onnx"
-    "pts_backbone_neck_head.onnx"
+    "pts_voxel_encoder_${CENTERPOINT_MODEL_NAME}.onnx"
+    "pts_backbone_neck_head_${CENTERPOINT_MODEL_NAME}.onnx"
 )
 
 # GHCR images (tags verified against the GHCR manifest API, all 200):
@@ -420,9 +427,9 @@ fixup_centerpoint_layout() {
         if [ -z "${src}" ]; then
             # fuzzy fallback: subdir files often carry variant-suffixed names
             case "${f}" in
-                pts_voxel_encoder.onnx)      src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name 'pts_voxel_encoder*.onnx' 2>/dev/null | sort | head -1)" ;;
-                pts_backbone_neck_head.onnx) src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name 'pts_backbone_neck_head*.onnx' 2>/dev/null | sort | head -1)" ;;
-                centerpoint_tiny_ml_package.param.yaml) src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name '*tiny*ml_package*.param.yaml' 2>/dev/null | sort | head -1)" ;;
+                "pts_voxel_encoder_${CENTERPOINT_MODEL_NAME}.onnx")      src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name 'pts_voxel_encoder*.onnx' 2>/dev/null | sort | head -1)" ;;
+                "pts_backbone_neck_head_${CENTERPOINT_MODEL_NAME}.onnx") src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name 'pts_backbone_neck_head*.onnx' 2>/dev/null | sort | head -1)" ;;
+                "${CENTERPOINT_MODEL_NAME}_ml_package.param.yaml") src="$(find "${CENTERPOINT_DATA_DIR}" -mindepth 2 -type f -name "*${CENTERPOINT_MODEL_NAME}*ml_package*.param.yaml" 2>/dev/null | sort | head -1)" ;;
             esac
         fi
         if [ -n "${src}" ]; then

--- a/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
@@ -20,8 +20,8 @@
 # DDS topology (validated 2026-08 on Town10, full classical stack):
 #   - The SIMULATOR runs Fast DDS (-rmw=fastdds) with a generated profile that
 #     whitelists ONLY the docker bridge IP (useBuiltinTransports=false).
-#     Do NOT use -rmw=cyclonedds on the simulator for now: our CycloneDDS
-#     receive path has a known fragmented-receive bug (being fixed separately).
+#     -rmw=cyclonedds is also validated (fragmented-receive fix b9c33737a);
+#     fastdds remains the default for its longer validation history.
 #   - The AUTOWARE side runs CycloneDDS pinned to the docker bridge interface
 #     via a generated cyclonedds.xml (MaxAutoParticipantIndex=300, 65500B max
 #     message size, 10-64MB socket buffers -- the official docker image's own
@@ -78,8 +78,7 @@ export PATH
 # ---------------------------------------------------------------- defaults --
 MODE=""
 TOWN="Town10HD_Opt"
-RMW="fastdds"                 # SIMULATOR-side RMW. cyclonedds has a known
-                              # fragmented-receive bug on the sim side -- keep fastdds.
+RMW="fastdds"                 # SIMULATOR-side RMW: fastdds (default) or cyclonedds, both validated.
 STACK="auto"                  # auto|source|docker : how to run Autoware (classical)
 MAP_PATH=""
 CARLA_ROOT_ARG="${CARLA_ROOT:-}"
@@ -119,9 +118,9 @@ Usage: $(basename "$0") --mode classical|e2e [options]
                          Must not collide with an existing container; this script
                          never touches containers it did not create.
   --rmw NAME             SIMULATOR RMW: fastdds|cyclonedds|zenoh (default: fastdds).
-                         cyclonedds is NOT recommended on the sim side for now
-                         (known fragmented-receive bug). The Autoware side always
-                         runs cyclonedds (zenoh: zenoh) with a generated config.
+                         fastdds and cyclonedds are both validated on the sim
+                         side; the Autoware side always runs cyclonedds
+                         (zenoh: zenoh) with a generated config.
   --map-path DIR         dir containing pointcloud_map.pcd, lanelet2_map.osm,
                          map_projector_info.yaml
                          (default: ../map_tools/maps/<town-without-_Opt>)
@@ -606,7 +605,7 @@ $DRY_RUN && log "DRY RUN -- nothing will be executed; preflight failures become 
 
 # Simulator RMW sanity
 if [[ "$RMW" == "cyclonedds" ]]; then
-    warn "-rmw=cyclonedds on the SIMULATOR has a known fragmented-receive bug (large messages, e.g. pointclouds, can be dropped). Use the default fastdds until it is fixed."
+    log "simulator RMW: cyclonedds (validated; fastdds is the default only by history)"
 fi
 
 # Resolve --stack auto (classical only; e2e always needs the source ws for VAD)

--- a/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
@@ -160,10 +160,14 @@ Usage: $(basename "$0") --mode classical|e2e [options]
   --with-display         do NOT pass -RenderOffScreen to the CARLA server
   --server-args "FLAGS"  extra flags appended verbatim to the simulator's own
                          command line, after every flag this script sets
-                         itself. E.g. "-log -carla-streaming-port=2001".
-                         Whitespace-split with shell-style quoting (quote a
-                         value to keep a space in it); never evaluated --
-                         \$, ;, \` etc. reach the simulator's argv literally.
+                         itself -- including the default -nosound (headless
+                         -game has no need for audio). Pass "-enablesound"
+                         here to restore it: Unreal's own flag for canceling
+                         a -nosound also present, regardless of order. E.g.
+                         "-log -carla-streaming-port=2001". Whitespace-split
+                         with shell-style quoting (quote a value to keep a
+                         space in it); never evaluated -- \$, ;, \` etc.
+                         reach the simulator's argv literally.
   --dry-run              print every command that would run; execute nothing;
                          preflight failures downgrade to warnings
   -h | --help            this text
@@ -819,7 +823,7 @@ if [[ "$RMW" == "zenoh" ]]; then
 fi
 
 # ---------------------------------------------------------- 1. CARLA server --
-SERVER_FLAGS="-ros2 -rmw=$RMW -carla-rpc-port=$RPC_PORT -ros-domain-id=$DOMAIN_ID"
+SERVER_FLAGS="-ros2 -rmw=$RMW -carla-rpc-port=$RPC_PORT -ros-domain-id=$DOMAIN_ID -nosound"
 $WITH_DISPLAY || SERVER_FLAGS+=" -RenderOffScreen"
 if [[ -n "$SERVER_ARGS" ]]; then
     # Reject a whitespace-only value the same way an unbalanced quote is

--- a/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
@@ -81,6 +81,7 @@ TOWN="Town10HD_Opt"
 RMW="fastdds"                 # SIMULATOR-side RMW: fastdds (default) or cyclonedds, both validated.
 STACK="auto"                  # auto|source|docker : how to run Autoware (classical)
 MAP_PATH=""
+SERVER_ARGS=""                # extra simulator flags, appended last (see --server-args)
 CARLA_ROOT_ARG="${CARLA_ROOT:-}"
 AUTOWARE_WS="${AUTOWARE_WS:-$HOME/autoware}"
 DOMAIN_ID=42
@@ -157,6 +158,12 @@ Usage: $(basename "$0") --mode classical|e2e [options]
                          DISPLAY passthrough; source stack: local rviz2)
   --log-dir DIR          per-process logs + pidfile (default: <this dir>/logs)
   --with-display         do NOT pass -RenderOffScreen to the CARLA server
+  --server-args "FLAGS"  extra flags appended verbatim to the simulator's own
+                         command line, after every flag this script sets
+                         itself. E.g. "-log -carla-streaming-port=2001".
+                         Whitespace-split with shell-style quoting (quote a
+                         value to keep a space in it); never evaluated --
+                         \$, ;, \` etc. reach the simulator's argv literally.
   --dry-run              print every command that would run; execute nothing;
                          preflight failures downgrade to warnings
   -h | --help            this text
@@ -188,6 +195,7 @@ while [[ $# -gt 0 ]]; do
         --with-rviz)    WITH_RVIZ=true; shift ;;
         --log-dir)      LOG_DIR="$2"; shift 2 ;;
         --with-display) WITH_DISPLAY=true; shift ;;
+        --server-args)  SERVER_ARGS="$2"; shift 2 ;;
         --dry-run)      DRY_RUN=true; shift ;;
         -h|--help)      usage; exit 0 ;;
         *) echo "ERROR: unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -813,6 +821,25 @@ fi
 # ---------------------------------------------------------- 1. CARLA server --
 SERVER_FLAGS="-ros2 -rmw=$RMW -carla-rpc-port=$RPC_PORT -ros-domain-id=$DOMAIN_ID"
 $WITH_DISPLAY || SERVER_FLAGS+=" -RenderOffScreen"
+if [[ -n "$SERVER_ARGS" ]]; then
+    # Reject a whitespace-only value the same way an unbalanced quote is
+    # rejected below, rather than letting it through to xargs/mapfile,
+    # which would turn it into one spurious empty argv token.
+    [[ "$SERVER_ARGS" =~ [^[:space:]] ]] \
+        || die "--server-args: value is empty or whitespace-only"
+    # Tokenize --server-args with xargs: it honors shell-style quoting
+    # (so a value containing a space can be kept as one token) but, unlike
+    # eval or an unquoted expansion, never performs variable/command
+    # substitution -- a metacharacter in the input stays inert text.
+    SERVER_ARGS_LINES="$(xargs -n1 printf '%s\n' <<<"$SERVER_ARGS")" \
+        || die "--server-args: unbalanced quoting in '$SERVER_ARGS'"
+    SERVER_ARGS_ARR=()
+    mapfile -t SERVER_ARGS_ARR <<<"$SERVER_ARGS_LINES"
+    # Re-quote each token with %q: start_proc() below re-parses the whole
+    # command string through `bash -c`, so each token must round-trip
+    # through that second parse as the single literal argument it is.
+    SERVER_FLAGS+="$(printf ' %q' "${SERVER_ARGS_ARR[@]}")"
+fi
 
 if [[ "$SERVER_KIND" == "packaged" ]]; then
     start_proc carla_server "${SIM_ENV}exec '$SERVER_LAUNCHER' $SERVER_FLAGS"

--- a/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
+++ b/PythonAPI/examples/av_stacks/autoware/run/run_carla_autoware.sh
@@ -91,6 +91,7 @@ WITH_RVIZ=false
 NO_AUTO=false
 NO_GATES=false
 NO_RECOVER=false
+NO_WHEEL_CHECK=false   # skip the installed-vs-this-tree carla wheel provenance check
 GOAL=""
 SPAWN_INDEX=""                # autoware_demo.py --spawn_index passthrough (e2e default: 52)
 LOG_DIR="$SCRIPT_DIR/logs"
@@ -154,6 +155,9 @@ Usage: $(basename "$0") --mode classical|e2e [options]
                          localization check + distortion-corrector health). The
                          gates exist because engaging on a diverged pose drives
                          the car into things -- only skip them knowingly.
+  --no-wheel-check       skip the carla module provenance check (installed
+                         .so vs any of this tree's built wheels) -- use
+                         only when you knowingly run a wheel from elsewhere
   --with-rviz            also start RViz (docker stack: separate container with
                          DISPLAY passthrough; source stack: local rviz2)
   --log-dir DIR          per-process logs + pidfile (default: <this dir>/logs)
@@ -196,6 +200,7 @@ while [[ $# -gt 0 ]]; do
         --no-auto)      NO_AUTO=true; shift ;;
         --no-gates)     NO_GATES=true; shift ;;
         --no-recover)   NO_RECOVER=true; shift ;;
+        --no-wheel-check) NO_WHEEL_CHECK=true; shift ;;
         --with-rviz)    WITH_RVIZ=true; shift ;;
         --log-dir)      LOG_DIR="$2"; shift 2 ;;
         --with-display) WITH_DISPLAY=true; shift ;;
@@ -763,6 +768,73 @@ fi
 if [[ -z "$CARLA_PY" ]]; then
     preflight_fail "no python3 (scrubbed PATH or original PATH) can 'import carla' -- install the CARLA wheel (Build/*/PythonAPI/dist/*.whl) into a python environment"
     CARLA_PY="python3"   # dry-run placeholder
+fi
+
+# Wheel provenance: 'import carla' above only proves *some* wheel is
+# installed, not that it is THIS tree's build. A wheel from another
+# worktree imported fine and then aborted load_town with
+# std::bad_array_new_length after a 15-minute setup (client/server RPC
+# layout mismatch) -- and the version string can't tell them apart, both
+# report 0.10.0. Compare the installed extension's sha256 against every
+# wheel this tree has built (any preset, any match -- the question is
+# "did this come from a build of this tree", not "the newest one").
+# Read wheel entries via $CARLA_PY's own zipfile module, not `unzip`: a
+# lookup miss (e.g. a differing Python ABI tag) is then just a skipped
+# candidate under Python's own try/except, never a set -e/pipefail exit
+# that this script would never see.
+if $NO_WHEEL_CHECK; then
+    log "carla module provenance check skipped (--no-wheel-check)"
+else
+    mapfile -t WHEEL_HITS < <(find "$REPO_ROOT/Build" -maxdepth 4 \
+        -path '*/PythonAPI/dist/carla-*.whl' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn)
+    WHEELS=()
+    for hit in "${WHEEL_HITS[@]}"; do
+        WHEELS+=("${hit#* }")
+    done
+    INSTALLED_SO="$("$CARLA_PY" -c 'import carla; print(carla.__file__)' 2>/dev/null || true)"
+    if [[ ${#WHEELS[@]} -eq 0 || "$INSTALLED_SO" != *.so ]]; then
+        warn "carla module provenance NOT verified (no built wheel under $REPO_ROOT/Build/*/PythonAPI/dist, or module is not a single .so) -- if this module was NOT built from this tree, load_town can abort ~15 minutes into the run with std::bad_array_new_length. Build one here: cmake --build Build/<preset> --target carla-python-api (or pass --no-wheel-check to silence this warning)"
+    else
+        # Two lines out: installed sha256 (empty if unreadable), then the
+        # first wheel whose same-named entry hashes the same (empty if
+        # none do). A missing zip entry is caught per-wheel and skipped,
+        # not raised -- see the comment above.
+        PROV_OUT="$("$CARLA_PY" -c '
+import sys, hashlib, zipfile
+installed_so = sys.argv[1]
+wheels = sys.argv[2:]
+try:
+    with open(installed_so, "rb") as f:
+        installed_hash = hashlib.sha256(f.read()).hexdigest()
+except OSError:
+    print("")
+    print("")
+    sys.exit(0)
+name = installed_so.rsplit("/", 1)[-1]
+matched = ""
+for wheel in wheels:
+    try:
+        with zipfile.ZipFile(wheel) as zf:
+            entry = zf.read(name)
+    except Exception:
+        continue
+    if hashlib.sha256(entry).hexdigest() == installed_hash:
+        matched = wheel
+        break
+print(installed_hash)
+print(matched)
+' "$INSTALLED_SO" "${WHEELS[@]}" 2>/dev/null || true)"
+        INSTALLED_SHA="$(sed -n '1p' <<<"$PROV_OUT")"
+        MATCHED_WHEEL="$(sed -n '2p' <<<"$PROV_OUT")"
+        if [[ -z "$INSTALLED_SHA" ]]; then
+            warn "carla module provenance not checked (could not hash $INSTALLED_SO)"
+        elif [[ -z "$MATCHED_WHEEL" ]]; then
+            preflight_fail "installed carla module ($INSTALLED_SO, sha256 ${INSTALLED_SHA:0:12}...) matches none of this tree's ${#WHEELS[@]} built wheel(s) under $REPO_ROOT/Build/*/PythonAPI/dist -- a client built elsewhere can import fine and still abort load_town with std::bad_array_new_length. Reinstall from this tree: $CARLA_PY -m pip install --force-reinstall '${WHEELS[0]}' (or pass --no-wheel-check to proceed anyway)"
+        else
+            log "carla module provenance OK: matches $(basename "$MATCHED_WHEEL") (sha256 ${INSTALLED_SHA:0:12}...)"
+        fi
+    fi
 fi
 
 # e2e-only preflight: VAD model + launch glue


### PR DESCRIPTION
#### Description

The in-tree Autoware layer under `PythonAPI/examples/av_stacks/autoware/` does not do what it documents, in five separate ways. Each is a self-contained commit; they are in one PR because they share a directory, a reviewer and a class of failure, and because splitting them would put `run_carla_autoware.sh` and `README.md` across several PRs for no review benefit.

**1. The only documented goal is off-lane, so a verbatim run silently refuses to drive.** `--goal "80.0,-16.5,90"` at `README.md:195` sits 19.4 m from the nearest lane centreline (17.7 m from the lane edge), so `mission_planner` rejects it with `Goal's footprint exceeds lane! / Goal is not valid!`. The run comes up healthy, passes both pre-engage gates, and then does nothing, with the reason buried in a routing-state error. The coordinate conversion is not at fault: the y-negation is intentional and documented, and a sign flip does not rescue the goal either. This documents a lane-aligned goal and the procedure for deriving one from a waypoint transform.

**2. The CycloneDDS-on-simulator warning is stale.** The README and the script both warned against `-rmw=cyclonedds` on the simulator side because of a fragmented-receive bug. That bug was fixed by `b9c33737a` ("reassemble fragmented CycloneDDS receives in `carla_cdr_from_ser`"), which is an ancestor of `ue58-dev` — verified rather than assumed. The warning is retired, the runtime `warn` becomes a `log`, and `fastdds` stays the default on the honest grounds that it has the longer validation history rather than because the alternative is broken.

**3. `--timeout` accepted values that hang forever.** A negative argument reached a `size_t` and became a near-maximum timeout, so `--timeout -1` hung indefinitely instead of failing. Adds a `parse_timeout` that raises `argparse.ArgumentTypeError` for anything `<= 0`.

**4. No way to pass simulator flags, and sound was on by default.** Adds a `--server-args` passthrough and defaults the simulator to `-nosound`, with `--server-args "-enablesound"` as the opt-out. The passthrough tokenizes quote-aware and re-quotes each token with `printf ' %q'` before the nested `bash -c`, and rejects all-whitespace input; appending the raw string to the flag list would be a shell-injection vector through that nested shell.

**5. The installer's `--check` probed model filenames the launcher never resolves.** `--check` looked for bare `pts_voxel_encoder.onnx` / `pts_backbone_neck_head.onnx` while the shipped launcher resolves `pts_voxel_encoder_$(var model_name).onnx`. `CENTERPOINT_FLAT_FILES` is now parameterized on `CENTERPOINT_MODEL_NAME` (default `centerpoint_tiny`). Two related fixes ride along: an absent centerpoint model directory now warns instead of returning silently, and `--check` additionally probes the UDP buffer sizes and the NVIDIA container runtime, both prerequisites that previously failed later and less legibly.

**6. Wheel provenance is now a preflight failure.** Running against a `carla` wheel that does not match the tree produces confusing downstream errors, so the preflight compares them via `$CARLA_PY` and `zipfile` and fails early, with `--no-wheel-check` to opt out. `zipfile` rather than `unzip -p` deliberately: `unzip -p` exits 11 on a missing member, which under `set -euo pipefail` terminated the script silently through a command substitution.

Fixes #

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04.4 LTS, RTX 5090 (driver 580.173.02)
  * **Python version(s):** 3.12.3
  * **Unreal Engine version(s):** 5.8.0 (`ue58-dev`, editor `-game` path)

**These commits have already been through a fork PR with CI green.** The identical tree ran as [youtalk/carla#35](https://github.com/youtalk/carla/pull/35), where both checks pass: `Ubuntu 24.04`, which builds inside the UE 5.8 toolchain container, and `Python tools and shell scripts`, which runs `shellcheck -S warning` over `run/`, `install/` and `map_tools/` plus the `map_tools` pytest suite. The diff proposed here is byte-identical to that branch minus a fork-only CI workflow commit, verified with `git diff --numstat`.

Beyond CI, the layer was exercised live on this branch: a full `--mode classical --stack docker` bring-up on `Town10HD_Opt` against `ghcr.io/autowarefoundation/autoware:universe-cuda-jazzy`, reaching autonomous driving. That run exercised the `--server-args`/`-nosound` path, the wheel-provenance preflight and the installer `--check` probe, and it measured control at 19.969 Hz (spec 20 +/- 5 Hz) and LiDAR at 9.999 Hz (spec 10 +/- 1 Hz). The lane-aligned goal documented in change 1 was driven to completion; the previously documented goal is the one that produces `Goal is not valid!`.

https://github.com/user-attachments/assets/ef3ef074-2dae-4557-87ee-dbced5903b0b

#### Possible Drawbacks

`-nosound` becomes the default for the simulator process this script launches. Anyone who relied on audio from this launcher must now pass `--server-args "-enablesound"`. This is deliberate — the headless `-game` path has no use for audio — but it is a behaviour change rather than a pure fix.

The wheel-provenance preflight will now fail runs that previously started, specifically when the installed `carla` module does not come from this tree. That is the point of the check, but it can surprise someone deliberately running a wheel from elsewhere; `--no-wheel-check` opts out.

Changes 1 and 2 alter documented guidance. If a reader has memorised the old goal coordinates or the old "do not use cyclonedds" advice, this PR contradicts them — intentionally, and with the evidence above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9873)
<!-- Reviewable:end -->

