### PR TITLE
fix(ros2): publish CARLA point clouds as is_dense

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaPointCloudPublisher.cpp
@@ -104,10 +104,9 @@ bool CarlaPointCloudPublisher::WritePointCloud(
   message->fields = BuildPointFields(GetFieldDescriptors(), GetFieldDescriptorCount());
   message->point_step = static_cast<std::uint32_t>(point_size);
   message->row_step = static_cast<std::uint32_t>(width * point_size);
-  // is_dense=false matches the upstream convention: lidar / radar scans contain
-  // invalid points (no return / max-range hits) and subscribers must not
-  // assume tightly packed valid data.
-  message->is_dense = false;
+  // CARLA's point-cloud sensors emit one point per actual return and never
+  // NaN/Inf placeholders, so every published cloud is dense.
+  message->is_dense = true;
   message->data = std::move(data);
 
   return true;


### PR DESCRIPTION
#### Description

`CarlaPointCloudPublisher` publishes every point cloud with `is_dense = false`. On the `sensor_msgs/PointCloud2` contract that field means "this cloud may contain invalid points" — non-finite XYZ that a consumer must filter before use. CARLA's LiDAR produces no such points: every point written into the message is a finite hit, so the flag is wrong as shipped.

The cost is not cosmetic for ROS 2 consumers. Autoware's cloud validator warns on it and states that it will become a hard error:

```
[sensing.lidar.top.crop_box_filter_self]: Invalid PointCloud: is_dense is false
```

That message repeats for the lifetime of a run — 99 occurrences in one recorded session, and continuously in others — which both drowns the log and commits the consumer to a filtering pass over every cloud that can never remove anything.

This sets `is_dense = true` at the point where the message is filled.

Fixes #

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04.4 LTS, RTX 5090 (driver 580.173.02)
  * **Python version(s):** 3.12.3
  * **Unreal Engine version(s):** 5.8.0 (`ue58-dev`, editor `-game` path)

**This commit has already been through a fork PR with CI green.** It ran as [youtalk/carla#28](https://github.com/youtalk/carla/pull/28), where both checks pass — including `Ubuntu 24.04`, which compiles `LibCarla` inside the UE 5.8 toolchain container and therefore compiles this exact file. The diff proposed here is byte-identical to that branch minus a fork-only CI workflow commit, verified with `git diff --numstat`.

The behavioural check is on the consumer side: with this change compiled in, live `--mode classical` runs against `ghcr.io/autowarefoundation/autoware:universe-cuda-jazzy` on `Town10HD_Opt` produce **zero** `is_dense is false` warnings, where the unfixed build produces them continuously. LiDAR rate in those runs measured 9.999 Hz (min 0.096 s, max 0.102 s) against a `sensor_tick` of 0.1, so the change does not disturb publication timing.

#### Possible Drawbacks

`is_dense = true` is an assertion that the cloud contains no non-finite points. It is correct for the data this publisher builds today, but it is a promise rather than an observation: if a future change lets a non-finite point reach the buffer — an unfiltered raycast miss, a NaN from a transform — consumers that trust the flag will no longer filter it out, and the failure would surface downstream rather than here. Anything that adds points to this publisher should keep that invariant in mind.

Consumers that currently branch on `is_dense == false` to run a filtering pass will stop doing so. That is the intended saving, but it is a change in what downstream code executes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla/9874)
<!-- Reviewable:end -->
